### PR TITLE
feat(engine): flows emit DAG with branches[] (Phase 1 — no branch-reason yet) (#1945)

### DIFF
--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -216,71 +216,76 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 		}
 	}
 
-	// BFS from each entry point.
-	best := make(map[traceKey][]string) // key -> longest chain
+	// #1945 Phase 1 — DAG walker. The pre-#1945 path projected branched
+	// call trees into N linear chains sharing a prefix, inflating Process
+	// counts 3-5×. Now we build ONE DAG per entry and persist it via a
+	// backward-compatible "primary linear chain" + a JSON-serialised DAG
+	// blob on the Process Properties map. Existing consumers (dashboard,
+	// MCP traces, JARVIS comet) continue to walk just the linear chain.
+	type dagEmit struct {
+		entry    string
+		terminal string
+		chain    []string
+		dag      *ChainStep
+		stats    dagBuildResult
+	}
+	emits := make([]dagEmit, 0, len(candidates))
+	dagCfg := dagWalkConfig{
+		MaxDepth:        cfg.MaxDepth,
+		BranchingFactor: cfg.BranchingFactor,
+		MaxNodes:        defaultDAGMaxNodes,
+	}
 	for _, c := range candidates {
-		traces, depthTrunc, fanTrunc := bfsTraces(c.id, adj, cfg)
-		stats.TruncatedDepth += depthTrunc
-		stats.TruncatedFanout += fanTrunc
-		for _, t := range traces {
-			// #754 — short chains are allowed when the chain traverses a
-			// FETCHES edge (i.e. crosses a repo boundary). Cross-repo
-			// bridges typically have a tiny intra-repo depth (caller →
-			// consumer endpoint = 2 steps) but the cross-stack signal is
-			// the load-bearing semantic, so keep them.
-			minSteps := cfg.MinSteps
-			if chainHasFetchesEdge(t, adj) || chainCrossesRepo(t, adj) {
-				// #769 — phantom cross-repo CALLS chains are typically
-				// shallow (caller → phantom terminal = 2 steps). Relax the
-				// MinSteps gate so they survive emission.
-				minSteps = 2
-			}
-			if len(t) < minSteps {
-				continue
-			}
-			term := t[len(t)-1]
-			k := traceKey{c.id, term}
-			if prev, ok := best[k]; !ok || len(t) > len(prev) {
-				best[k] = t
-			}
+		res := buildFlowDAG(c.id, adj, byID, dagCfg)
+		stats.TruncatedDepth += res.DepthTruncated
+		stats.TruncatedFanout += res.FanoutTruncated
+		if res.Root == nil {
+			continue
 		}
+		chain := primaryPath(res.Root)
+
+		// #754 — short chains are allowed when the chain traverses a
+		// FETCHES edge (cross-repo bridge) or a phantom cross-repo edge.
+		// Cross-repo bridges typically have a tiny intra-repo depth
+		// (caller → consumer endpoint = 2 steps); the cross-stack signal
+		// is load-bearing so we keep them.
+		minSteps := cfg.MinSteps
+		if chainHasFetchesEdge(chain, adj) || chainCrossesRepo(chain, adj) {
+			minSteps = 2
+		}
+		if len(chain) < minSteps {
+			continue
+		}
+		emits = append(emits, dagEmit{
+			entry:    c.id,
+			terminal: chain[len(chain)-1],
+			chain:    chain,
+			dag:      res.Root,
+			stats:    res,
+		})
 	}
 
-	// Stable, scored ordering of the surviving traces.
-	type emit struct {
-		chain     []string
-		entryName string
-		entryFile string
-	}
-	keys := make([]traceKey, 0, len(best))
-	for k := range best {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		// Longest chains first, then by entry id, then terminal id for
-		// determinism.
-		li := len(best[keys[i]])
-		lj := len(best[keys[j]])
+	// Stable ordering: longest primary chain first, then by entry id, then
+	// terminal id. Matches the prior tie-break so determinism tests pass.
+	sort.Slice(emits, func(i, j int) bool {
+		li := len(emits[i].chain)
+		lj := len(emits[j].chain)
 		if li != lj {
 			return li > lj
 		}
-		if keys[i].entry != keys[j].entry {
-			return keys[i].entry < keys[j].entry
+		if emits[i].entry != emits[j].entry {
+			return emits[i].entry < emits[j].entry
 		}
-		return keys[i].terminal < keys[j].terminal
+		return emits[i].terminal < emits[j].terminal
 	})
-	if len(keys) > cfg.MaxProcesses {
-		keys = keys[:cfg.MaxProcesses]
+	if len(emits) > cfg.MaxProcesses {
+		emits = emits[:cfg.MaxProcesses]
 	}
 
-	// Drop chains that are a strict prefix of a longer chain emitted from
-	// the same entry. This collapses sub-trace redundancy without losing
-	// the longest representation of any branch.
-	keys = dropPrefixSubtraces(keys, best)
-
-	// Emit Process entities + edges.
-	for _, k := range keys {
-		chain := best[k]
+	// Emit Process entities + edges. One Process per surviving entry —
+	// branches are captured inside the DAG attached as `branches_dag`.
+	for _, em := range emits {
+		chain := em.chain
 		entry := byID[chain[0]]
 		terminal := byID[chain[len(chain)-1]]
 		// #769 — phantom cross-repo terminals live in another repo's
@@ -385,6 +390,22 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 		// boundary is the endpoint step itself; see chainCrossesRepoBoundary).
 		if bridgeIdx := firstPhantomStepIndex(chain, adj); bridgeIdx >= 0 {
 			props["cross_stack_bridge_at_step"] = strconv.Itoa(bridgeIdx)
+		}
+
+		// #1945 Phase 1 — DAG metadata. `chain` above remains the primary
+		// linear path (leftmost depth-first) for backward compatibility;
+		// these new properties expose the full branched DAG that the
+		// walker produced. Phase 2 will populate per-step Reason values
+		// from per-language control-flow extraction; Phase 1 leaves
+		// Reason empty on every step.
+		props["dag_node_count"] = strconv.Itoa(em.stats.NodeCount)
+		props["branch_count"] = strconv.Itoa(em.stats.BranchCount)
+		props["is_dag"] = strconv.FormatBool(em.stats.BranchCount > 0)
+		if em.stats.NodeCapHit {
+			props["dag_node_cap_hit"] = "true"
+		}
+		if dagJSON := encodeDAGJSON(em.dag); dagJSON != "" {
+			props["branches_dag"] = dagJSON
 		}
 
 		doc.Entities = append(doc.Entities, graph.Entity{
@@ -647,114 +668,10 @@ func confidenceOK(r *graph.Relationship) bool {
 	return f >= 0.5
 }
 
-// bfsTraces runs forward BFS from entry, emitting one chain per reachable
-// terminal node within the configured depth + branching bounds. A "terminal"
-// is any node with no outgoing CALLS or the node at MaxDepth.
-//
-// Returns the slice of chains plus the count of depth- and fanout-truncated
-// branches (useful for stats).
-func bfsTraces(entry string, adj *callsAdjacency, cfg ProcessFlowConfig) ([][]string, int, int) {
-	type frame struct {
-		chain []string
-		seen  map[string]bool
-	}
-	initSeen := map[string]bool{entry: true}
-	work := []frame{{chain: []string{entry}, seen: initSeen}}
-	var out [][]string
-	depthTrunc, fanTrunc := 0, 0
-
-	for len(work) > 0 {
-		// Pop last (DFS-ish iterative — order doesn't matter for the
-		// emitted set since we dedupe by (entry,terminal)).
-		f := work[len(work)-1]
-		work = work[:len(work)-1]
-
-		current := f.chain[len(f.chain)-1]
-		neighbors := adj.out[current]
-		if len(neighbors) == 0 || len(f.chain) > cfg.MaxDepth {
-			if len(f.chain) > cfg.MaxDepth {
-				depthTrunc++
-			}
-			// Emit a copy — f.chain may alias slices we will mutate later.
-			out = append(out, append([]string(nil), f.chain...))
-			continue
-		}
-		// Sort + cap to branching factor for determinism.
-		sortedN := append([]string(nil), neighbors...)
-		sort.Strings(sortedN)
-		if len(sortedN) > cfg.BranchingFactor {
-			fanTrunc += len(sortedN) - cfg.BranchingFactor
-			sortedN = sortedN[:cfg.BranchingFactor]
-		}
-		extended := false
-		for _, n := range sortedN {
-			if f.seen[n] {
-				continue
-			}
-			extended = true
-			newSeen := make(map[string]bool, len(f.seen)+1)
-			for k := range f.seen {
-				newSeen[k] = true
-			}
-			newSeen[n] = true
-			newChain := append(append([]string(nil), f.chain...), n)
-			work = append(work, frame{chain: newChain, seen: newSeen})
-		}
-		if !extended {
-			// All neighbors already visited → terminal cycle stop.
-			out = append(out, append([]string(nil), f.chain...))
-		}
-	}
-	return out, depthTrunc, fanTrunc
-}
-
-// dropPrefixSubtraces removes chains that are strict prefixes of another
-// chain emitted from the same entry id. The longer chain is kept.
-func dropPrefixSubtraces(keys []traceKey, best map[traceKey][]string) []traceKey {
-	// Bucket by entry id.
-	byEntry := make(map[string][]traceKey)
-	for _, k := range keys {
-		byEntry[k.entry] = append(byEntry[k.entry], k)
-	}
-	keep := make(map[traceKey]bool, len(keys))
-	for _, ks := range byEntry {
-		// Longest first so we can short-circuit prefix checks.
-		sort.Slice(ks, func(i, j int) bool {
-			return len(best[ks[i]]) > len(best[ks[j]])
-		})
-		for i, k := range ks {
-			isPrefix := false
-			for j := 0; j < i; j++ {
-				if isStrictPrefix(best[k], best[ks[j]]) {
-					isPrefix = true
-					break
-				}
-			}
-			if !isPrefix {
-				keep[k] = true
-			}
-		}
-	}
-	out := make([]traceKey, 0, len(keep))
-	for _, k := range keys {
-		if keep[k] {
-			out = append(out, k)
-		}
-	}
-	return out
-}
-
-func isStrictPrefix(short, long []string) bool {
-	if len(short) >= len(long) {
-		return false
-	}
-	for i := range short {
-		if short[i] != long[i] {
-			return false
-		}
-	}
-	return true
-}
+// NOTE: the original `bfsTraces` (linear chain projection) was removed in
+// #1945 Phase 1. The DAG walker in process_flow_dag.go replaces it. The
+// query-time MCP traces walker (`internal/mcp/traces.go::followCallsBFS`)
+// is a separate read-side walker and remains untouched.
 
 // chainLabels returns the human-readable names of each step (or its ID
 // when the entity is missing).
@@ -1058,13 +975,6 @@ func computeProcessID(repo string, chain []string) string {
 		h.Write([]byte{0})
 	}
 	return "proc:" + hex.EncodeToString(h.Sum(nil))[:16]
-}
-
-// traceKey is a chain identity (defined here at file scope so the
-// dropPrefixSubtraces helper can take it as a parameter).
-type traceKey struct {
-	entry    string
-	terminal string
 }
 
 // pruneReachableEntries removes candidates that are reachable from any

--- a/internal/engine/process_flow_dag.go
+++ b/internal/engine/process_flow_dag.go
@@ -1,0 +1,279 @@
+// Process-flow DAG walker (#1945 Phase 1).
+//
+// The original `bfsTraces` walker projected a branched call tree into
+// multiple LINEAR chains sharing a prefix. That collapsed real branches
+// (if/else, try/catch, Promise.all, early returns) into 3-5× inflated
+// linear flows. Phase 1 replaces that projection with a true DAG: one
+// walk per entry, branches captured as child `ChainStep` nodes.
+//
+// Phase 1 scope:
+//   - Walker emits the DAG shape (this file).
+//   - `RunProcessFlowWithCompanions` derives a "primary path" (leftmost
+//     depth-first) for backward-compatible persistence of the `chain` /
+//     `chain_labels` properties + STEP_IN_PROCESS edges. Existing
+//     consumers (dashboard flows.tsx, JARVIS comet, MCP traces) ignore
+//     Branches and keep working.
+//   - New properties on the Process entity encode the full DAG:
+//       branch_count           — number of internal fan-out points
+//       dag_node_count         — total unique nodes reached
+//       is_dag                 — "true" iff any node has >1 children
+//       branches_dag           — JSON-serialised DAG (root ChainStep)
+//
+// Phase 2 (separate ticket) will populate `Reason` from per-language
+// control-flow extraction (if/try/switch/Promise.all). Phase 1 leaves
+// Reason empty.
+
+package engine
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ChainStep is one node in a process-flow DAG. Linear chains have
+// Branches == nil. Fan-out points (a node with >1 outgoing CALLS that
+// the walker decided to keep) populate Branches with one ChainStep per
+// child. Existing consumers can ignore Branches and walk only the first
+// step — the leftmost branch is the canonical "primary path".
+//
+// `Reason` is reserved for Phase 2 control-flow extraction
+// ("if" / "try" / "switch" / "promise_all"). Phase 1 always leaves it
+// empty.
+type ChainStep struct {
+	EntityID  string       `json:"entity_id"`
+	NodeID    string       `json:"node_id"`
+	StepIndex int          `json:"step_index"`
+	Name      string       `json:"name,omitempty"`
+	File      string       `json:"file,omitempty"`
+	Line      int          `json:"line,omitempty"`
+	Repo      string       `json:"repo,omitempty"`
+	Branches  []*ChainStep `json:"branches,omitempty"`
+	Reason    string       `json:"reason,omitempty"`
+}
+
+// dagBuildResult captures everything the caller needs after one DAG
+// walk: the root step, plus telemetry it can fold into processStats.
+type dagBuildResult struct {
+	Root            *ChainStep
+	NodeCount       int
+	BranchCount     int  // internal fan-out points (steps with len(Branches) > 1)
+	DepthTruncated  int  // branches dropped because depth cap was hit
+	FanoutTruncated int  // branches dropped because fan-out cap was hit
+	NodeCapHit      bool // expansion stopped because dag-node cap was reached
+}
+
+// dagWalkConfig is the subset of ProcessFlowConfig relevant to the DAG
+// walker, with Phase-1 specific bounds added.
+type dagWalkConfig struct {
+	MaxDepth        int // depth cap (cfg.MaxDepth)
+	BranchingFactor int // per-step fan-out cap (cfg.BranchingFactor)
+	MaxNodes        int // total nodes per DAG (Phase-1 cap = 50)
+}
+
+// defaultDAGMaxNodes is the per-flow node-count cap from #1945 Phase 1.
+// Caps DAG explosion in dense call graphs.
+const defaultDAGMaxNodes = 50
+
+// branchOverflowSuffix is appended to the EntityID of the sentinel
+// ChainStep that replaces dropped branches when the fan-out cap is hit.
+// (`+N more`). Stable suffix so the JSON encoding is deterministic.
+const branchOverflowEntityID = "__overflow__"
+
+// buildFlowDAG walks the CALLS adjacency forward from `entry` and
+// returns a single DAG rooted at the entry. All outgoing edges are
+// walked (not just the first), bounded by:
+//
+//   - cfg.MaxDepth        — depth cap (root counts as depth 1)
+//   - cfg.BranchingFactor — per-node fan-out cap; beyond N a synthetic
+//     "+N more" sentinel step is appended
+//   - cfg.MaxNodes        — total unique nodes per DAG (Phase-1 = 50)
+//   - cycle detection     — a node already on the current ancestor path
+//     is not re-expanded (matches the linear walker's cycle gate)
+//
+// Determinism: outgoing edges are sorted by target ID before expansion,
+// matching the existing linear walker's contract.
+func buildFlowDAG(entry string, adj *callsAdjacency, byID map[string]*graph.Entity, cfg dagWalkConfig) dagBuildResult {
+	res := dagBuildResult{}
+	if entry == "" || adj == nil {
+		return res
+	}
+	if cfg.MaxDepth <= 0 {
+		cfg.MaxDepth = 10
+	}
+	if cfg.BranchingFactor <= 0 {
+		cfg.BranchingFactor = 4
+	}
+	if cfg.MaxNodes <= 0 {
+		cfg.MaxNodes = defaultDAGMaxNodes
+	}
+
+	// visited tracks every node currently included anywhere in the DAG
+	// (across all branches). This is the global node-count cap. Cycle
+	// detection uses the per-path ancestor set passed into expand().
+	visited := map[string]bool{entry: true}
+
+	root := newChainStep(entry, 0, byID)
+	res.Root = root
+	res.NodeCount = 1
+
+	// expand walks one node's children. ancestors is the set of node IDs
+	// currently on the path from root → this node (inclusive). depth is
+	// 1-based so a single-node DAG has depth 1.
+	var expand func(node *ChainStep, ancestors map[string]bool, depth int)
+	expand = func(node *ChainStep, ancestors map[string]bool, depth int) {
+		if depth >= cfg.MaxDepth {
+			// Past the depth cap. Count outgoing-but-dropped children
+			// against DepthTruncated so stats stay comparable with the
+			// linear walker.
+			if n := len(adj.out[node.EntityID]); n > 0 {
+				res.DepthTruncated += n
+			}
+			return
+		}
+		neighbors := adj.out[node.EntityID]
+		if len(neighbors) == 0 {
+			return
+		}
+		sortedN := append([]string(nil), neighbors...)
+		sort.Strings(sortedN)
+
+		// Cycle filter: drop neighbors already on the current ancestor
+		// path. Preserves the linear walker's cycle invariant.
+		filtered := sortedN[:0]
+		// Use a fresh slice so we don't alias sortedN above.
+		filtered = make([]string, 0, len(sortedN))
+		for _, nb := range sortedN {
+			if ancestors[nb] {
+				continue
+			}
+			filtered = append(filtered, nb)
+		}
+
+		overflow := 0
+		if len(filtered) > cfg.BranchingFactor {
+			overflow = len(filtered) - cfg.BranchingFactor
+			res.FanoutTruncated += overflow
+			filtered = filtered[:cfg.BranchingFactor]
+		}
+
+		// Track which children we actually add so Branches stays in a
+		// deterministic order.
+		for i, nb := range filtered {
+			if res.NodeCount >= cfg.MaxNodes {
+				res.NodeCapHit = true
+				// Count any further dropped edges (including the ones
+				// we'd have expanded here) so the stats are honest.
+				res.DepthTruncated += len(filtered) - i + overflow
+				overflow = 0
+				break
+			}
+			// A child can appear multiple times in the DAG if reached
+			// from multiple parents (true DAG, not a tree). We add it
+			// as a fresh ChainStep node every time so the tree shape
+			// is unambiguous, but visited-tracking still counts unique
+			// EntityIDs for the global cap.
+			child := newChainStep(nb, depth, byID)
+			node.Branches = append(node.Branches, child)
+			if !visited[nb] {
+				visited[nb] = true
+				res.NodeCount++
+			}
+			// Recurse with extended ancestor set.
+			nextAncestors := make(map[string]bool, len(ancestors)+1)
+			for k := range ancestors {
+				nextAncestors[k] = true
+			}
+			nextAncestors[nb] = true
+			expand(child, nextAncestors, depth+1)
+		}
+
+		// Append "+N more" sentinel if we dropped branches to the
+		// fan-out cap. Sentinel is a leaf (no Branches) and does not
+		// count against MaxNodes (it isn't a real entity).
+		if overflow > 0 {
+			sentinel := &ChainStep{
+				EntityID:  branchOverflowEntityID,
+				NodeID:    branchOverflowEntityID,
+				StepIndex: depth, // sentinel sits at the child depth
+				Name:      "+" + strconv.Itoa(overflow) + " more",
+				Reason:    "fanout_cap",
+			}
+			node.Branches = append(node.Branches, sentinel)
+		}
+
+		// Tally internal fan-out (>1 real children, excluding the
+		// sentinel since it's a synthetic placeholder).
+		realKids := 0
+		for _, b := range node.Branches {
+			if b.EntityID != branchOverflowEntityID {
+				realKids++
+			}
+		}
+		if realKids > 1 {
+			res.BranchCount++
+		}
+	}
+
+	initAncestors := map[string]bool{entry: true}
+	expand(root, initAncestors, 1)
+
+	return res
+}
+
+// newChainStep materialises a ChainStep for a given entity ID, looking
+// up metadata in byID. Missing entities yield a step with only EntityID
+// / NodeID set (this is the phantom-cross-repo-target case).
+func newChainStep(id string, stepIndex int, byID map[string]*graph.Entity) *ChainStep {
+	s := &ChainStep{
+		EntityID:  id,
+		NodeID:    id,
+		StepIndex: stepIndex,
+	}
+	if e, ok := byID[id]; ok && e != nil {
+		s.Name = e.Name
+		s.File = e.SourceFile
+		s.Line = e.StartLine
+	}
+	return s
+}
+
+// primaryPath returns the leftmost depth-first path through the DAG.
+// This is the backward-compatible "linear chain" we still persist on
+// the Process entity so existing consumers (dashboard, MCP traces,
+// JARVIS) keep working unchanged. Stops at the first leaf or at the
+// overflow sentinel (which is never a real entity).
+func primaryPath(root *ChainStep) []string {
+	if root == nil {
+		return nil
+	}
+	out := []string{root.EntityID}
+	cur := root
+	for len(cur.Branches) > 0 {
+		next := cur.Branches[0]
+		if next.EntityID == branchOverflowEntityID {
+			break
+		}
+		out = append(out, next.EntityID)
+		cur = next
+	}
+	return out
+}
+
+// encodeDAGJSON marshals the DAG to a compact JSON blob suitable for
+// stashing on the Process entity's Properties map. Errors are swallowed:
+// the DAG fields are advisory metadata, not load-bearing semantics, and
+// the linear chain remains the authoritative timeline.
+func encodeDAGJSON(root *ChainStep) string {
+	if root == nil {
+		return ""
+	}
+	b, err := json.Marshal(root)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+

--- a/internal/engine/process_flow_dag_test.go
+++ b/internal/engine/process_flow_dag_test.go
@@ -1,0 +1,308 @@
+// Process-flow DAG walker tests (#1945 Phase 1).
+//
+// Exercises buildFlowDAG directly so we can assert the DAG shape
+// (Branches structure, cycle gate, depth + fanout + node caps) without
+// the noise of entry-point ranking + the rest of RunProcessFlow.
+// End-to-end tests covering the persisted properties live alongside
+// the existing process_flow_test.go cases.
+
+package engine
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// newAdj builds a callsAdjacency from a flat list of (from, to) pairs.
+// Test-only helper — production paths go through buildCallsAdjacency.
+func newAdj(edges ...[2]string) *callsAdjacency {
+	a := &callsAdjacency{
+		out:         make(map[string][]string),
+		in:          make(map[string]int),
+		fetches:     make(map[edgeKey]bool),
+		phantom:     make(map[edgeKey]bool),
+		handlerCont: make(map[edgeKey]bool),
+	}
+	seen := make(map[string]map[string]bool)
+	for _, e := range edges {
+		from, to := e[0], e[1]
+		if seen[from] == nil {
+			seen[from] = make(map[string]bool)
+		}
+		if seen[from][to] {
+			continue
+		}
+		seen[from][to] = true
+		a.out[from] = append(a.out[from], to)
+		a.in[to]++
+	}
+	return a
+}
+
+func TestBuildFlowDAG_LinearChainHasNilBranches(t *testing.T) {
+	// entry → a → b → c — single linear chain, no fan-out anywhere.
+	adj := newAdj([2]string{"entry", "a"}, [2]string{"a", "b"}, [2]string{"b", "c"})
+	res := buildFlowDAG("entry", adj, nil, dagWalkConfig{MaxDepth: 8, BranchingFactor: 4, MaxNodes: 50})
+	if res.Root == nil {
+		t.Fatal("Root is nil")
+	}
+	if res.BranchCount != 0 {
+		t.Errorf("BranchCount = %d, want 0 for linear chain", res.BranchCount)
+	}
+	if res.NodeCount != 4 {
+		t.Errorf("NodeCount = %d, want 4", res.NodeCount)
+	}
+	// Walk down: each step should have exactly one child until the leaf.
+	cur := res.Root
+	depth := 0
+	for cur != nil {
+		if depth < 3 {
+			if len(cur.Branches) != 1 {
+				t.Errorf("step %d: len(Branches) = %d, want 1", depth, len(cur.Branches))
+			}
+		} else {
+			if cur.Branches != nil {
+				t.Errorf("leaf step has non-nil Branches: %v", cur.Branches)
+			}
+		}
+		if len(cur.Branches) == 0 {
+			break
+		}
+		cur = cur.Branches[0]
+		depth++
+	}
+	if got := primaryPath(res.Root); strings.Join(got, ",") != "entry,a,b,c" {
+		t.Errorf("primaryPath = %v, want [entry a b c]", got)
+	}
+}
+
+func TestBuildFlowDAG_TwoWayFanOut(t *testing.T) {
+	// entry → {a, b} — single fan-out point. Both children appear in
+	// Branches and the leftmost (sorted) is the primary path.
+	adj := newAdj([2]string{"entry", "b"}, [2]string{"entry", "a"})
+	res := buildFlowDAG("entry", adj, nil, dagWalkConfig{MaxDepth: 8, BranchingFactor: 4, MaxNodes: 50})
+	if len(res.Root.Branches) != 2 {
+		t.Fatalf("len(Branches) = %d, want 2", len(res.Root.Branches))
+	}
+	// Sorted by EntityID → "a" then "b".
+	if res.Root.Branches[0].EntityID != "a" || res.Root.Branches[1].EntityID != "b" {
+		t.Errorf("Branches order = [%s %s], want [a b]",
+			res.Root.Branches[0].EntityID, res.Root.Branches[1].EntityID)
+	}
+	if res.BranchCount != 1 {
+		t.Errorf("BranchCount = %d, want 1", res.BranchCount)
+	}
+	if res.NodeCount != 3 {
+		t.Errorf("NodeCount = %d, want 3", res.NodeCount)
+	}
+}
+
+func TestBuildFlowDAG_NestedFanOut(t *testing.T) {
+	// entry → a → {b, c}
+	// One fan-out at depth 2. Inner Branches must themselves be inspectable.
+	adj := newAdj(
+		[2]string{"entry", "a"},
+		[2]string{"a", "b"},
+		[2]string{"a", "c"},
+	)
+	res := buildFlowDAG("entry", adj, nil, dagWalkConfig{MaxDepth: 8, BranchingFactor: 4, MaxNodes: 50})
+	if len(res.Root.Branches) != 1 {
+		t.Fatalf("root.Branches = %d, want 1", len(res.Root.Branches))
+	}
+	a := res.Root.Branches[0]
+	if a.EntityID != "a" {
+		t.Fatalf("first branch entity = %q, want a", a.EntityID)
+	}
+	if len(a.Branches) != 2 {
+		t.Errorf("a.Branches = %d, want 2", len(a.Branches))
+	}
+	for _, child := range a.Branches {
+		if child.Branches != nil {
+			t.Errorf("inner leaf %q has Branches=%v", child.EntityID, child.Branches)
+		}
+	}
+	if res.BranchCount != 1 {
+		t.Errorf("BranchCount = %d, want 1", res.BranchCount)
+	}
+}
+
+func TestBuildFlowDAG_CyclePrevention(t *testing.T) {
+	// entry → a → b → a (cycle back to a). The cycle MUST NOT cause
+	// infinite expansion; the second visit of `a` is dropped.
+	adj := newAdj(
+		[2]string{"entry", "a"},
+		[2]string{"a", "b"},
+		[2]string{"b", "a"},
+	)
+	res := buildFlowDAG("entry", adj, nil, dagWalkConfig{MaxDepth: 8, BranchingFactor: 4, MaxNodes: 50})
+	// Walk down — b should be a leaf (its only child `a` is on the
+	// ancestor path).
+	if res.Root == nil {
+		t.Fatal("Root nil")
+	}
+	a := res.Root.Branches[0]
+	if a == nil || a.EntityID != "a" {
+		t.Fatalf("first branch = %+v, want EntityID=a", a)
+	}
+	b := a.Branches[0]
+	if b == nil || b.EntityID != "b" {
+		t.Fatalf("inner branch = %+v, want EntityID=b", b)
+	}
+	if len(b.Branches) != 0 {
+		t.Errorf("b.Branches = %v, want empty (cycle should be cut)", b.Branches)
+	}
+}
+
+func TestBuildFlowDAG_BranchFanoutCap(t *testing.T) {
+	// entry has 7 outgoing edges; BranchingFactor=4 → 4 real children +
+	// a "+3 more" overflow sentinel. FanoutTruncated counts the dropped 3.
+	edges := [][2]string{}
+	for _, name := range []string{"n0", "n1", "n2", "n3", "n4", "n5", "n6"} {
+		edges = append(edges, [2]string{"entry", name})
+	}
+	adj := newAdj(edges...)
+	res := buildFlowDAG("entry", adj, nil, dagWalkConfig{MaxDepth: 8, BranchingFactor: 4, MaxNodes: 50})
+	if got := len(res.Root.Branches); got != 5 { // 4 real + 1 sentinel
+		t.Errorf("len(Branches) = %d, want 5 (4 real + 1 sentinel)", got)
+	}
+	sentinel := res.Root.Branches[len(res.Root.Branches)-1]
+	if sentinel.EntityID != branchOverflowEntityID {
+		t.Errorf("last branch is not the overflow sentinel: %+v", sentinel)
+	}
+	if sentinel.Reason != "fanout_cap" {
+		t.Errorf("sentinel.Reason = %q, want fanout_cap", sentinel.Reason)
+	}
+	if !strings.Contains(sentinel.Name, "3") {
+		t.Errorf("sentinel.Name = %q, want to contain dropped count 3", sentinel.Name)
+	}
+	if res.FanoutTruncated != 3 {
+		t.Errorf("FanoutTruncated = %d, want 3", res.FanoutTruncated)
+	}
+}
+
+func TestBuildFlowDAG_DepthCap(t *testing.T) {
+	// 12-deep linear chain, MaxDepth=4 → walker stops at depth 4 and
+	// records the dropped edge in DepthTruncated.
+	edges := [][2]string{}
+	for i := 0; i < 12; i++ {
+		from := "entry"
+		if i > 0 {
+			from = "n" + strconv.Itoa(i)
+		}
+		to := "n" + strconv.Itoa(i+1)
+		edges = append(edges, [2]string{from, to})
+	}
+	adj := newAdj(edges...)
+	res := buildFlowDAG("entry", adj, nil, dagWalkConfig{MaxDepth: 4, BranchingFactor: 4, MaxNodes: 50})
+	path := primaryPath(res.Root)
+	if len(path) > 4 {
+		t.Errorf("primary path length = %d, want ≤ 4 (depth cap)", len(path))
+	}
+	if res.DepthTruncated == 0 {
+		t.Errorf("DepthTruncated = 0, want > 0 — depth cap should have dropped edges")
+	}
+}
+
+func TestBuildFlowDAG_NodeCap(t *testing.T) {
+	// Wide tree: entry has 30 leaves. Default MaxNodes=50 → all fit.
+	// Now lower MaxNodes=5 → walker stops after 5 nodes.
+	edges := [][2]string{}
+	for i := 0; i < 30; i++ {
+		edges = append(edges, [2]string{"entry", "leaf" + strconv.Itoa(i)})
+	}
+	adj := newAdj(edges...)
+	res := buildFlowDAG("entry", adj, nil, dagWalkConfig{MaxDepth: 8, BranchingFactor: 30, MaxNodes: 5})
+	if res.NodeCount > 5 {
+		t.Errorf("NodeCount = %d, want ≤ 5", res.NodeCount)
+	}
+	if !res.NodeCapHit {
+		t.Errorf("NodeCapHit = false, want true")
+	}
+}
+
+func TestBuildFlowDAG_EncodeDAGJSONRoundTrip(t *testing.T) {
+	// The branches_dag property is a JSON-serialised ChainStep tree.
+	// Sanity-check that linear chains round-trip and fan-out points
+	// surface both children.
+	adj := newAdj(
+		[2]string{"entry", "a"},
+		[2]string{"a", "b"},
+		[2]string{"a", "c"},
+	)
+	byID := map[string]*graph.Entity{
+		"entry": {ID: "entry", Name: "handleSubmit", SourceFile: "x.go", StartLine: 10},
+		"a":     {ID: "a", Name: "validate", SourceFile: "x.go", StartLine: 20},
+		"b":     {ID: "b", Name: "writeDB", SourceFile: "x.go", StartLine: 30},
+		"c":     {ID: "c", Name: "writeLog", SourceFile: "x.go", StartLine: 40},
+	}
+	res := buildFlowDAG("entry", adj, byID, dagWalkConfig{MaxDepth: 8, BranchingFactor: 4, MaxNodes: 50})
+	js := encodeDAGJSON(res.Root)
+	if js == "" {
+		t.Fatal("encodeDAGJSON returned empty")
+	}
+	for _, want := range []string{`"entity_id":"entry"`, `"entity_id":"a"`, `"entity_id":"b"`, `"entity_id":"c"`, `"name":"validate"`, `"branches"`} {
+		if !strings.Contains(js, want) {
+			t.Errorf("encoded DAG missing %q\nfull: %s", want, js)
+		}
+	}
+}
+
+func TestProcessFlow_EmitsDAGPropertiesOnBranchedFlow(t *testing.T) {
+	// End-to-end: a branched entry should emit ONE Process with
+	// is_dag=true, branch_count>0, dag_node_count>chain_len, and a
+	// non-empty branches_dag JSON blob.
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "entry", Name: "handleSubmit", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+		{ID: "a", Name: "validate", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+		{ID: "b", Name: "writeDB", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+		{ID: "c", Name: "writeLog", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+	}
+	// entry → a, a → b, a → c — branched DAG at `a`.
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "entry", ToID: "a", Kind: "CALLS"},
+		{ID: "2", FromID: "a", ToID: "b", Kind: "CALLS"},
+		{ID: "3", FromID: "a", ToID: "c", Kind: "CALLS"},
+	}
+	stats := RunProcessFlow(doc, DefaultProcessFlowConfig())
+	if stats.Processes != 1 {
+		t.Fatalf("Processes = %d, want 1 (DAG collapses projections)", stats.Processes)
+	}
+	p := findProcess(doc)
+	if p == nil {
+		t.Fatal("no Process emitted")
+	}
+	if p.Properties["is_dag"] != "true" {
+		t.Errorf("is_dag = %q, want true", p.Properties["is_dag"])
+	}
+	if got := p.Properties["branch_count"]; got != "1" {
+		t.Errorf("branch_count = %q, want 1", got)
+	}
+	if got := p.Properties["dag_node_count"]; got != "4" {
+		t.Errorf("dag_node_count = %q, want 4", got)
+	}
+	if dagJSON := p.Properties["branches_dag"]; dagJSON == "" {
+		t.Errorf("branches_dag property is empty")
+	} else if !strings.Contains(dagJSON, `"entity_id":"c"`) {
+		t.Errorf("branches_dag missing branch child: %s", dagJSON)
+	}
+}
+
+func TestProcessFlow_LinearFlowMarkedNotDAG(t *testing.T) {
+	// A purely linear chain should have is_dag=false and branch_count=0.
+	doc := buildChainDoc("r", 4)
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	p := findProcess(doc)
+	if p == nil {
+		t.Fatal("no Process emitted")
+	}
+	if p.Properties["is_dag"] != "false" {
+		t.Errorf("linear chain is_dag = %q, want false", p.Properties["is_dag"])
+	}
+	if p.Properties["branch_count"] != "0" {
+		t.Errorf("linear chain branch_count = %q, want 0", p.Properties["branch_count"])
+	}
+}


### PR DESCRIPTION
## Summary

Process-flow walker now emits a true DAG instead of N linear-chain projections of one branched call tree. Phase 1 ships the data-shape change + walker rewrite; Phase 2 will populate per-step `Reason` from per-language control-flow extraction (if / try / switch / Promise.all).

Closes #1945 (Phase 1)

The pre-#1945 walker (`bfsTraces`) picked one outgoing CALLS edge per node and projected branched call trees into N linear flows sharing a prefix. On upvate / polyglot-platform that inflated Process counts ~3-5× and made cross-stack labelling wrong by some branching factor. Phase 1 collapses those projections into one DAG-bearing Process per entry.

## What changed

### New data shape — `internal/engine/process_flow_dag.go`

```go
type ChainStep struct {
    EntityID, NodeID, Name, File, Repo string
    StepIndex, Line                    int
    Branches                           []*ChainStep // nil on linear leaves; populated at fan-out points
    Reason                             string       // Phase 2 will populate; Phase 1 always empty
}
```

`buildFlowDAG(entry, adj, byID, cfg)` returns one DAG rooted at the entry, walking ALL outgoing CALLS at each node. Bounded by:

- `MaxDepth` (`cfg.MaxDepth`)
- `BranchingFactor` (`cfg.BranchingFactor`; default 4)
- `MaxNodes` (new Phase-1 per-flow node-count cap, default 50)
- Cycle detection on the current ancestor path
- `+N more` overflow sentinel (`Reason="fanout_cap"`) when fan-out is capped

### Walker integration — `internal/engine/process_flow.go`

`RunProcessFlowWithCompanions` now builds one DAG per surviving entry candidate and drops the old `(entry, terminal)` projection dedupe. That's where the 3-5× count drop comes from.

Backward compatibility is preserved: `chain` / `chain_labels` continue to encode the LEFTMOST depth-first path through the DAG. The dashboard, MCP traces walker, and JARVIS comet all read those and keep working unchanged.

The branched DAG is exposed via new Process Properties:

| property | type | meaning |
|----------|------|---------|
| `branches_dag` | JSON | serialised `*ChainStep` root |
| `is_dag` | bool | `true` iff any node has >1 children |
| `branch_count` | int | number of internal fan-out points |
| `dag_node_count` | int | total unique nodes in the DAG |
| `dag_node_cap_hit` | bool | present iff `MaxNodes` truncated expansion |

### Removed

- `bfsTraces`, `dropPrefixSubtraces`, `isStrictPrefix`, `traceKey` — no callers outside `process_flow.go`.
- The MCP query-time walker (`internal/mcp/traces.go::followCallsBFS`) is independent and untouched.

## How I verified it

```
go build ./...
go test ./internal/engine/... ./internal/docgen/...
```

All target packages PASS.

`go test ./internal/mcp/...` shows 4 pre-existing failures (`TestToolNameSurface`, `TestElapsedMSCoverageAllTools`, `TestMCPHandshakeBudget`, `TestMCPToolDescriptions`) that all reproduce on a clean `origin/main` checkout — they are about the registered-tool count + an `archigraph_status` description length, unrelated to this PR. Flow / trace / dashboard MCP tests (`go test ./internal/mcp/ -run 'Trace|Flow|Dashboard|Process'`) PASS.

## Tests added (10 new)

`internal/engine/process_flow_dag_test.go`

- `TestBuildFlowDAG_LinearChainHasNilBranches` — linear chain has `Branches=nil` on every leaf.
- `TestBuildFlowDAG_TwoWayFanOut` — fan-out point populates `Branches` with both children, sorted by `EntityID`.
- `TestBuildFlowDAG_NestedFanOut` — inner `ChainStep` also carries its own `Branches`.
- `TestBuildFlowDAG_CyclePrevention` — cycle back to an ancestor is cut (no infinite expansion).
- `TestBuildFlowDAG_BranchFanoutCap` — 7-way fan-out with cap=4 produces 4 real children + a `+3 more` sentinel; `FanoutTruncated == 3`.
- `TestBuildFlowDAG_DepthCap` — 12-deep chain with `MaxDepth=4` is bounded; `DepthTruncated > 0`.
- `TestBuildFlowDAG_NodeCap` — wide tree with `MaxNodes=5` stops at 5 unique nodes; `NodeCapHit=true`.
- `TestBuildFlowDAG_EncodeDAGJSONRoundTrip` — `branches_dag` JSON contains every entity + name.
- `TestProcessFlow_EmitsDAGPropertiesOnBranchedFlow` — end-to-end: branched entry → 1 Process, `is_dag=true`, `branch_count=1`, `dag_node_count=4`, non-empty `branches_dag`.
- `TestProcessFlow_LinearFlowMarkedNotDAG` — linear chain → `is_dag=false`, `branch_count=0`.

All 17 pre-existing `process_flow*` tests pass unchanged.

## Risk

Low.

- `chain` / `chain_labels` properties + `STEP_IN_PROCESS` edges keep the same shape (linear leftmost path). Every existing consumer reads those and continues to work.
- Net effect on existing consumers' data: they see fewer Process entities (the projections that previously appeared as separate flows now live as branches inside one DAG). The `dropPrefixSubtraces` post-processing that did this collapse partially today is no longer needed — the walker output is already non-redundant.
- New properties (`branches_dag`, `is_dag`, `branch_count`, `dag_node_count`, `dag_node_cap_hit`) are additive. Consumers that don't know about them are unaffected.
- `MaxNodes=50` cap is new; can be raised in `dagWalkConfig` once measured against real graphs.
- Cross-stack labelling (`cross_stack`, `cross_stack_reason`, `cross_stack_bridge_at_step`, `crosses_external_lib`) is computed on the linear primary chain — same semantics as before. Branches that cross repos are not yet labelled (Phase 1 limitation; same boundary as today).

## Tradeoffs

- **Primary path is leftmost depth-first.** Deterministic, matches the prior implicit choice (sorted neighbours, first-child). Alternative: choose the longest / cross-stack-bearing branch as the primary. Deferred — would change `chain` semantics in ways existing consumers might depend on. Phase 2 is a better time to revisit once `Reason` exists.
- **One Process per entry.** Today the (entry, terminal) dedupe emits multiple Processes when branches reach distinct terminals. Switching to one-per-entry is the load-bearing count drop the issue calls for. Side effect: total `stats.Processes` will drop sharply on indexed corpora (this IS the correct measurement).
- **Branches dedupe at the entity level.** A node reachable from two parents is materialised as two `ChainStep` nodes (tree, not graph). Keeps the JSON unambiguous; `visited`-tracking still bounds total unique entities at `MaxNodes`.

## Follow-ups

- **#2027 — JARVIS comet branch-aware rendering** (filed alongside this PR). Phase 1 keeps the comet on the linear primary path so it still works; #2027 covers the parallel-comet visualisation that uses `branches_dag` properly.
- **#1945 Phase 2** — per-language control-flow extraction populating `ChainStep.Reason` (`if` / `try` / `switch` / `promise_all` / `for`).
- **#1944 Event Flows** — inherits the branched data shape; fan-out is the normal pub/sub topology.
- **#1926 JARVIS** — original comet ticket, now needs the Phase-1-aware rendering update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)