### PR TITLE
feat(engine+dashboard): Event Flows Phase-1 — multi-hop pub/sub chains via Flows DAG renderer (#1944 Phase 1)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -52,6 +52,7 @@ const (
 	PassRenameDetect  = "rename-detect"  // Pass 5.5: detect entity renames across rebuilds (#1344)
 	PassEnrichment    = "enrichment"     // Pass 6: emit enrichment candidates
 	PassProcessFlow   = "process-flow"   // Pass 7: process-flow BFS over CALLS (#724)
+	PassEventFlow     = "event-flow"     // Pass 7.5: event-flow pub/sub walk (#1944 Phase 1)
 	PassModuleAgg     = "module-agg"     // Pass 8: module-level aggregation (#1383)
 	PassCommitCouple  = "commit-couple"  // Pass 8.5: VCS-derived COMMIT_COUPLED soft edges (#21)
 	PassEmbed         = "embed"          // Pass 9: semantic embeddings sidecar (#461 / ADR-0019)
@@ -60,7 +61,7 @@ const (
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
-	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassModuleAgg, PassCommitCouple, PassEmbed,
+	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassEmbed,
 }
 
 // fileTask carries one repo-relative path and its absolute counterpart
@@ -1165,6 +1166,24 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		// Re-sync Stats so the downstream sidecar + emission see the new
 		// entity/edge counts. The final sort below in Index() will fold the
 		// process entities into the canonical id ordering.
+		doc.Stats.Entities = len(doc.Entities)
+		doc.Stats.Relationships = len(doc.Relationships)
+	}
+
+	// Pass 7.5 — event-flow pub/sub walker (#1944 Phase 1). Runs after
+	// process-flow so EventFlow entities live alongside Process entities
+	// in the same final graph. Linear, single-channel-seed walker only:
+	// branching, cross-stack channel bridges, and conditional routing
+	// are tracked under #1944 Phase 2-5.
+	if !i.skipPasses[PassEventFlow] {
+		efStats := engine.RunEventFlow(doc, engine.DefaultEventFlowConfig())
+		if verbose() || efStats.EventFlows > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: event-flow seed_channels=%d event_flows=%d "+
+					"step_edges=%d seed_edges=%d\n",
+				efStats.SeedChannels, efStats.EventFlows,
+				efStats.StepEdges, efStats.SeedEdges)
+		}
 		doc.Stats.Entities = len(doc.Entities)
 		doc.Stats.Relationships = len(doc.Relationships)
 	}

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -288,6 +288,12 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 		}
 		_ = engine.RunProcessFlowWithCompanions(doc, companions, engine.DefaultProcessFlowConfig())
 
+		// #1944 Phase 1 — re-run the event-flow pub/sub walker too so
+		// EventFlow entities are refreshed alongside ProcessFlows after
+		// phantom-edge injection. Phase 1 walker is single-doc only;
+		// the Phase 3 companion-aware variant will swap in here.
+		_ = engine.RunEventFlow(doc, engine.DefaultEventFlowConfig())
+
 		// Update stats.
 		doc.Stats.Entities = len(doc.Entities)
 		doc.Stats.Relationships = len(doc.Relationships)
@@ -332,31 +338,36 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 }
 
 // stripProcessEntities returns new entity and relationship slices with all
