### PR TITLE
fix(python-extractor): resolve relative imports `from .X import Y` against current package (#2019)

### DIFF
--- a/internal/extractors/python/crossmodule_calls.go
+++ b/internal/extractors/python/crossmodule_calls.go
@@ -227,10 +227,24 @@ func resolvePythonImportModule(modNode *sitter.Node, file extractor.FileInput) s
 	// current file's leaf module. Two dots = parent package = drop two
 	// leaves (current leaf + parent package boundary), and so on.
 	//
-	// Note: filePathToModule already collapses __init__.py to the parent
-	// directory, so `from . import x` inside a package's __init__ correctly
-	// refers to that package itself.
+	// Issue #2019 — __init__.py special case: filePathToModule already
+	// collapses `pkg/__init__.py` to `pkg` (stripping the `__init__`
+	// leaf). For a regular file `pkg/sub/mod.py` the module path is
+	// `pkg.sub.mod`, so `from .X` (dots=1) should drop the leaf `mod`
+	// and resolve to `pkg.sub.X`. For `pkg/__init__.py` the module path
+	// is already `pkg` (no leaf to drop), so `from .X` should resolve to
+	// `pkg.X` — i.e. drop zero additional levels.
+	//
+	// We detect this case by checking whether the original file path ends
+	// with `__init__.py`. When it does, one dot of the climb is already
+	// accounted for by the filePathToModule collapse, so we reduce `drop`
+	// by one to avoid stripping the package root itself.
 	drop := dots
+	isInitFile := strings.HasSuffix(file.Path, "__init__.py") ||
+		strings.HasSuffix(file.Path, "__init__")
+	if isInitFile && drop > 0 {
+		drop--
+	}
 	if drop > len(parts) {
 		// Escapes the file's known package — leave unresolved rather than
 		// guess. The existing bare-name resolver still has the option of

--- a/internal/extractors/python/imports_test.go
+++ b/internal/extractors/python/imports_test.go
@@ -223,3 +223,165 @@ func TestImportsSkipsRelative(t *testing.T) {
 		}
 	}
 }
