### PR TITLE
feat(java-extractor): end_line emission + Class whole-body strategy + manifest parity (bases+decorators) + @Inject REFERENCES (#1994 #1995 #1996 #1997)

### DIFF
--- a/internal/docgen/issue1995_java_class_window_test.go
+++ b/internal/docgen/issue1995_java_class_window_test.go
@@ -1,0 +1,42 @@
+package docgen
+
+import "testing"
+
+// Issue #1995 — Java SCOPE.Component (class / interface / enum) entities
+// MUST resolve to the whole-body source_window strategy so multi-method
+// controller classes are not truncated to their first ~43 lines. The
+// W5R2 reproducer was TransfersController (10 methods, ~250 lines) whose
+// default ±20-line window clipped 9 of 10 method bodies.
+//
+// Profile lookup is keyed off (kind contains "component") AND
+// language=="java". Non-Java Components keep the default profile so
+// React component / Go struct rendering is unaffected.
+func TestResolveSectionProfile_JavaComponentUsesWholeBody(t *testing.T) {
+	cases := []struct {
+		name     string
+		kind     string
+		language string
+		wantWB   bool
+	}{
+		{"java class via SCOPE.Component", "SCOPE.Component", "java", true},
+		{"java class via bare Component", "Component", "java", true},
+		{"java class via lowercase", "component", "java", true},
+		{"python class — NOT java, default", "SCOPE.Component", "python", false},
+		{"js class — NOT java, default", "SCOPE.Component", "javascript", false},
+		{"no language hint — default", "SCOPE.Component", "", false},
+		// Operation kinds must NOT pick up the java-component profile even
+		// when language=java — they have their own size-aware tiers.
+		{"java operation does not pick up component profile", "SCOPE.Operation", "java", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := ResolveSectionProfile(tc.kind, tc.language)
+			gotWB := p.SourceWindowStrategy == SourceWindowStrategyWholeBody
+			if gotWB != tc.wantWB {
+				t.Errorf("ResolveSectionProfile(%q, %q): SourceWindowStrategy=%q, want WholeBody=%v",
+					tc.kind, tc.language, p.SourceWindowStrategy, tc.wantWB)
+			}
+		})
+	}
+}

--- a/internal/docgen/sections_by_kind.go
+++ b/internal/docgen/sections_by_kind.go
@@ -384,6 +384,30 @@ var sectionsByKind = map[string]SectionProfile{
 	},
 
 	// -------------------------------------------------------------------------
+	// component.java — Java class / interface (SCOPE.Component, language=java).
+	//
+	// #1995: Quarkus controller / JAX-RS handler / Spring controller classes
+	// commonly contain 5-15 method bodies on a single class page.  The default
+	// ±20-line source_window clips at the class header + first method stub,
+	// hiding 90% of the surface the LLM needs to write capabilities, flows,
+	// and api sections accurately.  Apply SourceWindowStrategyWholeBody so the
+	// whole class body (capped at SourceWindowWholeBodyMaxLines) is visible —
+	// the same treatment Model entities receive under #1876.
+	//
+	// Profile is selected explicitly via the (kind, language) pair inside
+	// ResolveSectionProfile; substring lookup intentionally skips dotted keys
+	// so this only activates for Java.
+	//
+	// Sections mirror the default 13-section list (no curation in this PR) —
+	// the change here is strictly about source_window completeness so the
+	// existing section guidance keeps working.
+	// -------------------------------------------------------------------------
+	"component.java": {
+		Sections:             KnownSections,
+		SourceWindowStrategy: SourceWindowStrategyWholeBody,
+	},
+
+	// -------------------------------------------------------------------------
 	// default — catch-all that preserves 100% backward-compatible behaviour for
 	// any kind not yet explicitly profiled.  Sections == KnownSections (all 13).
 	// -------------------------------------------------------------------------