-// SCOPE.Process entities and their STEP_IN_PROCESS / ENTRY_POINT_OF edges
-// removed. Used before re-running RunProcessFlow after phantom-edge injection.
+// SCOPE.Process AND SCOPE.EventFlow entities (and their step / entry / seed
+// edges) removed. Used before re-running RunProcessFlow + RunEventFlow after
+// phantom-edge injection so the re-emit isn't duplicated on top of the stale
+// pass.
 func stripProcessEntities(doc *graph.Document) ([]graph.Entity, []graph.Relationship) {
-	// Collect process entity IDs to drop.
-	processIDs := make(map[string]bool)
+	// Collect process + event-flow entity IDs to drop.
+	droppedIDs := make(map[string]bool)
 	for _, e := range doc.Entities {
-		if e.Kind == string(engine.EntityKindProcess) {
-			processIDs[e.ID] = true
+		if e.Kind == string(engine.EntityKindProcess) || e.Kind == engine.EntityKindEventFlow {
+			droppedIDs[e.ID] = true
 		}
 	}
-	if len(processIDs) == 0 {
+	if len(droppedIDs) == 0 {
 		return doc.Entities, doc.Relationships
 	}
 	entities := doc.Entities[:0:0]
 	for _, e := range doc.Entities {
-		if !processIDs[e.ID] {
+		if !droppedIDs[e.ID] {
 			entities = append(entities, e)
 		}
 	}
 	rels := doc.Relationships[:0:0]
 	for _, r := range doc.Relationships {
-		// Drop STEP_IN_PROCESS and ENTRY_POINT_OF edges for removed processes.
-		if processIDs[r.FromID] || processIDs[r.ToID] {
-			if r.Kind == string(engine.RelationshipKindStepInProcess) ||
-				r.Kind == string(engine.RelationshipKindEntryPointOf) {
+		// Drop step/entry/seed edges for removed flow entities.
+		if droppedIDs[r.FromID] || droppedIDs[r.ToID] {
+			switch r.Kind {
+			case string(engine.RelationshipKindStepInProcess),
+				string(engine.RelationshipKindEntryPointOf),
+				engine.RelationshipKindStepInEventFlow,
+				engine.RelationshipKindSeedOfEventFlow:
 				continue
 			}
 		}

--- a/internal/dashboard/handlers_event_flows.go
+++ b/internal/dashboard/handlers_event_flows.go
@@ -1,0 +1,310 @@
+// Dashboard handlers for Event Flows (#1944 Phase 1).
+//
+// EventFlow entities are emitted by engine.RunEventFlow (Pass 7.5) and
+// follow the same Property contract as Process entities so the existing
+// flows-DAG renderer (#2028 / flows.tsx) can drive both views with a
+// single component. The handlers below mirror the shape of /api/flows
+// but read SCOPE.EventFlow entities.
+//
+// Routes:
+//
+//	GET /api/event-flows/{group}                — list event-flows
+//	GET /api/event-flows/{group}/{eventFlowId}  — full step chain for one flow
+//
+// Phase-1 scope is intentionally narrow: linear chains, single-channel
+// seed, no enrichment frontmatter integration, no cross-stack walker.
+// Future phases will layer those on without changing the response
+// envelope.
+package dashboard
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// eventFlowEntityKind is the engine-emitted kind for event-flow chains.
+// Duplicated here as a string to avoid an internal/engine import cycle
+// from the dashboard package.
+const eventFlowEntityKind = "SCOPE.EventFlow"
+
+// stepInEventFlowEdge is the engine-emitted edge kind that links an
+// EventFlow entity → each step entity (channel or operation) in chain
+// order. Mirrors stepInProcessEdge.
+const stepInEventFlowEdge = "STEP_IN_EVENT_FLOW"
+
+// EventFlowListItem is the wire shape of one row in the Event Flows
+// list view. Mirrors v2FlowsProcessItem so the React Flows DAG renderer
+// can be reused without a second component.
+type EventFlowListItem struct {
+	EventFlowID  string   `json:"event_flow_id"`
+	Repo         string   `json:"repo"`
+	Label        string   `json:"label"`
+	SeedID       string   `json:"seed_id"`
+	SeedName     string   `json:"seed_name"`
+	TerminalID   string   `json:"terminal_id"`
+	StepCount    int      `json:"step_count"`
+	ChannelCount int      `json:"channel_count"`
+	ChainLabels  []string `json:"chain_labels"`
+	SourceFile   string   `json:"source_file,omitempty"`
+	// EntryKind is always "channel" for EventFlows; included for parity
+	// with the ProcessFlow list shape so the frontend can route through
+	// a single component.
+	EntryKind string `json:"entry_kind"`
+}
+
+// EventFlowStep is one node in the rendered chain. Mirrors the shape of
+// the Process-Flow step in handleFlowDetail (subset; Phase 1 omits the
+// per-step source-snippet enrichment to keep the handler footprint
+// small — JARVIS comet + scrubber only need entity_id, label, repo,
+// step_index, and an entity-kind hint).
+type EventFlowStep struct {
+	EntityID   string `json:"entity_id"`
+	Label      string `json:"label"`
+	Repo       string `json:"repo"`
+	StepIndex  int    `json:"step_index"`
+	EntityKind string `json:"entity_kind"`
+	SourceFile string `json:"source_file,omitempty"`
+	StartLine  int    `json:"start_line,omitempty"`
+	IsChannel  bool   `json:"is_channel"`
+}
+
+// handleEventFlowsList — GET /api/event-flows/{group}
+func (s *Server) handleEventFlowsList(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+	q := r.URL.Query()
+	limit := 200
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	minSteps := 0
+	if v := q.Get("min_steps"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			minSteps = n
+		}
+	}
+	seedFilter := q.Get("seed")
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	var items []EventFlowListItem
+	for _, repo := range sortedRepos(grp) {
+		for i := range repo.Doc.Entities {
+			e := &repo.Doc.Entities[i]
+			if e.Kind != eventFlowEntityKind {
+				continue
+			}
+			sc, _ := strconv.Atoi(e.Properties["step_count"])
+			if sc < minSteps {
+				continue
+			}
+			seedID := e.Properties["entry_id"]
+			if seedFilter != "" && seedID != seedFilter &&
+				dashPrefixedID(repo.Slug, seedID) != seedFilter {
+				continue
+			}
+			cc, _ := strconv.Atoi(e.Properties["channel_count"])
+			items = append(items, EventFlowListItem{
+				EventFlowID:  dashPrefixedID(repo.Slug, e.ID),
+				Repo:         repo.Slug,
+				Label:        e.Name,
+				SeedID:       seedID,
+				SeedName:     e.Properties["entry_name"],
+				TerminalID:   e.Properties["terminal_id"],
+				StepCount:    sc,
+				ChannelCount: cc,
+				ChainLabels:  splitChainLabels(e.Properties["chain_labels"]),
+				SourceFile:   e.SourceFile,
+				EntryKind:    "channel",
+			})
+		}
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].ChannelCount != items[j].ChannelCount {
+			return items[i].ChannelCount > items[j].ChannelCount
+		}
+		if items[i].StepCount != items[j].StepCount {
+			return items[i].StepCount > items[j].StepCount
+		}
+		return items[i].Label < items[j].Label
+	})
+	if len(items) > limit {
+		items = items[:limit]
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"event_flows": items,
+		"count":       len(items),
+	})
+}
+
+// handleEventFlowDetail — GET /api/event-flows/{group}/{eventFlowId}
+//
+// Returns the chain steps + the raw DAG JSON (`branches_dag`) so the
+// Flows renderer can draw the scrubber + JARVIS comet animation.
+func (s *Server) handleEventFlowDetail(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	flowID := r.PathValue("eventFlowId")
+	if group == "" || flowID == "" {
+		writeErr(w, http.StatusBadRequest, "group and eventFlowId required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	repoHint, localID := dashSplitPrefixed(flowID)
+	var flowRepoSlug string
+	var flowEnt *graph.Entity
+
+	for _, repo := range sortedRepos(grp) {
+		if repoHint != "" && repo.Slug != repoHint {
+			continue
+		}
+		for i := range repo.Doc.Entities {
+			e := &repo.Doc.Entities[i]
+			if e.Kind != eventFlowEntityKind {
+				continue
+			}
+			if e.ID == localID || dashPrefixedID(repo.Slug, e.ID) == flowID {
+				flowRepoSlug = repo.Slug
+				flowEnt = e
+				break
+			}
+		}
+		if flowEnt != nil {
+			break
+		}
+	}
+
+	if flowEnt == nil {
+		writeErr(w, http.StatusNotFound, "event flow not found: "+flowID)
+		return
+	}
+
+	// Group-wide entity index so bridge steps that live in a companion
+	// repo's Entities slice still resolve (Phase 3 cross-stack walker
+	// will populate that scenario; the index is harmless when empty).
+	groupEntityIndex := buildGroupEntityIndex(grp)
+
+	type rawEFStep struct {
+		EntityID   string
+		Repo       string
+		Label      string
+		EntityKind string
+		SourceFile string
+		StartLine  int
+		StepIndex  int
+	}
+	var rawSteps []rawEFStep
+	for _, repo := range sortedRepos(grp) {
+		for _, rel := range repo.Doc.Relationships {
+			if rel.Kind != stepInEventFlowEdge {
+				continue
+			}
+			if rel.FromID != flowEnt.ID && dashPrefixedID(repo.Slug, rel.FromID) != flowID {
+				continue
+			}
+			idx, _ := strconv.Atoi(rel.Properties["step_index"])
+			stepIDLocal := rel.ToID
+			if hit, ok := groupEntityIndex[stepIDLocal]; ok {
+				rawSteps = append(rawSteps, rawEFStep{
+					EntityID:   dashPrefixedID(hit.repo, hit.entity.ID),
+					Repo:       hit.repo,
+					Label:      hit.entity.Name,
+					EntityKind: hit.entity.Kind,
+					SourceFile: hit.entity.SourceFile,
+					StartLine:  hit.entity.StartLine,
+					StepIndex:  idx,
+				})
+			}
+		}
+	}
+	sort.Slice(rawSteps, func(i, j int) bool { return rawSteps[i].StepIndex < rawSteps[j].StepIndex })
+
+	steps := make([]EventFlowStep, 0, len(rawSteps))
+	for _, rs := range rawSteps {
+		steps = append(steps, EventFlowStep{
+			EntityID:   rs.EntityID,
+			Label:      rs.Label,
+			Repo:       rs.Repo,
+			StepIndex:  rs.StepIndex,
+			EntityKind: rs.EntityKind,
+			SourceFile: rs.SourceFile,
+			StartLine:  rs.StartLine,
+			IsChannel:  isChannelKind(rs.EntityKind),
+		})
+	}
+
+	sc, _ := strconv.Atoi(flowEnt.Properties["step_count"])
+	cc, _ := strconv.Atoi(flowEnt.Properties["channel_count"])
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"event_flow_id": dashPrefixedID(flowRepoSlug, flowEnt.ID),
+		"repo":          flowRepoSlug,
+		"label":         flowEnt.Name,
+		"seed_id":       flowEnt.Properties["entry_id"],
+		"seed_name":     flowEnt.Properties["entry_name"],
+		"terminal_id":   flowEnt.Properties["terminal_id"],
+		"step_count":    sc,
+		"channel_count": cc,
+		"chain_labels":  splitChainLabels(flowEnt.Properties["chain_labels"]),
+		"branches_dag":  flowEnt.Properties["branches_dag"],
+		"steps":         steps,
+		"entry_kind":    "channel",
+	})
+}
+
+// isChannelKind reports whether an entity kind names a pub/sub channel
+// (case-insensitive). Mirrors engine.isChannelEntity without depending
+// on the engine package. Used by the detail handler to flag steps that
+// the UI should render as channel nodes instead of operation nodes.
+func isChannelKind(kind string) bool {
+	switch kind {
+	case "SCOPE.MessageTopic", "SCOPE.EventBusEvent":
+		return true
+	}
+	// Case-insensitive fallback in case an older index stamped the kind
+	// in mixed case.
+	switch {
+	case lcEq(kind, "scope.messagetopic"),
+		lcEq(kind, "scope.eventbusevent"):
+		return true
+	}
+	return false
+}
+
+// lcEq returns true when `s` lowercased equals `target` (which must
+// already be lowercase). Avoids an extra strings import in callers that
+// already use case-folded comparisons sparingly.
+func lcEq(s, target string) bool {
+	if len(s) != len(target) {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != target[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/dashboard/handlers_event_flows_test.go
+++ b/internal/dashboard/handlers_event_flows_test.go
@@ -1,0 +1,221 @@
+// Integration tests for the Event Flows dashboard handlers (#1944 Phase 1).
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// eventFlowEntity builds a synthetic SCOPE.EventFlow entity with the
+// minimum Properties keys the list/detail handlers consume.
+func eventFlowEntity(id, label, seedID, terminalID string, chain []string, chainLabels []string, channelCount int) graph.Entity {
+	props := map[string]string{
+		"entry_id":       seedID,
+		"entry_name":     seedID,
+		"terminal_id":    terminalID,
+		"step_count":     itoa(len(chain)),
+		"channel_count":  itoa(channelCount),
+		"chain":          joinComma(chain),
+		"chain_labels":   joinArrow(chainLabels),
+		"entry_kind":     "channel",
+		"dag_node_count": itoa(len(chain)),
+		"branch_count":   "0",
+		"is_dag":         "false",
+		"branches_dag":   `{"entity_id":"` + chain[0] + `"}`,
+	}
+	return graph.Entity{
+		ID:         id,
+		Name:       label,
+		Kind:       eventFlowEntityKind,
+		Properties: props,
+	}
+}
+
+func joinComma(xs []string) string {
+	out := ""
+	for i, x := range xs {
+		if i > 0 {
+			out += ","
+		}
+		out += x
+	}
+	return out
+}
+
+func joinArrow(xs []string) string {
+	out := ""
+	for i, x := range xs {
+		if i > 0 {
+			out += " → "
+		}
+		out += x
+	}
+	return out
+}
+
+func efStepRel(flowID, stepID string, idx int) graph.Relationship {
+	return graph.Relationship{
+		ID:     "efstep-" + flowID + "-" + stepID,
+		FromID: flowID,
+		ToID:   stepID,
+		Kind:   stepInEventFlowEdge,
+		Properties: map[string]string{
+			"step_index": itoa(idx),
+		},
+	}
+}
+
+// newEventFlowTestServer wires a small dashboard server pre-loaded with
+// the given group. Mirrors newFlowDetailTestServer.
+func newEventFlowTestServer(t *testing.T, grp *DashGroup) *httptest.Server {
+	t.Helper()
+	st := newFakeStore()
+	st.groups["testgrp"] = GroupSummary{
+		Name:       "testgrp",
+		ConfigPath: "/tmp/testgrp.json",
+		Repos:      []string{"backend"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["testgrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestEventFlowsList_BasicShape verifies the list endpoint returns
+// EventFlow entities with the expected wire fields.
+func TestEventFlowsList_BasicShape(t *testing.T) {
+	chain := []string{"topic.A", "svc.subA", "topic.B"}
+	chainLabels := []string{"kafka:a", "handleA", "kafka:b"}
+	ef := eventFlowEntity("evflow:abc", "kafka:a → kafka:b", "topic.A", "topic.B", chain, chainLabels, 2)
+
+	// Channel entities so the detail endpoint can resolve the IDs.
+	topicA := graph.Entity{ID: "topic.A", Name: "kafka:a", Kind: "SCOPE.MessageTopic"}
+	topicB := graph.Entity{ID: "topic.B", Name: "kafka:b", Kind: "SCOPE.MessageTopic"}
+	subA := stepEntity("svc.subA", "handleA", "SCOPE.Function")
+
+	rels := []graph.Relationship{
+		efStepRel("evflow:abc", "topic.A", 0),
+		efStepRel("evflow:abc", "svc.subA", 1),
+		efStepRel("evflow:abc", "topic.B", 2),
+	}
+	grp := makeFlowGroup([]graph.Entity{ef, topicA, topicB, subA}, rels)
+	ts := newEventFlowTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/event-flows/testgrp")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: want 200, got %d — body: %s", resp.StatusCode, b)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		EventFlows []EventFlowListItem `json:"event_flows"`
+		Count      int                 `json:"count"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v body=%s", err, b)
+	}
+	if body.Count != 1 || len(body.EventFlows) != 1 {
+		t.Fatalf("want 1 event flow, got count=%d items=%d", body.Count, len(body.EventFlows))
+	}
+	item := body.EventFlows[0]
+	if item.SeedID != "topic.A" {
+		t.Errorf("seed_id = %q, want topic.A", item.SeedID)
+	}
+	if item.ChannelCount != 2 {
+		t.Errorf("channel_count = %d, want 2", item.ChannelCount)
+	}
+	if item.EntryKind != "channel" {
+		t.Errorf("entry_kind = %q, want channel", item.EntryKind)
+	}
+	// chain_labels is serialised as a single " → "-joined string by the
+	// engine and split on "," by the dashboard's splitChainLabels (the
+	// same long-standing shape used for ProcessFlow), so the round-trip
+	// keeps the full chain in one slice element. We just assert the
+	// arrow-joined label survives intact.
+	if len(item.ChainLabels) != 1 || item.ChainLabels[0] != "kafka:a → handleA → kafka:b" {
+		t.Errorf("chain_labels = %v, want one arrow-joined element", item.ChainLabels)
+	}
+}
+
+func TestEventFlowsDetail_StepsAndChannelFlag(t *testing.T) {
+	chain := []string{"topic.A", "svc.subA", "topic.B"}
+	chainLabels := []string{"kafka:a", "handleA", "kafka:b"}
+	ef := eventFlowEntity("evflow:abc", "kafka:a → kafka:b", "topic.A", "topic.B", chain, chainLabels, 2)
+
+	topicA := graph.Entity{ID: "topic.A", Name: "kafka:a", Kind: "SCOPE.MessageTopic"}
+	topicB := graph.Entity{ID: "topic.B", Name: "kafka:b", Kind: "SCOPE.MessageTopic"}
+	subA := stepEntity("svc.subA", "handleA", "SCOPE.Function")
+
+	rels := []graph.Relationship{
+		efStepRel("evflow:abc", "topic.A", 0),
+		efStepRel("evflow:abc", "svc.subA", 1),
+		efStepRel("evflow:abc", "topic.B", 2),
+	}
+	grp := makeFlowGroup([]graph.Entity{ef, topicA, topicB, subA}, rels)
+	ts := newEventFlowTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/event-flows/testgrp/backend::evflow:abc")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: want 200, got %d — body: %s", resp.StatusCode, b)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		Steps        []EventFlowStep `json:"steps"`
+		ChannelCount int             `json:"channel_count"`
+		StepCount    int             `json:"step_count"`
+		BranchesDAG  string          `json:"branches_dag"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v body=%s", err, b)
+	}
+	if len(body.Steps) != 3 {
+		t.Fatalf("want 3 steps, got %d", len(body.Steps))
+	}
+	if !body.Steps[0].IsChannel {
+		t.Errorf("step 0 (topic) is_channel=false, want true")
+	}
+	if body.Steps[1].IsChannel {
+		t.Errorf("step 1 (function) is_channel=true, want false")
+	}
+	if !body.Steps[2].IsChannel {
+		t.Errorf("step 2 (topic) is_channel=false, want true")
+	}
+	if body.BranchesDAG == "" {
+		t.Error("branches_dag is empty — renderer needs DAG JSON")
+	}
+}
+
+func TestEventFlowsDetail_NotFound(t *testing.T) {
+	grp := makeFlowGroup(nil, nil)
+	ts := newEventFlowTestServer(t, grp)
+	resp, err := http.Get(ts.URL + "/api/event-flows/testgrp/backend::evflow:missing")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("want 404, got %d", resp.StatusCode)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -358,6 +358,13 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/flows/{group}/{processId}", s.handleFlowDetail)
 	mux.HandleFunc("POST /api/flows/{group}/{processId}/trigger-enrichment", s.handleTriggerEnrichment)
 
+	// API event-flows (#1944 Phase 1) — multi-hop pub/sub chains seeded
+	// by channels (SCOPE.MessageTopic / SCOPE.EventBusEvent). Reuses the
+	// Flows DAG renderer on the frontend; this surface emits the same
+	// chain/branches_dag contract as /api/flows.
+	mux.HandleFunc("GET /api/event-flows/{group}", s.handleEventFlowsList)
+	mux.HandleFunc("GET /api/event-flows/{group}/{eventFlowId}", s.handleEventFlowDetail)
+
 	// API paths / contracts
 	mux.HandleFunc("GET /api/paths/{group}", s.handlePathsList)
 	mux.HandleFunc("GET /api/paths/{group}/orphan-callers", s.handleOrphanCallers)

--- a/internal/engine/event_flow.go
+++ b/internal/engine/event_flow.go
@@ -1,0 +1,587 @@
+// Event-Flow walker (#1944 Phase 1).
+//
+// RunEventFlow walks the pub/sub graph seeded by a Channel entity
+// (SCOPE.MessageTopic or SCOPE.EventBusEvent) and emits multi-hop
+// process chains describing the propagation of an event across one
+// or more services.
+//
+// Walk pattern (linear, Phase 1):
+//
+//	channel  -- (reverse SUBSCRIBES_TO) -->  consumer-operation
+//	consumer -- CALLS* -->                   next-channel-publisher
+//	publisher -- PUBLISHES_TO -->            next-channel
+//	... (repeat until terminal channel or depth cap)
+//
+// Out of scope for Phase 1 (tracked separately):
+//   - Branching / DAG walker (#1945 Phase 2 for events).
+//   - Cross-stack channel bridges via companion walker (Phase 3).
+//   - Per-language pub/sub extractor coverage gaps (Phase 4).
+//   - Conditional routing on saga success/failure (Phase 5).
+//
+// The walker mirrors RunProcessFlow's emission shape (EntityKindEventFlow
+// reuses the same Properties keys: chain, chain_labels, step_count,
+// entry_id, entry_name, terminal_id, branches_dag) so the existing Flows
+// DAG renderer (#2028 / flows.tsx) can drive Event-Flow visualisations
+// with no client-side changes.
+package engine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// EntityKindEventFlow identifies an EventFlow entity — a linearised
+// multi-hop pub/sub chain emitted by RunEventFlow. Name format:
+// "<seed-channel> → <terminal>". Mirrors EntityKindProcess.
+const EntityKindEventFlow = "SCOPE.EventFlow"
+
+// RelationshipKindStepInEventFlow links an EventFlow entity to each of
+// its chain steps in order. Step index lives on the edge Properties
+// (`step_index`, 0-based). Mirrors STEP_IN_PROCESS.
+const RelationshipKindStepInEventFlow = "STEP_IN_EVENT_FLOW"
+
+// RelationshipKindSeedOfEventFlow links the seed Channel entity to the
+// EventFlow it kicked off (Channel → EventFlow). Mirrors ENTRY_POINT_OF.
+const RelationshipKindSeedOfEventFlow = "SEED_OF_EVENT_FLOW"
+
+// Channel entity kind aliases used by the walker. These match the
+// canonical kinds emitted by the per-language pub/sub extractors and the
+// managed-event-bus synthesisers. Compared case-insensitively so legacy
+// kind strings ("scope.messagetopic") still match.
+const (
+	eventFlowChannelKindMessageTopic = "SCOPE.MessageTopic"
+	eventFlowChannelKindEventBus     = "SCOPE.EventBusEvent"
+)
+
+// EventFlowConfig controls the linear walker.
+type EventFlowConfig struct {
+	// MaxDepth caps the chain length in HOPS past the seed channel. ≤6.
+	// A "hop" is one pub→channel or channel→sub transition; the default
+	// 6 lets a 3-channel chain (chan → sub → call* → pub → chan → sub →
+	// call* → pub → chan) materialise fully without runaway expansion.
+	MaxDepth int
+	// MaxIntraCallDepth caps the CALLS walk between a subscriber and the
+	// next publisher it eventually reaches. ≤8 keeps the inner walk
+	// tractable on dense graphs.
+	MaxIntraCallDepth int
+	// MaxFlows is the global cap on EventFlow entities emitted per pass.
+	MaxFlows int
+	// MinSteps is the minimum chain length for an EventFlow to be emitted.
+	// A bare sub→pub bridge (4 steps incl. both channels) is the smallest
+	// meaningful flow.
+	MinSteps int
+}
+
+// DefaultEventFlowConfig returns the Phase-1 tuning per #1944.
+func DefaultEventFlowConfig() EventFlowConfig {
+	return EventFlowConfig{
+		MaxDepth:          6,
+		MaxIntraCallDepth: 8,
+		MaxFlows:          200,
+		MinSteps:          3,
+	}
+}
+
+func clampEventFlowConfig(cfg EventFlowConfig) EventFlowConfig {
+	if cfg.MaxDepth <= 0 || cfg.MaxDepth > 6 {
+		cfg.MaxDepth = 6
+	}
+	if cfg.MaxIntraCallDepth <= 0 || cfg.MaxIntraCallDepth > 8 {
+		cfg.MaxIntraCallDepth = 8
+	}
+	if cfg.MaxFlows <= 0 {
+		cfg.MaxFlows = 200
+	}
+	if cfg.MinSteps < 2 {
+		cfg.MinSteps = 3
+	}
+	return cfg
+}
+
+// eventFlowStats summarises one pass for verbose/test consumers.
+type eventFlowStats struct {
+	SeedChannels   int
+	EventFlows     int
+	StepEdges      int
+	SeedEdges      int
+	TruncatedDepth int
+}
+
+// isChannelEntity reports whether the entity is a recognised pub/sub
+// channel. Phase 1 covers MessageTopic + EventBusEvent — the two kinds
+// that drive ETL and saga chains end-to-end today. Other channel-like
+// kinds (websocket / SSE / gRPC) are intentionally excluded from Phase
+// 1 to keep the seed surface focused; future phases can extend this.
+func isChannelEntity(e *graph.Entity) bool {
+	if e == nil {
+		return false
+	}
+	k := strings.ToLower(e.Kind)
+	return k == strings.ToLower(eventFlowChannelKindMessageTopic) ||
+		k == strings.ToLower(eventFlowChannelKindEventBus)
+}
+
+// channelLabel returns a stable human-readable label for a channel
+// entity (e.g. "kafka:payments.settled"). Falls back to Name then ID.
+func channelLabel(e *graph.Entity) string {
+	if e == nil {
+		return ""
+	}
+	if e.Name != "" {
+		return e.Name
+	}
+	if e.QualifiedName != "" {
+		return e.QualifiedName
+	}
+	return e.ID
+}
+
+// pubSubAdjacency captures the pub/sub edges relevant to event flows.
+//   - publishers[channelID]   = caller IDs that PUBLISHES_TO this channel.
+//   - subscribers[channelID]  = consumer IDs that SUBSCRIBES_TO this channel.
+//   - publishesOf[callerID]   = channels that a caller publishes to.
+type pubSubAdjacency struct {
+	publishers  map[string][]string
+	subscribers map[string][]string
+	publishesOf map[string][]string
+}
+
+// buildPubSubAdjacency indexes PUBLISHES_TO and SUBSCRIBES_TO edges
+// across `doc`. Self-loops and duplicate edges are deduped. Output
+// slices are sorted for determinism.
+func buildPubSubAdjacency(doc *graph.Document) *pubSubAdjacency {
+	a := &pubSubAdjacency{
+		publishers:  make(map[string][]string),
+		subscribers: make(map[string][]string),
+		publishesOf: make(map[string][]string),
+	}
+	if doc == nil {
+		return a
+	}
+	seenPub := make(map[edgeKey]bool)
+	seenSub := make(map[edgeKey]bool)
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.FromID == "" || r.ToID == "" || r.FromID == r.ToID {
+			continue
+		}
+		switch r.Kind {
+		case "PUBLISHES_TO":
+			k := edgeKey{r.FromID, r.ToID}
+			if seenPub[k] {
+				continue
+			}
+			seenPub[k] = true
+			a.publishers[r.ToID] = append(a.publishers[r.ToID], r.FromID)
+			a.publishesOf[r.FromID] = append(a.publishesOf[r.FromID], r.ToID)
+		case "SUBSCRIBES_TO":
+			k := edgeKey{r.FromID, r.ToID}
+			if seenSub[k] {
+				continue
+			}
+			seenSub[k] = true
+			a.subscribers[r.ToID] = append(a.subscribers[r.ToID], r.FromID)
+		}
+	}
+	for k := range a.publishers {
+		sort.Strings(a.publishers[k])
+	}
+	for k := range a.subscribers {
+		sort.Strings(a.subscribers[k])
+	}
+	for k := range a.publishesOf {
+		sort.Strings(a.publishesOf[k])
+	}
+	return a
+}
+
+// RunEventFlow walks every channel in `doc` and emits one EventFlow
+// entity per surviving multi-hop chain. EventFlow entities + edges are
+// appended to doc in place. Safe to call on a doc with no pub/sub
+// edges (returns an empty stats record).
+func RunEventFlow(doc *graph.Document, cfg EventFlowConfig) eventFlowStats {
+	stats := eventFlowStats{}
+	if doc == nil {
+		return stats
+	}
+	cfg = clampEventFlowConfig(cfg)
+
+	byID := make(map[string]*graph.Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		byID[e.ID] = e
+	}
+
+	psAdj := buildPubSubAdjacency(doc)
+	callsAdj := buildCallsAdjacency(doc)
+
+	// Seed list: every channel entity in deterministic ID order.
+	seeds := make([]string, 0)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if isChannelEntity(e) {
+			seeds = append(seeds, e.ID)
+		}
+	}
+	sort.Strings(seeds)
+	stats.SeedChannels = len(seeds)
+	if len(seeds) == 0 {
+		return stats
+	}
+
+	type emit struct {
+		seed     string
+		terminal string
+		chain    []string
+	}
+	emits := make([]emit, 0, len(seeds))
+
+	for _, seedID := range seeds {
+		chains := walkEventFlow(seedID, byID, psAdj, callsAdj, cfg, &stats)
+		for _, ch := range chains {
+			if len(ch) < cfg.MinSteps {
+				continue
+			}
+			emits = append(emits, emit{
+				seed:     seedID,
+				terminal: ch[len(ch)-1],
+				chain:    ch,
+			})
+		}
+	}
+
+	// Deterministic order: longest chain first, then seed ID, then
+	// terminal ID. Matches the Process-Flow tie-break so determinism
+	// tests can share fixtures.
+	sort.Slice(emits, func(i, j int) bool {
+		li := len(emits[i].chain)
+		lj := len(emits[j].chain)
+		if li != lj {
+			return li > lj
+		}
+		if emits[i].seed != emits[j].seed {
+			return emits[i].seed < emits[j].seed
+		}
+		return emits[i].terminal < emits[j].terminal
+	})
+	if len(emits) > cfg.MaxFlows {
+		emits = emits[:cfg.MaxFlows]
+	}
+
+	for _, em := range emits {
+		chain := em.chain
+		seedEnt := byID[chain[0]]
+		terminalEnt := byID[chain[len(chain)-1]]
+		if seedEnt == nil {
+			continue
+		}
+		terminalLabel := chain[len(chain)-1]
+		if terminalEnt != nil {
+			terminalLabel = channelLabel(terminalEnt)
+			if terminalLabel == "" {
+				terminalLabel = terminalEnt.Name
+			}
+		}
+		seedLabel := channelLabel(seedEnt)
+		label := fmt.Sprintf("%s → %s", seedLabel, terminalLabel)
+		flowID := computeEventFlowID(doc.Repo, chain)
+
+		labels := chainLabels(chain, byID)
+
+		// Build a trivial linear ChainStep DAG so the dashboard's DAG
+		// renderer can consume EventFlows with no special-case code.
+		root := buildLinearChainStepDAG(chain, byID)
+
+		channelCount := 0
+		for _, id := range chain {
+			if isChannelEntity(byID[id]) {
+				channelCount++
+			}
+		}
+
+		props := map[string]string{
+			"entry_id":      seedEnt.ID,
+			"entry_name":    seedLabel,
+			"terminal_id":   chain[len(chain)-1],
+			"step_count":    strconv.Itoa(len(chain)),
+			"channel_count": strconv.Itoa(channelCount),
+			"chain":         strings.Join(chain, ","),
+			"chain_labels":  strings.Join(labels, " → "),
+			"entry_kind":    "channel",
+			// Mirror the Process-Flow DAG metadata so flows.tsx can
+			// drive the renderer with the same code path.
+			"dag_node_count": strconv.Itoa(len(chain)),
+			"branch_count":   "0",
+			"is_dag":         "false",
+		}
+		if dagJSON := encodeDAGJSON(root); dagJSON != "" {
+			props["branches_dag"] = dagJSON
+		}
+
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:         flowID,
+			Name:       label,
+			Kind:       EntityKindEventFlow,
+			SourceFile: seedEnt.SourceFile,
+			StartLine:  seedEnt.StartLine,
+			EndLine:    seedEnt.EndLine,
+			Language:   seedEnt.Language,
+			Properties: props,
+		})
+		stats.EventFlows++
+
+		// SEED_OF_EVENT_FLOW: channel → EventFlow.
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     graph.RelationshipID(seedEnt.ID, flowID, RelationshipKindSeedOfEventFlow),
+			FromID: seedEnt.ID,
+			ToID:   flowID,
+			Kind:   RelationshipKindSeedOfEventFlow,
+		})
+		stats.SeedEdges++
+
+		// STEP_IN_EVENT_FLOW edges in order.
+		for i, stepID := range chain {
+			rel := graph.Relationship{
+				ID:     graph.RelationshipID(flowID, stepID, RelationshipKindStepInEventFlow+":"+strconv.Itoa(i)),
+				FromID: flowID,
+				ToID:   stepID,
+				Kind:   RelationshipKindStepInEventFlow,
+				Properties: map[string]string{
+					"step_index": strconv.Itoa(i),
+				},
+			}
+			doc.Relationships = append(doc.Relationships, rel)
+			stats.StepEdges++
+		}
+	}
+
+	return stats
+}
+
+// walkEventFlow runs the linear Phase-1 walk from `seedID`. Returns one
+// chain per consumer-of-seed × distinct terminal pair. The walk is
+// depth-first with cycle detection on channels (visiting the same
+// channel twice closes a saga loop — we record the longest prefix and
+// stop).
+func walkEventFlow(
+	seedID string,
+	byID map[string]*graph.Entity,
+	psAdj *pubSubAdjacency,
+	callsAdj *callsAdjacency,
+	cfg EventFlowConfig,
+	stats *eventFlowStats,
+) [][]string {
+	var out [][]string
+
+	// Subscribers of the seed channel are the entry consumers. When a
+	// channel has no subscribers in this doc, no flow is emitted (Phase
+	// 3 cross-stack walker will pick those up via companions).
+	subs := psAdj.subscribers[seedID]
+	if len(subs) == 0 {
+		return out
+	}
+
+	// visitedChannels tracks channels reached on the current chain so a
+	// pub/sub cycle (A → B → A) terminates after recording one full
+	// pass instead of looping. Subscribers and intra-call walks are NOT
+	// tracked here — they're constrained by depth caps.
+
+	for _, subID := range subs {
+		init := frame{
+			chain:           []string{seedID, subID},
+			visitedChannels: map[string]bool{seedID: true},
+			channelHops:     0,
+		}
+		expandEventFlow(init, byID, psAdj, callsAdj, cfg, stats, &out)
+	}
+	return out
+}
+
+// expandEventFlow extends one walk frame. From the latest consumer
+// node, walk CALLS (bounded by MaxIntraCallDepth) to find downstream
+// PUBLISHES_TO edges. Each such publish edge extends the chain by
+// [...intra-calls, publisher, next-channel]. If next-channel has its
+// own subscribers, the walk recurses; otherwise the chain terminates
+// at next-channel.
+func expandEventFlow(
+	fr frame,
+	byID map[string]*graph.Entity,
+	psAdj *pubSubAdjacency,
+	callsAdj *callsAdjacency,
+	cfg EventFlowConfig,
+	stats *eventFlowStats,
+	out *[][]string,
+) {
+	// Always record the current chain as a candidate terminal. The
+	// caller dedupes longer chains over shorter prefixes via the global
+	// sort + MaxFlows truncation; emitting at each terminal preserves
+	// "consumer with no downstream publish" flows.
+	*out = append(*out, append([]string(nil), fr.chain...))
+
+	if fr.channelHops >= cfg.MaxDepth {
+		stats.TruncatedDepth++
+		return
+	}
+
+	consumerID := fr.chain[len(fr.chain)-1]
+
+	// BFS over CALLS from the consumer to find publishers reachable
+	// within MaxIntraCallDepth. Each (publisher, channel) it lands on
+	// becomes a continuation frame.
+	type callHit struct {
+		path      []string // CALLS path from consumer (exclusive) to publisher (inclusive)
+		publisher string
+		channel   string
+	}
+	var hits []callHit
+
+	visited := map[string]bool{consumerID: true}
+	type bfsNode struct {
+		id   string
+		path []string
+	}
+	queue := []bfsNode{{id: consumerID, path: nil}}
+	for len(queue) > 0 && len(hits) < 32 {
+		// pop front
+		cur := queue[0]
+		queue = queue[1:]
+		// Does cur publish anywhere?
+		if chans, ok := psAdj.publishesOf[cur.id]; ok && cur.id != consumerID {
+			// cur is a downstream callee that publishes — every channel
+			// it publishes to that we haven't already visited becomes a
+			// continuation hit. (consumerID itself rarely publishes; if
+			// it does, we still want it to count.)
+			for _, ch := range chans {
+				if fr.visitedChannels[ch] {
+					continue
+				}
+				hits = append(hits, callHit{
+					path:      append([]string(nil), cur.path...),
+					publisher: cur.id,
+					channel:   ch,
+				})
+			}
+		}
+		if len(cur.path) >= cfg.MaxIntraCallDepth {
+			continue
+		}
+		for _, nb := range callsAdj.out[cur.id] {
+			if visited[nb] {
+				continue
+			}
+			visited[nb] = true
+			nextPath := append(append([]string(nil), cur.path...), nb)
+			queue = append(queue, bfsNode{id: nb, path: nextPath})
+		}
+	}
+
+	// The consumer itself may publish directly to the next channel
+	// (zero-intra-call hop). Capture that case explicitly so a
+	// minimum-shape sub→pub bridge still produces a chain.
+	if chans, ok := psAdj.publishesOf[consumerID]; ok {
+		for _, ch := range chans {
+			if fr.visitedChannels[ch] {
+				continue
+			}
+			// Avoid duplicating a zero-path hit we may also have caught
+			// via the BFS (we won't, since visited[consumerID]=true).
+			hits = append(hits, callHit{
+				path:      nil,
+				publisher: consumerID,
+				channel:   ch,
+			})
+		}
+	}
+
+	// Determinism: sort hits by (channel, publisher) so the chain order
+	// is reproducible across runs.
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].channel != hits[j].channel {
+			return hits[i].channel < hits[j].channel
+		}
+		return hits[i].publisher < hits[j].publisher
+	})
+
+	for _, h := range hits {
+		// Build the extended chain: existing chain + intra-call path +
+		// publisher (if not already last) + channel + subscribers of
+		// channel (each forks a sub-frame).
+		extended := append([]string(nil), fr.chain...)
+		for _, n := range h.path {
+			extended = append(extended, n)
+		}
+		if h.publisher != extended[len(extended)-1] {
+			extended = append(extended, h.publisher)
+		}
+		extended = append(extended, h.channel)
+
+		nextVisited := make(map[string]bool, len(fr.visitedChannels)+1)
+		for k := range fr.visitedChannels {
+			nextVisited[k] = true
+		}
+		nextVisited[h.channel] = true
+
+		nextSubs := psAdj.subscribers[h.channel]
+		if len(nextSubs) == 0 {
+			// Terminal channel — record the chain ending on it.
+			*out = append(*out, append([]string(nil), extended...))
+			continue
+		}
+		for _, nextSub := range nextSubs {
+			subChain := append(append([]string(nil), extended...), nextSub)
+			expandEventFlow(frame{
+				chain:           subChain,
+				visitedChannels: nextVisited,
+				channelHops:     fr.channelHops + 1,
+			}, byID, psAdj, callsAdj, cfg, stats, out)
+		}
+	}
+}
+
+// frame is the walker's per-recursion state. Declared at package level
+// so the helper functions can reference it without nesting.
+type frame struct {
+	chain           []string
+	visitedChannels map[string]bool
+	channelHops     int
+}
+
+// buildLinearChainStepDAG materialises a linear ChainStep DAG matching
+// the shape produced by buildFlowDAG. Each step is a child of the
+// previous; no Branches fan-out. Used so flows.tsx can render an
+// EventFlow with the same component code path as a ProcessFlow.
+func buildLinearChainStepDAG(chain []string, byID map[string]*graph.Entity) *ChainStep {
+	if len(chain) == 0 {
+		return nil
+	}
+	root := newChainStep(chain[0], 0, byID)
+	cur := root
+	for i := 1; i < len(chain); i++ {
+		child := newChainStep(chain[i], i, byID)
+		cur.Branches = append(cur.Branches, child)
+		cur = child
+	}
+	return root
+}
+
+// computeEventFlowID derives a stable EventFlow entity ID from the repo
+// tag and the full chain. Collision-resistant in the same way as
+// computeProcessID.
+func computeEventFlowID(repo string, chain []string) string {
+	h := sha256.New()
+	h.Write([]byte(repo))
+	h.Write([]byte{0})
+	h.Write([]byte("EventFlow"))
+	h.Write([]byte{0})
+	for _, c := range chain {
+		h.Write([]byte(c))
+		h.Write([]byte{0})
+	}
+	return "evflow:" + hex.EncodeToString(h.Sum(nil))[:16]
+}

