### PR TITLE
feat(docgen): sectionsByKind guidance bundle — react_component api + size-aware Operation + module-readme boundary (#1970 #1986 #1992)

### DIFF
--- a/internal/docgen/sections_by_kind.go
+++ b/internal/docgen/sections_by_kind.go
@@ -31,6 +31,16 @@
 // The GuidanceOverrides for the existing sections already carry Model-specific
 // framing so the LLM output is correctly scoped even before a dedicated section
 // is introduced.
+//
+// # Size-aware Operation profiles (#1986)
+//
+// ResolveSectionProfile accepts an optional lineCount variadic argument.
+// When provided for an Operation kind, the profile is chosen from three tiers:
+//
+//   - small  (< 30 lines): skips reference-deployment, how-to-local-dev,
+//     reference-scripts; uses shorter capabilities/api guidance.
+//   - medium (30–149 lines): current guidance (baseline Operation profile).
+//   - large  (>= 150 lines): full deep-context template with all sections.
 package docgen
 
 import "strings"
@@ -128,7 +138,10 @@ var sectionsByKind = map[string]SectionProfile{
 			"reference-misc": "Capture migration history highlights, known technical debt, or links to the ADR that introduced this model.",
 			"glossary": "Define domain terms that appear in field names, association names, or enum values. One term per row.",
 			"module-readme": "Write a README-style intro for the module that owns this model: purpose, key sibling models, " +
-				"and how to run the associated tests.",
+				"and how to run the associated tests. " +
+				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
+				"`module_manifest.functions`, or `neighbour_briefs`. " +
+				"If you cite a sibling, name the bundle field it came from.",
 		},
 	},
 
@@ -173,7 +186,10 @@ var sectionsByKind = map[string]SectionProfile{
 			"how-to-local-dev": "Provide a numbered step-by-step local development guide for this module: " +
 				"clone, configure env vars, build, run tests, start the local server, and observe output.",
 			"module-readme": "Write a README-style introduction for this module: purpose, key entities, " +
-				"quickstart build/test/run commands, and link to the full documentation page.",
+				"quickstart build/test/run commands, and link to the full documentation page. " +
+				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
+				"`module_manifest.functions`, or `neighbour_briefs`. " +
+				"If you cite a sibling, name the bundle field it came from.",
 		},
 	},
 