@@ -426,8 +450,22 @@ func operationLineTier(lineCount int) string {
 // lineCount is the optional entity line span (end_line - start_line).  Pass
 // zero or omit the argument when the line count is unavailable; the medium
 // Operation profile is used in that case.
-func ResolveSectionProfile(kind, _ string, lineCount ...int) SectionProfile {
+func ResolveSectionProfile(kind, language string, lineCount ...int) SectionProfile {
 	k := strings.ToLower(kind)
+	lang := strings.ToLower(language)
+
+	// 0. Language-specific Component override (#1995).
+	//    Java class / interface entities need WholeBody source_window so the
+	//    full controller surface is visible to the LLM.  The default profile
+	//    used by every other Component kind still produces a ±20-line window;
+	//    only Java triggers the override.  No size gate — Quarkus controllers
+	//    routinely span 200-400 lines and even smaller classes benefit from
+	//    seeing every method body.
+	if lang == "java" && strings.Contains(k, "component") {
+		if p, ok := sectionsByKind["component.java"]; ok {
+			return p
+		}
+	}
 
 	// 1. Size-aware Operation tier selection (#1986).
 	//    Check whether the lowercased kind contains "operation" and a lineCount

--- a/internal/extractors/java/issue1994_endline_test.go
+++ b/internal/extractors/java/issue1994_endline_test.go
@@ -1,0 +1,152 @@
+package java_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/java"
+)
+
+// Issue #1994 — every entity emitted by the Java extractor MUST carry
+// non-zero start_line AND end_line so the docgen source_window helper
+// can build a complete excerpt. The W5R1 reproducer was a Quarkus
+// AuthController.login Operation entity whose end_line=0 sentinel
+// triggered the bundle-side by-name fallback (#1987); the underlying
+// extractor contract should also be honored.
+//
+// This regression covers BOTH primary-pass entities (class / method /
+// field / constructor) AND synthesized entities (Lombok / Panache),
+// because the synthesizers previously emitted zero line bounds.
+func TestJava_EndLine_NonZero_ForOperationsClassesAndFields(t *testing.T) {
+	src := `package client_fixture_x.api;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.inject.Inject;
+
+@Path("/auth")
+public class AuthController {
+
+    @Inject
+    UsersService usersService;
+
+    @POST
+    @Path("/login")
+    public Response login(LoginRequest req) {
+        if (req == null) {
+            return Response.status(400).build();
+        }
+        return usersService.authenticate(req);
+    }
+
+    public Response logout() {
+        return Response.ok().build();
+    }
+}
+`
+
+	ext, ok := extractor.Get("java")
+	if !ok {
+		t.Fatal("java extractor not registered")
+	}
+	out, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "client_fixture_x/api/AuthController.java",
+		Content:  []byte(src),
+		Language: "java",
+		Tree:     parseForTest(t, src),
+	})
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+
+	checkedClass := false
+	checkedMethod := false
+	checkedField := false
+
+	for _, ent := range out {
+		// EVERY entity must carry non-zero bounds (#1994 contract).
+		if ent.StartLine <= 0 {
+			t.Errorf("entity %q (%s/%s): start_line=%d (want > 0)",
+				ent.Name, ent.Kind, ent.Subtype, ent.StartLine)
+		}
+		if ent.EndLine <= 0 {
+			t.Errorf("entity %q (%s/%s): end_line=%d (want > 0)",
+				ent.Name, ent.Kind, ent.Subtype, ent.EndLine)
+		}
+		if ent.EndLine > 0 && ent.StartLine > 0 && ent.EndLine < ent.StartLine {
+			t.Errorf("entity %q: end_line(%d) < start_line(%d)",
+				ent.Name, ent.EndLine, ent.StartLine)
+		}
+
+		switch ent.Name {
+		case "AuthController":
+			checkedClass = true
+		case "AuthController.login":
+			checkedMethod = true
+		case "AuthController.usersService":
+			checkedField = true
+		}
+	}
+
+	if !checkedClass {
+		t.Fatalf("class entity AuthController not emitted; out has %d entities", len(out))
+	}
+	if !checkedMethod {
+		t.Fatalf("method entity AuthController.login not emitted; out has %d entities", len(out))
+	}
+	if !checkedField {
+		t.Fatalf("field entity AuthController.usersService not emitted; out has %d entities", len(out))
+	}
+}
+
+// Issue #1994 — synthesized entities (Lombok @Data getters / @Builder
+// methods) also need non-zero line bounds. Anchoring them to the
+// declaring class node is the convention.
+func TestJava_EndLine_NonZero_OnLombokSynthesizedEntities(t *testing.T) {
+	src := `package client_fixture_x.model;
+
+import lombok.Data;
+import lombok.Builder;
+
+@Data
+@Builder
+public class Order {
+    private Long id;
+    private String name;
+}
+`
+
+	ext, ok := extractor.Get("java")
+	if !ok {
+		t.Fatal("java extractor not registered")
+	}
+	out, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "client_fixture_x/model/Order.java",
+		Content:  []byte(src),
+		Language: "java",
+		Tree:     parseForTest(t, src),
+	})
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+
+	// We require ALL synthesized Lombok ops/comps to carry non-zero bounds.
+	sawSynth := false
+	for _, ent := range out {
+		isSynth := ent.Properties != nil &&
+			(ent.Properties["synthesized_from"] != "")
+		if !isSynth {
+			continue
+		}
+		sawSynth = true
+		if ent.StartLine <= 0 || ent.EndLine <= 0 {
+			t.Errorf("synthesized entity %q (%s/%s): start=%d end=%d (both must be > 0; synthesized_from=%s)",
+				ent.Name, ent.Kind, ent.Subtype, ent.StartLine, ent.EndLine,
+				ent.Properties["synthesized_from"])
+		}
+	}
+	if !sawSynth {
+		t.Fatal("no synthesized Lombok entities found; @Data + @Builder should produce several")
+	}
+}

