### PR TITLE
feat(docgen+python+graph): NeighbourBrief.Properties + Module hierarchy + edge Properties persistence (#2018 #2020 #2021)

### DIFF
--- a/internal/docgen/llm_bundle.go
+++ b/internal/docgen/llm_bundle.go
@@ -386,6 +386,38 @@ type NeighbourBrief struct {
 	// This field allows docgen to distinguish inbound callers from outbound
 	// callees when the Relationship kind alone is ambiguous (fixes #1965).
 	Direction string `json:"direction"`
+	// Properties carries the full Properties map from the underlying graph
+	// relationship (#2018). Extractor post-passes stamp annotations like
+	// `re_export=true`, `dead_import=true`, `live=false`, `is_async=true`,
+	// `is_task=true`, `public=true`, `alias=<name>`, `cross_repo=true`,
+	// `disposition_hint=ambiguous`, `import_alias`, `call_leaf`, etc. on
+	// edges (see Bundle B / C / D in internal/extractors/python and the
+	// cross-language linker). Surfacing the full map to docgen lets LLM
+	// section prose distinguish dead-vs-live imports, public re-exports,
+	// async callees, Celery task dispatch, and any future per-edge
+	// annotation without a NeighbourBrief schema change.
+	Properties map[string]string `json:"properties,omitempty"`
+	// DeadImport is a convenience accessor mirroring
+	// Properties["dead_import"] == "true". Stamped by Python's dead-import
+	// detector (#1985) on IMPORTS edges whose local binding is never
+	// referenced in the file body.
+	DeadImport bool `json:"dead_import,omitempty"`
+	// ReExport is a convenience accessor mirroring
+	// Properties["re_export"] == "true". Stamped by Python's __init__.py
+	// re-export annotator (#1991) on IMPORTS edges that participate in a
+	// package's public surface.
+	ReExport bool `json:"re_export,omitempty"`
+	// IsAsync is a convenience accessor mirroring
+	// Properties["is_async"] == "true". Stamped by Python's async-semantics
+	// pass (#1984) on Operation entities and CALLS edges produced by await
+	// expressions / channel_layer dispatch.
+	IsAsync bool `json:"is_async,omitempty"`
+	// Live is a convenience accessor mirroring
+	// Properties["live"] != "false". Defaults to true when the property is
+	// absent so existing edges (no live annotation) remain visible.
+	// Bundle C's dead-import detector stamps live=false on dead IMPORTS
+	// edges.
+	Live bool `json:"live,omitempty"`
 }
 
 // Canonical NeighbourBrief.Direction values.
@@ -622,7 +654,7 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 	// of a flat "RELATED" placeholder (#1879).
 	// neighbourDirections carries "inbound"/"outbound" per neighbour so that
 	// callers/callees can be distinguished (#1965).
-	_, entity, neighbours, neighbourKinds, neighbourDirections, seedRepo, err := loadEntityContext(opts.Group, opts.SeedEntityID)
+	_, entity, neighbours, neighbourKinds, neighbourDirections, neighbourProperties, seedRepo, err := loadEntityContext(opts.Group, opts.SeedEntityID)
 	if err != nil {
 		return nil, err
 	}
@@ -652,12 +684,35 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 		if i < len(neighbourDirections) && neighbourDirections[i] != "" {
 			dir = neighbourDirections[i]
 		}
+		// Issue #2018 — surface per-edge Properties so docgen LLM prose can
+		// see annotations like `re_export=true` (#1991), `dead_import=true`
+		// + `live=false` (#1985), `is_async=true` (#1984), `cross_repo=true`
+		// (#570), `disposition_hint=ambiguous`, `import_alias`, `call_leaf`,
+		// `package_init`, `public`, `alias`, etc. Without this map the LLM
+		// could not distinguish a live IMPORTS edge from a dead one, or a
+		// re-export from a private use — defeating half of Bundle B+C+D's
+		// extractor work.
+		var props map[string]string
+		if i < len(neighbourProperties) && neighbourProperties[i] != nil {
+			props = neighbourProperties[i]
+		}
 		briefs = append(briefs, NeighbourBrief{
 			EntityID:     n.ID,
 			Name:         n.Name,
 			Kind:         n.Kind,
 			Relationship: rel,
 			Direction:    dir,
+			Properties:   props,
+			// Convenience boolean accessors — derived once at build time
+			// so prompt templates and section-renderers don't need to
+			// repeat the string-comparison boilerplate.
+			DeadImport: props["dead_import"] == "true",
+			ReExport:   props["re_export"] == "true",
+			IsAsync:    props["is_async"] == "true",
+			// Live defaults to true when unset (existing edges with no
+			// dead-import pass coverage stay visible) and is false only
+			// when explicitly stamped live=false by the dead-import pass.
+			Live: props["live"] != "false",
 		})
 	}
 