@@ -184,6 +200,9 @@ var sectionsByKind = map[string]SectionProfile{
 	// units of behaviour.  They do NOT need reference-deployment/scripts/
 	// how-to-local-dev (module-level concerns) reducing boilerplate by ~3 sections.
 	// They DO need flows, patterns, and api for signature documentation.
+	//
+	// This is the "medium" (30–149 line) baseline profile.  ResolveSectionProfile
+	// selects "operation.small" or "operation.large" when a lineCount is supplied.
 	// -------------------------------------------------------------------------
 	"operation": {
 		Sections: []string{
@@ -217,7 +236,150 @@ var sectionsByKind = map[string]SectionProfile{
 			"reference-misc": "Capture performance notes, known edge cases, or links to the issue/ADR that introduced this operation.",
 			"glossary": "Define domain terms appearing in the function name, parameter names, or return type. One term per row.",
 			"module-readme": "Write a brief README-style intro for the module that contains this operation: " +
-				"purpose and key sibling operations.",
+				"purpose and key sibling operations. " +
+				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
+				"`module_manifest.functions`, or `neighbour_briefs`. " +
+				"If you cite a sibling, name the bundle field it came from.",
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// Operation.small — helper function / method under 30 lines.
+	//
+	// #1986: small operations are leaf helpers; padded deployment/dev sections
+	// produce generic boilerplate and degrade quality scores.  Skip the three
+	// heavy infrastructure sections and use tighter capabilities/api guidance.
+	// -------------------------------------------------------------------------
+	"operation.small": {
+		Sections: []string{
+			"overview",
+			"capabilities",
+			"flows",
+			"patterns",
+			"api",
+			"reference-config",
+			"reference-misc",
+			"glossary",
+			"module-readme",
+		},
+		GuidanceOverrides: map[string]string{
+			"overview": "Write 1–2 sentences describing what this small helper does and when it is called. " +
+				"State its single responsibility clearly.",
+			"capabilities": "List the observable behaviours of this helper in 1–3 bullets. " +
+				"Keep it concise — small operations have narrow contracts.",
+			"flows": "Describe the execution path briefly. A single mermaid flowchart node or a short prose paragraph is sufficient.",
+			"patterns": "Note any design pattern (guard clause, delegation, pure function, etc.) in one sentence.",
+			"api": "Document the function signature: parameters (name, type), return value, and any errors raised. " +
+				"One-liner usage example if the call site is non-obvious.",
+			"reference-config": "Note any config key or feature flag read by this helper, if any. Omit section if none.",
+			"reference-misc": "Capture edge cases or performance notes specific to this helper, if any.",
+			"glossary": "Define any non-obvious domain term in the function or parameter names. Omit if all names are self-evident.",
+			"module-readme": "One sentence positioning this helper within its module. " +
+				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
+				"`module_manifest.functions`, or `neighbour_briefs`. " +
+				"If you cite a sibling, name the bundle field it came from.",
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// Operation.large — service-level function / method 150+ lines.
+	//
+	// #1986: large operations act more like service entry-points and warrant the
+	// full template including deployment context, script references, and a
+	// comprehensive local-dev guide.
+	// -------------------------------------------------------------------------
+	"operation.large": {
+		Sections: []string{
+			"overview",
+			"capabilities",
+			"flows",
+			"patterns",
+			"api",
+			"reference-config",
+			"reference-dependencies",
+			"reference-deployment",
+			"reference-scripts",
+			"how-to-local-dev",
+			"reference-misc",
+			"glossary",
+			"module-readme",
+		},
+		GuidanceOverrides: map[string]string{
+			"overview": "Write a 2–4 sentence description of what this large operation does, why it is a critical-path entry point, " +
+				"and what subsystems it orchestrates. " +
+				"Highlight god-node or articulation-point status if applicable.",
+			"capabilities": "Enumerate all discrete business capabilities this operation provides. " +
+				"Group by outcome category. One bullet per observable contract.",
+			"flows": "Trace the full execution flow using a mermaid sequence diagram. " +
+				"Show the caller → this operation → all major callees and any fork/join or retry loops.",
+			"patterns": "Identify ALL structural and architectural patterns present " +
+				"(orchestrator, saga, pipeline, strategy, command, etc.). " +
+				"Cite specific neighbour relationships as evidence for each.",
+			"api": "Document the full function signature: every parameter (name, type, purpose), all return values, " +
+				"and every error or panic path. Include a realistic usage example showing a typical call site.",
+			"reference-config": "List every environment variable, config key, or feature flag read by this operation. " +
+				"Note which alter branching behaviour and which are required vs optional.",
+			"reference-dependencies": "List all external and internal dependencies called by this operation. " +
+				"Separate required production dependencies from optional/test-only dependencies.",
+			"reference-deployment": "Describe deployment concerns relevant to this operation: " +
+				"required env vars, scaling constraints, health signals, and sidecar or infrastructure dependencies.",
+			"reference-scripts": "List Makefile targets, scripts, or shell commands that exercise or deploy this operation.",
+			"how-to-local-dev": "Provide a numbered guide for running this operation locally: " +
+				"environment setup, build steps, test execution, and observability hooks.",
+			"reference-misc": "Capture performance benchmarks, known edge cases, concurrency considerations, " +
+				"or links to the ADR / issue that introduced this operation.",
+			"glossary": "Define every domain term appearing in the function name, parameters, or return types. One term per row.",
+			"module-readme": "Write a README-style intro for the module that contains this operation. " +
+				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
+				"`module_manifest.functions`, or `neighbour_briefs`. " +
+				"If you cite a sibling, name the bundle field it came from.",
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// react_component — React UI component (TSX/JSX).
+	//
+	// #1970: the generic function-signature template produces a state-table
+	// workaround instead of a proper props-interface doc.  React components
+	// have a distinct public surface: props (not raw parameters), JSX.Element
+	// return semantics, and children/slot patterns.
+	// -------------------------------------------------------------------------
+	"react_component": {
+		Sections: []string{
+			"overview",
+			"capabilities",
+			"api",
+			"patterns",
+			"reference-config",
+			"reference-dependencies",
+			"reference-misc",
+			"glossary",
+			"module-readme",
+		},
+		GuidanceOverrides: map[string]string{
+			"overview": "Write a 2–3 sentence description of what this React component renders and when it is used. " +
+				"State its primary responsibility in the UI (layout, data display, interaction, form control, etc.).",
+			"capabilities": "List the visual/interactive capabilities this component provides. " +
+				"One bullet per user-facing behaviour or observable output.",
+			"api": "Document the props interface — NOT the generic function signature. " +
+				"For each prop: name, TypeScript type (or JSDoc @param type), default value, required/optional, and one-line purpose. " +
+				"If TypeScript: pull the interface or type alias from the declared Props type. " +
+				"If JavaScript with JSDoc: pull from @param tags on the component function. " +
+				"Show the JSX.Element return semantics (what markup is produced). " +
+				"Document children semantics: are children accepted, required, or forbidden? " +
+				"Show a minimal JSX usage example. " +
+				"NEVER reuse the generic function-signature template for this section.",
+			"patterns": "Identify React composition patterns present " +
+				"(compound component, render prop, higher-order component, controlled/uncontrolled, context consumer, etc.). " +
+				"Cite specific prop names or hook calls as evidence.",
+			"reference-config": "List any environment variables, feature flags, or config context values that alter this component's behaviour.",
+			"reference-dependencies": "List direct package dependencies (hooks, context providers, UI library components) used by this component.",
+			"reference-misc": "Capture accessibility notes (ARIA roles, keyboard nav), known edge cases, or performance considerations.",
+			"glossary": "Define any domain terms appearing in prop names or type names. One term per row.",
+			"module-readme": "Write a brief README-style intro for the module that owns this component. " +
+				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
+				"`module_manifest.functions`, or `neighbour_briefs`. " +
+				"If you cite a sibling, name the bundle field it came from.",
 		},
 	},
 
@@ -231,28 +393,72 @@ var sectionsByKind = map[string]SectionProfile{
 	},
 }
 
+// operationLineTier classifies a line count into one of three Operation tiers.
+// It returns the key suffix to append to "operation" for profile lookup.
+//
+//   - lineCount < 30  → "small"
+//   - lineCount < 150 → ""      (medium — the default operation profile)
+//   - lineCount >= 150 → "large"
+func operationLineTier(lineCount int) string {
+	if lineCount < 30 {
+		return "small"
+	}
+	if lineCount < 150 {
+		return "" // medium — use the bare "operation" profile
+	}
+	return "large"
+}
+
 // ResolveSectionProfile returns the SectionProfile for the given entity kind
 // and language.  The lookup rules are:
 //
-//  1. Exact case-insensitive match on kind (e.g. "Model" → "model").
-//  2. Substring match — "SCOPE.Model" contains "model" → "model" profile.
-//  3. Fallback to "default" when no match is found.
+//  1. For Operation kinds, if lineCount is provided, a size tier is applied
+//     first: "operation.small" (<30 lines), "operation" (30–149 lines),
+//     or "operation.large" (>=150 lines).  See #1986.
+//  2. Exact case-insensitive match on kind (e.g. "Model" → "model").
+//  3. Substring match — "SCOPE.Model" contains "model" → "model" profile.
+//  4. Fallback to "default" when no match is found.
 //
 // The language parameter is accepted for future language-aware profiles
 // (e.g. Component kind differs for Java vs React); it is currently unused.
 // Pass an empty string when language is not available.
-func ResolveSectionProfile(kind, _ string) SectionProfile {
+//
+// lineCount is the optional entity line span (end_line - start_line).  Pass
+// zero or omit the argument when the line count is unavailable; the medium
+// Operation profile is used in that case.
+func ResolveSectionProfile(kind, _ string, lineCount ...int) SectionProfile {
 	k := strings.ToLower(kind)
 
-	// 1. Exact match (after lower-casing).
+	// 1. Size-aware Operation tier selection (#1986).
+	//    Check whether the lowercased kind contains "operation" and a lineCount
+	//    was provided.
+	if len(lineCount) > 0 && lineCount[0] > 0 && strings.Contains(k, "operation") {
+		tier := operationLineTier(lineCount[0])
+		profileKey := "operation"
+		if tier != "" {
+			profileKey = "operation." + tier
+		}
+		if p, ok := sectionsByKind[profileKey]; ok {
+			return p
+		}
+	}
+
+	// 2. Exact match (after lower-casing).
 	if p, ok := sectionsByKind[k]; ok {
 		return p
 	}
 
-	// 2. Substring match — covers dotted prefixes ("SCOPE.Model") and
+	// 3. Substring match — covers dotted prefixes ("SCOPE.Model") and
 	//    compound kind names ("DataModel", "ServiceModule", "OperationHandler").
+	//    Skip internal size-tier keys (e.g. "operation.small") to avoid
+	//    accidentally matching "operation" when kind is unrelated.
 	for key, profile := range sectionsByKind {
 		if key == "default" {
+			continue
+		}
+		// Skip dotted internal size-tier keys from the substring scan —
+		// they are only reachable via the explicit tier path above.
+		if strings.Contains(key, ".") {
 			continue
 		}
 		if strings.Contains(k, key) {
@@ -260,7 +466,7 @@ func ResolveSectionProfile(kind, _ string) SectionProfile {
 		}
 	}
 
-	// 3. Fallback to default — preserves current 13-section behaviour.
+	// 4. Fallback to default — preserves current 13-section behaviour.
 	return sectionsByKind["default"]
 }
 

--- a/internal/docgen/sections_by_kind_test.go
+++ b/internal/docgen/sections_by_kind_test.go
@@ -1,6 +1,7 @@
 package docgen_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -274,6 +275,298 @@ func TestSectionsForEntityKind_UnknownFallsToAllSections(t *testing.T) {
 			secs := docgen.SectionsForEntityKind(kind)
 			if len(secs) != len(docgen.KnownSections) {
 				t.Errorf("unknown kind %q: want %d sections, got %d", kind, len(docgen.KnownSections), len(secs))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1986 — size-aware Operation profiles
+// ---------------------------------------------------------------------------
+
+// TestResolveSectionProfile_OperationSmall verifies that an operation with
+// fewer than 30 lines resolves to the "small" profile which omits the three
+// heavy infrastructure sections.
+func TestResolveSectionProfile_OperationSmall(t *testing.T) {
+	p := docgen.ResolveSectionProfile("operation", "", 15)
+	mustAbsent := []string{"reference-deployment", "how-to-local-dev", "reference-scripts"}
+	for _, s := range mustAbsent {
+		if containsSection(p.Sections, s) {
+			t.Errorf("operation(small): section %q should be absent; got %v", s, p.Sections)
+		}
+	}
+	// Must still have core sections.
+	mustPresent := []string{"overview", "capabilities", "api", "flows"}
+	for _, s := range mustPresent {
+		if !containsSection(p.Sections, s) {
+			t.Errorf("operation(small): missing required section %q; got %v", s, p.Sections)
+		}
+	}
+}
+
+// TestResolveSectionProfile_OperationSmallGuidanceTerse verifies that the
+// small-tier capabilities guidance is shorter / tighter than the medium tier.
+func TestResolveSectionProfile_OperationSmallGuidanceTerse(t *testing.T) {
+	small := docgen.ResolveSectionProfile("operation", "", 10)
+	medium := docgen.ResolveSectionProfile("operation", "", 50)
+	gs := docgen.ResolveGuidance(small, "capabilities")
+	gm := docgen.ResolveGuidance(medium, "capabilities")
+	if gs == gm {
+		t.Errorf("operation small/medium capabilities guidance should differ; both returned %q", gs)
+	}
+}
+
+// TestResolveSectionProfile_OperationMedium verifies that the medium tier
+// (30–149 lines) returns the baseline operation profile without deployment
+// sections but without the stripped-down small profile either.
+func TestResolveSectionProfile_OperationMedium(t *testing.T) {
+	p := docgen.ResolveSectionProfile("operation", "", 75)
+	mustAbsent := []string{"reference-deployment", "how-to-local-dev", "reference-scripts"}
+	for _, s := range mustAbsent {
+		if containsSection(p.Sections, s) {
+			t.Errorf("operation(medium): section %q should be absent; got %v", s, p.Sections)
+		}
+	}
+	// Medium has reference-dependencies; small drops it.
+	if !containsSection(p.Sections, "reference-dependencies") {
+		t.Errorf("operation(medium): want reference-dependencies; got %v", p.Sections)
+	}
+}
+
+// TestResolveSectionProfile_OperationLarge verifies that an operation with
+// 150+ lines gets the full template including deployment and local-dev.
+func TestResolveSectionProfile_OperationLarge(t *testing.T) {
+	p := docgen.ResolveSectionProfile("operation", "", 200)
+	mustPresent := []string{
+		"overview", "capabilities", "flows", "patterns", "api",
+		"reference-config", "reference-dependencies",
+		"reference-deployment", "reference-scripts", "how-to-local-dev",
+		"reference-misc", "glossary", "module-readme",
+	}
+	for _, s := range mustPresent {
+		if !containsSection(p.Sections, s) {
+			t.Errorf("operation(large): missing section %q; got %v", s, p.Sections)
+		}
+	}
+}
+
+// TestResolveSectionProfile_OperationLargeGuidanceDeep verifies that the large
+// operation overview guidance explicitly mentions orchestration or critical-path.
+func TestResolveSectionProfile_OperationLargeGuidanceDeep(t *testing.T) {
+	p := docgen.ResolveSectionProfile("operation", "", 300)
+	g := docgen.ResolveGuidance(p, "overview")
+	if !strings.Contains(strings.ToLower(g), "orchestrat") && !strings.Contains(strings.ToLower(g), "critical") {
+		t.Errorf("operation(large) overview guidance should mention orchestration or critical-path; got %q", g)
+	}
+}
+
+// TestResolveSectionProfile_OperationNoLineCount verifies that when no
+// lineCount is passed, the medium (baseline) Operation profile is returned.
+func TestResolveSectionProfile_OperationNoLineCount(t *testing.T) {
+	withoutCount := docgen.ResolveSectionProfile("operation", "")
+	withZero := docgen.ResolveSectionProfile("operation", "", 0)
+	medium := docgen.ResolveSectionProfile("operation", "", 50)
+	for _, p := range []docgen.SectionProfile{withoutCount, withZero} {
+		if len(p.Sections) != len(medium.Sections) {
+			t.Errorf("operation without lineCount: want medium section count %d, got %d",
+				len(medium.Sections), len(p.Sections))
+		}
+	}
+}
+
+// TestResolveSectionProfile_OperationBoundary_29_30_149_150 verifies the exact
+// boundary values for tier transitions.
+func TestResolveSectionProfile_OperationBoundary(t *testing.T) {
+	cases := []struct {
+		lines        int
+		wantSmall    bool // expects "operation.small" (no reference-deployment)
+		wantLarge    bool // expects "operation.large" (has reference-deployment)
+	}{
+		{29, true, false},
+		{30, false, false},
+		{149, false, false},
+		{150, false, true},
+	}
+	for _, tc := range cases {
+		p := docgen.ResolveSectionProfile("operation", "", tc.lines)
+		hasDeployment := containsSection(p.Sections, "reference-deployment")
+		hasRefDeps := containsSection(p.Sections, "reference-dependencies")
+
+		if tc.wantSmall {
+			// small: no reference-deployment, no reference-dependencies
+			if hasDeployment {
+				t.Errorf("lines=%d: small tier should not have reference-deployment", tc.lines)
+			}
+			if hasRefDeps {
+				t.Errorf("lines=%d: small tier should not have reference-dependencies", tc.lines)
+			}
+		} else if tc.wantLarge {
+			// large: has reference-deployment
+			if !hasDeployment {
+				t.Errorf("lines=%d: large tier should have reference-deployment", tc.lines)
+			}
+		} else {
+			// medium: no reference-deployment, has reference-dependencies
+			if hasDeployment {
+				t.Errorf("lines=%d: medium tier should not have reference-deployment", tc.lines)
+			}
+			if !hasRefDeps {
+				t.Errorf("lines=%d: medium tier should have reference-dependencies", tc.lines)
+			}
+		}
+	}
+}
+
+// TestResolveSectionProfile_OperationScopedKind verifies that dotted-prefix
+// kinds like "SCOPE.Operation" still participate in size-tier selection.
+func TestResolveSectionProfile_OperationScopedKind(t *testing.T) {
+	small := docgen.ResolveSectionProfile("SCOPE.Operation", "", 10)
+	if containsSection(small.Sections, "reference-deployment") {
+		t.Errorf("SCOPE.Operation(small): reference-deployment should be absent")
+	}
+	large := docgen.ResolveSectionProfile("SCOPE.Operation", "", 200)
+	if !containsSection(large.Sections, "reference-deployment") {
+		t.Errorf("SCOPE.Operation(large): reference-deployment should be present")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1970 — react_component api section guidance
+// ---------------------------------------------------------------------------
+
+// TestResolveSectionProfile_ReactComponent_ExactMatch verifies that
+// "react_component" resolves to a dedicated profile.
+func TestResolveSectionProfile_ReactComponent_ExactMatch(t *testing.T) {
+	p := docgen.ResolveSectionProfile("react_component", "")
+	if len(p.Sections) == 0 {
+		t.Fatal("react_component: expected non-empty Sections")
+	}
+	if p.GuidanceOverrides == nil {
+		t.Fatal("react_component: expected GuidanceOverrides to be set")
+	}
+	mustPresent := []string{"overview", "capabilities", "api"}
+	for _, s := range mustPresent {
+		if !containsSection(p.Sections, s) {
+			t.Errorf("react_component: missing required section %q; got %v", s, p.Sections)
+		}
+	}
+	// React components don't need deployment sections.
+	mustAbsent := []string{"reference-deployment", "how-to-local-dev", "reference-scripts"}
+	for _, s := range mustAbsent {
+		if containsSection(p.Sections, s) {
+			t.Errorf("react_component: section %q should be absent; got %v", s, p.Sections)
+		}
+	}
+}
+
+// TestResolveSectionProfile_ReactComponent_ApiGuidanceIsPropsInterface verifies
+// that the api guidance for react_component specifically references props,
+// not the generic function-signature template.
+func TestResolveSectionProfile_ReactComponent_ApiGuidanceIsPropsInterface(t *testing.T) {
+	p := docgen.ResolveSectionProfile("react_component", "")
+	g := docgen.ResolveGuidance(p, "api")
+	lower := strings.ToLower(g)
+	mustContain := []string{"props", "jsx.element", "children"}
+	for _, word := range mustContain {
+		if !strings.Contains(lower, word) {
+			t.Errorf("react_component api guidance: want %q; guidance was: %q", word, g)
+		}
+	}
+	if strings.Contains(lower, "never reuse the generic function-signature") {
+		// The instruction must be in the guidance.
+	} else if !strings.Contains(lower, "never") {
+		t.Errorf("react_component api guidance: should include NEVER-reuse instruction; got: %q", g)
+	}
+}
+
+// TestResolveSectionProfile_ReactComponent_TypeScriptAndJSDoc verifies that
+// the api guidance mentions both TypeScript interface and JSDoc @param sources.
+func TestResolveSectionProfile_ReactComponent_TypeScriptAndJSDoc(t *testing.T) {
+	p := docgen.ResolveSectionProfile("react_component", "")
+	g := docgen.ResolveGuidance(p, "api")
+	lower := strings.ToLower(g)
+	if !strings.Contains(lower, "typescript") && !strings.Contains(lower, "ts") {
+		t.Errorf("react_component api guidance: should reference TypeScript; got: %q", g)
+	}
+	if !strings.Contains(lower, "jsdoc") && !strings.Contains(lower, "@param") {
+		t.Errorf("react_component api guidance: should reference JSDoc/@param; got: %q", g)
+	}
+}
+
+// TestResolveSectionProfile_ReactComponent_NotDefaultProfile verifies that
+// react_component does NOT resolve to the default profile.
+func TestResolveSectionProfile_ReactComponent_NotDefaultProfile(t *testing.T) {
+	p := docgen.ResolveSectionProfile("react_component", "")
+	if len(p.Sections) == len(docgen.KnownSections) && p.GuidanceOverrides == nil {
+		t.Error("react_component resolved to default profile (all 13 sections, no overrides)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1992 — module-readme boundary guidance (no fabricated siblings)
+// ---------------------------------------------------------------------------
+
+// TestModuleReadmeBoundaryGuidance_AllProfiles verifies that every explicit
+// profile's module-readme guidance contains the sibling-boundary instruction.
+func TestModuleReadmeBoundaryGuidance_AllProfiles(t *testing.T) {
+	profileKinds := []string{"model", "module", "operation", "react_component"}
+	// Also check size-aware tiers.
+	operationWithSizes := []struct {
+		kind      string
+		lineCount int
+	}{
+		{"operation", 10},  // small
+		{"operation", 50},  // medium
+		{"operation", 200}, // large
+	}
+
+	check := func(t *testing.T, label string, p docgen.SectionProfile) {
+		t.Helper()
+		if !containsSection(p.Sections, "module-readme") {
+			t.Skipf("%s: profile does not include module-readme section", label)
+		}
+		g := docgen.ResolveGuidance(p, "module-readme")
+		lower := strings.ToLower(g)
+		if !strings.Contains(lower, "module_manifest") {
+			t.Errorf("%s module-readme guidance: missing module_manifest boundary; got: %q", label, g)
+		}
+		if !strings.Contains(lower, "neighbour_briefs") {
+			t.Errorf("%s module-readme guidance: missing neighbour_briefs boundary; got: %q", label, g)
+		}
+		if !strings.Contains(lower, "do not mention") {
+			t.Errorf("%s module-readme guidance: missing 'do not mention' instruction; got: %q", label, g)
+		}
+	}
+
+	for _, kind := range profileKinds {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			check(t, kind, p)
+		})
+	}
+	for _, tc := range operationWithSizes {
+		label := fmt.Sprintf("%s(lines=%d)", tc.kind, tc.lineCount)
+		t.Run(label, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(tc.kind, "", tc.lineCount)
+			check(t, label, p)
+		})
+	}
+}
+
+// TestModuleReadmeBoundaryGuidance_CitationInstruction verifies that the
+// boundary guidance also instructs the LLM to cite the bundle field when a
+// sibling is mentioned.
+func TestModuleReadmeBoundaryGuidance_CitationInstruction(t *testing.T) {
+	for _, kind := range []string{"model", "module", "operation", "react_component"} {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			if !containsSection(p.Sections, "module-readme") {
+				t.Skipf("%s: no module-readme section", kind)
+			}
+			g := docgen.ResolveGuidance(p, "module-readme")
+			lower := strings.ToLower(g)
+			if !strings.Contains(lower, "bundle field") && !strings.Contains(lower, "came from") {
+				t.Errorf("%s module-readme guidance: missing citation instruction; got: %q", kind, g)
 			}
 		})
 	}


### PR DESCRIPTION
## 1. What / Why

Bundles three related guidance improvements to `internal/docgen/sections_by_kind.go` that address LLM output quality issues discovered in W1R4, W3R2, and W4R1 dogfood rounds.

## 2. Changes

### #1970 — react_component props-interface api guidance
Added `react_component` SectionProfile with a dedicated `api` override that instructs the LLM to:
- Document the props interface (name, type, default, required) — NOT the generic function-signature template.
- Pull from the TypeScript declared interface (TS) or JSDoc `@param` tags (JS).
- Show JSX.Element return semantics and children semantics.
- Include a minimal JSX usage example.
- Explicitly guards: "NEVER reuse the generic function-signature template."

Profile omits `reference-deployment`, `how-to-local-dev`, and `reference-scripts` (not applicable to UI components).

### #1986 — Size-aware Operation tier selection
Extended `ResolveSectionProfile` with an optional `lineCount ...int` variadic parameter. When provided for any Operation kind:

| Tier | Lines | Dropped sections | Notes |
|---|---|---|---|
| `operation.small` | < 30 | `reference-deployment`, `how-to-local-dev`, `reference-scripts`, `reference-dependencies` | Tighter capabilities/api guidance |
| `operation` (medium) | 30–149 | `reference-deployment`, `how-to-local-dev`, `reference-scripts` | Baseline — no behaviour change |
| `operation.large` | ≥ 150 | none | Full 13-section template |

- `SCOPE.Operation` dotted kinds participate in tier selection.
- Zero or absent `lineCount` → medium tier (backward-compatible, zero behaviour change for existing callers).
- Size-tier keys (`operation.small`, `operation.large`) are excluded from the substring-match scan to avoid accidental collisions.

### #1992 — module-readme sibling-boundary instruction
Added explicit anti-fabrication boundary to the `module-readme` guidance in **all profiles** (model, module, operation medium/small/large, react_component):

> "Do NOT mention sibling entities unless they appear in `module_manifest.classes`, `module_manifest.functions`, or `neighbour_briefs`. If you cite a sibling, name the bundle field it came from."

## 3. Tests

New test functions in `sections_by_kind_test.go`:
- `TestResolveSectionProfile_OperationSmall` — absent sections, present core sections
- `TestResolveSectionProfile_OperationSmallGuidanceTerse` — small/medium guidance differs
- `TestResolveSectionProfile_OperationMedium` — reference-dependencies present, no deployment
- `TestResolveSectionProfile_OperationLarge` — all 13 sections present
- `TestResolveSectionProfile_OperationLargeGuidanceDeep` — guidance mentions orchestration/critical-path
- `TestResolveSectionProfile_OperationNoLineCount` — no lineCount → medium (backward compat)
- `TestResolveSectionProfile_OperationBoundary` — exact boundary values 29/30/149/150
- `TestResolveSectionProfile_OperationScopedKind` — SCOPE.Operation tier delegation
- `TestResolveSectionProfile_ReactComponent_ExactMatch` — profile shape + absent deployment sections
- `TestResolveSectionProfile_ReactComponent_ApiGuidanceIsPropsInterface` — props/jsx.element/children in guidance
- `TestResolveSectionProfile_ReactComponent_TypeScriptAndJSDoc` — TS + @param sources mentioned
- `TestResolveSectionProfile_ReactComponent_NotDefaultProfile` — not the catch-all
- `TestModuleReadmeBoundaryGuidance_AllProfiles` — boundary text in all profiles + all Operation tiers
- `TestModuleReadmeBoundaryGuidance_CitationInstruction` — "came from" citation instruction present

`go test ./internal/docgen/...` — zero failures.

## 4. Backward Compatibility

`ResolveSectionProfile(kind, lang)` (two-arg form) is unchanged in behaviour. The new `lineCount` variadic is opt-in. All existing callers continue to receive the medium Operation profile.

## 5. Cross-cutting Notes

- No changes outside `internal/docgen/`.
- No `go install`, no daemon restart, no launchctl — guidance-only change.
- `KnownSections` is not modified; all new profile Sections entries are drawn from the existing set.

## 6. Linked Issues

Closes #1970
Closes #1986
Closes #1992

## 7. Checklist

- [x] `go test ./internal/docgen/...` passes (zero failures)
- [x] All three issues addressed in a single atomic commit
- [x] Backward-compatible API extension (variadic lineCount)
- [x] No files modified outside `internal/docgen/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)