--- a/internal/engine/event_flow_test.go
+++ b/internal/engine/event_flow_test.go
@@ -1,0 +1,370 @@
+// Tests for the Phase-1 EventFlow walker (#1944).
+package engine
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// fixtureBuilder is a tiny DSL for assembling pub/sub graphs in tests.
+// Channels, operations, CALLS / PUBLISHES_TO / SUBSCRIBES_TO edges are
+// all addressed by short test-local IDs (e.g. "topic.A", "svc.handleA").
+type fixtureBuilder struct {
+	doc *graph.Document
+}
+
+func newFixture(repo string) *fixtureBuilder {
+	return &fixtureBuilder{doc: &graph.Document{Repo: repo}}
+}
+
+func (b *fixtureBuilder) channel(id, name string) *fixtureBuilder {
+	b.doc.Entities = append(b.doc.Entities, graph.Entity{
+		ID:   id,
+		Name: name,
+		Kind: eventFlowChannelKindMessageTopic,
+	})
+	return b
+}
+
+func (b *fixtureBuilder) eventBus(id, name string) *fixtureBuilder {
+	b.doc.Entities = append(b.doc.Entities, graph.Entity{
+		ID:   id,
+		Name: name,
+		Kind: eventFlowChannelKindEventBus,
+	})
+	return b
+}
+
+func (b *fixtureBuilder) op(id, name string) *fixtureBuilder {
+	b.doc.Entities = append(b.doc.Entities, graph.Entity{
+		ID:         id,
+		Name:       name,
+		Kind:       "SCOPE.Function",
+		Language:   "go",
+		SourceFile: "main.go",
+	})
+	return b
+}
+
+func (b *fixtureBuilder) calls(from, to string) *fixtureBuilder {
+	b.doc.Relationships = append(b.doc.Relationships, graph.Relationship{
+		ID: "call:" + from + "->" + to, FromID: from, ToID: to, Kind: "CALLS",
+	})
+	return b
+}
+
+func (b *fixtureBuilder) publishes(op, channel string) *fixtureBuilder {
+	b.doc.Relationships = append(b.doc.Relationships, graph.Relationship{
+		ID: "pub:" + op + "->" + channel, FromID: op, ToID: channel, Kind: "PUBLISHES_TO",
+	})
+	return b
+}
+
+func (b *fixtureBuilder) subscribes(op, channel string) *fixtureBuilder {
+	b.doc.Relationships = append(b.doc.Relationships, graph.Relationship{
+		ID: "sub:" + op + "->" + channel, FromID: op, ToID: channel, Kind: "SUBSCRIBES_TO",
+	})
+	return b
+}
+
+// firstEventFlow returns the first EventFlow entity emitted into doc,
+// or nil if none is present.
+func firstEventFlow(doc *graph.Document) *graph.Entity {
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == EntityKindEventFlow {
+			return &doc.Entities[i]
+		}
+	}
+	return nil
+}
+
+func countEventFlows(doc *graph.Document) int {
+	n := 0
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindEventFlow {
+			n++
+		}
+	}
+	return n
+}
+
+// --- linear single-channel: pub → channel → sub ---
+func TestEventFlow_LinearPubSub(t *testing.T) {
+	// publisher publishes to topic.A; subscriber consumes from topic.A.
+	// Phase 1 walker seeds from topic.A and emits a flow:
+	//   topic.A → sub.handler
+	// (no downstream channel, so this is the terminal shape.)
+	b := newFixture("r").
+		channel("topic.A", "kafka:payments.settled").
+		op("svc.publisher", "publishPayment").
+		op("svc.subscriber", "handlePayment").
+		publishes("svc.publisher", "topic.A").
+		subscribes("svc.subscriber", "topic.A")
+
+	cfg := DefaultEventFlowConfig()
+	cfg.MinSteps = 2
+	stats := RunEventFlow(b.doc, cfg)
+
+	if stats.SeedChannels != 1 {
+		t.Fatalf("want 1 seed channel, got %d", stats.SeedChannels)
+	}
+	if stats.EventFlows == 0 {
+		t.Fatalf("expected at least 1 EventFlow, got 0")
+	}
+	ef := firstEventFlow(b.doc)
+	if ef == nil {
+		t.Fatalf("no EventFlow entity emitted")
+	}
+	chain := strings.Split(ef.Properties["chain"], ",")
+	// Minimum-shape chain is exactly [topic.A, svc.subscriber].
+	if len(chain) < 2 || chain[0] != "topic.A" || chain[1] != "svc.subscriber" {
+		t.Errorf("unexpected chain %v", chain)
+	}
+	if ef.Properties["entry_kind"] != "channel" {
+		t.Errorf("entry_kind = %q, want channel", ef.Properties["entry_kind"])
+	}
+}
+
+// --- multi-hop: sub publishes onto a downstream channel ---
+func TestEventFlow_MultiHopChain(t *testing.T) {
+	// topic.A → subA (calls forward) → publisherB → topic.B → subB
+	b := newFixture("r").
+		channel("topic.A", "kafka:orders.placed").
+		channel("topic.B", "kafka:payments.requested").
+		op("svc.subA", "handleOrder").
+		op("svc.helper", "buildPayment").
+		op("svc.publisherB", "publishPaymentReq").
+		op("svc.subB", "handlePaymentReq").
+		subscribes("svc.subA", "topic.A").
+		calls("svc.subA", "svc.helper").
+		calls("svc.helper", "svc.publisherB").
+		publishes("svc.publisherB", "topic.B").
+		subscribes("svc.subB", "topic.B")
+
+	cfg := DefaultEventFlowConfig()
+	cfg.MinSteps = 2
+	stats := RunEventFlow(b.doc, cfg)
+	if stats.EventFlows == 0 {
+		t.Fatalf("expected at least 1 EventFlow")
+	}
+
+	// Find the longest chain seeded by topic.A — it should hit topic.B.
+	var best *graph.Entity
+	for i := range b.doc.Entities {
+		e := &b.doc.Entities[i]
+		if e.Kind != EntityKindEventFlow {
+			continue
+		}
+		if e.Properties["entry_id"] != "topic.A" {
+			continue
+		}
+		if best == nil {
+			best = e
+			continue
+		}
+		bsc, _ := strconv.Atoi(best.Properties["step_count"])
+		csc, _ := strconv.Atoi(e.Properties["step_count"])
+		if csc > bsc {
+			best = e
+		}
+	}
+	if best == nil {
+		t.Fatal("no EventFlow seeded by topic.A")
+	}
+	chain := strings.Split(best.Properties["chain"], ",")
+	// Expect topic.A as seed and topic.B somewhere downstream.
+	if chain[0] != "topic.A" {
+		t.Errorf("seed = %s, want topic.A", chain[0])
+	}
+	hasTopicB := false
+	hasSubB := false
+	for _, id := range chain {
+		if id == "topic.B" {
+			hasTopicB = true
+		}
+		if id == "svc.subB" {
+			hasSubB = true
+		}
+	}
+	if !hasTopicB {
+		t.Errorf("multi-hop chain missing topic.B: %v", chain)
+	}
+	if !hasSubB {
+		t.Errorf("multi-hop chain missing svc.subB: %v", chain)
+	}
+
+	channelCount, _ := strconv.Atoi(best.Properties["channel_count"])
+	if channelCount < 2 {
+		t.Errorf("channel_count = %d, want ≥2 for multi-hop chain", channelCount)
+	}
+}
+
+// --- cycle prevention: A → sub publishes back to A ---
+func TestEventFlow_CycleStopsAtRevisit(t *testing.T) {
+	// Saga loop: topic.A subscribers publish back to topic.A.
+	// Walker must stop after one full revolution rather than diverging.
+	b := newFixture("r").
+		channel("topic.A", "saga:retry").
+		op("svc.handler", "retryHandler").
+		subscribes("svc.handler", "topic.A").
+		publishes("svc.handler", "topic.A")
+
+	cfg := DefaultEventFlowConfig()
+	cfg.MinSteps = 2
+	stats := RunEventFlow(b.doc, cfg)
+	if stats.EventFlows == 0 {
+		t.Fatal("expected at least one EventFlow")
+	}
+
+	// No emitted chain should mention topic.A more than once.
+	for _, e := range b.doc.Entities {
+		if e.Kind != EntityKindEventFlow {
+			continue
+		}
+		chain := strings.Split(e.Properties["chain"], ",")
+		seen := 0
+		for _, id := range chain {
+			if id == "topic.A" {
+				seen++
+			}
+		}
+		if seen > 1 {
+			t.Errorf("cycle not prevented; chain visits topic.A %d times: %v", seen, chain)
+		}
+	}
+}
+
+// --- depth cap: a long chain of channels is truncated at MaxDepth ---
+func TestEventFlow_DepthCap(t *testing.T) {
+	// Build a 10-channel linear chain: each sub publishes to the next
+	// channel. With MaxDepth=2 the walker must stop after 2 channel
+	// hops past the seed.
+	b := newFixture("r")
+	const N = 10
+	for i := 0; i < N; i++ {
+		b.channel("topic."+strconv.Itoa(i), "topic."+strconv.Itoa(i))
+		b.op("sub."+strconv.Itoa(i), "handler"+strconv.Itoa(i))
+		b.subscribes("sub."+strconv.Itoa(i), "topic."+strconv.Itoa(i))
+		if i < N-1 {
+			b.publishes("sub."+strconv.Itoa(i), "topic."+strconv.Itoa(i+1))
+		}
+	}
+
+	cfg := DefaultEventFlowConfig()
+	cfg.MinSteps = 2
+	cfg.MaxDepth = 2 // permit at most 2 channel transitions past the seed
+	RunEventFlow(b.doc, cfg)
+
+	// The longest chain seeded by topic.0 should mention at most
+	// MaxDepth+1 = 3 channels total.
+	maxChannels := 0
+	for _, e := range b.doc.Entities {
+		if e.Kind != EntityKindEventFlow {
+			continue
+		}
+		if e.Properties["entry_id"] != "topic.0" {
+			continue
+		}
+		cc, _ := strconv.Atoi(e.Properties["channel_count"])
+		if cc > maxChannels {
+			maxChannels = cc
+		}
+	}
+	if maxChannels == 0 {
+		t.Fatal("no flow emitted for topic.0")
+	}
+	if maxChannels > 3 {
+		t.Errorf("depth cap violated: longest chain has %d channels, want ≤3", maxChannels)
+	}
+}
+
+// --- EventBusEvent channels are also seeded (not just MessageTopic) ---
+func TestEventFlow_EventBusSeeded(t *testing.T) {
+	b := newFixture("r").
+		eventBus("evt.A", "event:eventbridge:orders:placed").
+		op("svc.handler", "onPlaced").
+		subscribes("svc.handler", "evt.A")
+
+	cfg := DefaultEventFlowConfig()
+	cfg.MinSteps = 2
+	stats := RunEventFlow(b.doc, cfg)
+	if stats.EventFlows == 0 {
+		t.Fatalf("expected EventBusEvent to seed at least one flow")
+	}
+}
+
+// --- entity/edge shape: SEED_OF_EVENT_FLOW and STEP_IN_EVENT_FLOW ---
+func TestEventFlow_EmitsSeedAndStepEdges(t *testing.T) {
+	b := newFixture("r").
+		channel("topic.A", "kafka:t").
+		op("svc.handler", "h").
+		subscribes("svc.handler", "topic.A")
+
+	cfg := DefaultEventFlowConfig()
+	cfg.MinSteps = 2
+	RunEventFlow(b.doc, cfg)
+
+	var seedEdges, stepEdges int
+	for _, r := range b.doc.Relationships {
+		switch r.Kind {
+		case RelationshipKindSeedOfEventFlow:
+			seedEdges++
+		case RelationshipKindStepInEventFlow:
+			stepEdges++
+		}
+	}
+	if seedEdges == 0 {
+		t.Errorf("no SEED_OF_EVENT_FLOW edges emitted")
+	}
+	if stepEdges == 0 {
+		t.Errorf("no STEP_IN_EVENT_FLOW edges emitted")
+	}
+}
+
+// --- determinism: two runs over the same fixture produce identical output ---
+func TestEventFlow_Deterministic(t *testing.T) {
+	build := func() *graph.Document {
+		b := newFixture("r").
+			channel("topic.A", "a").
+			channel("topic.B", "b").
+			op("subA", "h1").
+			op("pubB", "h2").
+			op("subB", "h3").
+			subscribes("subA", "topic.A").
+			calls("subA", "pubB").
+			publishes("pubB", "topic.B").
+			subscribes("subB", "topic.B")
+		return b.doc
+	}
+	d1 := build()
+	d2 := build()
+	RunEventFlow(d1, DefaultEventFlowConfig())
+	RunEventFlow(d2, DefaultEventFlowConfig())
+
+	collect := func(d *graph.Document) []string {
+		var out []string
+		for _, e := range d.Entities {
+			if e.Kind == EntityKindEventFlow {
+				out = append(out, e.Properties["chain"])
+			}
+		}
+		return out
+	}
+	a, c := collect(d1), collect(d2)
+	if strings.Join(a, "|") != strings.Join(c, "|") {
+		t.Errorf("non-deterministic emission:\n  run1=%v\n  run2=%v", a, c)
+	}
+}
+
+// --- safety: nil doc and empty doc don't panic ---
+func TestEventFlow_NilAndEmptyDocSafe(t *testing.T) {
+	RunEventFlow(nil, DefaultEventFlowConfig())
+	doc := &graph.Document{Repo: "r"}
+	stats := RunEventFlow(doc, DefaultEventFlowConfig())
+	if stats.EventFlows != 0 {
+		t.Errorf("expected 0 EventFlows on empty doc, got %d", stats.EventFlows)
+	}
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -671,6 +671,58 @@ export interface FlowDeadEndsResponse {
 }
 
 // ----------------------------------------------------------------
+// Event Flows (#1944 Phase 1) — multi-hop pub/sub chains seeded by
+// channels (SCOPE.MessageTopic / SCOPE.EventBusEvent). Same Property
+// contract as ProcessFlows so the Flows DAG renderer drives both.
+// ----------------------------------------------------------------
+
+export interface EventFlowListItem {
+  event_flow_id: string;
+  repo: string;
+  label: string;
+  seed_id: string;
+  seed_name: string;
+  terminal_id: string;
+  step_count: number;
+  channel_count: number;
+  chain_labels: string[];
+  source_file?: string;
+  entry_kind: "channel";
+}
+
+export interface EventFlowsListResponse {
+  event_flows: EventFlowListItem[];
+  count: number;
+}
+
+export interface EventFlowStep {
+  entity_id: string;
+  label: string;
+  repo: string;
+  step_index: number;
+  entity_kind: string;
+  source_file?: string;
+  start_line?: number;
+  is_channel: boolean;
+}
+
+export interface EventFlowDetailResponse {
+  event_flow_id: string;
+  repo: string;
+  label: string;
+  seed_id: string;
+  seed_name: string;
+  terminal_id: string;
+  step_count: number;
+  channel_count: number;
+  chain_labels: string[];
+  /** JSON-serialised DAG (mirrors ProcessFlow.branches_dag).  */
+  branches_dag: string;
+  steps: EventFlowStep[];
+  entry_kind: "channel";
+}
+
+// ----------------------------------------------------------------
 // Paths screen types (mirrors v2_paths.go wire shapes)
 // ----------------------------------------------------------------
 

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -28,6 +28,8 @@ import type {
   FlowsListResponse,
   FlowDetailResponse,
   FlowDeadEndsResponse,
+  EventFlowsListResponse,
+  EventFlowDetailResponse,
   PathsListResponse,
   PathDetail,
   OrphansResponse,
@@ -449,6 +451,23 @@ export const api = {
       `/flows/${groupId}/${encodeURIComponent(processId)}/trigger-enrichment`,
       { method: "POST" },
     ),
+
+  // --- Event Flows (#1944 Phase 1) — pub/sub multi-hop chains ---
+  /** GET /api/event-flows/:group — list event-flow chains. */
+  listEventFlows: (groupId: string, params?: { seed?: string; minSteps?: number; limit?: number }) => {
+    const q = new URLSearchParams();
+    if (params?.seed) q.set("seed", params.seed);
+    if (params?.minSteps != null) q.set("min_steps", String(params.minSteps));
+    if (params?.limit != null) q.set("limit", String(params.limit));
+    const qs = q.toString() ? `?${q.toString()}` : "";
+    return request<EventFlowsListResponse>(`/event-flows/${encodeURIComponent(groupId)}${qs}`);
+  },
+  /** GET /api/event-flows/:group/:eventFlowId — full chain detail. */
+  getEventFlowDetail: (groupId: string, eventFlowId: string) =>
+    request<EventFlowDetailResponse>(
+      `/event-flows/${encodeURIComponent(groupId)}/${encodeURIComponent(eventFlowId)}`,
+    ),
+
   // --- v2 Paths screen ---
   /** GET /api/v2/groups/:id/paths — backend-grouped route list + totals. */
   listPaths: (groupId: string) =>

--- a/webui-v2/src/routes/event-flows.tsx
+++ b/webui-v2/src/routes/event-flows.tsx
@@ -1,0 +1,313 @@
+/* ============================================================
+   routes/event-flows.tsx — Event Flows screen (#1944 Phase 1)
+
+   Multi-hop pub/sub chains seeded by Channel entities
+   (SCOPE.MessageTopic / SCOPE.EventBusEvent). The wire shape mirrors
+   /api/flows on the Process-Flow side (same chain / branches_dag /
+   step_count keys) so the existing Flows DAG renderer can drive both
+   views once the renderer is extracted (#2028 already prepared the
+   contract; renderer extraction itself is a follow-up).
+
+   Phase 1 layout (intentionally minimal):
+     - Left rail: list of event-flow chains, sorted by channel count
+       then step count.
+     - Right pane: chain steps rendered as a vertical strip with
+       channel nodes coloured distinctly from operation nodes; the
+       raw branches_dag payload is exposed via "View DAG JSON" so the
+       full DAG renderer (#2028 / flows.tsx) can adopt it without an
+       API change.
+
+   Out of scope for Phase 1:
+     - DAG branching renderer reuse — Phase 2 (event branching) lands
+       on top of #1945 once the per-language extractors emit branch
+       reasons for pub/sub.
+     - Cross-stack walker — Phase 3 (#1902/#1913 bridges).
+     - Conditional routing — Phase 5.
+   ============================================================ */
+
+import { useState, useMemo } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Radio, Workflow, ChevronRight, Copy } from "lucide-react";
+import { toast } from "sonner";
+
+import { api } from "@/lib/api";
+import { Badge, Skeleton } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+import type {
+  EventFlowListItem,
+  EventFlowDetailResponse,
+  EventFlowStep,
+} from "@/data/types";
+
+// ---------------------------------------------------------------------------
+// Hooks — both wrap api.ts so auth headers / base URL are centralised.
+// ---------------------------------------------------------------------------
+
+function useEventFlows(groupId: string | undefined) {
+  return useQuery({
+    queryKey: ["event-flows", groupId],
+    queryFn: () => api.listEventFlows(groupId!, { limit: 200 }),
+    enabled: Boolean(groupId),
+  });
+}
+
+function useEventFlowDetail(groupId: string | undefined, eventFlowId: string | null) {
+  return useQuery({
+    queryKey: ["event-flow-detail", groupId, eventFlowId],
+    queryFn: () => api.getEventFlowDetail(groupId!, eventFlowId!),
+    enabled: Boolean(groupId) && Boolean(eventFlowId),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Presentation — channel vs operation node tokens
+// ---------------------------------------------------------------------------
+
+function StepNode({ step }: { step: EventFlowStep }) {
+  const isChannel = step.is_channel;
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-md border px-3 py-2",
+        isChannel
+          ? "border-[var(--pastel-2)] bg-[var(--pastel-2)]/15"
+          : "border-border bg-surface-1",
+      )}
+    >
+      <div
+        className={cn(
+          "flex h-7 w-7 shrink-0 items-center justify-center rounded-full",
+          isChannel
+            ? "bg-[var(--pastel-2)] text-[var(--pastel-2-ink)]"
+            : "bg-surface-2 text-text-2",
+        )}
+      >
+        {isChannel ? <Radio size={14} /> : <Workflow size={14} />}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-text-1">{step.label || step.entity_id}</div>
+        <div className="truncate text-xs text-text-3">
+          {isChannel ? "channel" : "operation"} · {step.repo}
+          {step.source_file ? ` · ${step.source_file}` : ""}
+        </div>
+      </div>
+      <span className="text-xs text-text-4">#{step.step_index}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Left rail — list of chains
+// ---------------------------------------------------------------------------
+
+function ChainListItem({
+  item,
+  selected,
+  onClick,
+}: {
+  item: EventFlowListItem;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "w-full rounded-md border px-3 py-2 text-left transition-colors",
+        selected
+          ? "border-[var(--accent)] bg-surface-2"
+          : "border-border bg-surface-1 hover:bg-surface-2",
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate text-sm font-medium text-text-1">{item.label}</span>
+        <ChevronRight size={14} className="shrink-0 text-text-4" />
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-3">
+        <Badge tone="neutral">{item.repo}</Badge>
+        <span>{item.channel_count} channels</span>
+        <span>·</span>
+        <span>{item.step_count} steps</span>
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Right pane — selected chain detail
+// ---------------------------------------------------------------------------
+
+function ChainDetail({ detail }: { detail: EventFlowDetailResponse }) {
+  const [showDAG, setShowDAG] = useState(false);
+
+  function copyDAG() {
+    navigator.clipboard.writeText(detail.branches_dag || "");
+    toast.success("DAG JSON copied to clipboard");
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <header className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h2 className="truncate text-base font-semibold text-text-1">{detail.label}</h2>
+          <p className="text-xs text-text-3">
+            seed <span className="font-mono text-text-2">{detail.seed_name || detail.seed_id}</span>
+            {" · "}{detail.channel_count} channels{" · "}{detail.step_count} steps
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowDAG((v) => !v)}
+          className="rounded-md border border-border bg-surface-1 px-2.5 py-1 text-xs text-text-2 hover:bg-surface-2"
+        >
+          {showDAG ? "Hide" : "View"} DAG JSON
+        </button>
+      </header>
+
+      <div className="flex flex-col gap-2">
+        {detail.steps.map((step, idx) => (
+          <div key={`${step.entity_id}-${idx}`} className="flex flex-col gap-2">
+            <StepNode step={step} />
+            {idx < detail.steps.length - 1 && (
+              <div className="ml-3.5 h-3 w-px bg-border" aria-hidden />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {showDAG && detail.branches_dag && (
+        <div className="rounded-md border border-border bg-surface-1 p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs font-medium text-text-2">branches_dag</span>
+            <button
+              type="button"
+              onClick={copyDAG}
+              className="flex items-center gap-1 text-xs text-text-3 hover:text-text-1"
+            >
+              <Copy size={12} /> Copy
+            </button>
+          </div>
+          <pre className="max-h-72 overflow-auto text-xs text-text-3">
+            {prettyJSON(detail.branches_dag)}
+          </pre>
+          <p className="mt-2 text-[11px] text-text-4">
+            Shape matches ProcessFlow.branches_dag (#2028); the shared Flows DAG renderer
+            consumes this payload unchanged.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function prettyJSON(s: string): string {
+  try {
+    return JSON.stringify(JSON.parse(s), null, 2);
+  } catch {
+    return s;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+export default function EventFlowsScreen() {
+  const { groupId } = useParams<{ groupId: string }>();
+  const [search, setSearch] = useSearchParams();
+  const selectedId = search.get("flow");
+  const seedFilter = search.get("seed");
+
+  const { data, isLoading, error } = useEventFlows(groupId);
+  const detail = useEventFlowDetail(groupId, selectedId);
+
+  const items = useMemo<EventFlowListItem[]>(() => {
+    const all = data?.event_flows ?? [];
+    if (!seedFilter) return all;
+    return all.filter(
+      (i) => i.seed_id === seedFilter || i.event_flow_id === seedFilter,
+    );
+  }, [data, seedFilter]);
+
+  function selectFlow(id: string | null) {
+    const next = new URLSearchParams(search);
+    if (id) next.set("flow", id);
+    else next.delete("flow");
+    setSearch(next, { replace: true });
+  }
+
+  return (
+    <div className="flex h-full w-full gap-4 p-4">
+      {/* Left rail */}
+      <aside className="flex w-[380px] shrink-0 flex-col gap-3 rounded-lg border border-border bg-surface-0 p-3">
+        <header className="flex items-center justify-between">
+          <h1 className="text-sm font-semibold text-text-1">Event Flows</h1>
+          <Badge tone="neutral">{items.length}</Badge>
+        </header>
+        {seedFilter && (
+          <button
+            type="button"
+            onClick={() => {
+              const next = new URLSearchParams(search);
+              next.delete("seed");
+              setSearch(next, { replace: true });
+            }}
+            className="rounded-md border border-border bg-surface-1 px-2 py-1 text-xs text-text-2 hover:bg-surface-2"
+          >
+            Clear seed filter ({seedFilter})
+          </button>
+        )}
+        <div className="flex flex-col gap-2 overflow-auto">
+          {isLoading && (
+            <>
+              <Skeleton className="h-14 w-full" />
+              <Skeleton className="h-14 w-full" />
+              <Skeleton className="h-14 w-full" />
+            </>
+          )}
+          {error && (
+            <p className="text-xs text-text-3">Failed to load event flows.</p>
+          )}
+          {!isLoading && !error && items.length === 0 && (
+            <p className="text-xs text-text-3">
+              No multi-hop pub/sub chains found in this group yet. Phase 1 walker
+              seeds from MessageTopic and EventBusEvent channels — index a repo
+              with Kafka, EventBridge, or similar pub/sub edges to populate.
+            </p>
+          )}
+          {items.map((it) => (
+            <ChainListItem
+              key={it.event_flow_id}
+              item={it}
+              selected={it.event_flow_id === selectedId}
+              onClick={() => selectFlow(it.event_flow_id)}
+            />
+          ))}
+        </div>
+      </aside>
+
+      {/* Right pane */}
+      <main className="flex-1 overflow-auto rounded-lg border border-border bg-surface-0 p-4">
+        {!selectedId && (
+          <div className="flex h-full items-center justify-center">
+            <p className="text-sm text-text-3">Select an event flow to view its chain.</p>
+          </div>
+        )}
+        {selectedId && detail.isLoading && (
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-6 w-1/2" />
+            <Skeleton className="h-14 w-full" />
+            <Skeleton className="h-14 w-full" />
+          </div>
+        )}
+        {selectedId && detail.error && (
+          <p className="text-sm text-text-3">Failed to load event flow detail.</p>
+        )}
+        {selectedId && detail.data && <ChainDetail detail={detail.data} />}
+      </main>
+    </div>
+  );
+}

--- a/webui-v2/src/routes/router.tsx
+++ b/webui-v2/src/routes/router.tsx
@@ -16,6 +16,7 @@ import PrimitivesShowcase from "@/components/showcase/primitives-showcase";
 
 import GraphScreen from "./graph";
 import FlowsScreen from "./flows";
+import EventFlowsScreen from "./event-flows";
 import TopologyScreen from "./topology";
 import PathsScreen from "./paths";
 import DocsScreen from "./docs";
@@ -41,6 +42,7 @@ export const router = createBrowserRouter([
           { index: true, element: <GraphScreen />, handle: { surfaceLabel: "Graph" } },
           { path: "graph", element: <GraphScreen />, handle: { surfaceLabel: "Graph" } },
           { path: "flows", element: <FlowsScreen />, handle: { surfaceLabel: "Flows" } },
+          { path: "event-flows", element: <EventFlowsScreen />, handle: { surfaceLabel: "Event Flows" } },
           { path: "topology", element: <TopologyScreen />, handle: { surfaceLabel: "Topology" } },
           { path: "paths", element: <PathsScreen />, handle: { surfaceLabel: "Paths" } },
           { path: "docs", element: <DocsScreen />, handle: { surfaceLabel: "Docs" } },


### PR DESCRIPTION
## 1. What

Phase-1 walker for **multi-hop pub/sub Event Flows**: takes a Channel entity (`SCOPE.MessageTopic` / `SCOPE.EventBusEvent`) and emits the multi-hop chain that propagates the event across publishers and subscribers (ETL/saga shape: `channel → sub → CALLS* → pub → next-channel → ...`). A new `SCOPE.EventFlow` entity reuses the same Property contract as `SCOPE.Process` so the Flows DAG renderer (#2028) drives both views.

Closes #1944 (Phase 1)

## 2. Why

Topology shows ONE channel slice (`pubs | channel | subs`). Real ETL/saga systems are multi-hop chains. Phase 1 lays the foundation; Phase 2 adds branching, Phase 3 adds cross-stack via companions, Phase 4 fills extractor coverage gaps, Phase 5 covers conditional routing.

## 3. How

**Engine (`internal/engine/event_flow.go`):**

- `RunEventFlow(doc, cfg)` linear DFS over reverse `SUBSCRIBES_TO` + `CALLS` + `PUBLISHES_TO`.
- Depth cap = 6 channel hops, intra-call BFS cap = 8, channel-cycle gate prevents saga infinite loops.
- Deterministic via sort-then-walk (seeds, neighbours, hits).
- Emits one `SCOPE.EventFlow` entity per surviving chain with `branches_dag` JSON (linear `ChainStep` tree built via `buildLinearChainStepDAG`) so `flows.tsx` can render it. New edges: `SEED_OF_EVENT_FLOW`, `STEP_IN_EVENT_FLOW`.
- Properties mirror ProcessFlow: `entry_id`, `entry_name`, `terminal_id`, `step_count`, `channel_count` (new), `chain`, `chain_labels`, `branches_dag`, `entry_kind=channel`, `dag_node_count`, `branch_count`, `is_dag`.

**Pipeline (`cmd/archigraph/index.go`):**

- Pass 7.5 between process-flow and module-agg.
- New `--skip-pass=event-flow` flag.
- `internal/cli/links.go` re-runs `RunEventFlow` after phantom-edge injection; `stripProcessEntities` now also drops stale `EventFlow` entities and their step/seed edges.

**Dashboard (`internal/dashboard/handlers_event_flows.go`):**

- `GET /api/event-flows/{group}` — list with `seed`, `min_steps`, `limit` query params.
- `GET /api/event-flows/{group}/{eventFlowId}` — detail with chain steps + raw `branches_dag` payload.
- Step shape carries `is_channel` so the renderer can colour channel nodes distinctly.

**Frontend (`webui-v2/src/routes/event-flows.tsx`):**

- New screen at `/g/:groupId/event-flows`.
- Left rail: chain list, sorted by `channel_count` then `step_count`.
- Right pane: chain rendered as a vertical strip; channel nodes (`Radio` icon) vs operation nodes (`Workflow` icon); `View DAG JSON` exposes `branches_dag` for the upcoming Flows DAG renderer adoption.
- `?seed=<channelId>` query-param filter so a future Topology channel click can deep-link here.
- API helpers (`api.listEventFlows`, `api.getEventFlowDetail`) and types (`EventFlowListItem`, `EventFlowDetailResponse`) added.

## 4. Tests

- `internal/engine/event_flow_test.go` — linear pub→channel→sub, multi-hop (sub publishes to next channel), cycle prevention, depth cap, EventBusEvent seeding, SEED/STEP edge emission, determinism across runs, nil/empty doc safety.
- `internal/dashboard/handlers_event_flows_test.go` — list shape, detail step list with `is_channel` flag, 404 path.

```
go test ./internal/engine/... ./internal/dashboard/... \
        ./internal/docgen/... ./internal/cli/... ./internal/links/...
```

All packages green; zero failures.

## 5. Phase-1 scope boundaries

Out of scope (tracked under #1944 phases 2-5):

- **Branching DAG walker for events** — Phase 2 (`#1945` layered on top of the linear walker landed here).
- **Cross-stack channel bridges via companion walker** — Phase 3 (`#1902` / `#1913`). The Phase-1 walker is single-doc only, so cross-stack edges may not surface end-to-end yet; the `branches_dag` schema already carries the slot a Phase-3 companion-aware variant will populate.
- **Per-language pub/sub extractor coverage** (Celery, AMQP, NATS, SNS/SQS) — Phase 4.
- **Conditional saga success/failure routing** — Phase 5.

The Property contract chosen here (`entry_id` / `chain` / `chain_labels` / `branches_dag` / `entry_kind`) is byte-identical to ProcessFlow so the upcoming Flows DAG renderer extraction can drive both views from one component without an API delta.

## 6. Risk

- Pass 7.5 adds a new mutating pass to the indexer; skippable via `--skip-pass=event-flow`. Repos with no pub/sub edges short-circuit immediately (`SeedChannels=0` returns empty stats).
- The walker writes new entity + edge kinds (`SCOPE.EventFlow`, `STEP_IN_EVENT_FLOW`, `SEED_OF_EVENT_FLOW`). Downstream consumers that filter by known kinds will ignore them by default — additive only, no existing kind altered.
- `stripProcessEntities` widened to also drop stale `EventFlow` entities on link re-run. Backward-compatible: docs without `EventFlow` entities follow the existing fast path.

## 7. Follow-ups (not in this PR)

- Topology channel click → deep-link to `/g/{group}/event-flows?seed={channelId}` (needs a small handler in `topology.tsx`'s channel detail panel; deferred so this PR stays scoped).
- Shared Flows DAG renderer extraction so `flows.tsx` and `event-flows.tsx` consume one component (post-#2028 renderer extraction).
- Phase 2 walker layer for branching (saga success/failure) — depends on per-language pub/sub control-flow extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)