### PR TITLE
feat(java+auth): Phase 1 Java auth_policy resolver (annotations + class-level + Quarkus config + framework default) (#1942 Phase 1)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -3280,12 +3280,27 @@ func runJavaAnnotationRoutes(classified []classifiedFile) []types.EntityRecord {
 	}
 	contentByPath := make(map[string][]byte, len(classified))
 	var javaPaths []string
+	// #1942 Phase 1 — collect Quarkus signals so the synthesised endpoints
+	// carry a resolved auth_policy (annotations → class-level inheritance →
+	// Quarkus config-driven permissions → quarkus-security framework default).
+	buildDescriptors := map[string]string{}
+	propertiesFiles := map[string]string{}
 	for _, cf := range classified {
-		if cf.language != "java" {
-			continue
+		switch cf.language {
+		case "java":
+			contentByPath[cf.relPath] = cf.content
+			javaPaths = append(javaPaths, cf.relPath)
 		}
-		contentByPath[cf.relPath] = cf.content
-		javaPaths = append(javaPaths, cf.relPath)
+		base := cf.relPath
+		if idx := strings.LastIndex(base, "/"); idx >= 0 {
+			base = base[idx+1:]
+		}
+		switch base {
+		case "pom.xml", "build.gradle", "build.gradle.kts":
+			buildDescriptors[cf.relPath] = string(cf.content)
+		case "application.properties":
+			propertiesFiles[cf.relPath] = string(cf.content)
+		}
 	}
 	if len(javaPaths) == 0 {
 		return nil
@@ -3293,7 +3308,8 @@ func runJavaAnnotationRoutes(classified []classifiedFile) []types.EntityRecord {
 	reader := func(relPath string) []byte {
 		return contentByPath[relPath]
 	}
-	return engine.ApplyJavaAnnotationRoutes(javaPaths, reader)
+	authCtx := engine.BuildJavaAuthContext(buildDescriptors, propertiesFiles)
+	return engine.ApplyJavaAnnotationRoutesWithContext(javaPaths, reader, authCtx)
 }
 
 // releaseClassifiedASTs explicitly drops the tree-sitter parse trees + source

--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cajasmota/archigraph/internal/engine"
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/mcp"
 	"github.com/cajasmota/archigraph/internal/types"
@@ -37,8 +38,17 @@ type v2PathRoute struct {
 	IsWebhook       bool     `json:"is_webhook"`
 	WebhookProvider string   `json:"webhook_provider,omitempty"`
 	Auth            bool     `json:"auth"`
-	Repos           []string `json:"repos"`
-	Controller      string   `json:"controller"`
+	// AuthChip is the rendered chip label for the route in the left-rail
+	// list (e.g. `[Public]`, `[Auth required]`, `[Roles: ADMIN]`,
+	// `[Auth: default]`, `[Auth: probable]`, `[Auth: unknown]`). Computed
+	// from the resolved auth_policy emitted by the indexer (#1942 Phase 1).
+	AuthChip string `json:"auth_chip,omitempty"`
+	// AuthChipTone is the visual tone hint for the chip:
+	// "accent" | "muted" | "warning". Lets the frontend keep the chip
+	// taxonomy in sync without hard-coding label parsing.
+	AuthChipTone string   `json:"auth_chip_tone,omitempty"`
+	Repos        []string `json:"repos"`
+	Controller   string   `json:"controller"`
 	// Confidence (#1129) is the 0..1 candidate-quality score computed at
 	// list-build time. Always populated when the confidence filter ran.
 	Confidence float64 `json:"confidence,omitempty"`
@@ -177,6 +187,12 @@ type v2PathDetail struct {
 	WebhookProvider string             `json:"webhook_provider,omitempty"`
 	Auth            bool               `json:"auth"`
 	AuthScheme      string             `json:"auth_scheme,omitempty"`
+	// AuthPolicy is the structured posture resolved by the indexer
+	// (#1942 Phase 1). Frontend renders the header chip from AuthChip /
+	// AuthChipTone and the expandable evidence list from SourceChain.
+	AuthPolicy   *v2AuthPolicy      `json:"auth_policy,omitempty"`
+	AuthChip     string             `json:"auth_chip,omitempty"`
+	AuthChipTone string             `json:"auth_chip_tone,omitempty"`
 	Description     v2DescriptionBlock `json:"description"`
 	Parameters      []v2PathParameter  `json:"parameters"`
 	ResponseShapes  []v2ResponseShape  `json:"response_shapes"`
@@ -185,6 +201,30 @@ type v2PathDetail struct {
 	Outbound        v2OutboundQueries  `json:"outbound"`
 	SideEffects     []v2PathEntity     `json:"side_effects"`
 	Tests           []v2PathEntity     `json:"tests"`
+}
+
+// v2AuthSignal is one evidence row in the resolved auth_policy source chain.
+// Mirrors engine.AuthSignal but uses snake_case JSON for the wire format the
+// dashboard already consumes elsewhere.
+type v2AuthSignal struct {
+	Kind     string `json:"kind"`
+	EntityID string `json:"entity_id,omitempty"`
+	Text     string `json:"text"`
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+}
+
+// v2AuthPolicy is the wire shape of the resolved auth posture surfaced on
+// the endpoint detail response (#1942 Phase 1). The frontend renders the
+// header chip from Chip/ChipTone and the expandable evidence list from
+// SourceChain.
+type v2AuthPolicy struct {
+	Required    bool           `json:"required"`
+	Method      string         `json:"method"`
+	Roles       []string       `json:"roles,omitempty"`
+	Scopes      []string       `json:"scopes,omitempty"`
+	Confidence  string         `json:"confidence"`
+	SourceChain []v2AuthSignal `json:"source_chain,omitempty"`
 }
 
 // v2OrphanCaller is one orphan caller row.
@@ -256,6 +296,8 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 		ControllerID   string
 		ControllerFile string
 		Language       string
+		// #1942 Phase 1 — resolved auth_policy for this endpoint.
+		AuthPolicy engine.AuthPolicy
 	}
 
 	var eps []rawEP
@@ -338,6 +380,7 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 				controllerID = inferControllerName(e.Name)
 			}
 
+			authPolicy := readAuthPolicyFromEntity(e.Properties)
 			eps = append(eps, rawEP{
 				ID:             dashPrefixedID(repo.Slug, e.ID),
 				Path:           path,
@@ -346,7 +389,7 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 				Framework:      e.Properties["framework"],
 				IsWebhook:      e.Properties["is_webhook"] == "true",
 				WebhookProv:    e.Properties["webhook_provider"],
-				Auth:           e.Properties["auth"] == "true" || e.Properties["auth_scheme"] != "",
+				Auth:           e.Properties["auth"] == "true" || e.Properties["auth_scheme"] != "" || authPolicy.Required,
 				Repo:           repo.Slug,
 				SourceFile:     e.SourceFile,
 				StartLine:      e.StartLine,
@@ -354,6 +397,7 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 				ControllerID:   controllerID,
 				ControllerFile: controllerFile,
 				Language:       e.Language,
+				AuthPolicy:     authPolicy,
 			})
 		}
 	}
@@ -423,6 +467,15 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 		}
 		if ep.Auth {
 			pr.Auth = true
+		}
+		// #1942 Phase 1 — accumulate the strongest auth_policy across all
+		// handlers that share this path. Precedence: high > medium > low.
+		// We attach the rendered chip directly on the route so the left-rail
+		// renders without re-resolving on the client.
+		if pr.AuthChip == "" || authPolicyStronger(ep.AuthPolicy, pr.AuthChipTone) {
+			label, tone := resolveAuthChip(ep.AuthPolicy)
+			pr.AuthChip = label
+			pr.AuthChipTone = tone
 		}
 		if !containsStr(pr.Repos, ep.Repo) {
 			pr.Repos = append(pr.Repos, ep.Repo)
@@ -676,6 +729,10 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		// parameter annotations (populated for POST/PUT/PATCH endpoints).
 		RequestBodyType      string
 		RequestBodyParamName string
+		// #1942 Phase 1 — resolved auth_policy decoded from the endpoint's
+		// `auth_policy` property. Multiple `matched` entries for the same path
+		// are reduced to the strongest policy when building the response.
+		AuthPolicy engine.AuthPolicy
 	}
 
 	var hits []matched
@@ -820,6 +877,8 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 				// Issue #1909 — request body type from entity properties.
 				RequestBodyType:      e.Properties["request_body_type"],
 				RequestBodyParamName: e.Properties["request_body_param_name"],
+				// #1942 Phase 1 — auth_policy decoded from the endpoint entity.
+				AuthPolicy: readAuthPolicyFromEntity(e.Properties),
 			})
 		}
 	}