--- a/internal/docgen/llm_bundle_meta_2018_2020_test.go
+++ b/internal/docgen/llm_bundle_meta_2018_2020_test.go
@@ -1,0 +1,291 @@
+package docgen_test
+
+// llm_bundle_meta_2018_2020_test.go — bundle-side regression coverage for
+// the Wave 9 meta-fix bundle.
+//
+//   #2018 — NeighbourBrief.Properties surfaces the per-edge Properties
+//           map (and the convenience accessor fields DeadImport /
+//           ReExport / IsAsync / Live) so docgen LLM prose can read
+//           Bundle B/C/D annotations.
+//   #2020 — Module-seeded BuildBundle no longer returns an empty
+//           neighbour list. The extractor wires a CONTAINS edge from
+//           every Module to its parallel SCOPE.Component(file) entity,
+//           and loadEntityContext widens the walk so IMPORTS edges
+//           attached to the file entity surface on the Module's bundle.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/docgen"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// metaBundleHarness seeds an isolated daemon root with a Module entity
+// + parallel file SCOPE.Component + two IMPORTS edges (one re-exported,
+// one dead) and returns (groupName, moduleEntityID).
+//
+// The shape mirrors the Wave-9 W9R1 production case (a Python
+// __init__.py with `from .X import Y` re-exports and a dead `from .Z
+// import W`) reduced to the minimum surface needed for the test —
+// only the entities and edges loadEntityContext walks.
+func metaBundleHarness(t *testing.T) (groupName, moduleID string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName = "meta-bundle-test-group"
+
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir fleet config dir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]any{
+		"name":  groupName,
+		"repos": []map[string]any{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write fleet config: %v", err)
+	}
+
+	// Entity IDs.
+	moduleID = graph.EntityID("repo", "Module", "client_fixture_x", "client_fixture_x/__init__.py")
+	fileID := graph.EntityID("repo", "SCOPE.Component", "client_fixture_x/__init__.py", "client_fixture_x/__init__.py")
+	importedReExportID := graph.EntityID("repo", "SCOPE.Component", "client_fixture_x.models.User", "client_fixture_x/models.py")
+	importedDeadID := graph.EntityID("repo", "SCOPE.Component", "client_fixture_x.unused.Stale", "client_fixture_x/unused.py")
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Stats:          graph.Stats{Files: 2, Entities: 4, Relationships: 3},
+		Entities: []graph.Entity{
+			{
+				ID:         moduleID,
+				Name:       "client_fixture_x",
+				Kind:       "Module",
+				Subtype:    "package",
+				Language:   "python",
+				SourceFile: "client_fixture_x/__init__.py",
+				StartLine:  1,
+				EndLine:    5,
+			},
+			{
+				ID:         fileID,
+				Name:       "client_fixture_x/__init__.py",
+				Kind:       "SCOPE.Component",
+				Subtype:    "file",
+				Language:   "python",
+				SourceFile: "client_fixture_x/__init__.py",
+				StartLine:  1,
+				EndLine:    5,
+			},
+			{
+				ID:         importedReExportID,
+				Name:       "client_fixture_x.models.User",
+				Kind:       "SCOPE.Component",
+				Subtype:    "class",
+				Language:   "python",
+				SourceFile: "client_fixture_x/models.py",
+				StartLine:  1,
+				EndLine:    10,
+			},
+			{
+				ID:         importedDeadID,
+				Name:       "client_fixture_x.unused.Stale",
+				Kind:       "SCOPE.Component",
+				Subtype:    "class",
+				Language:   "python",
+				SourceFile: "client_fixture_x/unused.py",
+				StartLine:  1,
+				EndLine:    10,
+			},
+		},
+		Relationships: []graph.Relationship{
+			// #2020 — Module → file CONTAINS so Module-seeded bundles
+			// reach the file's IMPORTS edges.
+			{
+				ID:     graph.RelationshipID(moduleID, fileID, "CONTAINS"),
+				FromID: moduleID,
+				ToID:   fileID,
+				Kind:   "CONTAINS",
+			},
+			// IMPORTS edges attach to the file entity (per
+			// internal/extractors/python/imports.go +
+			// prune_import_placeholders.go), each carrying Bundle C
+			// annotations.
+			{
+				ID:     graph.RelationshipID(fileID, importedReExportID, "IMPORTS"),
+				FromID: fileID,
+				ToID:   importedReExportID,
+				Kind:   "IMPORTS",
+				Properties: map[string]string{
+					"local_name":    "User",
+					"source_module": "client_fixture_x.models",
+					"imported_name": "User",
+					"re_export":     "true",
+					"package_init":  "true",
+					"public":        "true",
+				},
+			},
+			{
+				ID:     graph.RelationshipID(fileID, importedDeadID, "IMPORTS"),
+				FromID: fileID,
+				ToID:   importedDeadID,
+				Kind:   "IMPORTS",
+				Properties: map[string]string{
+					"local_name":    "Stale",
+					"source_module": "client_fixture_x.unused",
+					"imported_name": "Stale",
+					"dead_import":   "true",
+					"live":          "false",
+				},
+			},
+		},
+	}
+	docJSON, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	return groupName, moduleID
+}
+
+// TestIssue2020_ModuleSeededBundleSurfacesFileImports verifies that
+// BuildBundle seeded with a Module entity no longer returns an empty
+// neighbour list — IMPORTS edges attached to the parallel file
+// SCOPE.Component now reach the bundle via the CONTAINS-traversal
+// widening in loadEntityContext.
+func TestIssue2020_ModuleSeededBundleSurfacesFileImports(t *testing.T) {
+	groupName, moduleID := metaBundleHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: moduleID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	briefs := bundle.GraphContext.NeighbourBriefs
+	if len(briefs) == 0 {
+		t.Fatalf("Module-seeded bundle returned 0 neighbours (#2020 regression: phantom Module node)")
+	}
+
+	// Expect at least the two IMPORTS targets to appear as neighbours.
+	var sawReExport, sawDead int
+	for _, b := range briefs {
+		if b.Relationship == "IMPORTS" {
+			if b.ReExport {
+				sawReExport++
+			}
+			if b.DeadImport {
+				sawDead++
+			}
+		}
+	}
+	if sawReExport == 0 {
+		t.Errorf("expected at least one IMPORTS neighbour with ReExport=true, got 0; briefs=%+v", briefs)
+	}
+	if sawDead == 0 {
+		t.Errorf("expected at least one IMPORTS neighbour with DeadImport=true, got 0; briefs=%+v", briefs)
+	}
+}
+
+// TestIssue2018_NeighbourBriefSurfacesEdgeProperties verifies that
+// BuildBundle populates NeighbourBrief.Properties (and the convenience
+// accessor fields) from the underlying graph Relationship.Properties.
+// Without this every Bundle B/C/D edge annotation (re_export,
+// dead_import, live, is_async, cross_repo, ...) is invisible to docgen.
+func TestIssue2018_NeighbourBriefSurfacesEdgeProperties(t *testing.T) {
+	groupName, moduleID := metaBundleHarness(t)
+
+	bundle, err := docgen.BuildBundle(context.Background(), docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: moduleID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	var (
+		sawReExportProp bool
+		sawDeadProp     bool
+		sawLiveFalse    bool
+		sawLiveTrue     bool
+	)
+	for _, b := range bundle.GraphContext.NeighbourBriefs {
+		if b.Relationship != "IMPORTS" {
+			continue
+		}
+		if b.Properties["re_export"] == "true" {
+			sawReExportProp = true
+		}
+		if b.Properties["dead_import"] == "true" {
+			sawDeadProp = true
+		}
+		// Convenience accessor: Live should be false for the dead edge
+		// (live=false stamped) and true for the re-export edge (live
+		// property absent → default true).
+		if b.DeadImport && !b.Live {
+			sawLiveFalse = true
+		}
+		if b.ReExport && b.Live {
+			sawLiveTrue = true
+		}
+	}
+	if !sawReExportProp {
+		t.Errorf("NeighbourBrief.Properties missing re_export=true (extractor stamped, bundle dropped — #2018)")
+	}
+	if !sawDeadProp {
+		t.Errorf("NeighbourBrief.Properties missing dead_import=true (extractor stamped, bundle dropped — #2018)")
+	}
+	if !sawLiveFalse {
+		t.Errorf("NeighbourBrief.Live convenience accessor wrong for dead edge — expected false, got true")
+	}
+	if !sawLiveTrue {
+		t.Errorf("NeighbourBrief.Live convenience accessor wrong for re-export edge — expected true (default), got false")
+	}
+}

--- a/internal/docgen/llm_bundle_test.go
+++ b/internal/docgen/llm_bundle_test.go
@@ -3,6 +3,7 @@ package docgen_test
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -199,7 +200,7 @@ func TestRoundTrip_NeighbourBrief(t *testing.T) {
 	if err := json.Unmarshal(b, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if got != orig {
+	if !reflect.DeepEqual(got, orig) {
 		t.Errorf("round-trip mismatch: got %+v want %+v", got, orig)
 	}
 }

--- a/internal/docgen/tier0.go
+++ b/internal/docgen/tier0.go
@@ -146,7 +146,7 @@ func Run(opts RunOpts) (mdPath string, scoreFile string, score Score, err error)
 	}
 
 	// Load the group's graphs and locate the seed entity.
-	doc, entity, neighbours, _, _, _, err := loadEntityContext(opts.Group, opts.SeedEntityID)
+	doc, entity, neighbours, _, _, _, _, err := loadEntityContext(opts.Group, opts.SeedEntityID)
 	if err != nil {
 		return
 	}
@@ -283,7 +283,7 @@ func normalizeSeedEntityID(id string) (string, error) { return NormalizeSeedEnti
 // source of the edge (seed → neighbour) and NeighbourDirectionInbound when the
 // seed is the target (neighbour → seed). This lets callers distinguish inbound
 // callers from outbound callees when the edge kind alone is ambiguous (#1965).
-func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.Entity, neighbours []graph.Entity, neighbourKinds []string, neighbourDirections []string, seedRepo string, err error) {
+func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.Entity, neighbours []graph.Entity, neighbourKinds []string, neighbourDirections []string, neighbourProperties []map[string]string, seedRepo string, err error) {
 	seedID, err = normalizeSeedEntityID(seedID)
 	if err != nil {
 		return
@@ -351,22 +351,29 @@ func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.E
 		}
 	}
 
-	// Collect 1-hop neighbours via relationships. neighbourKinds and
-	// neighbourDirections are built in lockstep with neighbours so that
-	// downstream NeighbourBrief construction can surface the typed edge kind
-	// (#1879) and the direction relative to the seed (#1965).
+	// Collect 1-hop neighbours via relationships. neighbourKinds,
+	// neighbourDirections, and neighbourProperties are built in lockstep with
+	// neighbours so that downstream NeighbourBrief construction can surface
+	// the typed edge kind (#1879), the direction relative to the seed (#1965),
+	// and the per-edge Properties map stamped by extractor post-passes
+	// (#2018 — e.g. dead_import, re_export, live, is_async, cross_repo).
 	seen := make(map[string]bool)
-	if seed != nil {
+	// collect collects a (rel, neighbourID, dir) triple from the neighbour
+	// of the supplied anchor entity (seed itself, or a sibling entity
+	// reachable from the seed via CONTAINS — see the Module→file pass
+	// below for #2020). Maintains the seen set across both walks so a
+	// neighbour reached via both anchors is surfaced only once.
+	collect := func(anchorID string) {
 		for _, rel := range allRels {
 			var neighbourID string
 			var dir string
 			switch {
-			case rel.FromID == seed.ID:
-				// Outbound: seed → neighbour (seed is the source).
+			case rel.FromID == anchorID:
+				// Outbound: anchor → neighbour (anchor is the source).
 				neighbourID = rel.ToID
 				dir = NeighbourDirectionOutbound
-			case rel.ToID == seed.ID:
-				// Inbound: neighbour → seed (seed is the target).
+			case rel.ToID == anchorID:
+				// Inbound: neighbour → anchor (anchor is the target).
 				neighbourID = rel.FromID
 				dir = NeighbourDirectionInbound
 			default:
@@ -380,11 +387,62 @@ func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.E
 				neighbours = append(neighbours, *n)
 				neighbourKinds = append(neighbourKinds, rel.Kind)
 				neighbourDirections = append(neighbourDirections, dir)
+				neighbourProperties = append(neighbourProperties, rel.Properties)
+			}
+		}
+	}
+	if seed != nil {
+		// Mark the seed itself so the second walk (Module→file pass below)
+		// never echoes the seed back as a neighbour.
+		seen[seed.ID] = true
+		collect(seed.ID)
+
+		// Issue #2020 — Python Module entities are dual-emitted alongside a
+		// parallel SCOPE.Component(file) entity for the same __init__.py
+		// source file. IMPORTS / CONTAINS edges attach to the file entity,
+		// not the Module, so Module-seeded docgen previously surfaced zero
+		// neighbours. The extractor now emits a CONTAINS edge from Module
+		// → the file SCOPE.Component (see emitPackageModuleEntity in
+		// internal/extractors/python/package_module.go), and we walk that
+		// contained file's 1-hop neighbourhood here so all IMPORTS edges
+		// surface on the Module's bundle. The first walk above already
+		// added the file entity itself as a neighbour (CONTAINS); this
+		// pass surfaces its outbound IMPORTS / inbound CALLS / etc.
+		if isPythonModuleEntity(seed) {
+			for _, rel := range allRels {
+				if rel.Kind != "CONTAINS" || rel.FromID != seed.ID {
+					continue
+				}
+				containedID := rel.ToID
+				contained, ok := byID[containedID]
+				if !ok {
+					continue
+				}
+				if contained.Kind != "SCOPE.Component" || contained.Subtype != "file" {
+					continue
+				}
+				collect(containedID)
 			}
 		}
 	}
 
 	return
+}
+
+// isPythonModuleEntity reports whether e is a Python package-Module entity
+// emitted by internal/extractors/python/package_module.go (#1884). Used by
+// loadEntityContext to widen the neighbour walk so Module-seeded bundles
+// surface the IMPORTS edges attached to the parallel file SCOPE.Component
+// (#2020). The check is intentionally narrow — only the python Module
+// emission has this dual-entity shape today.
+func isPythonModuleEntity(e *graph.Entity) bool {
+	if e == nil {
+		return false
+	}
+	if e.Kind != "Module" {
+		return false
+	}
+	return e.Language == "python" || e.Language == ""
 }
 
 // repoEntry pairs a graph state directory with its absolute repo path from the

--- a/internal/docgen/tier1.go
+++ b/internal/docgen/tier1.go
@@ -151,7 +151,7 @@ func RunTier1(opts Tier1RunOpts) (mdPath string, scorePath string, score Tier1Sc
 	}
 
 	// Load entity context — reuse tier0 machinery.
-	_, entity, neighbours, _, _, _, err := loadEntityContext(opts.Group, opts.SeedEntityID)
+	_, entity, neighbours, _, _, _, _, err := loadEntityContext(opts.Group, opts.SeedEntityID)
 	if err != nil {
 		return
 	}

--- a/internal/docgen/tier2.go
+++ b/internal/docgen/tier2.go
@@ -159,7 +159,7 @@ func RunTier2(opts Tier2RunOpts) (outDir string, score Tier2Score, err error) {
 	}
 
 	// Load entity context for the seed.
-	_, seedEntity, _, _, _, _, loadErr := loadEntityContext(opts.Group, opts.SeedEntityID)
+	_, seedEntity, _, _, _, _, _, loadErr := loadEntityContext(opts.Group, opts.SeedEntityID)
 	if loadErr != nil {
 		err = fmt.Errorf("load seed entity: %w", loadErr)
 		return

--- a/internal/extractor/structural_ref.go
+++ b/internal/extractor/structural_ref.go
@@ -94,6 +94,30 @@ func BuildConstraintStructuralRef(filePath, qualifiedName string) string {
 	return "scope:constraint:python:" + filepath.ToSlash(filePath) + ":" + qualifiedName
 }
 
+// BuildFileComponentStructuralRef returns the canonical Format A structural-ref
+// for CONTAINS edges that point at a per-source-file SCOPE.Component
+// (subtype="file") entity emitted by FileEntity (#577). Shape:
+//
+//	scope:component:file:<lang>:<file>:<file>
+//
+// The 6-segment Format A shape is intentional — the resolver's
+// lookupStructural splits on stubScopeSegments=6 and indexes
+// byLocation[<file>][<name>], with the file entity carrying Name=<file>.
+// The 3-segment short-form (scope:component:file:<path>) is reserved by
+// the cross-language imports extractor for "the file is a component"
+// markers (see isHeuristicScopeStub in internal/resolve/refs.go) and
+// would be classified Dynamic instead of resolved.
+//
+// Used by the Python package-Module pass (#2020) to wire a CONTAINS edge
+// from each __init__.py Module entity to its parallel file
+// SCOPE.Component — so that Module-seeded docgen surfaces the IMPORTS /
+// REFERENCES edges that attach to the file entity rather than landing on
+// an empty neighbour list.
+func BuildFileComponentStructuralRef(lang, filePath string) string {
+	slash := filepath.ToSlash(filePath)
+	return "scope:component:file:" + lang + ":" + slash + ":" + slash
+}
+
 // BuildModuleStructuralRef returns the canonical Format A structural-ref for
 // CONTAINS edges that point at a Python package-level Module entity (#1884).
 // Shape:

--- a/internal/extractors/python/meta_2018_2020_2021_test.go
+++ b/internal/extractors/python/meta_2018_2020_2021_test.go
@@ -1,0 +1,421 @@
+package python_test
+
+// meta_2018_2020_2021_test.go — regression coverage for the Wave 9 meta-fix
+// bundle.
+//
+//   #2018 — NeighbourBrief.Properties surfacing (docgen-side; covered by
+//           internal/docgen tests; here we cover the producer side by
+//           confirming the Properties stamped by Bundle C round-trip onto
+//           the file entity's IMPORTS edges).
+//   #2020 — Module entities are no longer phantom nodes: every Module
+//           emitted by emitPackageModuleEntity carries a CONTAINS edge
+//           pointing at the parallel SCOPE.Component (subtype="file")
+//           entity for the same source file.
+//   #2021 — Bundle C edge Properties round-trip through graph.fb
+//           persistence: re_export / dead_import / live annotations on
+//           IMPORTS edges survive Save → Load → re-read.
+//
+// Fixture: client-fixture-X, a minimal __init__.py + sibling module pair
+// mirroring the production W9R1 shape (upvate-core) without leaking any
+// client name (standing scrub rule).
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runPythonExtractor is a small wrapper that feeds a virtual file through
+// the registered Python extractor and returns the records. Mirrors the
+// helper used by the other bundle tests so this file stays self-contained.
+func runPythonExtractor(t *testing.T, path, content string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("python")
+	if !ok {
+		t.Fatalf("python extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    path,
+		Content: []byte(content),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return recs
+}
+
+// findIMPORTSEdges returns every IMPORTS RelationshipRecord embedded on
+// the supplied records, paired with the owning entity's name for error
+// messages.
+func findIMPORTSEdges(records []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range records {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// findEntityByKind returns the first record matching kind+subtype (and optional
+// Name) or nil.
+func findEntityByKind(records []types.EntityRecord, kind, subtype string) *types.EntityRecord {
+	for i := range records {
+		e := &records[i]
+		if e.Kind == kind && (subtype == "" || e.Subtype == subtype) {
+			return e
+		}
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------
+// #2020 — Module entity carries CONTAINS edge to parallel file entity.
+// -----------------------------------------------------------------------
+
+func TestIssue2020_ModuleContainsFileEntity(t *testing.T) {
+	t.Parallel()
+
+	// client-fixture-X __init__.py — re-exports two symbols from sibling
+	// modules. The base extractor emits a SCOPE.Component(file) entity
+	// for __init__.py + a Module entity for the package boundary. The
+	// fix wires a CONTAINS edge from the Module to the file entity.
+	src := `from .models import User
+from .celery import app as celery_app
+
+__all__ = ("User", "celery_app")
+`
+	records := runPythonExtractor(t, "client_fixture_x/__init__.py", src)
+
+	module := findEntityByKind(records, "Module", "package")
+	if module == nil {
+		t.Fatalf("no Module entity emitted; records=%d", len(records))
+	}
+
+	// The CONTAINS edge points at the file SCOPE.Component via a Format A
+	// structural ref. We assert by suffix to stay independent of
+	// extractor.BuildFileComponentStructuralRef's exact encoding.
+	wantSuffix := "client_fixture_x/__init__.py"
+	var found bool
+	for _, r := range module.Relationships {
+		if r.Kind == "CONTAINS" && strings.HasPrefix(r.ToID, "scope:component:file:python:") &&
+			strings.HasSuffix(r.ToID, wantSuffix) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Module entity missing CONTAINS → file edge; relationships=%v", module.Relationships)
+	}
+
+	// Sanity: the per-source-file SCOPE.Component still exists and is
+	// the IMPORTS carrier (so the docgen-side traversal in
+	// loadEntityContext will actually find IMPORTS when it walks the
+	// contained file entity).
+	fileEntity := findEntityByKind(records, "SCOPE.Component", "file")
+	if fileEntity == nil {
+		t.Fatalf("no per-file SCOPE.Component entity emitted")
+	}
+	var importsOnFile int
+	for _, r := range fileEntity.Relationships {
+		if r.Kind == "IMPORTS" {
+			importsOnFile++
+		}
+	}
+	if importsOnFile < 2 {
+		t.Errorf("expected ≥2 IMPORTS edges on file entity, got %d (relationships=%v)",
+			importsOnFile, fileEntity.Relationships)
+	}
+}
+
+// Plain .py file (non-__init__) — the Module still wires the CONTAINS
+// → file edge so a docgen page seeded on the module surfaces the file's
+// IMPORTS / REFERENCES.
+func TestIssue2020_PlainModuleContainsFileEntity(t *testing.T) {
+	t.Parallel()
+
+	src := `import json
+
+def helper():
+    return json.dumps({})
+`
+	records := runPythonExtractor(t, "client_fixture_x/helpers.py", src)
+
+	module := findEntityByKind(records, "Module", "package")
+	if module == nil {
+		t.Fatalf("no Module entity emitted; records=%d", len(records))
+	}
+
+	var found bool
+	for _, r := range module.Relationships {
+		if r.Kind == "CONTAINS" &&
+			strings.HasPrefix(r.ToID, "scope:component:file:python:") &&
+			strings.HasSuffix(r.ToID, "client_fixture_x/helpers.py") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("plain-module CONTAINS → file edge missing; relationships=%v", module.Relationships)
+	}
+}
+
+// -----------------------------------------------------------------------
+// #2021 — Bundle C edge Properties (re_export, dead_import, live)
+//         persist through the graph.fb round-trip.
+// -----------------------------------------------------------------------
+
+func TestIssue2021_BundleCPropertiesRoundTripThroughFB(t *testing.T) {
+	t.Parallel()
+
+	// __init__.py with one re-export (User) listed in __all__ as
+	// public. Bundle C's applyReExports + applyDeadImports stamp the
+	// re_export / package_init / public properties on the file
+	// entity's IMPORTS edge.
+	src := `from .models import User
+
+__all__ = ("User",)
+`
+	records := runPythonExtractor(t, "client_fixture_x/__init__.py", src)
+
+	// Build a minimal graph.Document directly from the extracted records
+	// so we exercise the same fbwriter / fbreader paths used by the
+	// daemon's index pipeline (no need to spin up the full Indexer for
+	// a property-persistence test).
+	var rels []graph.Relationship
+	for _, e := range records {
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			rels = append(rels, graph.Relationship{
+				ID:         graph.RelationshipID(r.FromID, r.ToID, r.Kind),
+				FromID:     r.FromID,
+				ToID:       r.ToID,
+				Kind:       r.Kind,
+				Properties: r.Properties,
+			})
+		}
+	}
+	if len(rels) == 0 {
+		t.Fatalf("no IMPORTS edges produced by extractor; cannot test graph.fb round-trip")
+	}
+
+	// Pre-condition: at least one IMPORTS edge carries re_export=true on
+	// the in-memory records. If this fails the regression is upstream of
+	// graph.fb persistence (in the Bundle C extractor passes themselves).
+	var preReExport bool
+	for _, r := range rels {
+		if r.Properties["re_export"] == "true" {
+			preReExport = true
+			break
+		}
+	}
+	if !preReExport {
+		t.Fatalf("in-memory IMPORTS edge missing re_export=true property — extractor regression (Bundle C #1991 / #2006)")
+	}
+
+	doc := &graph.Document{
+		Version:       graph.SchemaVersion,
+		Repo:          "client-fixture-x",
+		Entities:      nil, // entities not needed for IMPORTS-only round-trip
+		Relationships: rels,
+	}
+
+	// Save to graph.fb in a tempdir, then load via the canonical
+	// LoadGraphFromDir path the daemon + docgen use in production.
+	tmp := t.TempDir()
+	fbPath := filepath.Join(tmp, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("fbwriter.WriteAtomic: %v", err)
+	}
+	loaded, err := graph.LoadGraphFromDir(tmp)
+	if err != nil {
+		t.Fatalf("graph.LoadGraphFromDir: %v", err)
+	}
+
+	// Post-condition: round-tripped IMPORTS edge still carries re_export=true.
+	// This is the exact assertion #2021 requested as a smoke test.
+	var postReExport bool
+	for _, r := range loaded.Relationships {
+		if r.Kind != "IMPORTS" {
+			continue
+		}
+		if r.Properties["re_export"] == "true" {
+			postReExport = true
+			break
+		}
+	}
+	if !postReExport {
+		t.Fatalf("re_export=true property LOST after graph.fb round-trip — properties stripped by fbwriter/fbreader path")
+	}
+
+	// Also assert package_init (every IMPORTS on an __init__.py) and
+	// public (User is in __all__) survive — these are the other
+	// annotations Bundle C surfaces and that #2021's full-graph scan
+	// reported as missing.
+	var sawPackageInit, sawPublic bool
+	for _, r := range loaded.Relationships {
+		if r.Kind != "IMPORTS" {
+			continue
+		}
+		if r.Properties["package_init"] == "true" {
+			sawPackageInit = true
+		}
+		if r.Properties["public"] == "true" {
+			sawPublic = true
+		}
+	}
+	if !sawPackageInit {
+		t.Errorf("package_init=true LOST after graph.fb round-trip")
+	}
+	if !sawPublic {
+		t.Errorf("public=true LOST after graph.fb round-trip")
+	}
+}
+
+// Companion assertion for the dead-import side (#1985): an unused
+// import is stamped with live=false / dead_import=true and those
+// annotations also survive the graph.fb round-trip.
+func TestIssue2021_DeadImportPropertiesRoundTripThroughFB(t *testing.T) {
+	t.Parallel()
+
+	// `Unused` is imported but never referenced in the body — Bundle C
+	// should mark it live=false / dead_import=true. `Used` is referenced
+	// by helper() so it stays live. Module-level `import x` is excluded
+	// from dead detection (side-effect imports), so we use the
+	// `from X import Y` shape that Bundle C does flag.
+	src := `from .models import Used
+from .models import Unused
+
+def helper():
+    return Used()
+`
+	records := runPythonExtractor(t, "client_fixture_x/helpers.py", src)
+
+	var rels []graph.Relationship
+	for _, e := range records {
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			rels = append(rels, graph.Relationship{
+				ID:         graph.RelationshipID(r.FromID, r.ToID, r.Kind),
+				FromID:     r.FromID,
+				ToID:       r.ToID,
+				Kind:       r.Kind,
+				Properties: r.Properties,
+			})
+		}
+	}
+	if len(rels) < 2 {
+		t.Fatalf("expected ≥2 IMPORTS edges (json + os), got %d", len(rels))
+	}
+
+	doc := &graph.Document{
+		Version:       graph.SchemaVersion,
+		Repo:          "client-fixture-x",
+		Relationships: rels,
+	}
+	tmp := t.TempDir()
+	fbPath := filepath.Join(tmp, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("fbwriter.WriteAtomic: %v", err)
+	}
+	loaded, err := graph.LoadGraphFromDir(tmp)
+	if err != nil {
+		t.Fatalf("graph.LoadGraphFromDir: %v", err)
+	}
+
+	var sawDead, sawLiveFalse bool
+	for _, r := range loaded.Relationships {
+		if r.Kind != "IMPORTS" {
+			continue
+		}
+		// dead_import marker stamped on the `os` edge.
+		if r.Properties["dead_import"] == "true" {
+			sawDead = true
+		}
+		if r.Properties["live"] == "false" {
+			sawLiveFalse = true
+		}
+	}
+	if !sawDead {
+		t.Errorf("dead_import=true property LOST after graph.fb round-trip")
+	}
+	if !sawLiveFalse {
+		t.Errorf("live=false property LOST after graph.fb round-trip")
+	}
+}
+
+// -----------------------------------------------------------------------
+// #2018 — Edge Properties stamped by Bundle C are visible on the
+//         extractor output (producer side). Docgen-side surfacing in
+//         NeighbourBrief is covered in internal/docgen/llm_bundle_test.go.
+// -----------------------------------------------------------------------
+
+func TestIssue2018_ExtractorStampsEdgePropertiesOnFileEntity(t *testing.T) {
+	t.Parallel()
+
+	// __init__.py — exercises the re_export + alias annotations.
+	// Every IMPORTS edge on an __init__.py is marked re_export=true by
+	// applyReExports, and Bundle C never flags __init__.py imports dead
+	// (they're treated as the package's public surface). So we test the
+	// dead_import annotation against a plain module below.
+	initSrc := `from .models import User as PublicUser
+
+__all__ = ("PublicUser",)
+`
+	initRecords := runPythonExtractor(t, "client_fixture_x/__init__.py", initSrc)
+	initEdges := findIMPORTSEdges(initRecords)
+	if len(initEdges) == 0 {
+		t.Fatalf("expected ≥1 IMPORTS edge on __init__.py, got 0")
+	}
+	var sawReExport, sawAlias bool
+	for _, r := range initEdges {
+		if r.Properties["re_export"] == "true" {
+			sawReExport = true
+		}
+		if r.Properties["alias"] == "PublicUser" {
+			sawAlias = true
+		}
+	}
+	if !sawReExport {
+		t.Errorf("expected at least one IMPORTS edge with re_export=true on __init__.py")
+	}
+	if !sawAlias {
+		t.Errorf("expected at least one IMPORTS edge with alias=PublicUser on __init__.py")
+	}
+
+	// Plain module — exercises the dead-import annotation. Bundle C
+	// only flags from-import shapes (module-level `import x` is treated
+	// as a side-effect import and never flagged dead).
+	modSrc := `from .models import Used
+from .models import Unused
+
+def helper():
+    return Used()
+`
+	modRecords := runPythonExtractor(t, "client_fixture_x/helpers.py", modSrc)
+	modEdges := findIMPORTSEdges(modRecords)
+	if len(modEdges) < 2 {
+		t.Fatalf("expected ≥2 IMPORTS edges on plain module, got %d", len(modEdges))
+	}
+	var sawDead bool
+	for _, r := range modEdges {
+		if r.Properties["dead_import"] == "true" {
+			sawDead = true
+		}
+	}
+	if !sawDead {
+		t.Errorf("expected at least one IMPORTS edge with dead_import=true (unused `Unused` import)")
+	}
+}

--- a/internal/extractors/python/package_module.go
+++ b/internal/extractors/python/package_module.go
@@ -229,6 +229,25 @@ func emitPackageModuleEntity(file extractor.FileInput, out *[]types.EntityRecord
 		Properties:    props,
 	}
 
+	// Issue #2020 — wire a CONTAINS edge from this Module to the parallel
+	// per-source-file SCOPE.Component (subtype="file") emitted by
+	// extractor.FileEntity at the top of Extract. Without this edge, a
+	// Module-seeded docgen pass cannot reach the IMPORTS / REFERENCES
+	// edges that attach to the file entity (the dominant cause of
+	// "phantom Module" empty-neighbours observed in W4R5 / W8R4 / W9R1
+	// across all 3 languages). Emitted unconditionally for both
+	// __init__.py packages AND plain .py file-modules so that
+	// per-module docgen pages work uniformly.
+	//
+	// The structural-ref is resolved by lookupStructural in
+	// internal/resolve/refs.go via byLocation[<file>][<file>] — the file
+	// entity carries Name=<file.Path> and SourceFile=<file.Path>, so the
+	// kind-aware probe in componentKindFamily finds it.
+	rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+		ToID: extractor.BuildFileComponentStructuralRef("python", file.Path),
+		Kind: string(types.RelationshipKindContains),
+	})
+
 	// For __init__.py files: wire CONTAINS edges from this Module to every
 	// top-level class and function entity that was emitted from this same file
 	// by the main walkNode pass. We look for entities in *out whose SourceFile


### PR DESCRIPTION
## Summary

Wave 9 ground-truth on the W9R1 corpus uncovered three composing meta-bugs that silently defeated half of the Bundle B/C/D extractor work. Fixed together because they share a common failure mode: producer stamps an annotation, a downstream consumer drops it.

Closes #2018
Closes #2020
Closes #2021

## What changed

### #2018 — NeighbourBrief drops edge Properties (HIGH)

`internal/docgen/llm_bundle.go`
- `NeighbourBrief.Properties map[string]string` — the full per-edge Properties map.
- Convenience accessors: `DeadImport` / `ReExport` / `IsAsync` / `Live`.
- `Live` defaults to `true` when the property is absent so existing edges stay visible; only an explicit `live=false` stamp flips it.

`internal/docgen/tier0.go`
- `loadEntityContext` now returns `neighbourProperties` in lockstep with `neighbours` / `neighbourKinds` / `neighbourDirections`. All four callers updated (tier0, tier1, tier2, llm_bundle).
- `BuildBundle` populates the new fields from the per-edge Properties map so downstream LLM section prose can read `re_export` / `dead_import` / `is_async` / `cross_repo` / `disposition_hint` / `import_alias` / `call_leaf` / `public` / `alias` / `package_init` / ... without a schema change.

### #2020 — Module entities are phantom nodes (HIGH)

`internal/extractor/structural_ref.go`
- `BuildFileComponentStructuralRef` emits the canonical Format A `scope:component:file:<lang>:<file>:<file>` shape. Distinct from the 3-segment short-form `scope:component:file:<path>` reserved by `internal/extractors/cross/imports` for "the file is a component" heuristic markers (`isHeuristicScopeStub`).

`internal/extractors/python/package_module.go`
- `emitPackageModuleEntity` wires a CONTAINS edge from every Module (both `__init__.py` and plain `.py`) to its parallel `SCOPE.Component(subtype="file")` entity via the new structural ref. The resolver binds it through `byLocation[<file>][<file>]` against the file entity's Name=file.Path.

`internal/docgen/tier0.go`
- `loadEntityContext` widens the neighbour walk: when the seed is a Python Module, walk neighbours of any CONTAINED `SCOPE.Component(file)` too. Module-seeded bundles now surface the IMPORTS / REFERENCES edges that attach to the file entity — closing every W1–W8 finding about empty Module bundles (#1969 W4R5 W8R4 #1975).

Option A from the ticket — preserves the file-level granularity distinction; no edge mass migration; resolver/disposition surface untouched.

### #2021 — Bundle C edge Properties round-trip through graph.fb (MED)

Verified the existing path:
- `applyReExports` / `applyDeadImports` stamp Properties on file-entity IMPORTS edges ✓
- `cmd/archigraph/index.go:3206` forwards `rel.Properties` into `graph.Relationship` ✓
- `internal/graph/fbwriter/writer.go:191 buildRelationship` serialises via `buildPropertyVector` ✓
- `internal/graph/load.go:252-263` loads back the full Properties map ✓

The Wave 9 "32,735 zero-property edges" finding reflected stale graph.fb data indexed before Bundle C (#2006) landed. Added a regression test that performs the exact graph.fb round-trip the ticket prescribed as a smoke test, so any future refactor that drops Properties from `buildRelationship` (or any pipeline step between extractor and disk) surfaces immediately.

## How I verified it

Ran:

```
go build ./...
go test ./internal/docgen/... ./internal/extractors/python/... \
        ./internal/graph/... ./internal/extractor/... ./internal/resolve/...
```

All target packages PASS. Pre-existing failures on `origin/main` (`TestModuleCoverage_AllEntitiesTagged`, `TestMCPHandshakeBudget`, `TestMCPToolDescriptions`) are unrelated and reproduced on a clean `origin/main` checkout.

## Tests added (7 new)

`internal/extractors/python/meta_2018_2020_2021_test.go`
- `TestIssue2018_ExtractorStampsEdgePropertiesOnFileEntity` — extractor stamps `re_export` / `alias` / `dead_import` on file-entity IMPORTS edges.
- `TestIssue2020_ModuleContainsFileEntity` — `__init__.py` Module carries CONTAINS → file structural ref.
- `TestIssue2020_PlainModuleContainsFileEntity` — plain `.py` Module also carries the CONTAINS edge.
- `TestIssue2021_BundleCPropertiesRoundTripThroughFB` — `re_export` / `package_init` / `public` survive `fbwriter.WriteAtomic` → `graph.LoadGraphFromDir`.
- `TestIssue2021_DeadImportPropertiesRoundTripThroughFB` — `dead_import` / `live=false` survive the same round-trip.

`internal/docgen/llm_bundle_meta_2018_2020_test.go`
- `TestIssue2020_ModuleSeededBundleSurfacesFileImports` — Module-seeded `BuildBundle` no longer returns empty neighbours; IMPORTS edges from the parallel file entity reach the bundle.
- `TestIssue2018_NeighbourBriefSurfacesEdgeProperties` — `NeighbourBrief.Properties` and the convenience accessors (`Live`, `DeadImport`, `ReExport`) reflect the underlying graph relationship Properties.

## Risk

Low.

- `NeighbourBrief` field additions are additive; existing serialised bundles deserialise unchanged.
- The new CONTAINS edge on Module entities is structurally identical to the existing CONTAINS edges Module already emits to top-level classes/functions; the resolver path (`byLocation`) is the same.
- The `loadEntityContext` widening only fires when `seed.Kind == "Module"`. Non-Module bundles see byte-identical behaviour.
- No graph.fb / fbwriter / fbreader changes — #2021 is a regression-test-only delta.

## Tradeoffs

- Could have replaced the dual emission (Module + SCOPE.Component for `__init__.py`) with a single entity (ticket Option B). Picked Option A because it keeps the file-level granularity distinction other extractor passes rely on (`extractor.FileEntity` is the IMPORTS carrier across every language) and avoids touching the cross-repo linker.
- `Live` defaults to `true` rather than echoing the raw property — chose convenience over fidelity because every existing edge in production has no `live` property and would otherwise render as "dead".

## Follow-ups (not in this PR)

- `internal/dashboard/handlers_graph.go:243` `graphEdgeWire` also strips Properties (called out in #2018 as "separate but related"); fix in a follow-up so the dashboard /api/graph endpoint surfaces the same metadata.
- Generalise the Module→file CONTAINS to Java/JS/TS Module entities once they adopt the dual-emission pattern.

## Constraints checklist

- [x] Branched off latest `origin/main` (eada7ad2).
- [x] Title includes `feat(docgen+python+graph): NeighbourBrief.Properties + Module hierarchy + edge Properties persistence (#2018 #2020 #2021)`.
- [x] PR body contains `Closes #2018`, `Closes #2020`, `Closes #2021`.
- [x] LOCKED 7-section format (Summary / What changed / How I verified it / Tests added / Risk / Tradeoffs / Follow-ups).
- [x] Stayed in worktree at `archigraph-worktrees/meta-fix-2018-2020-2021`; no `go install` / `launchctl kickstart` / daemon mutations.
- [x] `go test ./internal/extractors/python/... ./internal/docgen/... ./internal/graph/...` zero failures.
- [x] `go build ./...` clean.
- [x] Regression tests cover all three fixes specifically.
- [x] No client names — uses `client-fixture-X` throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)