+
+// Issue #2019 — Python relative-import resolution regression tests.
+//
+// `from .X import Y` was misresolved as external library X (leading dot
+// stripped before package resolution). The root cause: for __init__.py
+// files, filePathToModule already collapses the __init__ leaf, so
+// resolvePythonImportModule was dropping one extra level, leaving the
+// package root empty and causing celery/etc. to be mistaken for the
+// well-known external package of the same name.
+
+// TestRelativeImport_SingleDot verifies that `from .X import Y` inside a
+// regular module resolves source_module to the sibling module path, NOT to
+// the bare name X (which could collide with an external library).
+//
+// client-fixture-X: simple package layout simulating real project structure.
+//
+// `client_fixture_x/services/orders.py` + `from .helpers import format_id`
+// → source_module = "client_fixture_x.services.helpers"
+// → ToID = "client_fixture_x.services.helpers.format_id"  (NOT ext:helpers)
+func TestRelativeImport_SingleDot(t *testing.T) {
+	ex := &Extractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:    "client_fixture_x/services/orders.py",
+		Content: []byte("from .helpers import format_id\n"),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	r := findImportEdge(ents, "client_fixture_x.services.helpers")
+	if r == nil {
+		t.Fatalf("missing IMPORTS edge with source_module=client_fixture_x.services.helpers; got edges:")
+	}
+	if strings.HasPrefix(r.ToID, "ext:") {
+		t.Errorf("relative import from regular module got ext: ToID = %q, want internal form", r.ToID)
+	}
+	want := "client_fixture_x.services.helpers.format_id"
+	if r.ToID != want {
+		t.Errorf("ToID = %q, want %q", r.ToID, want)
+	}
+}
+
+// TestRelativeImport_SingleDot_InitPy is the W9R1 ground-truth regression:
+// `from .celery import app` in `client_fixture_x/__init__.py` must resolve
+// to source_module = "client_fixture_x.celery", NOT to "celery" (which
+// would then be rewritten to ext:celery:app by resolveImportToIDs).
+func TestRelativeImport_SingleDot_InitPy(t *testing.T) {
+	ex := &Extractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:    "client_fixture_x/__init__.py",
+		Content: []byte("from .celery import app\n"),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	// Must NOT have an ext:celery edge.
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			if strings.HasPrefix(r.ToID, "ext:celery") {
+				t.Errorf("__init__.py relative import got ext:celery ToID = %q, want internal resolution", r.ToID)
+			}
+		}
+	}
+	// Must have the correctly resolved edge.
+	r := findImportEdge(ents, "client_fixture_x.celery")
+	if r == nil {
+		t.Fatalf("missing IMPORTS edge with source_module=client_fixture_x.celery")
+	}
+	want := "client_fixture_x.celery.app"
+	if r.ToID != want {
+		t.Errorf("ToID = %q, want %q", r.ToID, want)
+	}
+}
+
+// TestRelativeImport_DoubleDot verifies `from ..X import Y` climbs one level
+// above the current package.
+//
+// `client_fixture_x/foo/bar.py` + `from ..models import BaseModel`
+// → source_module = "client_fixture_x.models"
+// → ToID = "client_fixture_x.models.BaseModel"
+func TestRelativeImport_DoubleDot(t *testing.T) {
+	ex := &Extractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:    "client_fixture_x/foo/bar.py",
+		Content: []byte("from ..models import BaseModel\n"),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	r := findImportEdge(ents, "client_fixture_x.models")
+	if r == nil {
+		t.Fatalf("missing IMPORTS edge with source_module=client_fixture_x.models")
+	}
+	want := "client_fixture_x.models.BaseModel"
+	if r.ToID != want {
+		t.Errorf("ToID = %q, want %q", r.ToID, want)
+	}
+}
+
+// TestRelativeImport_FromDotImport covers `from . import Y` (no module name
+// between dot and import keyword). The imported name Y is a sibling module.
+//
+// `client_fixture_x/services/dispatch.py` + `from . import helpers`
+// → source_module = "client_fixture_x.services"
+// → IMPORTS ToID should be internal (not ext:)
+func TestRelativeImport_FromDotImport(t *testing.T) {
+	ex := &Extractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:    "client_fixture_x/services/dispatch.py",
+		Content: []byte("from . import helpers\n"),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	// Any IMPORTS edge produced must NOT be ext: prefixed.
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			if strings.HasPrefix(r.ToID, "ext:") {
+				t.Errorf("from . import got ext: ToID = %q", r.ToID)
+			}
+		}
+	}
+}
+
+// TestRelativeImport_AliasedImport verifies that `from .X import Y as Z`
+// preserves the alias on the IMPORTS edge (local_name=Z, imported_name=Y).
+//
+// `client_fixture_x/api/views.py` + `from .serializers import OrderSerializer as OS`
+// → local_name = "OS"
+// → imported_name = "OrderSerializer"
+// → source_module = "client_fixture_x.api.serializers"
+func TestRelativeImport_AliasedImport(t *testing.T) {
+	ex := &Extractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:    "client_fixture_x/api/views.py",
+		Content: []byte("from .serializers import OrderSerializer as OS\n"),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	r := findImportEdge(ents, "client_fixture_x.api.serializers")
+	if r == nil {
+		t.Fatalf("missing IMPORTS edge with source_module=client_fixture_x.api.serializers")
+	}
+	if r.Properties == nil {
+		t.Fatalf("IMPORTS edge has nil Properties")
+	}
+	if got := r.Properties["local_name"]; got != "OS" {
+		t.Errorf("local_name = %q, want %q", got, "OS")
+	}
+	if got := r.Properties["imported_name"]; got != "OrderSerializer" {
+		t.Errorf("imported_name = %q, want %q", got, "OrderSerializer")
+	}
+	if strings.HasPrefix(r.ToID, "ext:") {
+		t.Errorf("aliased relative import got ext: ToID = %q", r.ToID)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the misresolution of Python relative imports (`from .X import Y`) that caused them to be treated as external library imports instead of internal module references.

**Root cause**: `resolvePythonImportModule` in `crossmodule_calls.go` dropped one too many package levels for `__init__.py` files. `filePathToModule` already collapses `pkg/__init__.py` → `pkg` (stripping the `__init__` leaf). With `dots=1`, the climb then dropped `pkg` itself, leaving `base=""`, so `from .celery import app` in `upvate_core/__init__.py` resolved to `source_module="celery"`. `resolveImportToIDs` found `celery` in `pythonKnownExternalRoots` and rewrote the `ToID` to `ext:celery:app`.

**Fix**: detect `__init__.py` files (path ends with `__init__.py`) and reduce `drop` by 1, so the already-collapsed package name is preserved as the base for relative resolution.

## What changed

- `internal/extractors/python/crossmodule_calls.go` — `resolvePythonImportModule`: detect `__init__.py` caller and reduce drop count by 1 to account for `filePathToModule`'s `__init__` collapse.
- `internal/extractors/python/imports_test.go` — five regression tests covering: single-dot regular module, single-dot `__init__.py` (W9R1 ground truth), double-dot parent climb, `from . import Y`, and `from .X import Y as Z` (alias preservation).

## Test results

```
go test ./internal/extractors/python/... ./internal/docgen/...
ok  github.com/cajasmota/archigraph/internal/extractors/python  1.2s
ok  github.com/cajasmota/archigraph/internal/docgen              1.5s
```

Zero failures. All five new regression tests pass.

## Composing issues

- **Closes #2019**
- After this lands, re-test #1991 (`from .X import Y` re-export emission via `__init__.py`) — the extractor issue was the root cause of the NULL edges there.
- #1985 (dead imports) and #2015 (downstream resolver) depend on correct import resolution; both should benefit from this fix.
- Branched from `origin/main` at `8b783e3c` (post-#2025 Module CONTAINS file entity).

## Impact

Every `from .X import Y` relative import in Python projects now resolves to the correct internal `Module` entity instead of a spurious `ext:` external. This is the dominant intra-package import style in Django / Python projects — fixes IMPORTS graph edges across all packages using `__init__.py` re-exports.

## Regression coverage

| Test | Scenario | Verifies |
|---|---|---|
| `TestRelativeImport_SingleDot` | `from .helpers import format_id` in regular module | `source_module=pkg.sub.helpers`, no `ext:` |
| `TestRelativeImport_SingleDot_InitPy` | `from .celery import app` in `__init__.py` | W9R1 ground truth; no `ext:celery`, `source_module=pkg.celery` |
| `TestRelativeImport_DoubleDot` | `from ..models import BaseModel` | parent-package climb correct |
| `TestRelativeImport_FromDotImport` | `from . import helpers` | no `ext:` on bare dot import |
| `TestRelativeImport_AliasedImport` | `from .serializers import X as Y` | `local_name=Y`, `imported_name=X`, no `ext:` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)