@@ -1045,6 +1104,28 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// #1942 Phase 1 — pick the strongest auth_policy across all matched
+	// handlers (a single path can have several verbs each with its own
+	// policy; the detail page shows the most decisive verdict).
+	var strongest engine.AuthPolicy
+	strongest.Method = "unknown"
+	strongest.Confidence = "low"
+	bestRank := 0
+	for _, h := range hits {
+		_, tone := resolveAuthChip(h.AuthPolicy)
+		if r := toneRank(tone); r > bestRank {
+			bestRank = r
+			strongest = h.AuthPolicy
+		}
+	}
+	authChip, authChipTone := resolveAuthChip(strongest)
+	authPolicyWire := authPolicyToWire(strongest)
+	// Detail-level `auth` boolean now also reflects a structurally resolved
+	// requirement (not only legacy `auth=true` / `auth_scheme=` props).
+	if !auth && strongest.Required {
+		auth = true
+	}
+
 	writeV2JSON(w, http.StatusOK, v2OK(v2PathDetail{
 		PathHash:        pathHash,
 		Path:            pathStr,
@@ -1053,6 +1134,9 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		IsWebhook:       isWebhook,
 		WebhookProvider: webhookProv,
 		Auth:            auth,
+		AuthPolicy:      authPolicyWire,
+		AuthChip:        authChip,
+		AuthChipTone:    authChipTone,
 		AuthScheme:      authScheme,
 		Description:     description,
 		Parameters:      params,

--- a/internal/dashboard/v2_paths_auth.go
+++ b/internal/dashboard/v2_paths_auth.go
@@ -1,0 +1,160 @@
+// v2_paths_auth.go — auth_policy surfacing for the v2 paths API.
+//
+// Phase 1 (#1942) wired the resolver into the Java extractor; this file is
+// the bridge that turns the persisted `auth_policy` JSON property on
+// http_endpoint entities into the v2 wire shape consumed by the dashboard
+// (chip label + tone + expandable source chain).
+//
+// Future phases (#1942 Phase 2-4: Python / NestJS / Go) emit the SAME
+// `auth_policy` property shape so this dashboard plumbing needs zero
+// changes per-language.
+package dashboard
+
+import (
+	"github.com/cajasmota/archigraph/internal/engine"
+)
+
+// authChipTone is the visual tone the frontend should use for an auth chip.
+const (
+	authToneAccent  = "accent"
+	authToneMuted   = "muted"
+	authToneWarning = "warning"
+)
+
+// resolveAuthChip projects an engine.AuthPolicy into the dashboard chip
+// label + tone pair. Ordering of branches encodes the precedence specified
+// in #1942 Phase 1:
+//
+//   - high confidence + roles non-empty → `[Roles: ADMIN]` (accent)
+//   - high confidence + required=false → `[Public]` (muted)
+//   - high confidence + required=true → `[Auth required]` (accent)
+//   - method=framework_default + required=true → `[Auth: default]` (warning)
+//   - method=config (medium) → `[Auth: probable]` (warning)
+//   - method=unknown / low confidence → `[Auth: unknown]` (muted)
+func resolveAuthChip(p engine.AuthPolicy) (label, tone string) {
+	if p.Confidence == "high" {
+		if len(p.Roles) > 0 {
+			return "[Roles: " + joinRoles(p.Roles) + "]", authToneAccent
+		}
+		if !p.Required {
+			return "[Public]", authToneMuted
+		}
+		return "[Auth required]", authToneAccent
+	}
+	if p.Method == "framework_default" && p.Required {
+		return "[Auth: default]", authToneWarning
+	}
+	if p.Method == "config" && p.Confidence == "medium" {
+		return "[Auth: probable]", authToneWarning
+	}
+	return "[Auth: unknown]", authToneMuted
+}
+
+// joinRoles joins resolved roles for the chip label. Up to two roles are
+// surfaced inline; longer lists are abbreviated with a "+N" suffix to keep
+// the chip narrow.
+func joinRoles(roles []string) string {
+	switch len(roles) {
+	case 0:
+		return ""
+	case 1:
+		return roles[0]
+	case 2:
+		return roles[0] + ", " + roles[1]
+	default:
+		// Show first two roles, summarise the rest.
+		extra := len(roles) - 2
+		return roles[0] + ", " + roles[1] + ", +" + authChipItoa(extra)
+	}
+}
+
+// authChipItoa is a zero-alloc helper for small non-negative integers (chip labels
+// rarely exceed two digits). Avoids pulling strconv into the chip hot path.
+func authChipItoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [10]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+// authPolicyToWire converts an engine.AuthPolicy into the v2 wire shape.
+func authPolicyToWire(p engine.AuthPolicy) *v2AuthPolicy {
+	out := &v2AuthPolicy{
+		Required:   p.Required,
+		Method:     p.Method,
+		Roles:      append([]string(nil), p.Roles...),
+		Scopes:     append([]string(nil), p.Scopes...),
+		Confidence: p.Confidence,
+	}
+	if len(p.SourceChain) > 0 {
+		out.SourceChain = make([]v2AuthSignal, 0, len(p.SourceChain))
+		for _, s := range p.SourceChain {
+			out.SourceChain = append(out.SourceChain, v2AuthSignal{
+				Kind:     s.Kind,
+				EntityID: s.EntityID,
+				Text:     s.Text,
+				File:     s.File,
+				Line:     s.Line,
+			})
+		}
+	}
+	return out
+}
+
+// authPolicyStronger returns true when the supplied policy outranks the
+// already-chosen chip tone for a route. Accent (high-confidence explicit)
+// beats warning (config/default), which beats muted (unknown). Used by the
+// left-rail aggregation to keep the strongest signal visible when multiple
+// handlers share a path.
+func authPolicyStronger(p engine.AuthPolicy, currentTone string) bool {
+	newTone := toneFromPolicy(p)
+	return toneRank(newTone) > toneRank(currentTone)
+}
+
+func toneFromPolicy(p engine.AuthPolicy) string {
+	_, tone := resolveAuthChip(p)
+	return tone
+}
+
+func toneRank(tone string) int {
+	switch tone {
+	case authToneAccent:
+		return 3
+	case authToneWarning:
+		return 2
+	case authToneMuted:
+		return 1
+	}
+	return 0
+}
+
+// readAuthPolicyFromEntity decodes the `auth_policy` JSON property emitted by
+// the indexer. When the property is missing (e.g. Phase 0 endpoints, or
+// non-Java endpoints until Phases 2-4 ship) it falls back to a synthesized
+// "unknown" policy that matches the Phase 0 muted-chip behaviour from #1950.
+func readAuthPolicyFromEntity(props map[string]string) engine.AuthPolicy {
+	if props == nil {
+		return engine.AuthPolicy{Method: "unknown", Confidence: "low"}
+	}
+	if raw := props["auth_policy"]; raw != "" {
+		return engine.DecodeAuthPolicy(raw)
+	}
+	// Pre-Phase-1 fallback: if older `auth=true` / `auth_scheme=Bearer` flags
+	// were emitted by a non-Java extractor, treat them as a high-confidence
+	// "auth required" without a structured source chain.
+	if props["auth"] == "true" || props["auth_scheme"] != "" {
+		return engine.AuthPolicy{
+			Required:   true,
+			Method:     "annotation",
+			Confidence: "high",
+		}
+	}
+	return engine.AuthPolicy{Method: "unknown", Confidence: "low"}
+}

--- a/internal/dashboard/v2_paths_auth_test.go
+++ b/internal/dashboard/v2_paths_auth_test.go
@@ -1,0 +1,142 @@
+// Tests for the v2 dashboard auth chip + auth_policy wire surfacing.
+//
+// Refs #1942 Phase 1.
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/engine"
+)
+
+func TestResolveAuthChip_RolesHighConfidence(t *testing.T) {
+	p := engine.AuthPolicy{
+		Required:   true,
+		Method:     "annotation",
+		Roles:      []string{"ADMIN"},
+		Confidence: "high",
+	}
+	label, tone := resolveAuthChip(p)
+	if label != "[Roles: ADMIN]" {
+		t.Errorf("label = %q", label)
+	}
+	if tone != authToneAccent {
+		t.Errorf("tone = %q", tone)
+	}
+}
+
+func TestResolveAuthChip_PublicHighConfidence(t *testing.T) {
+	p := engine.AuthPolicy{Required: false, Method: "annotation", Confidence: "high"}
+	label, tone := resolveAuthChip(p)
+	if label != "[Public]" || tone != authToneMuted {
+		t.Errorf("got (%q,%q), want ([Public], muted)", label, tone)
+	}
+}
+
+func TestResolveAuthChip_AuthRequiredHighConfidence(t *testing.T) {
+	p := engine.AuthPolicy{Required: true, Method: "annotation", Confidence: "high"}
+	label, tone := resolveAuthChip(p)
+	if label != "[Auth required]" || tone != authToneAccent {
+		t.Errorf("got (%q,%q)", label, tone)
+	}
+}
+
+func TestResolveAuthChip_FrameworkDefault(t *testing.T) {
+	p := engine.AuthPolicy{Required: true, Method: "framework_default", Confidence: "low"}
+	label, tone := resolveAuthChip(p)
+	if label != "[Auth: default]" || tone != authToneWarning {
+		t.Errorf("got (%q,%q)", label, tone)
+	}
+}
+
+func TestResolveAuthChip_ConfigDriven(t *testing.T) {
+	p := engine.AuthPolicy{Required: true, Method: "config", Confidence: "medium"}
+	label, tone := resolveAuthChip(p)
+	if label != "[Auth: probable]" || tone != authToneWarning {
+		t.Errorf("got (%q,%q)", label, tone)
+	}
+}
+
+func TestResolveAuthChip_Unknown(t *testing.T) {
+	p := engine.AuthPolicy{Method: "unknown", Confidence: "low"}
+	label, tone := resolveAuthChip(p)
+	if label != "[Auth: unknown]" || tone != authToneMuted {
+		t.Errorf("got (%q,%q)", label, tone)
+	}
+}
+
+func TestResolveAuthChip_MultiRoleAbbreviated(t *testing.T) {
+	p := engine.AuthPolicy{
+		Required:   true,
+		Method:     "annotation",
+		Roles:      []string{"ADMIN", "USER", "OPS", "AUDITOR"},
+		Confidence: "high",
+	}
+	label, _ := resolveAuthChip(p)
+	if label != "[Roles: ADMIN, USER, +2]" {
+		t.Errorf("got %q", label)
+	}
+}
+
+func TestReadAuthPolicyFromEntity_JSONRoundTrip(t *testing.T) {
+	in := engine.AuthPolicy{
+		Required:   true,
+		Method:     "annotation",
+		Roles:      []string{"ADMIN"},
+		Confidence: "high",
+		SourceChain: []engine.AuthSignal{{
+			Kind: "annotation", Text: "@RolesAllowed(\"ADMIN\")", File: "X.java", Line: 42,
+		}},
+	}
+	props := map[string]string{"auth_policy": engine.EncodeAuthPolicy(in)}
+	got := readAuthPolicyFromEntity(props)
+	if !got.Required || got.Confidence != "high" {
+		t.Fatalf("got %#v", got)
+	}
+	if len(got.SourceChain) != 1 || got.SourceChain[0].Line != 42 {
+		t.Errorf("source chain lost: %#v", got.SourceChain)
+	}
+}
+
+func TestReadAuthPolicyFromEntity_LegacyAuthFlag(t *testing.T) {
+	// Legacy non-Java endpoint with only the old `auth=true` flag.
+	got := readAuthPolicyFromEntity(map[string]string{"auth": "true"})
+	if !got.Required || got.Confidence != "high" {
+		t.Errorf("legacy auth=true should resolve to required+high; got %#v", got)
+	}
+}
+
+func TestReadAuthPolicyFromEntity_EmptyReturnsUnknown(t *testing.T) {
+	got := readAuthPolicyFromEntity(nil)
+	if got.Method != "unknown" || got.Confidence != "low" {
+		t.Errorf("got %#v", got)
+	}
+}
+
+func TestAuthPolicyToWire(t *testing.T) {
+	in := engine.AuthPolicy{
+		Required:   true,
+		Method:     "config",
+		Confidence: "medium",
+		Roles:      []string{"ADMIN"},
+		SourceChain: []engine.AuthSignal{{
+			Kind: "config", Text: "x", File: "application.properties", Line: 7,
+		}},
+	}
+	wire := authPolicyToWire(in)
+	if wire == nil || !wire.Required || wire.Method != "config" || wire.Confidence != "medium" {
+		t.Fatalf("wire = %#v", wire)
+	}
+	if len(wire.SourceChain) != 1 || wire.SourceChain[0].File != "application.properties" {
+		t.Errorf("wire source chain = %#v", wire.SourceChain)
+	}
+}
+
+func TestToneRank_AccentBeatsWarningBeatsMuted(t *testing.T) {
+	if toneRank(authToneAccent) <= toneRank(authToneWarning) {
+		t.Error("accent should outrank warning")
+	}
+	if toneRank(authToneWarning) <= toneRank(authToneMuted) {
+		t.Error("warning should outrank muted")
+	}
+}

--- a/internal/engine/java_annotation_routes.go
+++ b/internal/engine/java_annotation_routes.go
@@ -273,6 +273,48 @@ func extractParamTypeAndName(p string) (typ, name string) {
 	return typ, name
 }
 
+// ApplyJavaAnnotationRoutesWithContext is the auth-aware variant of
+// ApplyJavaAnnotationRoutes. The JavaAuthContext supplies project-wide
+// signals (Quarkus security extension + application.properties permission
+// blocks) so each emitted endpoint carries a resolved auth_policy
+// (#1942 Phase 1).
+//
+// Existing callers can continue using ApplyJavaAnnotationRoutes which
+// forwards an empty context — endpoints from those callsites get the
+// "unknown" policy (matching the Phase 0 #1950 muted chip).
+func ApplyJavaAnnotationRoutesWithContext(
+	javaFiles []string,
+	fileReader JavaAnnotationFileReader,
+	authCtx JavaAuthContext,
+) []types.EntityRecord {
+	var out []types.EntityRecord
+	seen := map[string]bool{}
+
+	for _, relPath := range javaFiles {
+		if !strings.HasSuffix(relPath, ".java") {
+			continue
+		}
+		content := fileReader(relPath)
+		if len(content) == 0 {
+			continue
+		}
+		src := string(content)
+		// Cheap pre-filter: skip files that have no HTTP annotation.
+		if !containsAnyHTTPAnnotation(src) {
+			continue
+		}
+
+		for _, ep := range extractJavaEndpointsWithAuth(src, relPath, authCtx) {
+			if seen[ep.ID] {
+				continue
+			}
+			seen[ep.ID] = true
+			out = append(out, ep)
+		}
+	}
+	return out
+}
+
 // ApplyJavaAnnotationRoutes scans the supplied Java files for JAX-RS or
 // Spring MVC annotation patterns and returns a slice of synthetic
 // http_endpoint EntityRecords. Caller appends these to the existing
@@ -294,32 +336,7 @@ func ApplyJavaAnnotationRoutes(
 	javaFiles []string,
 	fileReader JavaAnnotationFileReader,
 ) []types.EntityRecord {
-	var out []types.EntityRecord
-	seen := map[string]bool{}
-
-	for _, relPath := range javaFiles {
-		if !strings.HasSuffix(relPath, ".java") {
-			continue
-		}
-		content := fileReader(relPath)
-		if len(content) == 0 {
-			continue
-		}
-		src := string(content)
-		// Cheap pre-filter: skip files that have no HTTP annotation.
-		if !containsAnyHTTPAnnotation(src) {
-			continue
-		}
-
-		for _, ep := range extractJavaEndpoints(src, relPath) {
-			if seen[ep.ID] {
-				continue
-			}
-			seen[ep.ID] = true
-			out = append(out, ep)
-		}
-	}
-	return out
+	return ApplyJavaAnnotationRoutesWithContext(javaFiles, fileReader, JavaAuthContext{})
 }
 
 // containsAnyHTTPAnnotation reports whether the source likely contains
@@ -349,12 +366,20 @@ func containsAnyHTTPAnnotation(src string) bool {
 // classFrame holds per-class state during file scan: the class name (for
 // handler-reference composition), the class-level path prefix, and
 // class-level content-type metadata that method-level routes inherit.
+//
+// classAnnoText / classLine are the auth-resolver inputs added in #1942
+// Phase 1: the joined annotation block above the class declaration and the
+// 1-based line on which `class ClassName` appears. Both are propagated
+// to every endpoint emitted under this frame so class-level @Secured /
+// @RolesAllowed / @PermitAll inherit correctly.
 type classFrame struct {
 	name          string
 	prefix        string
 	framework     string // "jaxrs" or "spring" (best-effort)
 	classConsumes string
 	classProduces string
+	classAnnoText string
+	classLine     int
 }
 
 // extractJavaEndpoints walks a Java source file and returns the synthetic
@@ -375,6 +400,14 @@ type classFrame struct {
 // on the full buffer, so @POST @PermitAll @Path("/login") @Operation
 // correctly produces "/login" as the method path.
 func extractJavaEndpoints(src, relPath string) []types.EntityRecord {
+	return extractJavaEndpointsWithAuth(src, relPath, JavaAuthContext{})
+}
+
+// extractJavaEndpointsWithAuth is the auth-aware variant. It tracks line
+// numbers for class and method declarations so the resolved auth_policy
+// source-chain can point at file:line refs (consumed by the dashboard's
+// expandable evidence panel — #1949 RefLine).
+func extractJavaEndpointsWithAuth(src, relPath string, authCtx JavaAuthContext) []types.EntityRecord {
 	lines := strings.Split(src, "\n")
 
 	var out []types.EntityRecord
@@ -389,7 +422,8 @@ func extractJavaEndpoints(src, relPath string) []types.EntityRecord {
 		return buf
 	}
 
-	for _, line := range lines {
+	for idx, line := range lines {
+		lineNo := idx + 1
 		trimmed := strings.TrimSpace(line)
 
 		// Track annotation lines (and blank lines, which can occur between
@@ -408,6 +442,8 @@ func extractJavaEndpoints(src, relPath string) []types.EntityRecord {
 		if m := javaClassDeclRe.FindStringSubmatch(line); m != nil {
 			classAnnos := flushAnnoBuf()
 			cur = buildClassFrame(m[1], classAnnos)
+			cur.classAnnoText = strings.Join(classAnnos, "\n")
+			cur.classLine = lineNo
 			continue
 		}
 
@@ -426,7 +462,7 @@ func extractJavaEndpoints(src, relPath string) []types.EntityRecord {
 				// in valid Java but harmless to skip).
 				continue
 			}
-			eps := buildMethodEndpoints(cur, methodName, paramFrag, methodAnnos, relPath)
+			eps := buildMethodEndpointsWithAuth(cur, methodName, paramFrag, methodAnnos, lineNo, relPath, authCtx)
 			out = append(out, eps...)
 			continue
 		}
@@ -492,6 +528,22 @@ func buildClassFrame(className string, annos []string) classFrame {
 // Issue #1909: paramFrag is the rest of the method declaration line after the
 // opening '(' — used to infer the JAX-RS request body parameter type.
 func buildMethodEndpoints(cf classFrame, methodName, paramFrag string, annos []string, relPath string) []types.EntityRecord {
+	return buildMethodEndpointsWithAuth(cf, methodName, paramFrag, annos, 0, relPath, JavaAuthContext{})
+}
+
+// buildMethodEndpointsWithAuth is the auth-aware variant. It accepts the
+// method's declaration line (1-based) so the resolved auth_policy
+// source-chain entries point at file:line refs, and a JavaAuthContext so
+// Quarkus framework default + config-driven permissions contribute when
+// no explicit annotation covers the handler. Refs #1942 Phase 1.
+func buildMethodEndpointsWithAuth(
+	cf classFrame,
+	methodName, paramFrag string,
+	annos []string,
+	methodLine int,
+	relPath string,
+	authCtx JavaAuthContext,
+) []types.EntityRecord {
 	joined := strings.Join(annos, "\n")
 
 	// Collect method-level paths (may be empty).
@@ -582,6 +634,14 @@ func buildMethodEndpoints(cf classFrame, methodName, paramFrag string, annos []s
 	// inferRequestBodyParam needs the full verb list to decide eligibility.
 	bodyType, bodyParamName := inferRequestBodyParam(paramFrag, uniqueVerbs)
 
+	// #1942 Phase 1 — resolve auth_policy from class + method + Quarkus context.
+	policy := ResolveJavaAuthPolicy(
+		joined, methodLine,
+		cf.classAnnoText, cf.name, cf.classLine,
+		relPath, canonical, authCtx,
+	)
+	policyJSON := EncodeAuthPolicy(policy)
+
 	var out []types.EntityRecord
 	for _, verb := range uniqueVerbs {
 		id := httproutes.SyntheticID(verb, canonical)
@@ -593,6 +653,22 @@ func buildMethodEndpoints(cf classFrame, methodName, paramFrag string, annos []s
 			// Fix for #682: use "SCOPE.Operation:ClassName.methodName" to
 			// match the kind/name the Java AST extractor emits.
 			"source_handler": "SCOPE.Operation:" + cf.name + "." + methodName,
+		}
+		// #1942 Phase 1 — serialise the resolved auth policy on every emitted
+		// endpoint. The dashboard reads `auth_policy` (JSON) for the source
+		// chain and the flat companion fields for cheap filtering.
+		if policyJSON != "" {
+			props["auth_policy"] = policyJSON
+		}
+		props["auth_method"] = policy.Method
+		props["auth_confidence"] = policy.Confidence
+		if policy.Required {
+			props["auth_required"] = "true"
+		} else if policy.Method != "unknown" {
+			props["auth_required"] = "false"
+		}
+		if len(policy.Roles) > 0 {
+			props["auth_roles"] = strings.Join(policy.Roles, ",")
 		}
 		if methodConsumes != "" {
 			props["consumes"] = methodConsumes

--- a/internal/engine/java_auth_policy.go
+++ b/internal/engine/java_auth_policy.go
@@ -1,0 +1,549 @@
+// Java auth_policy resolver — Phase 1 of #1942.
+//
+// Resolves a structured `auth_policy` for each Java endpoint by combining
+// four kinds of static signals:
+//
+//  1. Handler-level annotations.
+//     @PermitAll                       → public, high confidence
+//     @DenyAll                         → required (always rejects), high
+//     @RolesAllowed({"ADMIN","USER"})  → required + roles, high
+//     @Secured("ROLE_ADMIN")           → required + roles, high (Spring)
+//     @PreAuthorize("hasRole('ADMIN')")→ required + roles, high (Spring)
+//
+//  2. Class-level annotation inheritance.
+//     The same annotations applied to the controller class apply to every
+//     method that doesn't override with @PermitAll. Walked here.
+//
+//  3. Quarkus config-driven policies (application.properties).
+//     `quarkus.http.auth.permission.<name>.paths=/api/foo/*`
+//     `quarkus.http.auth.permission.<name>.policy=authenticated|deny|permit`
+//     `quarkus.http.auth.permission.<name>.roles-allowed=ADMIN,USER`
+//
+//  4. Framework default posture (Quarkus).
+//     When the project declares the `quarkus-security` extension and no
+//     @PermitAll / @RolesAllowed annotation covers the endpoint, the
+//     framework default is "auth required" with LOW confidence.
+//
+// Output is a structured AuthPolicy serialized as JSON on the synthetic
+// http_endpoint entity (`properties["auth_policy"]`). Flat companion fields
+// (`auth_required`, `auth_method`, `auth_confidence`) are also written so
+// downstream consumers that don't unmarshal JSON can still filter cheaply.
+//
+// This file ships Phase 1 (Java only). Phases 2-4 (Python / NestJS / Go)
+// reuse the AuthPolicy / AuthSignal shapes and the same dashboard surfacing.
+//
+// Refs #1942 (Phase 1).
+package engine
+
+import (
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// AuthPolicy is the resolved auth posture for a single endpoint.
+//
+// Confidence levels:
+//   - high   = explicit annotation directly on the handler or its class.
+//   - medium = config-driven policy matching the endpoint path.
+//   - low    = framework default (no explicit signal).
+type AuthPolicy struct {
+	Required    bool         `json:"required"`
+	Method      string       `json:"method"` // "annotation" | "middleware" | "config" | "framework_default" | "unknown"
+	Roles       []string     `json:"roles,omitempty"`
+	Scopes      []string     `json:"scopes,omitempty"`
+	Confidence  string       `json:"confidence"` // "high" | "medium" | "low"
+	SourceChain []AuthSignal `json:"source_chain,omitempty"`
+}
+
+// AuthSignal is one piece of evidence that contributed to the policy.
+type AuthSignal struct {
+	Kind     string `json:"kind"` // "annotation" | "middleware" | "config" | "framework_default"
+	EntityID string `json:"entity_id,omitempty"`
+	Text     string `json:"text"`
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+}
+
+// JavaAuthContext carries cross-file signals used during resolution. It is
+// optional — when empty the resolver falls back to handler/class-only
+// signals (still useful for Spring projects without a Quarkus config).
+type JavaAuthContext struct {
+	// QuarkusSecurityEnabled is true when the project pulls in the
+	// quarkus-security / quarkus-smallrye-jwt / quarkus-oidc extension
+	// (detected from pom.xml or build.gradle). When true, the framework
+	// default for any endpoint without @PermitAll is "auth required" at
+	// LOW confidence.
+	QuarkusSecurityEnabled bool
+
+	// QuarkusSecurityFile is the path of the build descriptor that
+	// declared the security extension (used for the source-chain entry).
+	QuarkusSecurityFile string
+
+	// QuarkusPermissions are the parsed `quarkus.http.auth.permission.*`
+	// blocks from application.properties. Each entry is checked against
+	// the endpoint path; a match contributes a config-source signal.
+	QuarkusPermissions []QuarkusPermission
+}
+
+// QuarkusPermission models one `quarkus.http.auth.permission.<name>.*`
+// block from a Quarkus application.properties.
+type QuarkusPermission struct {
+	Name         string
+	Paths        []string // raw path patterns from `.paths=`
+	Policy       string   // "authenticated" | "deny" | "permit" | <named-policy>
+	RolesAllowed []string
+	File         string
+	Line         int
+}
+
+// Annotation regexes (handler-/class-level).
+var (
+	javaPermitAllRe = regexp.MustCompile(`@PermitAll\b`)
+	javaDenyAllRe   = regexp.MustCompile(`@DenyAll\b`)
+	// @RolesAllowed("ADMIN") | @RolesAllowed({"ADMIN","USER"}) | @RolesAllowed(value = {...})
+	javaRolesAllowedRe = regexp.MustCompile(`@RolesAllowed\s*\(([^)]*)\)`)
+	// Spring @Secured("ROLE_ADMIN") / @Secured({"ROLE_ADMIN","ROLE_USER"})
+	javaSecuredRe = regexp.MustCompile(`@Secured\s*\(([^)]*)\)`)
+	// Spring @PreAuthorize("hasRole('ADMIN')") / @PreAuthorize("hasAnyRole('A','B')")
+	javaPreAuthorizeRe = regexp.MustCompile(`@PreAuthorize\s*\(\s*"([^"]*)"\s*\)`)
+)
+
+// authRoleArgRe extracts quoted role names from an annotation argument list,
+// stripping the conventional Spring "ROLE_" prefix to keep policies portable
+// across frameworks.
+var authRoleArgRe = regexp.MustCompile(`"([^"]+)"`)
+
+// preAuthRoleRe extracts role names from a Spring SpEL expression such as
+// `hasRole('ADMIN')`, `hasAnyRole('ADMIN','USER')`, or `hasAuthority('SCOPE_x')`.
+var preAuthRoleRe = regexp.MustCompile(`(?:hasRole|hasAnyRole|hasAuthority|hasAnyAuthority)\s*\(\s*([^)]+)\)`)
+
+// preAuthQuotedRe pulls quoted args (single or double quoted) out of the SpEL
+// expression captured by preAuthRoleRe.
+var preAuthQuotedRe = regexp.MustCompile(`['"]([^'"]+)['"]`)
+
+// ResolveJavaAuthPolicy combines per-method, per-class, and project-level
+// signals into a structured AuthPolicy.
+//
+//   - methodAnnoText: the joined annotation block immediately above the
+//     handler method declaration.
+//   - methodLine: 1-based line number where the handler method is declared.
+//   - classAnnoText: the joined annotation block immediately above the
+//     controller class declaration.
+//   - classLine: 1-based line number where the controller class is declared.
+//   - file: repo-relative source file path.
+//   - canonicalPath: the resolved endpoint route (e.g. "/auth/login"). Used
+//     to match Quarkus permission path patterns.
+//   - ctx: optional cross-file context (Quarkus extension + permissions).
+//
+// Precedence (highest first):
+//  1. Method-level @PermitAll / @DenyAll / @RolesAllowed / @Secured / @PreAuthorize.
+//  2. Class-level @RolesAllowed / @Secured / @PreAuthorize / @PermitAll.
+//  3. Quarkus permission policy matching `canonicalPath`.
+//  4. Quarkus framework default (when security extension is present).
+//  5. "unknown" (no signal at all).
+func ResolveJavaAuthPolicy(
+	methodAnnoText string,
+	methodLine int,
+	classAnnoText string,
+	className string,
+	classLine int,
+	file string,
+	canonicalPath string,
+	ctx JavaAuthContext,
+) AuthPolicy {
+	// ---- 1. Method-level signals (highest precedence) ----
+	if mp, ok := matchAnnotationPolicy(methodAnnoText, methodLine, file, "method"); ok {
+		return mp
+	}
+
+	// ---- 2. Class-level inheritance ----
+	if cp, ok := matchAnnotationPolicy(classAnnoText, classLine, file, "class"); ok {
+		// Decorate the source-chain text to make it obvious the signal
+		// comes from the class, not the method.
+		for i := range cp.SourceChain {
+			cp.SourceChain[i].EntityID = className
+		}
+		return cp
+	}
+
+	// ---- 3. Quarkus config-driven policy ----
+	if canonicalPath != "" {
+		for _, perm := range ctx.QuarkusPermissions {
+			if quarkusPermMatches(perm, canonicalPath) {
+				return policyFromQuarkusPermission(perm)
+			}
+		}
+	}
+
+	// ---- 4. Quarkus framework default ----
+	if ctx.QuarkusSecurityEnabled {
+		return AuthPolicy{
+			Required:   true,
+			Method:     "framework_default",
+			Confidence: "low",
+			SourceChain: []AuthSignal{{
+				Kind: "framework_default",
+				Text: "quarkus-security extension detected; default posture requires authentication unless @PermitAll covers the handler",
+				File: ctx.QuarkusSecurityFile,
+				Line: 0,
+			}},
+		}
+	}
+
+	// ---- 5. Unknown — no signal at all ----
+	return AuthPolicy{
+		Method:     "unknown",
+		Confidence: "low",
+	}
+}
+
+// matchAnnotationPolicy inspects a single annotation block (method-level or
+// class-level) and produces an AuthPolicy if any auth annotation matched.
+// The bool indicates whether a match was found. `tier` is "method" or
+// "class" — used only for the source-chain `kind` (always "annotation",
+// but the surrounding caller may decorate further).
+func matchAnnotationPolicy(annoText string, line int, file, _ string) (AuthPolicy, bool) {
+	if annoText == "" {
+		return AuthPolicy{}, false
+	}
+
+	// @PermitAll — explicit public.
+	if javaPermitAllRe.MatchString(annoText) {
+		return AuthPolicy{
+			Required:   false,
+			Method:     "annotation",
+			Confidence: "high",
+			SourceChain: []AuthSignal{{
+				Kind: "annotation",
+				Text: "@PermitAll",
+				File: file,
+				Line: line,
+			}},
+		}, true
+	}
+
+	// @DenyAll — explicit blanket reject. Treat as required=true (any
+	// request will be rejected) so the dashboard surfaces it as locked
+	// down rather than public.
+	if javaDenyAllRe.MatchString(annoText) {
+		return AuthPolicy{
+			Required:   true,
+			Method:     "annotation",
+			Confidence: "high",
+			SourceChain: []AuthSignal{{
+				Kind: "annotation",
+				Text: "@DenyAll",
+				File: file,
+				Line: line,
+			}},
+		}, true
+	}
+
+	// @RolesAllowed({...}) — JAX-RS / Jakarta Security.
+	if m := javaRolesAllowedRe.FindStringSubmatch(annoText); m != nil {
+		roles := extractQuotedTokens(m[1])
+		return AuthPolicy{
+			Required:   true,
+			Method:     "annotation",
+			Roles:      roles,
+			Confidence: "high",
+			SourceChain: []AuthSignal{{
+				Kind: "annotation",
+				Text: "@RolesAllowed(" + strings.TrimSpace(m[1]) + ")",
+				File: file,
+				Line: line,
+			}},
+		}, true
+	}
+
+	// @Secured(...) — Spring.
+	if m := javaSecuredRe.FindStringSubmatch(annoText); m != nil {
+		roles := stripRolePrefix(extractQuotedTokens(m[1]))
+		return AuthPolicy{
+			Required:   true,
+			Method:     "annotation",
+			Roles:      roles,
+			Confidence: "high",
+			SourceChain: []AuthSignal{{
+				Kind: "annotation",
+				Text: "@Secured(" + strings.TrimSpace(m[1]) + ")",
+				File: file,
+				Line: line,
+			}},
+		}, true
+	}
+
+	// @PreAuthorize("...") — Spring SpEL.
+	if m := javaPreAuthorizeRe.FindStringSubmatch(annoText); m != nil {
+		roles := parsePreAuthorizeRoles(m[1])
+		return AuthPolicy{
+			Required:   true,
+			Method:     "annotation",
+			Roles:      roles,
+			Confidence: "high",
+			SourceChain: []AuthSignal{{
+				Kind: "annotation",
+				Text: "@PreAuthorize(\"" + m[1] + "\")",
+				File: file,
+				Line: line,
+			}},
+		}, true
+	}
+
+	return AuthPolicy{}, false
+}
+
+// extractQuotedTokens pulls every "quoted" token out of an annotation
+// argument list. Preserves source order.
+func extractQuotedTokens(s string) []string {
+	matches := authRoleArgRe.FindAllStringSubmatch(s, -1)
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		v := strings.TrimSpace(m[1])
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// stripRolePrefix removes Spring's conventional "ROLE_" prefix from each
+// captured role so policies are portable across frameworks.
+func stripRolePrefix(roles []string) []string {
+	out := make([]string, 0, len(roles))
+	for _, r := range roles {
+		out = append(out, strings.TrimPrefix(r, "ROLE_"))
+	}
+	return out
+}
+
+// parsePreAuthorizeRoles parses a Spring SpEL expression such as
+// `hasRole('ADMIN')` or `hasAnyRole('ADMIN','USER')` and returns the
+// captured role names. Returns nil when no role helper is recognised.
+func parsePreAuthorizeRoles(spel string) []string {
+	var roles []string
+	for _, m := range preAuthRoleRe.FindAllStringSubmatch(spel, -1) {
+		for _, q := range preAuthQuotedRe.FindAllStringSubmatch(m[1], -1) {
+			r := strings.TrimPrefix(strings.TrimSpace(q[1]), "ROLE_")
+			if r != "" {
+				roles = append(roles, r)
+			}
+		}
+	}
+	return roles
+}
+
+// quarkusPermMatches reports whether any of the permission's path patterns
+// covers `endpointPath`. The grammar matches Quarkus's documented behaviour:
+//   - exact match
+//   - `*` suffix wildcard (`/api/foo/*` matches `/api/foo/bar`)
+func quarkusPermMatches(perm QuarkusPermission, endpointPath string) bool {
+	for _, pat := range perm.Paths {
+		pat = strings.TrimSpace(pat)
+		if pat == "" {
+			continue
+		}
+		if pat == endpointPath {
+			return true
+		}
+		if strings.HasSuffix(pat, "/*") {
+			prefix := strings.TrimSuffix(pat, "/*")
+			if endpointPath == prefix || strings.HasPrefix(endpointPath, prefix+"/") {
+				return true
+			}
+		}
+		if strings.HasSuffix(pat, "*") {
+			prefix := strings.TrimSuffix(pat, "*")
+			if strings.HasPrefix(endpointPath, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// policyFromQuarkusPermission projects a Quarkus permission block onto an
+// AuthPolicy. Confidence is "medium" — config-driven but not annotation-direct.
+func policyFromQuarkusPermission(perm QuarkusPermission) AuthPolicy {
+	pol := strings.ToLower(strings.TrimSpace(perm.Policy))
+	required := true
+	if pol == "permit" {
+		required = false
+	}
+	signal := AuthSignal{
+		Kind: "config",
+		Text: "quarkus.http.auth.permission." + perm.Name + ".policy=" + perm.Policy,
+		File: perm.File,
+		Line: perm.Line,
+	}
+	return AuthPolicy{
+		Required:    required,
+		Method:      "config",
+		Roles:       append([]string(nil), perm.RolesAllowed...),
+		Confidence:  "medium",
+		SourceChain: []AuthSignal{signal},
+	}
+}
+
+// EncodeAuthPolicy serializes the policy to a stable JSON string suitable
+// for storing in an EntityRecord.Properties map. Roles/Scopes are sorted
+// to keep the encoded form deterministic across runs.
+func EncodeAuthPolicy(p AuthPolicy) string {
+	cp := p
+	if len(cp.Roles) > 1 {
+		sort.Strings(cp.Roles)
+	}
+	if len(cp.Scopes) > 1 {
+		sort.Strings(cp.Scopes)
+	}
+	b, err := json.Marshal(cp)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// DecodeAuthPolicy is the inverse of EncodeAuthPolicy. Returns the zero
+// AuthPolicy when the input is empty or malformed (defensive — callers
+// fall back to the "unknown" chip).
+func DecodeAuthPolicy(s string) AuthPolicy {
+	if s == "" {
+		return AuthPolicy{Method: "unknown", Confidence: "low"}
+	}
+	var p AuthPolicy
+	if err := json.Unmarshal([]byte(s), &p); err != nil {
+		return AuthPolicy{Method: "unknown", Confidence: "low"}
+	}
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// Quarkus context extraction
+// ---------------------------------------------------------------------------
+
+// quarkusSecurityExtensionMarkers are the artifact identifiers that signal a
+// Quarkus security extension is on the classpath. When any of these appears
+// in pom.xml or build.gradle the framework default for unannotated endpoints
+// becomes "auth required" at LOW confidence.
+var quarkusSecurityExtensionMarkers = []string{
+	"quarkus-security",
+	"quarkus-smallrye-jwt",
+	"quarkus-oidc",
+	"quarkus-elytron-security",
+	"quarkus-keycloak-authorization",
+}
+
+// DetectQuarkusSecurityExtension returns (true, descriptorFile) when any of
+// the known Quarkus security extension markers appears in the supplied
+// pom.xml / build.gradle / build.gradle.kts content map.
+func DetectQuarkusSecurityExtension(buildDescriptors map[string]string) (bool, string) {
+	// Stable iteration order so the picked descriptor is deterministic.
+	paths := make([]string, 0, len(buildDescriptors))
+	for p := range buildDescriptors {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		content := buildDescriptors[p]
+		for _, marker := range quarkusSecurityExtensionMarkers {
+			if strings.Contains(content, marker) {
+				return true, p
+			}
+		}
+	}
+	return false, ""
+}
+
+// quarkusPermissionLineRe matches one application.properties line of the form
+//
+//	quarkus.http.auth.permission.<name>.<field>=<value>
+//
+// where <field> is one of `paths`, `policy`, `roles-allowed`.
+var quarkusPermissionLineRe = regexp.MustCompile(
+	`^\s*quarkus\.http\.auth\.permission\.([^.]+)\.(paths|policy|roles-allowed)\s*=\s*(.+?)\s*$`,
+)
+
+// ParseQuarkusPermissions parses a Quarkus application.properties file and
+// returns one QuarkusPermission per `quarkus.http.auth.permission.<name>.*`
+// block found. Unknown fields are ignored. Comments (`#` / `!`) are skipped.
+func ParseQuarkusPermissions(content, file string) []QuarkusPermission {
+	if content == "" {
+		return nil
+	}
+	byName := map[string]*QuarkusPermission{}
+	order := []string{}
+	for i, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
+			continue
+		}
+		m := quarkusPermissionLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		name, field, value := m[1], m[2], m[3]
+		perm, ok := byName[name]
+		if !ok {
+			perm = &QuarkusPermission{Name: name, File: file, Line: i + 1}
+			byName[name] = perm
+			order = append(order, name)
+		}
+		switch field {
+		case "paths":
+			perm.Paths = splitAuthCSV(value)
+		case "policy":
+			perm.Policy = value
+		case "roles-allowed":
+			perm.RolesAllowed = splitAuthCSV(value)
+		}
+	}
+	out := make([]QuarkusPermission, 0, len(order))
+	for _, n := range order {
+		out = append(out, *byName[n])
+	}
+	return out
+}
+
+// splitAuthCSV splits a comma-separated value, trims each token, and drops
+// empties.
+func splitAuthCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// BuildJavaAuthContext is the convenience constructor: given the raw text of
+// every pom.xml / build.gradle / build.gradle.kts and every
+// application.properties in the repo, it produces a populated
+// JavaAuthContext ready to pass into ApplyJavaAnnotationRoutesWithContext.
+func BuildJavaAuthContext(
+	buildDescriptors map[string]string,
+	propertiesFiles map[string]string,
+) JavaAuthContext {
+	ctx := JavaAuthContext{}
+	if ok, file := DetectQuarkusSecurityExtension(buildDescriptors); ok {
+		ctx.QuarkusSecurityEnabled = true
+		ctx.QuarkusSecurityFile = file
+	}
+	// Stable order for deterministic permission precedence.
+	files := make([]string, 0, len(propertiesFiles))
+	for f := range propertiesFiles {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		ctx.QuarkusPermissions = append(
+			ctx.QuarkusPermissions,
+			ParseQuarkusPermissions(propertiesFiles[f], f)...,
+		)
+	}
+	return ctx
+}

--- a/internal/engine/java_auth_policy_test.go
+++ b/internal/engine/java_auth_policy_test.go
@@ -1,0 +1,392 @@
+// Tests for the Java auth_policy resolver (#1942 Phase 1).
+//
+// Coverage:
+//   - Handler-level @PermitAll wins over Quarkus framework default.
+//   - Class-level @Secured inherits when method has no auth annotation.
+//   - Method-level @PermitAll overrides class-level @Secured.
+//   - Quarkus quarkus-security extension → framework_default required, low.
+//   - Quarkus application.properties permission policy → config-driven medium.
+//   - Multi-role @RolesAllowed({"ADMIN","USER"}) preserves both roles.
+//   - @PreAuthorize SpEL parsing.
+//   - End-to-end ApplyJavaAnnotationRoutesWithContext emits auth_policy props.
+//
+// Fixture names use the client-fixture-X convention (no client-name leaks).
+package engine
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestResolveJavaAuthPolicy_MethodPermitAll(t *testing.T) {
+	policy := ResolveJavaAuthPolicy(
+		"@POST\n@PermitAll\n@Path(\"/login\")",
+		42,
+		"@Path(\"/auth\")", "AuthController", 10,
+		"client-fixture-x/AuthController.java",
+		"/auth/login",
+		JavaAuthContext{QuarkusSecurityEnabled: true, QuarkusSecurityFile: "pom.xml"},
+	)
+	if policy.Required {
+		t.Errorf("expected required=false for @PermitAll, got true")
+	}
+	if policy.Method != "annotation" {
+		t.Errorf("expected method=annotation, got %q", policy.Method)
+	}
+	if policy.Confidence != "high" {
+		t.Errorf("expected confidence=high, got %q", policy.Confidence)
+	}
+	if len(policy.SourceChain) != 1 || policy.SourceChain[0].Text != "@PermitAll" {
+		t.Errorf("expected @PermitAll signal, got %#v", policy.SourceChain)
+	}
+	if policy.SourceChain[0].Line != 42 {
+		t.Errorf("expected method line 42 in source chain, got %d", policy.SourceChain[0].Line)
+	}
+}
+
+func TestResolveJavaAuthPolicy_ClassLevelSecuredInherits(t *testing.T) {
+	// Method has no auth annotation; class has @Secured("ROLE_ADMIN"). The
+	// resolver must inherit from the class and report confidence=high.
+	policy := ResolveJavaAuthPolicy(
+		"@GET\n@Path(\"/admin/users\")",
+		55,
+		"@Secured(\"ROLE_ADMIN\")\n@Path(\"/admin\")", "AdminController", 12,
+		"client-fixture-x/AdminController.java",
+		"/admin/users",
+		JavaAuthContext{},
+	)
+	if !policy.Required {
+		t.Fatalf("expected required=true via class-level @Secured")
+	}
+	if len(policy.Roles) != 1 || policy.Roles[0] != "ADMIN" {
+		t.Errorf("expected roles=[ADMIN] (ROLE_ prefix stripped), got %v", policy.Roles)
+	}
+	if policy.Confidence != "high" {
+		t.Errorf("expected confidence=high, got %q", policy.Confidence)
+	}
+	if len(policy.SourceChain) == 0 || policy.SourceChain[0].Line != 12 {
+		t.Errorf("expected class-line 12 in source chain, got %#v", policy.SourceChain)
+	}
+	if policy.SourceChain[0].EntityID != "AdminController" {
+		t.Errorf("expected class-level signal entity_id=AdminController, got %q", policy.SourceChain[0].EntityID)
+	}
+}
+
+func TestResolveJavaAuthPolicy_MethodOverridesClass(t *testing.T) {
+	// Class has @Secured; method has @PermitAll. The method wins.
+	policy := ResolveJavaAuthPolicy(
+		"@GET\n@PermitAll\n@Path(\"/health\")",
+		28,
+		"@Secured(\"ROLE_ADMIN\")", "AdminController", 12,
+		"client-fixture-x/AdminController.java",
+		"/admin/health",
+		JavaAuthContext{},
+	)
+	if policy.Required {
+		t.Errorf("expected required=false (method @PermitAll wins)")
+	}
+	if policy.SourceChain[0].Text != "@PermitAll" {
+		t.Errorf("expected source chain text=@PermitAll, got %q", policy.SourceChain[0].Text)
+	}
+	if policy.SourceChain[0].Line != 28 {
+		t.Errorf("expected method line 28, got %d", policy.SourceChain[0].Line)
+	}
+}
+
+func TestResolveJavaAuthPolicy_QuarkusFrameworkDefault(t *testing.T) {
+	// No annotations at all + quarkus-security on the classpath → framework
+	// default required at LOW confidence.
+	policy := ResolveJavaAuthPolicy(
+		"@GET\n@Path(\"/ping\")",
+		7,
+		"", "PingResource", 4,
+		"client-fixture-x/PingResource.java",
+		"/ping",
+		JavaAuthContext{QuarkusSecurityEnabled: true, QuarkusSecurityFile: "pom.xml"},
+	)
+	if !policy.Required {
+		t.Fatalf("expected required=true via Quarkus framework default")
+	}
+	if policy.Method != "framework_default" {
+		t.Errorf("expected method=framework_default, got %q", policy.Method)
+	}
+	if policy.Confidence != "low" {
+		t.Errorf("expected confidence=low, got %q", policy.Confidence)
+	}
+	if len(policy.SourceChain) != 1 || policy.SourceChain[0].Kind != "framework_default" {
+		t.Errorf("expected framework_default signal, got %#v", policy.SourceChain)
+	}
+	if policy.SourceChain[0].File != "pom.xml" {
+		t.Errorf("expected file=pom.xml in source chain, got %q", policy.SourceChain[0].File)
+	}
+}
+
+func TestResolveJavaAuthPolicy_QuarkusConfigDriven(t *testing.T) {
+	// Quarkus permission block declares /api/admin/* requires authenticated.
+	// Endpoint /api/admin/users has no annotation but matches the pattern.
+	policy := ResolveJavaAuthPolicy(
+		"@GET",
+		20,
+		"@Path(\"/api/admin\")", "AdminResource", 8,
+		"client-fixture-x/AdminResource.java",
+		"/api/admin/users",
+		JavaAuthContext{
+			QuarkusSecurityEnabled: true,
+			QuarkusSecurityFile:    "pom.xml",
+			QuarkusPermissions: []QuarkusPermission{{
+				Name:   "admin",
+				Paths:  []string{"/api/admin/*"},
+				Policy: "authenticated",
+				File:   "src/main/resources/application.properties",
+				Line:   3,
+			}},
+		},
+	)
+	if !policy.Required {
+		t.Fatalf("expected required=true via config-driven permission")
+	}
+	if policy.Method != "config" {
+		t.Errorf("expected method=config, got %q", policy.Method)
+	}
+	if policy.Confidence != "medium" {
+		t.Errorf("expected confidence=medium, got %q", policy.Confidence)
+	}
+	if len(policy.SourceChain) != 1 || policy.SourceChain[0].Kind != "config" {
+		t.Errorf("expected config signal, got %#v", policy.SourceChain)
+	}
+	if policy.SourceChain[0].Line != 3 {
+		t.Errorf("expected config signal line 3, got %d", policy.SourceChain[0].Line)
+	}
+}
+
+func TestResolveJavaAuthPolicy_MultiRoleRolesAllowed(t *testing.T) {
+	policy := ResolveJavaAuthPolicy(
+		`@GET
+@RolesAllowed({"ADMIN", "USER"})
+@Path("/multi")`,
+		30,
+		"", "MultiResource", 5,
+		"client-fixture-x/MultiResource.java",
+		"/multi",
+		JavaAuthContext{},
+	)
+	if !policy.Required {
+		t.Fatal("expected required=true for @RolesAllowed")
+	}
+	sort.Strings(policy.Roles)
+	if strings.Join(policy.Roles, ",") != "ADMIN,USER" {
+		t.Errorf("expected roles=[ADMIN,USER], got %v", policy.Roles)
+	}
+}
+
+func TestResolveJavaAuthPolicy_PreAuthorize(t *testing.T) {
+	policy := ResolveJavaAuthPolicy(
+		`@GetMapping("/audit")
+@PreAuthorize("hasAnyRole('ADMIN','AUDITOR')")`,
+		45,
+		"", "AuditController", 9,
+		"client-fixture-x/AuditController.java",
+		"/audit",
+		JavaAuthContext{},
+	)
+	if !policy.Required {
+		t.Fatal("expected required=true for @PreAuthorize")
+	}
+	sort.Strings(policy.Roles)
+	if strings.Join(policy.Roles, ",") != "ADMIN,AUDITOR" {
+		t.Errorf("expected roles=[ADMIN,AUDITOR], got %v", policy.Roles)
+	}
+}
+
+func TestResolveJavaAuthPolicy_DenyAll(t *testing.T) {
+	policy := ResolveJavaAuthPolicy(
+		"@GET\n@DenyAll",
+		18,
+		"", "Locked", 4, "client-fixture-x/Locked.java", "/locked",
+		JavaAuthContext{},
+	)
+	if !policy.Required {
+		t.Errorf("expected required=true for @DenyAll")
+	}
+	if policy.SourceChain[0].Text != "@DenyAll" {
+		t.Errorf("expected source chain @DenyAll, got %q", policy.SourceChain[0].Text)
+	}
+}
+
+func TestResolveJavaAuthPolicy_UnknownWhenNoSignals(t *testing.T) {
+	policy := ResolveJavaAuthPolicy(
+		"@GET", 5, "", "Bare", 2, "client-fixture-x/Bare.java", "/bare",
+		JavaAuthContext{},
+	)
+	if policy.Method != "unknown" {
+		t.Errorf("expected method=unknown, got %q", policy.Method)
+	}
+	if policy.Required {
+		t.Errorf("expected required=false for unknown policy")
+	}
+}
+
+func TestParseQuarkusPermissions(t *testing.T) {
+	content := `# Quarkus permissions
+quarkus.http.auth.permission.admin.paths=/api/admin/*
+quarkus.http.auth.permission.admin.policy=authenticated
+quarkus.http.auth.permission.admin.roles-allowed=ADMIN,SUPER
+
+quarkus.http.auth.permission.public.paths=/health,/metrics
+quarkus.http.auth.permission.public.policy=permit
+`
+	perms := ParseQuarkusPermissions(content, "application.properties")
+	if len(perms) != 2 {
+		t.Fatalf("expected 2 permissions, got %d", len(perms))
+	}
+	byName := map[string]QuarkusPermission{}
+	for _, p := range perms {
+		byName[p.Name] = p
+	}
+	admin := byName["admin"]
+	if strings.Join(admin.Paths, "|") != "/api/admin/*" {
+		t.Errorf("admin paths = %v", admin.Paths)
+	}
+	if admin.Policy != "authenticated" {
+		t.Errorf("admin policy = %q", admin.Policy)
+	}
+	if strings.Join(admin.RolesAllowed, ",") != "ADMIN,SUPER" {
+		t.Errorf("admin roles = %v", admin.RolesAllowed)
+	}
+	pub := byName["public"]
+	if pub.Policy != "permit" {
+		t.Errorf("public policy = %q", pub.Policy)
+	}
+	if strings.Join(pub.Paths, "|") != "/health|/metrics" {
+		t.Errorf("public paths = %v", pub.Paths)
+	}
+}
+
+func TestDetectQuarkusSecurityExtension(t *testing.T) {
+	bd := map[string]string{
+		"client-fixture-x/pom.xml": `<project>
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-jwt</artifactId>
+    </dependency>
+  </dependencies>
+</project>`,
+	}
+	ok, file := DetectQuarkusSecurityExtension(bd)
+	if !ok {
+		t.Fatal("expected quarkus-smallrye-jwt to be detected")
+	}
+	if file != "client-fixture-x/pom.xml" {
+		t.Errorf("expected file=client-fixture-x/pom.xml, got %q", file)
+	}
+
+	none := map[string]string{
+		"client-fixture-x/pom.xml": "<project><dependencies></dependencies></project>",
+	}
+	if ok, _ := DetectQuarkusSecurityExtension(none); ok {
+		t.Error("expected no detection on empty pom.xml")
+	}
+}
+
+func TestEncodeDecodeAuthPolicy(t *testing.T) {
+	in := AuthPolicy{
+		Required:   true,
+		Method:     "annotation",
+		Roles:      []string{"USER", "ADMIN"}, // unsorted to verify EncodeAuthPolicy sorts
+		Confidence: "high",
+		SourceChain: []AuthSignal{{
+			Kind: "annotation", Text: "@RolesAllowed({\"ADMIN\",\"USER\"})", File: "X.java", Line: 42,
+		}},
+	}
+	enc := EncodeAuthPolicy(in)
+	if enc == "" {
+		t.Fatal("EncodeAuthPolicy returned empty string")
+	}
+	dec := DecodeAuthPolicy(enc)
+	if !dec.Required || dec.Method != "annotation" || dec.Confidence != "high" {
+		t.Errorf("roundtrip mismatch: %#v", dec)
+	}
+	if strings.Join(dec.Roles, ",") != "ADMIN,USER" {
+		t.Errorf("expected sorted roles, got %v", dec.Roles)
+	}
+	// Source chain preserved.
+	if len(dec.SourceChain) != 1 || dec.SourceChain[0].File != "X.java" {
+		t.Errorf("source chain lost in roundtrip: %#v", dec.SourceChain)
+	}
+}
+
+func TestDecodeAuthPolicy_EmptyReturnsUnknown(t *testing.T) {
+	p := DecodeAuthPolicy("")
+	if p.Method != "unknown" {
+		t.Errorf("expected unknown, got %q", p.Method)
+	}
+}
+
+// ApplyJavaAnnotationRoutesWithContext end-to-end: emits a synthetic
+// http_endpoint that carries the resolved auth_policy in its properties.
+func TestApplyJavaAnnotationRoutesWithContext_AuthPolicyEmitted(t *testing.T) {
+	src := `package com.example;
+import jakarta.ws.rs.*;
+import jakarta.annotation.security.*;
+
+@Path("/auth")
+public class AuthController {
+    @POST
+    @PermitAll
+    @Path("/login")
+    public Object login() { return null; }
+
+    @GET
+    @Path("/me")
+    public Object me() { return null; }
+}
+`
+	files := map[string]string{"client-fixture-x/AuthController.java": src}
+	authCtx := JavaAuthContext{
+		QuarkusSecurityEnabled: true,
+		QuarkusSecurityFile:    "client-fixture-x/pom.xml",
+	}
+	got := ApplyJavaAnnotationRoutesWithContext(
+		[]string{"client-fixture-x/AuthController.java"},
+		mapReader(files), authCtx,
+	)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(got))
+	}
+	byID := map[string]map[string]string{}
+	for _, e := range got {
+		byID[e.ID] = e.Properties
+	}
+	login := byID["http:POST:/auth/login"]
+	if login == nil {
+		ids := make([]string, 0, len(byID))
+		for k := range byID {
+			ids = append(ids, k)
+		}
+		sort.Strings(ids)
+		t.Fatalf("missing POST /auth/login; got IDs: %v", ids)
+	}
+	if login["auth_method"] != "annotation" || login["auth_required"] != "false" || login["auth_confidence"] != "high" {
+		t.Errorf("login auth props = %v", login)
+	}
+	// auth_policy JSON should round-trip.
+	var p AuthPolicy
+	if err := json.Unmarshal([]byte(login["auth_policy"]), &p); err != nil {
+		t.Fatalf("auth_policy JSON invalid: %v", err)
+	}
+	if len(p.SourceChain) != 1 || p.SourceChain[0].Text != "@PermitAll" {
+		t.Errorf("login source chain = %#v", p.SourceChain)
+	}
+
+	me := byID["http:GET:/auth/me"]
+	if me == nil {
+		t.Fatalf("missing GET /auth/me")
+	}
+	if me["auth_method"] != "framework_default" || me["auth_required"] != "true" || me["auth_confidence"] != "low" {
+		t.Errorf("me auth props = %v", me)
+	}
+}
+


### PR DESCRIPTION
Closes #1942 (Phase 1)

## 1. Why

Phase 0 (#1950) only renamed the misleading `[No auth]` label to muted `[Auth: unknown]`. Engineers still saw zero structural information about which endpoints were actually locked down by `@PermitAll` / `@RolesAllowed` / class-level `@Secured` / Quarkus config / framework default. This PR ships the actual resolver for Java so the dashboard can show a verdict and the evidence behind it.

## 2. What changed

- **`internal/engine/java_auth_policy.go`** — new resolver. Public types: `AuthPolicy`, `AuthSignal`, `JavaAuthContext`, `QuarkusPermission`. Public functions: `ResolveJavaAuthPolicy`, `EncodeAuthPolicy`, `DecodeAuthPolicy`, `BuildJavaAuthContext`, `ParseQuarkusPermissions`, `DetectQuarkusSecurityExtension`.
- **`internal/engine/java_annotation_routes.go`** — added `ApplyJavaAnnotationRoutesWithContext`. Old `ApplyJavaAnnotationRoutes` is a thin wrapper forwarding an empty context (zero behaviour change for callers that haven't migrated). `classFrame` now tracks `classAnnoText` + `classLine` so class-level inheritance is line-accurate. `extractJavaEndpointsWithAuth` + `buildMethodEndpointsWithAuth` carry the resolver-needed line numbers into each emitted synthetic.
- **`cmd/archigraph/index.go`** — `runJavaAnnotationRoutes` now also gathers `pom.xml` / `build.gradle*` / `application.properties` from the classified-file set and builds a `JavaAuthContext` before delegating to the auth-aware variant.
- **`internal/dashboard/v2_paths.go` + `v2_paths_auth.go`** — `v2PathRoute` gains `auth_chip` / `auth_chip_tone`; `v2PathDetail` gains a structured `auth_policy` block + chip pair. Chip resolution lives in `resolveAuthChip` so the taxonomy is testable in one place.

## 3. Resolution rules

Precedence (highest first):
1. Method-level `@PermitAll` / `@DenyAll` / `@RolesAllowed` / Spring `@Secured` / `@PreAuthorize`.
2. Class-level inheritance of the same annotations.
3. Quarkus `quarkus.http.auth.permission.<name>.{paths,policy,roles-allowed}` matching the endpoint path (medium confidence).
4. Quarkus framework default: when any of `quarkus-security` / `quarkus-smallrye-jwt` / `quarkus-oidc` / `quarkus-elytron-security` / `quarkus-keycloak-authorization` appears in `pom.xml` or `build.gradle*` and no `@PermitAll` covers the handler, require auth at low confidence.
5. Unknown (no signal at all).

Chip taxonomy: `[Roles: X]` / `[Public]` / `[Auth required]` (accent), `[Auth: default]` / `[Auth: probable]` (warning), `[Auth: unknown]` (muted).

## 4. Tests

- `internal/engine/java_auth_policy_test.go` — handler `@PermitAll` wins over Quarkus default; class-level `@Secured` inherits; method `@PermitAll` overrides class `@Secured`; Quarkus framework default; Quarkus config-driven permission matching; multi-role `@RolesAllowed({"ADMIN","USER"})`; `@PreAuthorize("hasAnyRole(...)")` SpEL parsing; `@DenyAll`; Encode/Decode roundtrip; `application.properties` parser; `pom.xml` extension detection; end-to-end `ApplyJavaAnnotationRoutesWithContext` emits the policy on synthesised endpoints.
- `internal/dashboard/v2_paths_auth_test.go` — every chip branch (roles, public, required, framework default, config, unknown, multi-role abbreviation), legacy `auth=true` fallback, JSON wire shape, tone ranking.

Test command run locally: `go test ./internal/extractors/java/... ./internal/docgen/... ./internal/dashboard/... ./internal/engine/... -count=1` — all green, zero regressions.

## 5. Backward compatibility

- Old `ApplyJavaAnnotationRoutes` keeps its signature; non-Java callsites and Java callers that don't supply a `JavaAuthContext` continue to work — their endpoints just emit the "unknown" policy (matching Phase 0 chip behaviour).
- Legacy `auth=true` / `auth_scheme=Bearer` properties on non-Java endpoints are still respected by `readAuthPolicyFromEntity` and surface as `[Auth required]` high-confidence until Phases 2-4 ship structured policies for those languages.

## 6. Risks

- Property bloat: every Java endpoint now carries an `auth_policy` JSON blob (~150-300 bytes). Acceptable — total Java endpoint count is bounded by handler count and the JSON is deterministic.
- Quarkus config matcher is intentionally conservative — only exact + suffix `/*` wildcard. Path templates with regex are NOT matched; they fall through to the framework default. Documented in the matcher.
- `@PreAuthorize` parsing only recognises `hasRole` / `hasAnyRole` / `hasAuthority` / `hasAnyAuthority`. Custom SpEL beans fall through to required+high with empty roles — still strictly more informative than the pre-PR `[No auth]` chip.

## 7. Follow-ups

- **Phase 2** (Python): DRF `permission_classes`, Django `@login_required` / `LoginRequiredMixin`, FastAPI `Depends(get_current_user)`, Flask-Login.
- **Phase 3** (NestJS): `@UseGuards()` per-method / per-controller / global + Express `app.use(authMiddleware)` chains.
- **Phase 4** (Go): gin `router.Use`, echo middleware, chi `r.With`.
- **UI** (small follow-up ticket): render the new `auth_chip` / `auth_chip_tone` / `auth_policy.source_chain` blocks in the WebUI v2 endpoint detail pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
