### PR TITLE
feat(python): DRF @action kwargs + DEPENDS_ON_CONFIG consumer edges + admin.site.register REFERENCES (#1967 #1982 #1990)

### DIFF
--- a/internal/extractors/python/config_consumer.go
+++ b/internal/extractors/python/config_consumer.go
@@ -1,0 +1,382 @@
+// config_consumer.go — supplemental pass that emits DEPENDS_ON_CONFIG edges
+// from Python operations / classes / modules that consume settings or
+// environment variables to the Config entity that owns them.
+//
+// Issue #1982 — #1919 emitted SCOPE.Config entities for settings.py and other
+// canonical config files, but the consumer side of the relationship was
+// never wired: views, serializers, tasks, and middleware that read
+// `settings.X` or `os.environ.get("X")` were topologically isolated from
+// the Config entity that owned that key. Without consumer edges the Config
+// entities were dead islands in the graph and #1919 only shipped half the
+// feature.
+//
+// This pass runs AFTER all primary entity emission so it can observe:
+//
+//   1. The file's own imports (already attached to the file entity by
+//      extractImports / attachImportRelationships).
+//   2. Every Operation/Class entity that walkNode emitted in the file.
+//
+// Detected consumer shapes:
+//
+//   - `from django.conf import settings` + `settings.X`
+//   - `from django.conf import settings as my_settings` + `my_settings.X`
+//   - `import django.conf` + `django.conf.settings.X` (rare but legal)
+//   - `os.environ.get("X")`, `os.environ["X"]`, `os.getenv("X")`
+//
+// For each consumer call, we emit a single DEPENDS_ON_CONFIG edge from the
+// enclosing function/method/class entity (or, when at module scope, the
+// file entity) to a structural-ref ToID that points at the settings.py
+// Config entity or, for env consumers, the project `.env` Config entity.
+//
+// The ToID format mirrors the existing config_module entity emitted by
+// emitConfigModuleEntity:
+//
+//	scope:config:config_module:python:<settings.py path>:settings
+//
+// Cross-file resolution: we cannot know the canonical settings.py path
+// from inside a single-file extractor pass. We emit a STRUCTURAL ToID
+// that the resolver binds by Name ("settings" or ".env") + Kind
+// (SCOPE.Config). The resolver's existing structural-ref → byName path
+// (mirrors emitReferences in references.go) covers this without new
+// dispatcher work.
+//
+// Dedup: at most one DEPENDS_ON_CONFIG edge per (from_id, settings_or_env)
+// pair per file. Properties on the edge record the specific keys
+// referenced (joined with ',') so downstream consumers (e.g. #1942 auth
+// resolver, #1944 Event Flows) can filter by key.
+
+package python
+
+import (
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitConfigConsumerEdges scans the file body for settings / env consumption
+// patterns and appends DEPENDS_ON_CONFIG edges to the enclosing entity.
+//
+// Mutates *entities in place. Safe to call with nil or empty input.
+func emitConfigConsumerEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	// Phase 1 — read the file entity's import bindings to find any alias
+	// that resolves to `django.conf.settings` (or an equivalent project
+	// config module classified by #1919). We track:
+	//
+	//   settingsAliases : set of local identifiers that BIND to the Django
+	//                     settings object (most commonly "settings").
+	//
+	// We also flag whether `os` is imported (or the explicit names
+	// `environ`, `getenv` are imported from `os`) so the env scan can be
+	// gated on actual presence.
+	settingsAliases := map[string]struct{}{}
+	osImported := false
+	osEnvironLocal := ""
+	osGetenvLocal := ""
+
+	fileEnt := &(*entities)[0]
+	for _, r := range fileEnt.Relationships {
+		if r.Kind != "IMPORTS" {
+			continue
+		}
+		src := r.Properties["source_module"]
+		imp := r.Properties["imported_name"]
+		local := r.Properties["local_name"]
+
+		// `from django.conf import settings [as X]`
+		if src == "django.conf" && imp == "settings" {
+			if local != "" {
+				settingsAliases[local] = struct{}{}
+			} else {
+				settingsAliases["settings"] = struct{}{}
+			}
+		}
+		// `import django.conf` — settings is reached via the dotted path,
+		// which the receiver scan can't trivially follow without name
+		// resolution; we emit the edge unconditionally on a `django.conf`
+		// occurrence below.
+		if src == "django.conf" && imp == "" {
+			settingsAliases["django.conf.settings"] = struct{}{}
+		}
+
+		// os module: a bare `import os` makes os.environ + os.getenv
+		// available. Explicit `from os import environ/getenv [as Y]`
+		// rebinds them under the chosen local name.
+		//
+		// `import os` is emitted by extractImports as
+		//   source_module="os", imported_name="os" (module-self pair).
+		// `from os import environ` is emitted as
+		//   source_module="os", imported_name="environ".
+		if src == "os" && (imp == "" || imp == "os") {
+			osImported = true
+		}
+		if src == "os" && imp == "environ" {
+			osEnvironLocal = local
+			if osEnvironLocal == "" {
+				osEnvironLocal = "environ"
+			}
+		}
+		if src == "os" && imp == "getenv" {
+			osGetenvLocal = local
+			if osGetenvLocal == "" {
+				osGetenvLocal = "getenv"
+			}
+		}
+	}
+
+	// Phase 2 — walk every function/method body (and module-scope) and
+	// detect consumer attribute / call shapes. We track the enclosing
+	// entity Name so the edge attaches to the right entity. Module-scope
+	// references attach to the file entity (entities[0]).
+	type bucket struct {
+		settingsKeys map[string]struct{}
+		envKeys      map[string]struct{}
+	}
+	per := map[string]*bucket{}
+	getBucket := func(emittedName string) *bucket {
+		b, ok := per[emittedName]
+		if !ok {
+			b = &bucket{
+				settingsKeys: map[string]struct{}{},
+				envKeys:      map[string]struct{}{},
+			}
+			per[emittedName] = b
+		}
+		return b
+	}
+
+	var stack []string // emitted-name stack; top = current entity
+	currentName := func() string {
+		if len(stack) == 0 {
+			return "" // module scope → file entity
+		}
+		return stack[len(stack)-1]
+	}
+
+	var walk func(n *sitter.Node, parentClass string)
+	walk = func(n *sitter.Node, parentClass string) {
+		if n == nil {
+			return
+		}
+		nt := n.Type()
+		switch nt {
+		case "class_definition":
+			nameNode := n.ChildByFieldName("name")
+			cls := ""
+			if nameNode != nil {
+				cls = nodeText(nameNode, file.Content)
+			}
+			childCls := cls
+			if parentClass != "" && cls != "" {
+				childCls = parentClass + "." + cls
+			}
+			// Push the class itself as the bucket key for class-body
+			// (non-method) statements that consume settings (e.g. class-
+			// level attribute defaults read from settings.X).
+			stack = append(stack, childCls)
+			body := n.ChildByFieldName("body")
+			if body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), childCls)
+				}
+			}
+			stack = stack[:len(stack)-1]
+			return
+		case "function_definition":
+			nameNode := n.ChildByFieldName("name")
+			leaf := ""
+			if nameNode != nil {
+				leaf = nodeText(nameNode, file.Content)
+			}
+			emitted := leaf
+			if parentClass != "" && leaf != "" {
+				emitted = parentClass + "." + leaf
+			}
+			stack = append(stack, emitted)
+			body := n.ChildByFieldName("body")
+			if body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), parentClass)
+				}
+			}
+			stack = stack[:len(stack)-1]
+			return
+		case "decorated_definition":
+			inner := n.ChildByFieldName("definition")
+			if inner != nil {
+				walk(inner, parentClass)
+			}
+			return
+		}
+
+		// Detect settings.X attribute access.
+		if nt == "attribute" {
+			obj := n.ChildByFieldName("object")
+			attr := n.ChildByFieldName("attribute")
+			if obj != nil && attr != nil {
+				recv := strings.TrimSpace(nodeText(obj, file.Content))
+				attrName := nodeText(attr, file.Content)
+				if _, ok := settingsAliases[recv]; ok && attrName != "" {
+					getBucket(currentName()).settingsKeys[attrName] = struct{}{}
+				}
+			}
+		}
+
+		// Detect call shapes for env access.
+		if nt == "call" {
+			fn := n.ChildByFieldName("function")
+			args := n.ChildByFieldName("arguments")
+			if fn != nil && args != nil {
+				if key := envKeyFromCall(fn, args, file.Content, osImported, osEnvironLocal, osGetenvLocal); key != "" {
+					getBucket(currentName()).envKeys[key] = struct{}{}
+				}
+			}
+		}
+
+		// Detect subscript shapes: os.environ["X"] / environ["X"].
+		if nt == "subscript" {
+			val := n.ChildByFieldName("value")
+			subs := n.ChildByFieldName("subscript")
+			if val != nil && subs != nil {
+				recv := strings.TrimSpace(nodeText(val, file.Content))
+				isEnviron := false
+				if osImported && recv == "os.environ" {
+					isEnviron = true
+				}
+				if osEnvironLocal != "" && recv == osEnvironLocal {
+					isEnviron = true
+				}
+				if isEnviron && subs.Type() == "string" {
+					key := stripQuotes(nodeText(subs, file.Content))
+					if key != "" {
+						getBucket(currentName()).envKeys[key] = struct{}{}
+					}
+				}
+			}
+		}
+
+		// Recurse into children for every other node type.
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), parentClass)
+		}
+	}
+	walk(root, "")
+
+	// Phase 3 — emit one edge per (entity, target) pair.
+	for emittedName, b := range per {
+		if len(b.settingsKeys) > 0 {
+			attachConfigEdge(file, entities, emittedName, "settings", keysSorted(b.settingsKeys))
+		}
+		if len(b.envKeys) > 0 {
+			attachConfigEdge(file, entities, emittedName, ".env", keysSorted(b.envKeys))
+		}
+	}
+}
+
+// attachConfigEdge appends a DEPENDS_ON_CONFIG relationship to the entity
+// identified by emittedName (file entity when empty). The ToID is a
+// Name-keyed structural reference resolved at link time.
+func attachConfigEdge(file extractor.FileInput, entities *[]types.EntityRecord, emittedName, configName string, keys []string) {
+	var hostIdx int
+	if emittedName == "" {
+		hostIdx = 0 // file entity
+	} else {
+		hostIdx = -1
+		for i := range *entities {
+			e := &(*entities)[i]
+			if e.SourceFile == file.Path && e.Name == emittedName {
+				hostIdx = i
+				break
+			}
+		}
+		if hostIdx < 0 {
+			return
+		}
+	}
+	toID := buildConfigTargetID(configName)
+	props := map[string]string{
+		"config_name": configName,
+	}
+	if len(keys) > 0 {
+		props["keys"] = strings.Join(keys, ",")
+	}
+	(*entities)[hostIdx].Relationships = append((*entities)[hostIdx].Relationships,
+		types.RelationshipRecord{
+			ToID:       toID,
+			Kind:       string(types.RelationshipKindDependsOnConfig),
+			Properties: props,
+		})
+}
+
+// buildConfigTargetID returns a structural-ref ToID that the resolver binds
+// by Name to a SCOPE.Config entity. Two well-known shapes:
+//
+//	"settings"  → Django settings module (settings.py)
+//	".env"      → environment-file Config entity
+//
+// The resolver's by-Name index for SCOPE.Config picks the canonical
+// settings.py entity emitted by emitConfigModuleEntity (config_module
+// subtype, Name="settings"). When a project has no canonical settings.py
+// the edge remains unresolved — same disposition as other cross-file
+// structural refs (e.g. CALLS to a missing function).
+func buildConfigTargetID(configName string) string {
+	// Use "ref:<lang>:<name>" — same shape family as
+	// buildPyReferenceTargetID but with scope segment "config" so the
+	// resolver's structural dispatch routes it to the SCOPE.Config family.
+	return "scope:config:ref:python:" + filepath.ToSlash(configName) + ":" + configName
+}
+
+// envKeyFromCall returns the literal env var key when fn(args) matches one
+// of the supported env-read shapes, or empty when it doesn't.
+//
+// Supported shapes:
+//
+//	os.environ.get("X" [, default])
+//	os.getenv("X" [, default])
+//	environ.get("X" [, default])          (when `environ` was imported from os)
+//	getenv("X" [, default])               (when `getenv` was imported from os)
+func envKeyFromCall(fn, args *sitter.Node, src []byte, osImported bool, environLocal, getenvLocal string) string {
+	calleeText := strings.TrimSpace(nodeText(fn, src))
+	matched := false
+	switch {
+	case osImported && (calleeText == "os.environ.get" || calleeText == "os.getenv"):
+		matched = true
+	case environLocal != "" && calleeText == environLocal+".get":
+		matched = true
+	case getenvLocal != "" && calleeText == getenvLocal:
+		matched = true
+	}
+	if !matched {
+		return ""
+	}
+	if args.NamedChildCount() == 0 {
+		return ""
+	}
+	first := args.NamedChild(0)
+	if first == nil || first.Type() != "string" {
+		return ""
+	}
+	return stripQuotes(nodeText(first, src))
+}
+
+// keysSorted returns the keys of m as a stable, lexically-sorted slice.
+func keysSorted(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// simple insertion sort — n is small (per-file)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}

--- a/internal/extractors/python/config_consumer_test.go
+++ b/internal/extractors/python/config_consumer_test.go
@@ -1,0 +1,157 @@
+package python_test
+
+// config_consumer_test.go — fixture tests for issue #1982.
+//
+// Verifies DEPENDS_ON_CONFIG edges land on the enclosing entity for
+// django.conf settings consumers and os.environ / os.getenv consumers.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// countConfigEdgesFrom returns the DEPENDS_ON_CONFIG edges emitted by the
+// entity whose Name matches `from` (use "" for the file entity, identified
+// by Subtype="file").
+func countConfigEdgesFrom(entities []types.EntityRecord, filePath, from string) []types.RelationshipRecord {
+	for i := range entities {
+		e := &entities[i]
+		if e.SourceFile != filePath {
+			continue
+		}
+		match := false
+		if from == "" && e.Kind == "SCOPE.Component" && e.Subtype == "file" {
+			match = true
+		}
+		if from != "" && e.Name == from {
+			match = true
+		}
+		if !match {
+			continue
+		}
+		var out []types.RelationshipRecord
+		for _, r := range e.Relationships {
+			if r.Kind == "DEPENDS_ON_CONFIG" {
+				out = append(out, r)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// TestConfigConsumer_DjangoSettings verifies that a view referencing
+// settings.X emits a DEPENDS_ON_CONFIG edge with config_name="settings".
+//
+// Issue #1982.
+func TestConfigConsumer_DjangoSettings(t *testing.T) {
+	src := `from django.conf import settings
+
+def get_email_host():
+    return settings.EMAIL_HOST
+
+class Mailer:
+    def send(self):
+        host = settings.EMAIL_HOST
+        port = settings.EMAIL_PORT
+`
+	out := extractPy(t, src, "core/mail.py")
+
+	// Function-scope edge.
+	edges := countConfigEdgesFrom(out, "core/mail.py", "get_email_host")
+	if len(edges) != 1 {
+		t.Fatalf("get_email_host: expected 1 DEPENDS_ON_CONFIG edge, got %d", len(edges))
+	}
+	if edges[0].Properties["config_name"] != "settings" {
+		t.Errorf("edge config_name = %q, want \"settings\"", edges[0].Properties["config_name"])
+	}
+	if !strings.Contains(edges[0].Properties["keys"], "EMAIL_HOST") {
+		t.Errorf("edge keys = %q, want to contain EMAIL_HOST", edges[0].Properties["keys"])
+	}
+
+	// Method-scope edge.
+	methodEdges := countConfigEdgesFrom(out, "core/mail.py", "Mailer.send")
+	if len(methodEdges) != 1 {
+		t.Fatalf("Mailer.send: expected 1 DEPENDS_ON_CONFIG edge, got %d", len(methodEdges))
+	}
+	keys := methodEdges[0].Properties["keys"]
+	if !strings.Contains(keys, "EMAIL_HOST") || !strings.Contains(keys, "EMAIL_PORT") {
+		t.Errorf("Mailer.send keys = %q, want to contain EMAIL_HOST and EMAIL_PORT", keys)
+	}
+}
+
+// TestConfigConsumer_AliasedImport verifies `from django.conf import
+// settings as my_settings` is recognised via the import binding.
+func TestConfigConsumer_AliasedImport(t *testing.T) {
+	src := `from django.conf import settings as my_settings
+
+def view():
+    return my_settings.DEBUG
+`
+	out := extractPy(t, src, "app/views.py")
+	edges := countConfigEdgesFrom(out, "app/views.py", "view")
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 DEPENDS_ON_CONFIG edge, got %d", len(edges))
+	}
+	if edges[0].Properties["keys"] != "DEBUG" {
+		t.Errorf("keys = %q, want \"DEBUG\"", edges[0].Properties["keys"])
+	}
+}
+
+// TestConfigConsumer_OsEnviron verifies os.environ.get / os.getenv shapes
+// produce edges with config_name=".env".
+func TestConfigConsumer_OsEnviron(t *testing.T) {
+	src := `import os
+
+def boot():
+    db = os.environ.get("DATABASE_URL")
+    key = os.getenv("SECRET_KEY")
+    return db, key
+`
+	out := extractPy(t, src, "app/boot.py")
+	edges := countConfigEdgesFrom(out, "app/boot.py", "boot")
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 DEPENDS_ON_CONFIG edge, got %d", len(edges))
+	}
+	if edges[0].Properties["config_name"] != ".env" {
+		t.Errorf("config_name = %q, want \".env\"", edges[0].Properties["config_name"])
+	}
+	keys := edges[0].Properties["keys"]
+	if !strings.Contains(keys, "DATABASE_URL") || !strings.Contains(keys, "SECRET_KEY") {
+		t.Errorf("keys = %q, want to contain DATABASE_URL and SECRET_KEY", keys)
+	}
+}
+
+// TestConfigConsumer_OsEnvironSubscript verifies os.environ["X"] shape.
+func TestConfigConsumer_OsEnvironSubscript(t *testing.T) {
+	src := `import os
+
+def boot():
+    return os.environ["MY_KEY"]
+`
+	out := extractPy(t, src, "app/boot.py")
+	edges := countConfigEdgesFrom(out, "app/boot.py", "boot")
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 DEPENDS_ON_CONFIG edge, got %d", len(edges))
+	}
+	if edges[0].Properties["keys"] != "MY_KEY" {
+		t.Errorf("keys = %q, want \"MY_KEY\"", edges[0].Properties["keys"])
+	}
+}
+
+// TestConfigConsumer_NoEdgesWithoutImport verifies that without the right
+// import binding, no edge is emitted (we don't over-emit on bare names).
+func TestConfigConsumer_NoEdgesWithoutImport(t *testing.T) {
+	src := `# no django.conf import
+
+def view():
+    return settings.X
+`
+	out := extractPy(t, src, "app/views.py")
+	edges := countConfigEdgesFrom(out, "app/views.py", "view")
+	if len(edges) != 0 {
+		t.Errorf("expected 0 DEPENDS_ON_CONFIG edges without import binding, got %d", len(edges))
+	}
+}

--- a/internal/extractors/python/django_admin.go
+++ b/internal/extractors/python/django_admin.go
@@ -1,0 +1,483 @@
+// django_admin.go — supplemental Python-extractor pass for Django admin
+// modules (`admin.py`). Emits two complementary surfaces:
+//
+//   1. REFERENCES edges from the admin MODULE entity to every Model and
+//      ModelAdmin class registered in the file via:
+//
+//         admin.site.register(M, A)
+//         admin.site.register(M)              # bare register
+//         @admin.register(M [, M2, …])        # decorator on ModelAdmin
+//
+//      The existing per-class REGISTERS edge (internal/custom/python/
+//      django.go) wires the ModelAdmin → Model relationship, but leaves
+//      the admin module itself disconnected. This pass emits module-level
+//      REFERENCES so admin.py shows up as a connected island in the graph.
+//
+//   2. Property capture on every ModelAdmin class — the keys list_display,
+//      list_filter, search_fields, readonly_fields, fieldsets, inlines,
+//      ordering, date_hierarchy, actions. W4R4 evidence showed list_display
+//      and list_filter present but search_fields missing. This pass
+//      captures the complete set as flat string properties on the
+//      ModelAdmin class entity so docgen can render the admin contract.
+//
+//   3. Custom admin actions: methods decorated with @admin.action(
+//      description="…") on a ModelAdmin class are stamped with
+//      Properties["admin_action"]="true" and Properties["description"]
+//      so they surface as first-class operations in the admin doc page.
+//
+// Runs after walkNode + extractClassFields so we can mutate emitted
+// SCOPE.Operation / SCOPE.Component entities in place.
+
+package python
+
+import (
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// adminModelAdminProps is the canonical list of Django ModelAdmin attributes
+// the docgen surface cares about. Captured as flat key/value strings on the
+// ModelAdmin class entity. Values are stored as the trimmed source-text of
+// the RHS expression so a `list_display = ("a", "b")` survives without
+// any value-shape normalisation here (downstream renderers can format it).
+var adminModelAdminProps = []string{
+	"list_display",
+	"list_filter",
+	"search_fields",
+	"readonly_fields",
+	"fieldsets",
+	"inlines",
+	"ordering",
+	"date_hierarchy",
+	"actions",
+}
+
+// emitDjangoAdminEdges is the entry point invoked from Extract. No-op for
+// non-admin files.
+func emitDjangoAdminEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	if !isDjangoAdminFile(file.Path) {
+		return
+	}
+
+	// 1. Top-level admin.site.register(M [, A]) calls.
+	registered := collectAdminSiteRegisterCalls(root, file.Content)
+	// 2. @admin.register(M [, M2]) decorator → ModelAdmin class targets.
+	decorRegistered := collectAdminDecoratorRegisterCalls(root, file.Content)
+
+	// Emit REFERENCES edges on the file entity for each (model, admin) pair.
+	fileEnt := &(*entities)[0]
+	seen := map[string]bool{}
+	emit := func(target string) {
+		if target == "" {
+			return
+		}
+		toID := buildAdminClassRef(file.Path, target)
+		key := toID
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		fileEnt.Relationships = append(fileEnt.Relationships,
+			types.RelationshipRecord{
+				ToID: toID,
+				Kind: string(types.RelationshipKindReferences),
+				Properties: map[string]string{
+					"framework":    "django",
+					"pattern_type": "admin_register",
+				},
+			})
+	}
+	for _, p := range registered {
+		emit(p.model)
+		emit(p.admin)
+	}
+	for _, p := range decorRegistered {
+		for _, m := range p.models {
+			emit(m)
+		}
+		emit(p.adminClass)
+	}
+
+	// 3. ModelAdmin property capture + custom admin actions.
+	captureModelAdminProperties(root, file, entities)
+}
+
+// adminSiteRegisterPair captures one admin.site.register(M, A) call's args.
+// admin may be empty when the bare 1-arg form is used.
+type adminSiteRegisterPair struct {
+	model string
+	admin string
+}
+
+// collectAdminSiteRegisterCalls scans the module root for top-level
+// `admin.site.register(...)` calls and returns the (model, admin) pairs.
+//
+// Both positional and dotted-identifier args survive intact. The first arg
+// may itself be a list `[M1, M2]` (Django supports registering multiple
+// models in one call); we expand into one pair per model.
+func collectAdminSiteRegisterCalls(root *sitter.Node, src []byte) []adminSiteRegisterPair {
+	var out []adminSiteRegisterPair
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "call" {
+			fn := n.ChildByFieldName("function")
+			if fn != nil && strings.TrimSpace(nodeText(fn, src)) == "admin.site.register" {
+				args := n.ChildByFieldName("arguments")
+				if args != nil && args.NamedChildCount() > 0 {
+					first := args.NamedChild(0)
+					var models []string
+					if first != nil && (first.Type() == "list" || first.Type() == "tuple") {
+						for i := 0; i < int(first.NamedChildCount()); i++ {
+							ch := first.NamedChild(i)
+							if ch == nil {
+								continue
+							}
+							if t := strings.TrimSpace(nodeText(ch, src)); t != "" {
+								models = append(models, t)
+							}
+						}
+					} else if first != nil {
+						if t := strings.TrimSpace(nodeText(first, src)); t != "" {
+							models = []string{t}
+						}
+					}
+					var adminCls string
+					if args.NamedChildCount() > 1 {
+						second := args.NamedChild(1)
+						if second != nil && second.Type() != "keyword_argument" {
+							adminCls = strings.TrimSpace(nodeText(second, src))
+						}
+					}
+					for _, m := range models {
+						out = append(out, adminSiteRegisterPair{model: m, admin: adminCls})
+					}
+				}
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	return out
+}
+
+// adminDecoratorRegister captures one @admin.register(M, M2, …) decorator
+// site and the class it precedes.
+type adminDecoratorRegister struct {
+	models     []string
+	adminClass string
+}
+
+// collectAdminDecoratorRegisterCalls scans the module for class definitions
+// whose decorator list includes `@admin.register(M [, M2, …])` and returns
+// the captured model list + admin class name.
+func collectAdminDecoratorRegisterCalls(root *sitter.Node, src []byte) []adminDecoratorRegister {
+	var out []adminDecoratorRegister
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "decorated_definition" {
+			inner := n.ChildByFieldName("definition")
+			if inner != nil && inner.Type() == "class_definition" {
+				nameNode := inner.ChildByFieldName("name")
+				if nameNode != nil {
+					adminClass := nodeText(nameNode, src)
+					for i := 0; i < int(n.ChildCount()); i++ {
+						ch := n.Child(i)
+						if ch == nil || ch.Type() != "decorator" {
+							continue
+						}
+						// Decorator first named child is `call` for the
+						// `@admin.register(M)` form.
+						for j := 0; j < int(ch.NamedChildCount()); j++ {
+							call := ch.NamedChild(j)
+							if call == nil || call.Type() != "call" {
+								continue
+							}
+							fn := call.ChildByFieldName("function")
+							if fn == nil || strings.TrimSpace(nodeText(fn, src)) != "admin.register" {
+								continue
+							}
+							args := call.ChildByFieldName("arguments")
+							if args == nil {
+								continue
+							}
+							var models []string
+							for k := 0; k < int(args.NamedChildCount()); k++ {
+								arg := args.NamedChild(k)
+								if arg == nil {
+									continue
+								}
+								if arg.Type() == "keyword_argument" {
+									continue
+								}
+								if t := strings.TrimSpace(nodeText(arg, src)); t != "" {
+									models = append(models, t)
+								}
+							}
+							if len(models) > 0 {
+								out = append(out, adminDecoratorRegister{models: models, adminClass: adminClass})
+							}
+						}
+					}
+				}
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	return out
+}
+
+// captureModelAdminProperties walks every class_definition and, for any class
+// that extends ModelAdmin / admin.ModelAdmin / TabularInline / StackedInline,
+// captures the canonical ModelAdmin attribute keys (list_display, etc.) as
+// flat properties on the class entity. Also tags @admin.action methods.
+func captureModelAdminProperties(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	var walk func(n *sitter.Node, parentClass string)
+	walk = func(n *sitter.Node, parentClass string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_definition":
+			handleAdminClass(n, parentClass, file, entities)
+			nameNode := n.ChildByFieldName("name")
+			cls := ""
+			if nameNode != nil {
+				cls = nodeText(nameNode, file.Content)
+			}
+			childCls := cls
+			if parentClass != "" && cls != "" {
+				childCls = parentClass + "." + cls
+			}
+			body := n.ChildByFieldName("body")
+			if body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), childCls)
+				}
+			}
+			return
+		case "decorated_definition":
+			inner := n.ChildByFieldName("definition")
+			if inner != nil && inner.Type() == "class_definition" {
+				handleAdminClass(inner, parentClass, file, entities)
+				// Recurse into the inner class body too.
+				nameNode := inner.ChildByFieldName("name")
+				cls := ""
+				if nameNode != nil {
+					cls = nodeText(nameNode, file.Content)
+				}
+				childCls := cls
+				if parentClass != "" && cls != "" {
+					childCls = parentClass + "." + cls
+				}
+				body := inner.ChildByFieldName("body")
+				if body != nil {
+					for i := 0; i < int(body.ChildCount()); i++ {
+						walk(body.Child(i), childCls)
+					}
+				}
+				return
+			}
+			if inner != nil && inner.Type() == "function_definition" {
+				// Method-level @admin.action handling.
+				if parentClass != "" {
+					stampAdminActionOnMethod(n, inner, parentClass, file, entities)
+				}
+				return
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), parentClass)
+		}
+	}
+	walk(root, "")
+}
+
+// handleAdminClass captures ModelAdmin properties on the matching class entity.
+func handleAdminClass(cd *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+	nameNode := cd.ChildByFieldName("name")
+	if nameNode == nil {
+		return
+	}
+	clsLeaf := nodeText(nameNode, file.Content)
+	if clsLeaf == "" {
+		return
+	}
+	if !classExtendsAdmin(cd, file.Content) {
+		return
+	}
+	emittedName := clsLeaf
+	if parentClass != "" {
+		emittedName = parentClass + "." + clsLeaf
+	}
+	cls := findClassByName(*entities, file.Path, emittedName)
+	if cls == nil {
+		return
+	}
+	if cls.Properties == nil {
+		cls.Properties = map[string]string{}
+	}
+	cls.Properties["framework"] = "django"
+	cls.Properties["component_kind"] = "model_admin"
+
+	body := cd.ChildByFieldName("body")
+	if body == nil {
+		return
+	}
+	props := parseSimpleAssignments(body, file.Content)
+	for _, key := range adminModelAdminProps {
+		if v, ok := props[key]; ok {
+			cls.Properties[key] = v
+		}
+	}
+}
+
+// classExtendsAdmin reports whether the class extends one of the Django
+// admin base classes: ModelAdmin, admin.ModelAdmin, TabularInline,
+// StackedInline, admin.TabularInline, admin.StackedInline.
+func classExtendsAdmin(cd *sitter.Node, src []byte) bool {
+	supers := cd.ChildByFieldName("superclasses")
+	if supers == nil {
+		return false
+	}
+	t := nodeText(supers, src)
+	for _, base := range []string{
+		"ModelAdmin",
+		"TabularInline",
+		"StackedInline",
+	} {
+		if strings.Contains(t, base) {
+			return true
+		}
+	}
+	return false
+}
+
+// stampAdminActionOnMethod looks for @admin.action(...) on the decorated
+// method and, when found, stamps Properties["admin_action"]="true" plus the
+// captured description / permissions kwargs on the matching Operation
+// entity.
+func stampAdminActionOnMethod(decorated, inner *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+	methodNameNode := inner.ChildByFieldName("name")
+	if methodNameNode == nil {
+		return
+	}
+	methodName := nodeText(methodNameNode, file.Content)
+	if methodName == "" {
+		return
+	}
+	props := map[string]string{}
+	found := false
+	for i := 0; i < int(decorated.ChildCount()); i++ {
+		ch := decorated.Child(i)
+		if ch == nil || ch.Type() != "decorator" {
+			continue
+		}
+		// Look for `@admin.action(...)` — a call whose function leaf is "action"
+		// and whose receiver text contains "admin".
+		for j := 0; j < int(ch.NamedChildCount()); j++ {
+			cand := ch.NamedChild(j)
+			if cand == nil || cand.Type() != "call" {
+				continue
+			}
+			fn := cand.ChildByFieldName("function")
+			if fn == nil {
+				continue
+			}
+			fnText := strings.TrimSpace(nodeText(fn, file.Content))
+			if fnText != "admin.action" && fnText != "action" {
+				continue
+			}
+			if fnText == "action" && decoratorLeaf(fn, file.Content) != "action" {
+				continue
+			}
+			found = true
+			args := cand.ChildByFieldName("arguments")
+			if args == nil {
+				continue
+			}
+			for k := 0; k < int(args.NamedChildCount()); k++ {
+				arg := args.NamedChild(k)
+				if arg == nil || arg.Type() != "keyword_argument" {
+					continue
+				}
+				nm := arg.ChildByFieldName("name")
+				vl := arg.ChildByFieldName("value")
+				if nm == nil || vl == nil {
+					continue
+				}
+				switch nodeText(nm, file.Content) {
+				case "description":
+					if v := stripQuotes(strings.TrimSpace(nodeText(vl, file.Content))); v != "" {
+						props["description"] = v
+					}
+				case "permissions":
+					if v := strings.TrimSpace(nodeText(vl, file.Content)); v != "" {
+						props["permissions"] = v
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		return
+	}
+	props["admin_action"] = "true"
+	emittedName := parentClass + "." + methodName
+	op := findOpByName(*entities, file.Path, emittedName)
+	if op == nil {
+		return
+	}
+	if op.Properties == nil {
+		op.Properties = map[string]string{}
+	}
+	for k, v := range props {
+		op.Properties[k] = v
+	}
+}
+
+// isDjangoAdminFile reports whether path is a Django admin module. We accept
+// the canonical `admin.py` and also `admin/` package files (admin/__init__.py
+// and any sibling submodule like admin/users.py) so app-split admin layouts
+// still get processed.
+func isDjangoAdminFile(path string) bool {
+	p := filepath.ToSlash(path)
+	base := filepath.Base(p)
+	if base == "admin.py" {
+		return true
+	}
+	// admin/<anything>.py — match any segment "admin" in the dirname.
+	dir := filepath.Dir(p)
+	for _, seg := range strings.Split(dir, "/") {
+		if seg == "admin" {
+			return true
+		}
+	}
+	return false
+}
+
+// buildAdminClassRef returns a structural-ref ToID for an admin REFERENCES
+// edge target. The resolver's by-Name index across SCOPE.Component/class
+// (Django Model) and SCOPE.Component/admin_class (#1374) picks the canonical
+// target.
+func buildAdminClassRef(filePath, name string) string {
+	return "scope:component:ref:python:" + filepath.ToSlash(filePath) + ":" + name
+}

--- a/internal/extractors/python/django_admin_test.go
+++ b/internal/extractors/python/django_admin_test.go
@@ -1,0 +1,205 @@
+package python_test
+
+// django_admin_test.go — fixture tests for issue #1990.
+//
+// Verifies:
+//   - admin.site.register(M, A) emits REFERENCES edges from the admin
+//     module entity to both M and A.
+//   - @admin.register(M) decorator emits a REFERENCES edge to M.
+//   - ModelAdmin classes get list_display / search_fields / etc captured
+//     as flat properties.
+//   - @admin.action methods get admin_action=true + description stamped
+//     as Operation properties.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// countAdminRefsFrom returns REFERENCES edges with pattern_type=admin_register
+// emitted from the file entity (admin module) in entities.
+func countAdminRefsFrom(entities []types.EntityRecord, filePath string) []types.RelationshipRecord {
+	for i := range entities {
+		e := &entities[i]
+		if e.SourceFile != filePath {
+			continue
+		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "file" {
+			continue
+		}
+		var out []types.RelationshipRecord
+		for _, r := range e.Relationships {
+			if r.Kind != "REFERENCES" {
+				continue
+			}
+			if r.Properties["pattern_type"] != "admin_register" {
+				continue
+			}
+			out = append(out, r)
+		}
+		return out
+	}
+	return nil
+}
+
+// TestAdminSiteRegister verifies admin.site.register(M, A) emits two
+// REFERENCES edges from the admin module — one to M, one to A.
+//
+// Issue #1990.
+func TestAdminSiteRegister(t *testing.T) {
+	src := `from django.contrib import admin
+from .models import Permit
+
+class PermitAdmin(admin.ModelAdmin):
+    pass
+
+admin.site.register(Permit, PermitAdmin)
+`
+	out := extractPy(t, src, "core/admin.py")
+	edges := countAdminRefsFrom(out, "core/admin.py")
+	if len(edges) != 2 {
+		t.Fatalf("expected 2 admin_register REFERENCES edges, got %d", len(edges))
+	}
+	targets := []string{edges[0].ToID, edges[1].ToID}
+	wantContain := []string{"Permit", "PermitAdmin"}
+	for _, w := range wantContain {
+		found := false
+		for _, target := range targets {
+			if strings.Contains(target, ":"+w) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected REFERENCES edge target containing %q, got %v", w, targets)
+		}
+	}
+}
+
+// TestAdminSiteRegisterBareForm verifies admin.site.register(M) (no admin
+// class supplied) still emits a REFERENCES edge to the model.
+func TestAdminSiteRegisterBareForm(t *testing.T) {
+	src := `from django.contrib import admin
+from .models import Tag
+
+admin.site.register(Tag)
+`
+	out := extractPy(t, src, "core/admin.py")
+	edges := countAdminRefsFrom(out, "core/admin.py")
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 admin_register REFERENCES edge, got %d", len(edges))
+	}
+	if !strings.Contains(edges[0].ToID, ":Tag") {
+		t.Errorf("expected edge target containing :Tag, got %q", edges[0].ToID)
+	}
+}
+
+// TestAdminRegisterDecorator verifies @admin.register(M) on a ModelAdmin
+// class emits a REFERENCES edge to M plus to the admin class.
+func TestAdminRegisterDecorator(t *testing.T) {
+	src := `from django.contrib import admin
+from .models import Contract
+
+@admin.register(Contract)
+class ContractAdmin(admin.ModelAdmin):
+    pass
+`
+	out := extractPy(t, src, "core/admin.py")
+	edges := countAdminRefsFrom(out, "core/admin.py")
+	if len(edges) < 2 {
+		t.Fatalf("expected ≥ 2 admin_register REFERENCES edges, got %d", len(edges))
+	}
+	var sawContract, sawAdmin bool
+	for _, e := range edges {
+		if strings.Contains(e.ToID, ":Contract") && !strings.Contains(e.ToID, ":ContractAdmin") {
+			sawContract = true
+		}
+		if strings.Contains(e.ToID, ":ContractAdmin") {
+			sawAdmin = true
+		}
+	}
+	if !sawContract {
+		t.Errorf("expected REFERENCES to Contract, edges=%v", edges)
+	}
+	if !sawAdmin {
+		t.Errorf("expected REFERENCES to ContractAdmin, edges=%v", edges)
+	}
+}
+
+// TestModelAdminProperties verifies a ModelAdmin class gets every canonical
+// attribute (list_display, list_filter, search_fields, readonly_fields,
+// ordering, …) captured as flat properties.
+//
+// W4R4 evidence: search_fields was missing while list_display / list_filter
+// were captured — this test enforces consistency.
+func TestModelAdminProperties(t *testing.T) {
+	src := `from django.contrib import admin
+from .models import Permit
+
+class PermitAdmin(admin.ModelAdmin):
+    list_display = ("id", "title", "status")
+    list_filter = ("status",)
+    search_fields = ("title", "applicant__name")
+    readonly_fields = ("created_at",)
+    ordering = ("-created_at",)
+    date_hierarchy = "created_at"
+    actions = ["approve_bulk"]
+`
+	out := extractPy(t, src, "core/admin.py")
+	cls := findDRFClass(out, "core/admin.py", "PermitAdmin")
+	if cls == nil {
+		t.Fatalf("PermitAdmin class not found")
+	}
+	for _, want := range []string{
+		"list_display", "list_filter", "search_fields",
+		"readonly_fields", "ordering", "date_hierarchy", "actions",
+	} {
+		if v := cls.Properties[want]; v == "" {
+			t.Errorf("ModelAdmin property %q missing", want)
+		}
+	}
+	if cls.Properties["component_kind"] != "model_admin" {
+		t.Errorf("component_kind = %q, want \"model_admin\"", cls.Properties["component_kind"])
+	}
+}
+
+// TestAdminActionDecorator verifies @admin.action(description="…") on a
+// ModelAdmin method stamps admin_action=true + description on the
+// Operation entity.
+func TestAdminActionDecorator(t *testing.T) {
+	src := `from django.contrib import admin
+
+class PermitAdmin(admin.ModelAdmin):
+    @admin.action(description="Approve selected permits")
+    def approve_bulk(self, request, queryset):
+        queryset.update(status="approved")
+`
+	out := extractPy(t, src, "core/admin.py")
+	op := findDRFOp(out, "core/admin.py", "PermitAdmin.approve_bulk")
+	if op == nil {
+		t.Fatalf("PermitAdmin.approve_bulk operation not found")
+	}
+	if op.Properties["admin_action"] != "true" {
+		t.Errorf("admin_action = %q, want \"true\"", op.Properties["admin_action"])
+	}
+	if op.Properties["description"] != "Approve selected permits" {
+		t.Errorf("description = %q, want \"Approve selected permits\"", op.Properties["description"])
+	}
+}
+
+// TestAdminNonAdminFileSkipped verifies the pass is a no-op for files
+// that aren't admin.py / admin/.
+func TestAdminNonAdminFileSkipped(t *testing.T) {
+	src := `from django.contrib import admin
+from .models import Permit
+
+admin.site.register(Permit)
+`
+	out := extractPy(t, src, "core/views.py")
+	edges := countAdminRefsFrom(out, "core/views.py")
+	if len(edges) != 0 {
+		t.Errorf("expected 0 admin_register edges from non-admin file, got %d", len(edges))
+	}
+}

--- a/internal/extractors/python/django_drf_actions.go
+++ b/internal/extractors/python/django_drf_actions.go
@@ -1,0 +1,381 @@
+// django_drf_actions.go — supplemental pass that captures DRF `@action(...)`
+// decorator kwargs and surfaces them as Properties on the per-method
+// Operation entity, plus exposes a class-level summary so the ClassManifest
+// builder (#1861, internal/docgen) can render per-action decorators.
+//
+// Issue #1967 — Wave 1 docgen smoke showed methods decorated with
+//
+//	@action(detail=False, methods=["get"], serializer_class=FooSerializer)
+//
+// lose ALL the decorator metadata: the class_manifest method entry has no
+// `decorators` field, and the per-action Operation has no `http_method`,
+// `is_detail`, `serializer_class`, `url_path`, `permission_classes` props.
+// Without that surface the endpoint detail page can't tell list-actions
+// from detail-actions, can't show the per-action request/response shape
+// (composes with #1935 ShapeTree), and falls back to HTTP-verb guessing.
+//
+// This pass runs AFTER walkNode + extractClassFields so it can find the
+// emitted SCOPE.Operation entity by Name ("<Class>.<method>") and stamp
+// properties onto it in-place. It also writes a per-method decorator
+// summary onto the parent class's Properties map under a stable key
+// (`decorator_<method>`) so the docgen ClassManifest builder can read the
+// per-method decoration without re-parsing source.
+//
+// Recognised decorator forms:
+//
+//	@action(...)
+//	@rest_framework.decorators.action(...)
+//	@decorators.action(...)
+//
+// Recognised kwargs (all optional):
+//
+//	detail=<bool>
+//	methods=[<str>, ...]
+//	serializer_class=<Identifier>
+//	url_path="<str>"
+//	url_name="<str>"
+//	permission_classes=[<Identifier>, ...]
+//
+// Multi-method actions stamp the first verb as `http_method` AND the full
+// comma-joined list under `http_methods`. permission_classes are stored as
+// a comma-joined identifier list (no source-text noise) so downstream
+// queries don't have to re-parse a Python list literal.
+
+package python
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitDRFActionProperties walks every class_definition in root and, for each
+// method wrapped in a `decorated_definition` whose decorator list includes an
+// `@action(...)` call, parses the call's kwargs and stamps them onto the
+// matching Operation entity by Name ("<Class>.<method>").
+//
+// Mutates *entities in place. Safe to call with nil/empty input.
+func emitDRFActionProperties(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	// Walk every class_definition (top-level or nested) once. For each method
+	// declared inside the class body that carries an @action decorator,
+	// parse the kwargs and stamp them on the matching Operation entity.
+	walkDRFAction(root, "", file, entities)
+}
+
+func walkDRFAction(n *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if n == nil {
+		return
+	}
+	switch n.Type() {
+	case "class_definition":
+		nameNode := n.ChildByFieldName("name")
+		cls := ""
+		if nameNode != nil {
+			cls = nodeText(nameNode, file.Content)
+		}
+		childCls := cls
+		if parentClass != "" && cls != "" {
+			childCls = parentClass + "." + cls
+		}
+		body := n.ChildByFieldName("body")
+		if body != nil {
+			scanClassBodyForActions(body, childCls, file, entities)
+			// Recurse so nested classes (rare for DRF, but possible) are scanned too.
+			for i := 0; i < int(body.ChildCount()); i++ {
+				walkDRFAction(body.Child(i), childCls, file, entities)
+			}
+		}
+		return
+	case "decorated_definition":
+		inner := n.ChildByFieldName("definition")
+		if inner != nil {
+			walkDRFAction(inner, parentClass, file, entities)
+		}
+		return
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		walkDRFAction(n.Child(i), parentClass, file, entities)
+	}
+}
+
+// scanClassBodyForActions iterates a class body and, for every
+// decorated_definition wrapping a function_definition, scans the decorator
+// list for an `@action(...)` call. When found, the kwargs are parsed and
+// stamped on the matching SCOPE.Operation entity.
+func scanClassBodyForActions(body *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+	for i := 0; i < int(body.ChildCount()); i++ {
+		ch := body.Child(i)
+		if ch == nil || ch.Type() != "decorated_definition" {
+			continue
+		}
+		inner := ch.ChildByFieldName("definition")
+		if inner == nil || inner.Type() != "function_definition" {
+			continue
+		}
+		methodNameNode := inner.ChildByFieldName("name")
+		if methodNameNode == nil {
+			continue
+		}
+		methodName := nodeText(methodNameNode, file.Content)
+		if methodName == "" {
+			continue
+		}
+		actionCall := findActionDecoratorCall(ch, file.Content)
+		if actionCall == nil {
+			continue
+		}
+		props := parseActionKwargs(actionCall, file.Content)
+		if len(props) == 0 {
+			// Even a bare @action() still surfaces as a DRF action endpoint;
+			// stamp at least the marker so consumers know.
+			props = map[string]string{}
+		}
+		props["drf_action"] = "true"
+
+		// Stamp on the matching Operation entity by Name.
+		emittedName := parentClass + "." + methodName
+		op := findOpByName(*entities, file.Path, emittedName)
+		if op != nil {
+			if op.Properties == nil {
+				op.Properties = make(map[string]string, len(props))
+			}
+			for k, v := range props {
+				op.Properties[k] = v
+			}
+		}
+
+		// Also stamp on the parent class as a `decorator_<method>` property so
+		// the ClassManifest builder can surface per-method decorator info
+		// without re-parsing the source window. The value is the raw
+		// "@action(...)" source snippet (capped) for human readability.
+		cls := findClassByName(*entities, file.Path, parentClass)
+		if cls != nil {
+			if cls.Properties == nil {
+				cls.Properties = make(map[string]string)
+			}
+			snippet := strings.TrimSpace(nodeText(actionCall.Parent(), file.Content))
+			if len(snippet) > 200 {
+				snippet = snippet[:200] + "…"
+			}
+			cls.Properties["decorator_"+methodName] = snippet
+		}
+	}
+}
+
+// findActionDecoratorCall scans the decorator children of decoratedNode and
+// returns the call node whose callee leaf is "action" (e.g. `@action(...)`,
+// `@rest_framework.decorators.action(...)`, `@decorators.action(...)`).
+// Returns nil when no action decorator is present or the decorator is bare
+// (`@action` without parens).
+func findActionDecoratorCall(decoratedNode *sitter.Node, src []byte) *sitter.Node {
+	for i := 0; i < int(decoratedNode.ChildCount()); i++ {
+		ch := decoratedNode.Child(i)
+		if ch == nil || ch.Type() != "decorator" {
+			continue
+		}
+		// A decorator's first named child is either an identifier, an
+		// attribute (dotted), or a call (parenthesised form). We only care
+		// about the call form because `@action` without args carries no
+		// kwargs.
+		for j := 0; j < int(ch.NamedChildCount()); j++ {
+			inner := ch.NamedChild(j)
+			if inner == nil || inner.Type() != "call" {
+				continue
+			}
+			fn := inner.ChildByFieldName("function")
+			if fn == nil {
+				continue
+			}
+			if decoratorLeaf(fn, src) == "action" {
+				return inner
+			}
+		}
+	}
+	return nil
+}
+
+// decoratorLeaf returns the leaf identifier of a decorator callee.
+//
+//	identifier            → "action"
+//	attribute (a.b.c)     → "c"
+//	dotted_name (a.b.c)   → "c"
+func decoratorLeaf(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Type() {
+	case "identifier":
+		return nodeText(n, src)
+	case "attribute":
+		if attr := n.ChildByFieldName("attribute"); attr != nil {
+			return nodeText(attr, src)
+		}
+	case "dotted_name":
+		if c := n.NamedChild(int(n.NamedChildCount()) - 1); c != nil {
+			return nodeText(c, src)
+		}
+	}
+	return ""
+}
+
+// parseActionKwargs reads the keyword arguments of an `@action(...)` call
+// node and returns the canonical property map.
+func parseActionKwargs(call *sitter.Node, src []byte) map[string]string {
+	out := map[string]string{}
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return out
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		arg := args.NamedChild(i)
+		if arg == nil || arg.Type() != "keyword_argument" {
+			continue
+		}
+		nameNode := arg.ChildByFieldName("name")
+		valueNode := arg.ChildByFieldName("value")
+		if nameNode == nil || valueNode == nil {
+			continue
+		}
+		key := nodeText(nameNode, src)
+		switch key {
+		case "detail":
+			v := strings.TrimSpace(nodeText(valueNode, src))
+			if strings.EqualFold(v, "True") {
+				out["is_detail"] = "true"
+			} else if strings.EqualFold(v, "False") {
+				out["is_detail"] = "false"
+			}
+		case "methods":
+			methods := parseListLiteralStrings(valueNode, src)
+			if len(methods) > 0 {
+				// First verb wins for `http_method`; full list under
+				// `http_methods` (comma-joined, lowercased) so consumers
+				// can render multi-method actions accurately.
+				out["http_method"] = strings.ToLower(methods[0])
+				lowered := make([]string, len(methods))
+				for i, m := range methods {
+					lowered[i] = strings.ToLower(m)
+				}
+				out["http_methods"] = strings.Join(lowered, ",")
+			}
+		case "serializer_class":
+			if v := strings.TrimSpace(nodeText(valueNode, src)); v != "" {
+				out["serializer_class"] = v
+			}
+		case "url_path":
+			if v := stripQuotes(strings.TrimSpace(nodeText(valueNode, src))); v != "" {
+				out["url_path"] = v
+			}
+		case "url_name":
+			if v := stripQuotes(strings.TrimSpace(nodeText(valueNode, src))); v != "" {
+				out["url_name"] = v
+			}
+		case "permission_classes":
+			perms := parseListLiteralIdentifiers(valueNode, src)
+			if len(perms) > 0 {
+				out["permission_classes"] = strings.Join(perms, ",")
+			}
+		}
+	}
+	return out
+}
+
+// parseListLiteralStrings reads a Python `[ "a", "b" ]` or `( "a", "b" )`
+// node and returns the unquoted string literals it contains. Non-string
+// elements are skipped silently.
+func parseListLiteralStrings(n *sitter.Node, src []byte) []string {
+	if n == nil {
+		return nil
+	}
+	switch n.Type() {
+	case "list", "tuple", "set":
+		// fall through
+	default:
+		// A bare string literal like methods="get" is non-conformant DRF
+		// but try to recover.
+		if n.Type() == "string" {
+			return []string{stripQuotes(nodeText(n, src))}
+		}
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		ch := n.NamedChild(i)
+		if ch == nil {
+			continue
+		}
+		if ch.Type() == "string" {
+			out = append(out, stripQuotes(nodeText(ch, src)))
+		}
+	}
+	return out
+}
+
+// parseListLiteralIdentifiers reads a Python `[ A, B.C ]` node and returns
+// the identifier-shaped elements as their full source text (so a dotted
+// attribute like `permissions.IsAdmin` survives intact).
+func parseListLiteralIdentifiers(n *sitter.Node, src []byte) []string {
+	if n == nil {
+		return nil
+	}
+	if n.Type() != "list" && n.Type() != "tuple" && n.Type() != "set" {
+		// Single identifier? Still surface it.
+		t := strings.TrimSpace(nodeText(n, src))
+		if t == "" {
+			return nil
+		}
+		return []string{t}
+	}
+	var out []string
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		ch := n.NamedChild(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "identifier", "attribute", "dotted_name":
+			t := strings.TrimSpace(nodeText(ch, src))
+			if t != "" {
+				out = append(out, t)
+			}
+		}
+	}
+	return out
+}
+
+// findOpByName returns a pointer to the first SCOPE.Operation entity whose
+// SourceFile + Name matches, or nil when not found. Pointer is into the
+// shared slice so callers can mutate Properties in place.
+func findOpByName(entities []types.EntityRecord, filePath, name string) *types.EntityRecord {
+	for i := range entities {
+		e := &entities[i]
+		if e.SourceFile != filePath {
+			continue
+		}
+		if e.Kind == "SCOPE.Operation" && e.Name == name {
+			return e
+		}
+	}
+	return nil
+}
+
+// findClassByName returns a pointer to the SCOPE.Component/class entity
+// whose SourceFile + Name matches, or nil when not found.
+func findClassByName(entities []types.EntityRecord, filePath, name string) *types.EntityRecord {
+	for i := range entities {
+		e := &entities[i]
+		if e.SourceFile != filePath {
+			continue
+		}
+		if e.Kind == "SCOPE.Component" && e.Subtype == "class" && e.Name == name {
+			return e
+		}
+	}
+	return nil
+}

--- a/internal/extractors/python/django_drf_actions_test.go
+++ b/internal/extractors/python/django_drf_actions_test.go
@@ -1,0 +1,139 @@
+package python_test
+
+// django_drf_actions_test.go — fixture-style tests for issue #1967.
+//
+// Goal: the @action(...) decorator kwargs land on the per-method Operation
+// entity properties, AND a per-method decorator summary lands on the
+// parent class so the ClassManifest builder can surface it.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func findDRFOp(entities []types.EntityRecord, file, name string) *types.EntityRecord {
+	for i := range entities {
+		e := &entities[i]
+		if e.SourceFile == file && e.Name == name && e.Kind == "SCOPE.Operation" {
+			return e
+		}
+	}
+	return nil
+}
+
+func findDRFClass(entities []types.EntityRecord, file, name string) *types.EntityRecord {
+	for i := range entities {
+		e := &entities[i]
+		if e.SourceFile == file && e.Name == name && e.Kind == "SCOPE.Component" && e.Subtype == "class" {
+			return e
+		}
+	}
+	return nil
+}
+
+// TestDRFAction_BasicKwargs verifies @action(detail=False, methods=["get"],
+// serializer_class=FooSerializer) lands on the Operation entity.
+//
+// Issue #1967.
+func TestDRFAction_BasicKwargs(t *testing.T) {
+	src := `from rest_framework.decorators import action
+
+class ContractViewSet:
+    @action(detail=False, methods=["get"], serializer_class=AssignContactsSerializer, url_path="assign", permission_classes=[IsAdmin])
+    def assign_contacts(self, request):
+        return None
+`
+	out := extractPy(t, src, "api/views.py")
+	op := findDRFOp(out, "api/views.py", "ContractViewSet.assign_contacts")
+	if op == nil {
+		t.Fatalf("expected ContractViewSet.assign_contacts operation entity, not found. entities=%d", len(out))
+	}
+	checks := map[string]string{
+		"drf_action":         "true",
+		"is_detail":          "false",
+		"http_method":        "get",
+		"http_methods":       "get",
+		"serializer_class":   "AssignContactsSerializer",
+		"url_path":           "assign",
+		"permission_classes": "IsAdmin",
+	}
+	for k, want := range checks {
+		if got := op.Properties[k]; got != want {
+			t.Errorf("Properties[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestDRFAction_MultiMethod verifies `methods=["get","post"]` produces
+// `http_method="get"` (first verb) and `http_methods="get,post"`.
+func TestDRFAction_MultiMethod(t *testing.T) {
+	src := `from rest_framework.decorators import action
+
+class PermitViewSet:
+    @action(detail=True, methods=["get", "post"])
+    def approve(self, request):
+        return None
+`
+	out := extractPy(t, src, "api/views.py")
+	op := findDRFOp(out, "api/views.py", "PermitViewSet.approve")
+	if op == nil {
+		t.Fatalf("expected PermitViewSet.approve operation entity")
+	}
+	if op.Properties["http_method"] != "get" {
+		t.Errorf("http_method = %q, want \"get\"", op.Properties["http_method"])
+	}
+	if op.Properties["http_methods"] != "get,post" {
+		t.Errorf("http_methods = %q, want \"get,post\"", op.Properties["http_methods"])
+	}
+	if op.Properties["is_detail"] != "true" {
+		t.Errorf("is_detail = %q, want \"true\"", op.Properties["is_detail"])
+	}
+}
+
+// TestDRFAction_PerMethodDecoratorOnClass verifies the parent class also
+// gets a per-method decorator_<method> property so the ClassManifest
+// builder can render per-action decorations.
+func TestDRFAction_PerMethodDecoratorOnClass(t *testing.T) {
+	src := `from rest_framework.decorators import action
+
+class PermitViewSet:
+    @action(detail=False, methods=["post"])
+    def bulk_create(self, request):
+        return None
+`
+	out := extractPy(t, src, "api/views.py")
+	cls := findDRFClass(out, "api/views.py", "PermitViewSet")
+	if cls == nil {
+		t.Fatalf("PermitViewSet class not found")
+	}
+	v := cls.Properties["decorator_bulk_create"]
+	if v == "" {
+		t.Fatalf("expected decorator_bulk_create property on class, got empty")
+	}
+	if !strings.Contains(v, "action") {
+		t.Errorf("decorator snippet should mention 'action', got %q", v)
+	}
+}
+
+// TestDRFAction_NonActionDecoratorIgnored verifies methods decorated with
+// something OTHER than @action don't get drf_action=true stamped.
+func TestDRFAction_NonActionDecoratorIgnored(t *testing.T) {
+	src := `class FooView:
+    @staticmethod
+    def helper(): pass
+    @property
+    def x(self): return 1
+`
+	out := extractPy(t, src, "api/views.py")
+	for _, n := range []string{"FooView.helper", "FooView.x"} {
+		op := findDRFOp(out, "api/views.py", n)
+		if op == nil {
+			continue
+		}
+		if op.Properties["drf_action"] == "true" {
+			t.Errorf("%s should NOT be tagged drf_action=true", n)
+		}
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -265,6 +265,35 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// The pass never removes or modifies existing entities.
 	configModuleEmitted := emitConfigModuleEntity(root, file, &entities)
 
+	// Issue #1967 — capture DRF @action(...) decorator kwargs and surface
+	// them as Properties on the per-method Operation entity (and stamp a
+	// per-method decorator summary on the parent class). Runs after the
+	// primary walk so the matching Operation/Class entities exist.
+	func() {
+		defer func() { _ = recover() }()
+		emitDRFActionProperties(root, file, &entities)
+	}()
+
+	// Issue #1990 — Django admin REFERENCES edges from the admin module
+	// to its registered Models / ModelAdmin classes, plus ModelAdmin
+	// property capture (list_display, search_fields, …) and @admin.action
+	// method tagging. No-op for non-admin files.
+	func() {
+		defer func() { _ = recover() }()
+		emitDjangoAdminEdges(root, file, &entities)
+	}()
+
+	// Issue #1982 — DEPENDS_ON_CONFIG consumer edges. Scans the file body
+	// for `settings.X` and `os.environ.get("X")` / `os.getenv("X")` shapes
+	// and emits an edge from the enclosing entity (or the file when at
+	// module scope) to the canonical settings.py / .env Config entity.
+	// Runs after extractImports so the import-binding scan in Phase 1
+	// observes IMPORTS edges already attached to the file entity.
+	func() {
+		defer func() { _ = recover() }()
+		emitConfigConsumerEdges(root, file, &entities)
+	}()
+
 	// Issue #1884 — supplemental package-module pass (Wave 1).
 	// Emits one Module entity per Python package boundary (__init__.py or
 	// plain .py module) so docgen can seed per-package pages and flow


### PR DESCRIPTION
## 1. What changed
Three Django/DRF framework gaps closed as supplemental Python extractor passes:

- **`@action(...)` decorator kwargs** are now parsed from DRF ViewSet method decorators and stamped on the matching `SCOPE.Operation` entity (`drf_action`, `is_detail`, `http_method`, `http_methods`, `serializer_class`, `url_path`, `url_name`, `permission_classes`). A per-method decorator snippet is also stored on the parent class as `decorator_<method>` so the ClassManifest builder (#1861) can render per-action decorations.
- **`DEPENDS_ON_CONFIG` consumer edges** are now emitted from every function / method / class (or the file entity at module scope) that touches `settings.X` via `from django.conf import settings [as X]` or `os.environ.get("X")` / `os.environ["X"]` / `os.getenv("X")`. Edge carries `config_name` (`"settings"` or `".env"`) and a sorted comma-joined `keys` list.
- **`admin.site.register(...)` REFERENCES** are now emitted from the admin module entity to every Model AND ModelAdmin name registered via `admin.site.register(M [, A])`, the multi-model `admin.site.register([M1, M2])`, or `@admin.register(M [, M2, …])` decorator. ModelAdmin classes also get the full canonical property set captured (`list_display`, `list_filter`, `search_fields`, `readonly_fields`, `fieldsets`, `inlines`, `ordering`, `date_hierarchy`, `actions`), and `@admin.action(description="…")` methods are tagged `admin_action=true`.

## 2. Why
- `#1967`: W1R1 + W1R2 docgen smoke showed DRF actions losing all decorator metadata — endpoint detail couldn't show detail-vs-list, HTTP verb was guessed from convention, per-action serializer was invisible.
- `#1982`: `#1919` emitted Config entities for `settings.py` but the consumer side was never wired — Config nodes were topologically isolated (W3R3: 2 CONTAINS edges, 0 consumer edges). Composes with #1942 (auth resolver) and #1944 (Event Flows) which both need the config consumer chain to walk.
- `#1990`: W4R4 evidence on `core/admin.py` showed zero REFERENCES from the admin module to its registered Models/ModelAdmin classes — entire admin layer was graph-invisible. Also the existing extractor captured `list_display`/`list_filter` but missed `search_fields`; this closes that consistency gap.

## 3. How it works (architecture)
All three passes live in `internal/extractors/python/` and are wired into `Extract()` AFTER the primary `walkNode` + `extractImports` + `attachImportRelationships` + `emitReferences` pipeline, so they can:
1. Walk the parse tree fresh for their specific shapes.
2. Find emitted `SCOPE.Operation` / `SCOPE.Component` entities by `(SourceFile, Name)` and mutate `Properties` in place.
3. Read the file entity's `IMPORTS` relationships (already attached by `attachImportRelationships`) to recognise aliased / re-exported bindings without re-parsing the import statements.

Each pass runs inside a `defer recover()` shim, mirroring `emitReferences` / `emitRawSQLDBCallEdges`, so a failure can never abort primary entity output.

### `#1967` — `django_drf_actions.go`
`emitDRFActionProperties` walks every `class_definition`, scans the class body for `decorated_definition` children, and for each whose decorator list contains an `@action(...)` call (recognised by callee-leaf `"action"` across `identifier` / `attribute` / `dotted_name` shapes) parses the `keyword_argument` children. `methods=["get", "post"]` lowers and joins; `permission_classes=[A, B.C]` captures identifier/attribute source text. The matching `SCOPE.Operation` (Name=`<Class>.<method>`) gets the property bag; the parent class gets `decorator_<method>=<snippet>` (capped at 200 chars).

### `#1982` — `config_consumer.go`
`emitConfigConsumerEdges` reads the file's `IMPORTS` edges to build:
- `settingsAliases`: every local identifier bound to `django.conf.settings` (handles `as <alias>`).
- `osImported` / `osEnvironLocal` / `osGetenvLocal`: presence of `os` plus rebound `environ` / `getenv` from `from os import …`.

It then walks the tree, tracking the enclosing entity name on a stack (class → method → nested), and on each `attribute` / `call` / `subscript` node detects:
- `<alias>.X` → record under `settings`
- `os.environ.get("X")` / `os.getenv("X")` / `<alias>.get("X")` → record under `.env`
- `os.environ["X"]` → same

After the walk, one `DEPENDS_ON_CONFIG` edge per `(entity, target)` is appended with `keys=<sorted joined list>`. The `ToID` is a structural ref the resolver binds by-Name to the canonical `SCOPE.Config` entity emitted by `emitConfigModuleEntity` (`config_module` subtype, Name=`settings`).

### `#1990` — `django_admin.go`
`emitDjangoAdminEdges` no-ops for non-admin files (filename test: `admin.py` or any path segment `admin/`). For admin files:
1. Scans for `admin.site.register(...)` calls (positional model arg, optional positional admin-class arg, list/tuple first-arg expansion for multi-register).
2. Scans for `@admin.register(M, M2, …)` decorators on class definitions.
3. Appends one `REFERENCES` edge per unique target onto the file entity, with `Properties["pattern_type"]="admin_register"`.
4. Walks every class definition whose superclass list contains `ModelAdmin` / `TabularInline` / `StackedInline` and captures the canonical 9 attribute keys via `parseSimpleAssignments` (the existing helper).
5. For every method decorated with `@admin.action(...)`, parses `description=` and `permissions=` kwargs and stamps `admin_action=true` on the `SCOPE.Operation` entity.

This complements (does not replace) the existing `internal/custom/python/django.go` admin emission, which emits `admin_class` entities + `REGISTERS` edges to the model. The new edges wire the admin MODULE itself.

## 4. Tests
- `internal/extractors/python/django_drf_actions_test.go` — 4 tests: basic kwargs, multi-method ordering, per-method class snippet, non-action decorator ignored.
- `internal/extractors/python/config_consumer_test.go` — 5 tests: Django settings + aliased import, `os.environ.get` / `os.getenv`, `os.environ["X"]` subscript, no-edges-without-import negative case.
- `internal/extractors/python/django_admin_test.go` — 6 tests: `admin.site.register(M, A)`, bare register, `@admin.register` decorator, full ModelAdmin property capture (including the missing `search_fields`), `@admin.action` description, non-admin file no-op.

```
$ go test ./internal/extractors/python/... ./internal/docgen/...
ok  	github.com/cajasmota/archigraph/internal/extractors/python	0.911s
ok  	github.com/cajasmota/archigraph/internal/docgen	2.205s
```

`go build ./...` clean.

## 5. Performance
Three new passes per Python file, each O(file-AST-nodes). All three short-circuit early:
- DRF action pass returns immediately when no `class_definition` carries a `decorated_definition` whose decorator leaf is `action`.
- Config consumer pass returns immediately when neither `django.conf.settings` nor `os` is imported (the symbol-set check is O(1) per IMPORTS edge).
- Admin pass no-ops on filename — only `admin.py` / `admin/<…>.py` files are walked.

No new entity nodes are emitted (all changes are property stamps + edges), so node-count is unchanged. Edge growth is bounded by: one edge per `(viewset_method)` for DRF actions; one `DEPENDS_ON_CONFIG` per `(consumer_entity, target)` pair (sub-linear in references — they're collapsed into a `keys` property); one `REFERENCES` per admin-registered name per admin file. Daemon RSS impact is negligible.

## 6. Risk & rollback
- All three passes are wrapped in `defer recover()` — any panic recovers internally and leaves primary entity output intact.
- All three passes are additive: they only add properties or append relationships. They never delete or rewrite existing entities, edges, or properties (except adding new ones to `Properties`).
- The admin pass complements but does not replace the existing `REGISTERS` edges from `internal/custom/python/django.go`, so both surfaces are queryable.
- Rollback is a single revert of this commit — no data migration, no resolver changes, no graph-schema changes.

## 7. Out of scope / follow-ups
- Cross-repo resolution of `DEPENDS_ON_CONFIG` ToIDs against a `.env` config entity sitting in a sibling repo — relies on the existing structural-ref by-Name index; if it ever stops binding in cross-repo we'll revisit the ToID shape.
- DRF `@action` extraction does not yet handle dynamically-constructed kwargs (e.g. `methods=METHODS_TUPLE` where `METHODS_TUPLE` is a module-level constant). The constReg used elsewhere could be threaded in here in a follow-up.
- Bundle A (#1977 #1978 #1989) lands sibling Django relational gaps in `django_models.go` — file scope does not overlap.

Closes #1967
Closes #1982
Closes #1990