### PR TITLE
fix(mcp): expand accepts entity_id + traces action default + inspect surfaces qualified_name (#1916 #1917)

### DIFF
--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -78,7 +78,10 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	entities = append(entities, extractor.FileEntity(file))
 	root := file.Tree.RootNode()
 	imports := collectImportNames(root, file.Content)
-	walk(root, file, "", nil, imports, &entities)
+	// Issue #1917 — extract the file's package declaration so QualifiedName
+	// can be set to "<package>.<ClassName>" and "<package>.<Class>.<method>".
+	pkgName := collectPackageName(root, file.Content)
+	walk(root, file, "", nil, imports, pkgName, &entities)
 
 	// Issue #681 — attach IMPORTS relationships directly to the file-level
 	// entity instead of emitting a separate SCOPE.Component placeholder
@@ -166,6 +169,7 @@ func walk(
 	parentType string,
 	cc *classCtx,
 	imports map[string]bool,
+	pkgName string,
 	out *[]types.EntityRecord,
 ) {
 	if node == nil {
@@ -181,12 +185,12 @@ func walk(
 		case "enum_declaration":
 			subtype = "enum"
 		}
-		rec, ok := buildComponent(node, file, subtype)
+		rec, ok := buildComponent(node, file, subtype, pkgName)
 		if !ok {
 			// Still recurse so nested types/imports below this node are
 			// captured even when the class itself is malformed.
 			for i := range node.ChildCount() {
-				walk(node.Child(int(i)), file, parentType, cc, imports, out)
+				walk(node.Child(int(i)), file, parentType, cc, imports, pkgName, out)
 			}
 			return
 		}
@@ -212,11 +216,11 @@ func walk(
 				child := body.Child(int(i))
 				if child != nil && child.Type() == "enum_body_declarations" {
 					for j := range child.ChildCount() {
-						walk(child.Child(int(j)), file, rec.Name, localCtx, imports, out)
+						walk(child.Child(int(j)), file, rec.Name, localCtx, imports, pkgName, out)
 					}
 					continue
 				}
-				walk(child, file, rec.Name, localCtx, imports, out)
+				walk(child, file, rec.Name, localCtx, imports, pkgName, out)
 			}
 			after := len(*out)
 			for k := before; k < after; k++ {
@@ -321,7 +325,7 @@ func walk(
 		return
 
 	case "method_declaration":
-		if rec, ok := buildOperation(node, file, "method", parentType); ok {
+		if rec, ok := buildOperation(node, file, "method", parentType, pkgName); ok {
 			// Self-recursion is detected by the bare callee identifier;
 			// extractCallRelationships compares against the caller name.
 			selfName := rec.Name
@@ -339,7 +343,7 @@ func walk(
 		return
 
 	case "constructor_declaration":
-		if rec, ok := buildOperation(node, file, "constructor", parentType); ok {
+		if rec, ok := buildOperation(node, file, "constructor", parentType, pkgName); ok {
 			selfName := rec.Name
 			if nameNode := node.ChildByFieldName("name"); nameNode != nil {
 				selfName = nodeText(nameNode, file.Content)
@@ -375,7 +379,7 @@ func walk(
 	// they have no stable enclosing-type identifier, and their receiver
 	// resolution starts from a fresh scope.
 	for i := range node.ChildCount() {
-		walk(node.Child(int(i)), file, "", nil, imports, out)
+		walk(node.Child(int(i)), file, "", nil, imports, pkgName, out)
 	}
 }
 
@@ -865,6 +869,36 @@ func collectImportNames(root *sitter.Node, src []byte) map[string]bool {
 	return out
 }
 
+// collectPackageName extracts the dotted package name from the file's
+// package_declaration node (issue #1917). Returns "" when no package
+// declaration is present (default package).
+//
+// Example: `package com.example.users.controllers;` → "com.example.users.controllers"
+func collectPackageName(root *sitter.Node, src []byte) string {
+	if root == nil {
+		return ""
+	}
+	for i := range root.ChildCount() {
+		child := root.Child(int(i))
+		if child == nil || child.Type() != "package_declaration" {
+			continue
+		}
+		// The package name is the entire text between "package" keyword and ";",
+		// captured by the scoped_identifier / identifier children. Using the raw
+		// node text minus the leading keyword and trailing semicolon is the most
+		// robust approach across grammar versions.
+		raw := string(src[child.StartByte():child.EndByte()])
+		raw = strings.TrimSpace(raw)
+		raw = strings.TrimPrefix(raw, "package ")
+		raw = strings.TrimSuffix(raw, ";")
+		raw = strings.TrimSpace(raw)
+		if raw != "" {
+			return raw
+		}
+	}
+	return ""
+}
+
 // findAllNodes returns every descendant of root whose Type() is in kinds.
 func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	if root == nil {
@@ -890,14 +924,23 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 }
 
 // buildComponent creates a Component entity for class/interface declarations.
-func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+//
+// Issue #1917 — QualifiedName is set to "<package>.<ClassName>" when pkgName
+// is non-empty, giving inspect consumers a fully-qualified type reference.
+func buildComponent(node *sitter.Node, file extractor.FileInput, subtype, pkgName string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
 	}
 
+	qn := name
+	if pkgName != "" {
+		qn = pkgName + "." + name
+	}
+
 	return types.EntityRecord{
 		Name:               name,
+		QualifiedName:      qn,
 		Kind:               "SCOPE.Component",
 		Subtype:            subtype,
 		SourceFile:         file.Path,
@@ -916,7 +959,10 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 // same-named methods produce distinct ComputeID(SourceFile+Kind+Name) values.
 // The dotted form is the encoding consumed by resolve.Index.byMember, which
 // splits on the first '.'.
-func buildOperation(node *sitter.Node, file extractor.FileInput, subtype, parentType string) (types.EntityRecord, bool) {
+//
+// Issue #1917 — QualifiedName is set to "<package>.<emittedName>" when pkgName
+// is non-empty, giving inspect consumers a fully-qualified method reference.
+func buildOperation(node *sitter.Node, file extractor.FileInput, subtype, parentType, pkgName string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -927,8 +973,14 @@ func buildOperation(node *sitter.Node, file extractor.FileInput, subtype, parent
 		emittedName = parentType + "." + name
 	}
 
+	qn := emittedName
+	if pkgName != "" {
+		qn = pkgName + "." + emittedName
+	}
+
 	return types.EntityRecord{
 		Name:               emittedName,
+		QualifiedName:      qn,
 		Kind:               "SCOPE.Operation",
 		Subtype:            subtype,
 		SourceFile:         file.Path,

--- a/internal/extractors/java/java_test.go
+++ b/internal/extractors/java/java_test.go
@@ -605,3 +605,97 @@ func TestJavaExtractor_DuplicateMethodsFromFixture(t *testing.T) {
 			describe.Kind, describe.Subtype)
 	}
 }
+
+// TestJavaExtractor_QualifiedName verifies that entities extracted from a file
+// with a package declaration carry a non-empty QualifiedName of the form
+// "<package>.<ClassName>" for classes and "<package>.<Class>.<method>" for
+// methods (#1917).
+func TestJavaExtractor_QualifiedName(t *testing.T) {
+	src := `package com.example.orders.controllers;
+
+public class OrderController {
+    public void createOrder() {}
+}
+`
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("java")
+	if !ok {
+		t.Fatal("java extractor not registered")
+	}
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "src/controllers/OrderController.java",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+
+	byName := make(map[string]types.EntityRecord)
+	for _, e := range entities {
+		byName[e.Name] = e
+	}
+
+	cls, ok := byName["OrderController"]
+	if !ok {
+		t.Fatal("expected class entity OrderController")
+	}
+	wantClassQN := "com.example.orders.controllers.OrderController"
+	if cls.QualifiedName != wantClassQN {
+		t.Errorf("OrderController QualifiedName = %q, want %q", cls.QualifiedName, wantClassQN)
+	}
+
+	method, ok := byName["OrderController.createOrder"]
+	if !ok {
+		t.Fatal("expected method entity OrderController.createOrder")
+	}
+	wantMethodQN := "com.example.orders.controllers.OrderController.createOrder"
+	if method.QualifiedName != wantMethodQN {
+		t.Errorf("OrderController.createOrder QualifiedName = %q, want %q", method.QualifiedName, wantMethodQN)
+	}
+}
+
+// TestJavaExtractor_QualifiedName_NoPackage verifies that entities in a file
+// without a package declaration still get a non-empty QualifiedName equal to
+// the class/method name (default package, #1917).
+func TestJavaExtractor_QualifiedName_NoPackage(t *testing.T) {
+	src := `public class Foo {
+    public void bar() {}
+}
+`
+	tree := parseForTest(t, src)
+	ext, ok2 := extractor.Get("java")
+	if !ok2 {
+		t.Fatal("java extractor not registered")
+	}
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "Foo.java",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+
+	byName := make(map[string]types.EntityRecord)
+	for _, e := range entities {
+		byName[e.Name] = e
+	}
+
+	cls, ok := byName["Foo"]
+	if !ok {
+		t.Fatal("expected class entity Foo")
+	}
+	// No package → QualifiedName falls back to bare class name.
+	if cls.QualifiedName != "Foo" {
+		t.Errorf("Foo QualifiedName = %q, want \"Foo\"", cls.QualifiedName)
+	}
+
+	method, ok := byName["Foo.bar"]
+	if !ok {
+		t.Fatal("expected method entity Foo.bar")
+	}
+	if method.QualifiedName != "Foo.bar" {
+		t.Errorf("Foo.bar QualifiedName = %q, want \"Foo.bar\"", method.QualifiedName)
+	}
+}

--- a/internal/mcp/param_rename_test.go
+++ b/internal/mcp/param_rename_test.go
@@ -188,6 +188,61 @@ func TestInspectNewParamEntityID(t *testing.T) {
 	}
 }
 
+// (g) new name "entity_id" works for archigraph_expand — no deprecation warning (#1916).
+func TestExpandNewParamEntityID(t *testing.T) {
+	srv := newSmokeSrv(t)
+
+	var resultIsHardError bool
+	stderr := captureStderr(func() {
+		r := callTool(t, srv, "archigraph_expand", map[string]any{
+			"entity_id": "DashboardScreen",
+			"group":     "g",
+		})
+		if r.IsError {
+			text := resultText(r)
+			if strings.Contains(text, "missing required argument") {
+				resultIsHardError = true
+			}
+		}
+	})
+
+	if resultIsHardError {
+		t.Error("new param 'entity_id' should be accepted by archigraph_expand, got missing-arg error")
+	}
+	if strings.Contains(stderr, "[archigraph deprecation]") {
+		t.Errorf("new param 'entity_id' should NOT emit a deprecation warning, got stderr: %s", stderr)
+	}
+}
+
+// (h) old name "node" works for archigraph_expand AND deprecation log fires (#1916).
+func TestExpandOldParamNode_DeprecationFires(t *testing.T) {
+	srv := newSmokeSrv(t)
+
+	var resultIsHardError bool
+	stderr := captureStderr(func() {
+		r := callTool(t, srv, "archigraph_expand", map[string]any{
+			"node":  "DashboardScreen",
+			"group": "g",
+		})
+		if r.IsError {
+			text := resultText(r)
+			if strings.Contains(text, "missing required argument") {
+				resultIsHardError = true
+			}
+		}
+	})
+
+	if resultIsHardError {
+		t.Error("legacy param 'node' should still work (compat alias), got missing-arg error")
+	}
+	if !strings.Contains(stderr, "[archigraph deprecation]") {
+		t.Errorf("expected deprecation warning on stderr for legacy param 'node', got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "archigraph_expand") {
+		t.Errorf("deprecation message should name the tool, got: %q", stderr)
+	}
+}
+
 // (f) old name "label_or_id" works for archigraph_inspect AND deprecation log fires.
 func TestInspectOldParamLabelOrID_DeprecationFires(t *testing.T) {
 	srv := newSmokeSrv(t)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -295,8 +295,10 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_inspect", s.handleGetNode))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_expand",
-		mcpapi.WithDescription("Return neighbors of a node up to a given depth."),
-		mcpapi.WithString("node", mcpapi.Required()),
+		mcpapi.WithDescription("Return neighbors of entity_id up to depth. 'node' is a deprecated alias."),
+		mcpapi.WithString("entity_id", mcpapi.Required()),
+		// 'node' kept as a deprecated alias for one release cycle (#1916).
+		mcpapi.WithString("node"),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(1)),
 		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(800)),
 		mcpapi.WithArray("repo_filter"),
@@ -314,10 +316,10 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_trace", s.handleShortestPath))
 
 	// archigraph_traces — process-flow query surface (#724).
-	// action=list|get|follow
+	// action=list|get|follow — defaults to "list" when omitted.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_traces",
-		mcpapi.WithDescription("Process-flow traces: list=ranked, get=steps, follow=BFS."),
-		mcpapi.WithString("action", mcpapi.Required()),
+		mcpapi.WithDescription("Process-flow traces. action=list|get|follow (default: list)."),
+		mcpapi.WithString("action"),
 		mcpapi.WithAny("process_id"),
 		mcpapi.WithAny("entry_point_id"),
 		mcpapi.WithNumber("max_depth", mcpapi.DefaultNumber(8)),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -781,9 +781,16 @@ func serializeEntity(repo string, e *graph.Entity, scopeIsOne bool, verbose ...b
 // ---------------------------------------------------------------------------
 
 func (s *Server) handleGetNeighbors(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	key, err := req.RequireString("node")
-	if err != nil {
-		return mcpapi.NewToolResultError(err.Error()), nil
+	// canonical name is "entity_id"; accept legacy "node" with a deprecation log (#1916).
+	key := argString(req, "entity_id", "")
+	if key == "" {
+		key = argString(req, "node", "")
+		if key != "" {
+			fmt.Fprintln(os.Stderr, "[archigraph deprecation] archigraph_expand: param 'node' is deprecated, use 'entity_id'")
+		}
+	}
+	if key == "" {
+		return mcpapi.NewToolResultError("missing required argument: entity_id"), nil
 	}
 	_, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {

--- a/internal/mcp/traces.go
+++ b/internal/mcp/traces.go
@@ -38,11 +38,12 @@ const (
 )
 
 // handleTraces dispatches archigraph_traces to one of its sub-actions.
+//
+// action is optional; omitting it defaults to "list" for discoverability.
+// Valid values: list (ranked process flows), get (full step chain for a
+// process by id), follow (ad-hoc forward BFS from an entry-point entity).
 func (s *Server) handleTraces(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	action, err := req.RequireString("action")
-	if err != nil {
-		return mcpapi.NewToolResultError(err.Error()), nil
-	}
+	action := argString(req, "action", "list")
 	switch strings.ToLower(action) {
 	case "list":
 		return s.handleTracesList(ctx, req)

--- a/internal/mcp/traces_test.go
+++ b/internal/mcp/traces_test.go
@@ -157,6 +157,24 @@ func TestTraces_InvalidActionReturnsError(t *testing.T) {
 	}
 }
 
+// TestTraces_NoActionDefaultsList verifies that omitting the action argument
+// defaults to "list" instead of returning a hard error (#archigraph_traces).
+func TestTraces_NoActionDefaultsList(t *testing.T) {
+	srv := setupTracesServer(t)
+	// min_steps=0 so the short-flow filter doesn't hide the fixture processes.
+	res := callTool(t, srv, "archigraph_traces", map[string]any{"min_steps": 0})
+	if res == nil {
+		t.Fatal("nil result when action is omitted")
+	}
+	if res.IsError {
+		t.Errorf("omitting action should default to list, got tool error: %s", resultText(res))
+	}
+	txt := resultText(res)
+	if !strings.Contains(txt, "\"count\"") {
+		t.Errorf("expected list response with count, got: %s", txt)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // #1738: token_budget enforcement for traces action=list
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 1 · Why

Three small friction points in `internal/mcp/` confirmed across multiple Wave rounds:

1. **#1916** — `archigraph_expand` required `node` while every other tool uses `entity_id`. Scripts that tried `entity_id` got a hard error.
2. **archigraph_traces `action`** — omitting `action` returned `required argument "action" not found` even though `list` is always the sensible default.
3. **#1917** — `archigraph_inspect` returned `"qualified_name": ""` for every Java entity. Root cause: the Java extractor never populated `QualifiedName`; the MCP serializer was already correct.

## 2 · What changed

| File | Change |
|------|--------|
| `internal/mcp/server.go` | `archigraph_expand`: `entity_id` is canonical required param; `node` is optional deprecated alias. `archigraph_traces`: `action` no longer required (defaults to `list`). |
| `internal/mcp/tools.go` | `handleGetNeighbors`: prefer `entity_id`, fall back to `node` with deprecation log. |
| `internal/mcp/traces.go` | `handleTraces`: replace `RequireString("action")` with `argString(…, "list")` default. |
| `internal/extractors/java/java.go` | Add `collectPackageName()` (parses `package_declaration` CST node). Thread `pkgName` through `walk` → `buildComponent` / `buildOperation`. Set `QualifiedName = pkgName + "." + name`. |

## 3 · Tests

```
go test ./internal/mcp/... ./internal/extractors/java/...
```

New tests added:
- `TestExpandNewParamEntityID` — entity_id accepted, no deprecation
- `TestExpandOldParamNode_DeprecationFires` — node still works, deprecation logs
- `TestTraces_NoActionDefaultsList` — omitting action returns list result
- `TestJavaExtractor_QualifiedName` — package+class+method FQN populated
- `TestJavaExtractor_QualifiedName_NoPackage` — default-package falls back to bare name

Pre-existing failures on main (`TestElapsedMSCoverageAllTools` count=30, `TestMCPHandshakeBudget` ceiling) are NOT introduced by this PR and are tracked separately.

## 4 · Acceptance check

- `archigraph_expand` with `entity_id=…` → works, no deprecation
- `archigraph_expand` with `node=…` → works, deprecation on stderr
- `archigraph_traces` with no `action` → returns list
- Java entities after reindex → `qualified_name: "com.example.pkg.ClassName"` in inspect output

## 5 · Deprecation trail

`node` param on `archigraph_expand` is removed one release after this lands (same pattern as `label_or_id` → `entity_id` on inspect, `node_id` on get_source).

## 6 · Risks

- `collectPackageName` scans only `root.Child(i)` top-level nodes; it cannot be confused by inner package references. Falls back to `""` (bare name) when no `package_declaration` is present.
- No change to entity `ID` or `Name` fields — only `QualifiedName` is new, which is additive.

## 7 · Linked issues

Closes #1916
Closes #1917
archigraph_traces `action` default fix included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)