--- a/internal/extractors/java/issue1996_1997_manifest_inject_test.go
+++ b/internal/extractors/java/issue1996_1997_manifest_inject_test.go
@@ -1,0 +1,126 @@
+package java_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/java"
+)
+
+// Issue #1996 — Java class entities MUST emit EXTENDS / IMPLEMENTS edges
+// so the docgen ClassManifest can populate the `bases` and `interfaces`
+// fields with cross-language parity. Pre-fix Java emitted zero structural
+// edges for class hierarchy; the manifest's bases array was always empty.
+//
+// Issue #1997 — @Inject-annotated fields MUST also produce a REFERENCES
+// edge from the containing class entity to the injected type, matching
+// the Python convention. The Schema/CONTAINS edge for the field stays
+// (option B in #1997).
+func TestJava_ClassManifest_EmitsExtendsImplementsAndInjectReferences(t *testing.T) {
+	src := `package client_fixture_x.api;
+
+import jakarta.inject.Inject;
+
+@Secured
+@RequestScoped
+@Path("/api/transfers")
+@Tag(name = "transfers")
+public class TransfersController extends BaseController implements ApiService, Auditable {
+
+    @Inject
+    UsersService usersService;
+
+    @Inject
+    AuditLog auditLog;
+
+    public Response list() {
+        return Response.ok().build();
+    }
+}
+`
+
+	ext, ok := extractor.Get("java")
+	if !ok {
+		t.Fatal("java extractor not registered")
+	}
+	out, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "client_fixture_x/api/TransfersController.java",
+		Content:  []byte(src),
+		Language: "java",
+		Tree:     parseForTest(t, src),
+	})
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+
+	var classRels []string // ToID:Kind tokens for the class entity
+	var classSig string
+	for _, ent := range out {
+		if ent.Name != "TransfersController" || ent.Kind != "SCOPE.Component" {
+			continue
+		}
+		classSig = ent.Signature
+		for _, r := range ent.Relationships {
+			classRels = append(classRels, r.Kind+":"+r.ToID)
+		}
+	}
+	if len(classRels) == 0 {
+		t.Fatalf("TransfersController class entity not found or has no relationships; out has %d entities", len(out))
+	}
+
+	hasRel := func(kind, toID string) bool {
+		needle := kind + ":" + toID
+		for _, r := range classRels {
+			if r == needle {
+				return true
+			}
+		}
+		return false
+	}
+
+	// #1996 — EXTENDS edge.
+	if !hasRel("EXTENDS", "BaseController") {
+		t.Errorf("expected EXTENDS BaseController edge; got rels=%v", classRels)
+	}
+	// #1996 — IMPLEMENTS edges (both interfaces).
+	if !hasRel("IMPLEMENTS", "ApiService") {
+		t.Errorf("expected IMPLEMENTS ApiService edge; got rels=%v", classRels)
+	}
+	if !hasRel("IMPLEMENTS", "Auditable") {
+		t.Errorf("expected IMPLEMENTS Auditable edge; got rels=%v", classRels)
+	}
+
+	// #1997 — REFERENCES edges to injected types.
+	if !hasRel("REFERENCES", "UsersService") {
+		t.Errorf("expected REFERENCES UsersService edge (from @Inject); got rels=%v", classRels)
+	}
+	if !hasRel("REFERENCES", "AuditLog") {
+		t.Errorf("expected REFERENCES AuditLog edge (from @Inject); got rels=%v", classRels)
+	}
+
+	// #1996 — class signature must retain the @-prefixed annotation tokens
+	// so the docgen ClassManifest decorator regex can extract them. We
+	// don't assert exact text (whitespace varies) but each annotation
+	// must appear as an @Name token in the signature.
+	for _, ann := range []string{"@Secured", "@RequestScoped", "@Path", "@Tag"} {
+		if !contains(classSig, ann) {
+			t.Errorf("expected class signature to contain %q (for ClassManifest decorators); got %q",
+				ann, classSig)
+		}
+	}
+}
+
+// contains is strings.Contains without the import (the test file already
+// pulls heavy package deps; this avoids adding another import line).
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -128,6 +128,28 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// imported_name properties.
 	resolveImportToIDs(entities)
 
+	// Issue #1994 — final safety net for line-bound emission. Every entity
+	// MUST carry non-zero start_line + end_line so the docgen source_window
+	// helper has a usable anchor. Class-scoped synthesizers (Lombok, Panache)
+	// are stamped per-class above; this pass catches any file-level
+	// synthesized entity (Panache DSL interfaces, top-level helpers) that
+	// the per-class pass cannot reach. We use line 1 / file end as a
+	// conservative fallback — the bundle-side by-name fallback (#1987) will
+	// still rebind to the real source location when needed, but a non-zero
+	// sentinel keeps downstream rendering safe.
+	fileEnd := int(root.EndPoint().Row) + 1
+	if fileEnd < 1 {
+		fileEnd = 1
+	}
+	for i := range entities {
+		if entities[i].StartLine == 0 {
+			entities[i].StartLine = 1
+		}
+		if entities[i].EndLine == 0 {
+			entities[i].EndLine = fileEnd
+		}
+	}
+
 	span.SetAttributes(
 		attribute.Int("entity_count", len(entities)),
 		attribute.Int("error_pattern_count", len(errorPatterns)),
@@ -186,6 +208,39 @@ func walk(
 			subtype = "enum"
 		}
 		rec, ok := buildComponent(node, file, subtype, pkgName)
+		if ok {
+			// Issue #1996 — emit EXTENDS / IMPLEMENTS edges so the docgen
+			// ClassManifest can populate `bases` and `interfaces`. The
+			// tree-sitter Java grammar exposes the parent class via a
+			// `superclass` named child (with a single nested
+			// type_identifier) and implemented interfaces via
+			// `super_interfaces` → `type_list` → many type_identifiers.
+			// Both shapes are best-effort: malformed source still emits
+			// the class entity, just without these structural edges.
+			for _, base := range javaSuperclassNames(node, file.Content) {
+				rec.Relationships = append(rec.Relationships,
+					types.RelationshipRecord{ToID: base, Kind: "EXTENDS"})
+			}
+			for _, iface := range javaSuperInterfaceNames(node, file.Content) {
+				rec.Relationships = append(rec.Relationships,
+					types.RelationshipRecord{ToID: iface, Kind: "IMPLEMENTS"})
+			}
+			// Issue #1997 — emit a REFERENCES edge from the class entity
+			// to every type appearing on an @Inject-annotated field. This
+			// matches the cross-language convention that "consumers of X"
+			// queries walk REFERENCES edges; previously Java DI fields
+			// only produced a SCOPE.Schema child with a CONTAINS edge,
+			// which made find-consumers traversals miss them. The Schema
+			// child is preserved (extracted separately in field_declaration)
+			// for source-level symmetry — this is option B from #1997, the
+			// safer choice for downstream consumers.
+			if body := node.ChildByFieldName("body"); body != nil {
+				for _, injectedType := range javaInjectFieldTypes(body, file.Content) {
+					rec.Relationships = append(rec.Relationships,
+						types.RelationshipRecord{ToID: injectedType, Kind: "REFERENCES"})
+				}
+			}
+		}
 		if !ok {
 			// Still recurse so nested types/imports below this node are
 			// captured even when the class itself is malformed.
@@ -301,6 +356,46 @@ func walk(
 			//   SCOPE.Operation  → extractor.BuildOperationStructuralRef
 			//   SCOPE.Component  → scope:component:ref:java:<file>:<name>
 			//   SCOPE.Schema     → not emitted by synthesizers, skip
+			// Issue #1994 — stamp StartLine/EndLine on every synthesized entity
+			// (Lombok / Panache / @NamedQuery) with the class node's source
+			// range. Synthesized entities have no AST node of their own, so the
+			// next-best anchor is the declaring class — this guarantees that
+			// docgen's source_window helper and the bundle-side fallback always
+			// see non-zero line bounds and can emit useful excerpts.
+			classStart := int(node.StartPoint().Row) + 1
+			classEnd := int(node.EndPoint().Row) + 1
+			stampSynthLines := func(slice []types.EntityRecord) {
+				for i := range slice {
+					if slice[i].StartLine == 0 {
+						slice[i].StartLine = classStart
+					}
+					if slice[i].EndLine == 0 {
+						slice[i].EndLine = classEnd
+					}
+				}
+			}
+			// The class-scoped synthesizers were appended directly to *out
+			// above; mutate the trailing region of the slice in place. Each
+			// append set begins at the recorded len(*out) before it ran, but
+			// for simplicity we mutate the full lombok+panache block by
+			// stamping the local slices and re-using the post-append region.
+			stampSynthLines(lombokSynth)
+			stampSynthLines(lombokFieldSynth)
+			stampSynthLines(panacheSynth)
+			// Re-walk the *out tail to apply line numbers to entities that
+			// were appended-by-value (their stamped versions live only in the
+			// local slices above). We seek the matching name/kind in the tail
+			// and stamp in place.
+			tailStart := classIdx + 1
+			for i := tailStart; i < len(*out); i++ {
+				if (*out)[i].StartLine == 0 {
+					(*out)[i].StartLine = classStart
+				}
+				if (*out)[i].EndLine == 0 {
+					(*out)[i].EndLine = classEnd
+				}
+			}
+
 			allSynth := append(lombokSynth, lombokFieldSynth...)
 			allSynth = append(allSynth, panacheSynth...)
 			for _, s := range allSynth {
@@ -1105,6 +1200,165 @@ func buildClassSignature(node *sitter.Node, src []byte, name string) string {
 	// Strip annotation arguments: @Foo("bar") -> @Foo
 	raw = stripAnnotationArgs(raw)
 	return strings.TrimSpace(raw)
+}
+
+// javaSuperclassNames extracts the parent class name from a class_declaration
+// node's `superclass` child. Returns a slice (always 0 or 1 elements) for
+// uniform call-site iteration with javaSuperInterfaceNames. Generics are
+// stripped — `extends List<Owner>` yields "List".
+//
+// Issue #1996 — required input for the docgen ClassManifest `bases` field.
+func javaSuperclassNames(node *sitter.Node, src []byte) []string {
+	if node == nil {
+		return nil
+	}
+	sc := node.ChildByFieldName("superclass")
+	if sc == nil {
+		return nil
+	}
+	// `superclass` wraps either a type_identifier, a generic_type, or a
+	// scoped_type_identifier. leafTypeName covers all three.
+	for i := 0; i < int(sc.NamedChildCount()); i++ {
+		ch := sc.NamedChild(i)
+		if ch == nil {
+			continue
+		}
+		if name := leafTypeName(ch, src); name != "" {
+			return []string{name}
+		}
+	}
+	return nil
+}
+
+// javaSuperInterfaceNames extracts the implemented-interface names from a
+// class_declaration node's `interfaces` child (`super_interfaces` in the
+// grammar, exposed via the `interfaces` field). The interface list is a
+// `type_list` of type_identifier (or generic_type) nodes; each is
+// reduced to its leaf type identifier.
+//
+// Issue #1996 — required input for the docgen ClassManifest `interfaces`
+// field.
+func javaSuperInterfaceNames(node *sitter.Node, src []byte) []string {
+	if node == nil {
+		return nil
+	}
+	si := node.ChildByFieldName("interfaces")
+	if si == nil {
+		// Fallback: scan named children for super_interfaces (the field
+		// name varies between grammar versions).
+		for i := 0; i < int(node.NamedChildCount()); i++ {
+			ch := node.NamedChild(i)
+			if ch != nil && ch.Type() == "super_interfaces" {
+				si = ch
+				break
+			}
+		}
+	}
+	if si == nil {
+		return nil
+	}
+	var out []string
+	// si may directly be a type_list, or wrap one.
+	var list *sitter.Node
+	if si.Type() == "type_list" {
+		list = si
+	} else {
+		for i := 0; i < int(si.NamedChildCount()); i++ {
+			ch := si.NamedChild(i)
+			if ch != nil && ch.Type() == "type_list" {
+				list = ch
+				break
+			}
+		}
+	}
+	if list == nil {
+		return nil
+	}
+	for i := 0; i < int(list.NamedChildCount()); i++ {
+		ch := list.NamedChild(i)
+		if ch == nil {
+			continue
+		}
+		if name := leafTypeName(ch, src); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// javaInjectFieldTypes returns the declared leaf type of every field on a
+// class body whose `modifiers` block contains an @Inject (or @Autowired)
+// annotation. The match is case-sensitive and accepts both
+// `marker_annotation` (`@Inject`) and `annotation` (`@Inject(qualifier=...)`).
+//
+// Issue #1997 — cross-language DI consistency. Java extractor emits
+// REFERENCES edges from the containing class entity to every injected
+// type so "find consumers of UsersService" queries walk consistently with
+// Python (which already uses REFERENCES for the same shape).
+//
+// The Schema/CONTAINS edge for the field itself is still emitted by the
+// regular field_declaration case in walk(); this function does not
+// suppress it.
+func javaInjectFieldTypes(body *sitter.Node, src []byte) []string {
+	if body == nil {
+		return nil
+	}
+	var out []string
+	seen := map[string]bool{}
+	for i := 0; i < int(body.NamedChildCount()); i++ {
+		ch := body.NamedChild(i)
+		if ch == nil || ch.Type() != "field_declaration" {
+			continue
+		}
+		if !javaFieldHasInjectAnnotation(ch, src) {
+			continue
+		}
+		typ := leafTypeName(ch.ChildByFieldName("type"), src)
+		if typ == "" || seen[typ] {
+			continue
+		}
+		seen[typ] = true
+		out = append(out, typ)
+	}
+	return out
+}
+
+// javaFieldHasInjectAnnotation reports whether a field_declaration node
+// carries an @Inject or @Autowired annotation in its `modifiers` child.
+func javaFieldHasInjectAnnotation(field *sitter.Node, src []byte) bool {
+	if field == nil {
+		return false
+	}
+	for i := 0; i < int(field.NamedChildCount()); i++ {
+		ch := field.NamedChild(i)
+		if ch == nil || ch.Type() != "modifiers" {
+			continue
+		}
+		for j := 0; j < int(ch.NamedChildCount()); j++ {
+			ann := ch.NamedChild(j)
+			if ann == nil {
+				continue
+			}
+			if ann.Type() != "marker_annotation" && ann.Type() != "annotation" {
+				continue
+			}
+			nameNode := ann.ChildByFieldName("name")
+			if nameNode == nil {
+				continue
+			}
+			name := string(src[nameNode.StartByte():nameNode.EndByte()])
+			// Accept the simple name as well as fully-qualified forms
+			// (`javax.inject.Inject` / `jakarta.inject.Inject` /
+			// `org.springframework.beans.factory.annotation.Autowired`).
+			if dot := strings.LastIndexByte(name, '.'); dot >= 0 {
+				name = name[dot+1:]
+			}
+			if name == "Inject" || name == "Autowired" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // stripAnnotationArgs removes parenthesised arguments from Java annotations.


### PR DESCRIPTION
## Why

Wave 5 client-fixture-de smoke surfaced four related Java extractor gaps that compose into a single corruption of the docgen page contract for Quarkus / JAX-RS / Spring controllers:

- **#1994** Operation `end_line=0` on Java — #1987 by-name fallback masked it but the underlying contract was never honored on synthesized Lombok / Panache entities.
- **#1995** Java Class `source_window` truncated to ~43 lines — multi-method controllers lost 9 of 10 method bodies in the bundle.
- **#1996** `class_manifest` parity — no `bases` array, no `decorators` array (both present on Python per #1925); blocks #1942 Phase 1 auth resolver.
- **#1997** `@Inject` DI fields inconsistent — Java emitted only a CONTAINS Schema child, no REFERENCES edge; cross-language "find consumers of T" walks broke.

## How

### #1994 end_line emission
- `internal/extractors/java/java.go`: every class-scoped synthesizer (Lombok `@Data` / `@Builder` / `@Value` / accessors / `@NamedQuery` / Panache) is stamped with the declaring class node's `StartPoint` / `EndPoint` row range immediately after synthesis. The class entity, methods, constructors, and fields already carried correct lines via the primary `buildComponent` / `buildOperation` / `buildField` calls.
- Final safety-net pass in `Extract` backfills any remaining zero lines on file-scoped synthesized entities (Panache DSL interfaces) using line 1 and the file end row. The bundle-side by-name fallback from #1987 remains in place as a defence in depth.

### #1995 Class whole-body source_window
- `internal/docgen/sections_by_kind.go`: added a `component.java` profile with `SourceWindowStrategyWholeBody` and routed Java components to it via a language-aware short-circuit at the top of `ResolveSectionProfile`. The `language` parameter (previously unused) is now consulted; non-Java Components keep the default ±20-line window unchanged. Sections list is the default 13 — this PR is strictly about source-window completeness.

### #1996 class_manifest parity
- Class entities now emit EXTENDS edges for `extends X` and IMPLEMENTS edges for `implements Y, Z`. Generics are stripped to leaf names (`List<Owner>` → `List`). The docgen `buildClassManifest` already consumes these to populate `bases[]` and `interfaces[]` — no docgen-side change required.
- Class signatures already include annotations (`@Path`, `@Tag`, etc.) with their arguments stripped, so the existing `decoratorTokenRE` in `buildClassManifest` populates `decorators[]` automatically.

### #1997 @Inject REFERENCES
- Scan the class body for `field_declaration` nodes whose `modifiers` block contains an `@Inject` or `@Autowired` marker_annotation (simple or fully-qualified name). For each, emit a REFERENCES edge from the containing class entity to the field's declared leaf type. **Option B from the ticket:** the Schema/CONTAINS edge for the field stays so syntactic containment queries still resolve.

## Files touched

- `internal/extractors/java/java.go` — class hierarchy + @Inject edges, per-class synth line stamping, final extract-side backfill, four new helpers (`javaSuperclassNames`, `javaSuperInterfaceNames`, `javaInjectFieldTypes`, `javaFieldHasInjectAnnotation`).
- `internal/docgen/sections_by_kind.go` — `component.java` profile + language-aware short-circuit in `ResolveSectionProfile`.
- `internal/extractors/java/issue1994_endline_test.go` — every entity must carry non-zero start/end lines, including Lombok-synthesized.
- `internal/extractors/java/issue1996_1997_manifest_inject_test.go` — EXTENDS / IMPLEMENTS / REFERENCES edges on TransfersController-like fixture, plus class signature carries @-prefixed annotation tokens.
- `internal/docgen/issue1995_java_class_window_test.go` — Java Component → WholeBody; Python/JS/no-lang Components → default.

## Verification

- `go test ./internal/extractors/java/... ./internal/docgen/...` — all pass (including the four new regression tests).
- `go build ./...` — clean.
- `go test ./...` — only pre-existing MCP handshake-budget failures unrelated to this PR (verified by re-running against `origin/main` with the changes stashed: the same `TestMCPHandshakeBudget` / `TestToolNameSurface` failures appear).

## Impact

- Java class entity emission grows by 1 EXTENDS + N IMPLEMENTS + K REFERENCES relationships per class with parents / interfaces / @Inject fields. No new top-level entities; the existing Schema/CONTAINS path for fields is preserved.
- Java `source_window` for class pages now covers the whole class body (capped at `SourceWindowWholeBodyMaxLines = 400`) instead of ±20 lines. Existing Model entities already used WholeBody under #1876; this extends the same treatment to Java Components only.
- `ClassManifest` for Java now populates `bases`, `interfaces`, and `decorators` for parity with Python (#1925). #1942 Phase 1 auth resolver and #1936 param coverage are unblocked downstream.

## Composes with

- #1987 — bundle-side by-name fallback remains the defence-in-depth.
- #1925 — Python class manifest; Java now matches its surface.
- #1942 — auth resolver Phase 1 (needs `@PermitAll` / `@RolesAllowed`).

Closes #1994
Closes #1995
Closes #1996
Closes #1997

🤖 Generated with [Claude Code](https://claude.com/claude-code)