### PR TITLE
feat(java-extractor): Phase 1 full parameter-location coverage — query/header/cookie/form/matrix (#1936 Phase 1)

### DIFF
--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -729,6 +729,9 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		// parameter annotations (populated for POST/PUT/PATCH endpoints).
 		RequestBodyType      string
 		RequestBodyParamName string
+		// Issue #1936 Phase 1 — full per-parameter JSON list emitted by the
+		// Java annotation extractor. Decoded into v2PathParameter rows below.
+		ParametersJSON string
 		// #1942 Phase 1 — resolved auth_policy decoded from the endpoint's
 		// `auth_policy` property. Multiple `matched` entries for the same path
 		// are reduced to the strongest policy when building the response.
@@ -877,6 +880,8 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 				// Issue #1909 — request body type from entity properties.
 				RequestBodyType:      e.Properties["request_body_type"],
 				RequestBodyParamName: e.Properties["request_body_param_name"],
+				// Issue #1936 Phase 1 — full parameter list (Java extractor).
+				ParametersJSON: e.Properties["parameters"],
 				// #1942 Phase 1 — auth_policy decoded from the endpoint entity.
 				AuthPolicy: readAuthPolicyFromEntity(e.Properties),
 			})
@@ -984,11 +989,66 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 	// Extract parameters from path segments (dynamic path params).
 	params := extractPathParameters(pathStr, verbs)
 
+	// Issue #1936 Phase 1 — when the Java extractor produced a full per-param
+	// list (parameters property), surface every row with its `in` chip
+	// populated. We merge across verbs: identical (name, in) rows accumulate
+	// their verb set so a parameter shared by multiple methods of the same
+	// path collapses to one row. Path rows from the URL template are kept as
+	// a fallback when the extractor did not emit them.
+	type paramKey struct {
+		Name string
+		In   string
+	}
+	emitted := map[paramKey]int{} // index into params
+	// Seed with path rows from URL template so paths without an annotation
+	// extractor still get a baseline.
+	for i, p := range params {
+		emitted[paramKey{p.Name, p.In}] = i
+	}
+	for _, h := range hits {
+		if h.ParametersJSON == "" {
+			continue
+		}
+		decoded := engine.DecodeJavaParameters(h.ParametersJSON)
+		for _, jp := range decoded {
+			key := paramKey{jp.Name, jp.In}
+			if idx, ok := emitted[key]; ok {
+				// Same (name, in) — extend verb set; never demote required.
+				if !containsStr(params[idx].Verbs, h.Verb) {
+					params[idx].Verbs = append(params[idx].Verbs, h.Verb)
+				}
+				if jp.Required {
+					params[idx].Required = true
+				}
+				continue
+			}
+			row := v2PathParameter{
+				Name:     jp.Name,
+				In:       jp.In,
+				Type:     jp.Type,
+				Required: jp.Required,
+				Desc:     describeJavaParam(jp),
+				Verbs:    []string{h.Verb},
+			}
+			params = append(params, row)
+			emitted[key] = len(params) - 1
+		}
+	}
+
 	// Issue #1909 — append request body parameter when the Java extractor
-	// captured a JAX-RS / Spring request body type. Collect from all matched
-	// hits (may differ per verb); first non-empty wins per verb.
+	// captured a JAX-RS / Spring request body type AND the richer Phase 1
+	// parameter list did not already surface a body row for that verb. This
+	// keeps backwards compatibility with older indexer outputs that still
+	// only emit request_body_type / request_body_param_name.
 	{
 		seenBodyVerbs := map[string]bool{}
+		for _, p := range params {
+			if p.In == "body" {
+				for _, v := range p.Verbs {
+					seenBodyVerbs[v] = true
+				}
+			}
+		}
 		for _, h := range hits {
 			if h.RequestBodyType == "" || seenBodyVerbs[h.Verb] {
 				continue
@@ -1379,6 +1439,37 @@ func inferServiceTypeV2(backendName string, repos []string) string {
 		return "GraphQL"
 	}
 	return "REST"
+}
+
+// describeJavaParam renders a short human-readable description for one
+// parameter extracted by the Java annotation pass (#1936 Phase 1). The
+// dashboard already renders the `In` chip; this string is shown in the
+// description column and mentions default-value + key annotation hints.
+func describeJavaParam(p engine.JavaParam) string {
+	parts := make([]string, 0, 3)
+	switch p.In {
+	case "query":
+		parts = append(parts, "Query parameter.")
+	case "header":
+		parts = append(parts, "Request header.")
+	case "cookie":
+		parts = append(parts, "Cookie value.")
+	case "form":
+		parts = append(parts, "Form field.")
+	case "matrix":
+		parts = append(parts, "Matrix parameter.")
+	case "body":
+		parts = append(parts, "Request body.")
+	case "path":
+		parts = append(parts, "Path segment.")
+	}
+	if p.DefaultValue != "" {
+		parts = append(parts, "Default: "+p.DefaultValue+".")
+	}
+	if len(p.Annotations) > 0 {
+		parts = append(parts, strings.Join(p.Annotations, " "))
+	}
+	return strings.TrimSpace(strings.Join(parts, " "))
 }
 
 // extractPathParameters builds a minimal parameter list from the path's

--- a/internal/dashboard/v2_paths_test.go
+++ b/internal/dashboard/v2_paths_test.go
@@ -525,3 +525,82 @@ func TestV2PathsList_V1Untouched(t *testing.T) {
 		t.Errorf("v1 GET /api/paths/{group}: want 200, got %d", resp.StatusCode)
 	}
 }
+
+// TestV2PathDetail_Issue1936_JavaParametersSurfaced verifies that when the
+// Java annotation extractor emits a `parameters` JSON property on an
+// http_endpoint entity, every parameter location surfaces in the detail
+// response with the correct `in` bucket — query/header/cookie/body in
+// addition to the path row synthesised from the URL template.
+func TestV2PathDetail_Issue1936_JavaParametersSurfaced(t *testing.T) {
+	path := "/transfers/confirm/{transferId}"
+	hash := hashStr(path)
+	// Mirror what ApplyJavaAnnotationRoutes would produce on a JAX-RS
+	// PUT handler with mixed parameter locations.
+	paramsJSON := `[` +
+		`{"name":"transferId","in":"path","type":"String","required":true,"annotations":["@PathParam"]},` +
+		`{"name":"dryRun","in":"query","type":"boolean","required":false,"default_value":"false","annotations":["@QueryParam","@DefaultValue"]},` +
+		`{"name":"X-Request-ID","in":"header","type":"String","required":true,"annotations":["@HeaderParam"]},` +
+		`{"name":"session","in":"cookie","type":"String","required":false,"annotations":["@CookieParam"]},` +
+		`{"name":"body","in":"body","type":"ConfirmRequest","required":true,"annotations":["@Valid"]}` +
+		`]`
+	entities := []graph.Entity{
+		{
+			ID:         "e-java-1",
+			Name:       "TransfersResource.confirm",
+			Kind:       "http_endpoint",
+			SourceFile: "src/main/java/TransfersResource.java",
+			StartLine:  17,
+			Language:   "java",
+			Properties: map[string]string{
+				"path":       path,
+				"verb":       "PUT",
+				"framework":  "jaxrs",
+				"parameters": paramsJSON,
+			},
+		},
+	}
+	grp := makePathsTestGroup(entities, nil)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths/" + hash)
+	if err != nil {
+		t.Fatalf("GET detail: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK   bool         `json:"ok"`
+		Data v2PathDetail `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	wantIns := map[string]string{
+		"transferId":   "path",
+		"dryRun":       "query",
+		"X-Request-ID": "header",
+		"session":      "cookie",
+		"body":         "body",
+	}
+	gotByName := map[string]v2PathParameter{}
+	for _, p := range body.Data.Parameters {
+		gotByName[p.Name] = p
+	}
+	for name, wantIn := range wantIns {
+		p, ok := gotByName[name]
+		if !ok {
+			t.Errorf("[#1936] parameter %q missing from detail response", name)
+			continue
+		}
+		if p.In != wantIn {
+			t.Errorf("[#1936] %q: want in=%s, got %s", name, wantIn, p.In)
+		}
+	}
+	// dryRun must be optional (default value present).
+	if dr, ok := gotByName["dryRun"]; ok && dr.Required {
+		t.Errorf("[#1936] dryRun: should not be required when default value present, got %+v", dr)
+	}
+}

--- a/internal/engine/java_annotation_params.go
+++ b/internal/engine/java_annotation_params.go
@@ -1,0 +1,372 @@
+// Java JAX-RS / Spring / Quarkus parameter-location extraction (#1936 Phase 1).
+//
+// The Phase 0 indexer already extracted path + (implicit/explicit) body parameters
+// for Java HTTP handlers (see #1908 / #1909). Real REST controllers also take
+// query, header, cookie, form, and matrix parameters — these need to be
+// surfaced in the endpoint detail Parameters table so the dashboard tells the
+// FULL story for an endpoint, not just the URL template + body.
+//
+// Coverage (Phase 1):
+//
+//   - JAX-RS:  @PathParam, @QueryParam, @HeaderParam, @CookieParam,
+//     @FormParam, @MatrixParam, @BeanParam
+//   - Spring:  @PathVariable, @RequestParam (query OR form), @RequestHeader,
+//     @CookieValue, @RequestBody, @ModelAttribute (form)
+//   - Common:  @DefaultValue, Bean Validation (@NotNull, @Valid,
+//     @Min/@Max/@Size/@Pattern/@Email/@NotBlank/@NotEmpty)
+//
+// Each emitted parameter is serialised as a JSON record and the full list is
+// written to the `parameters` property on the http_endpoint_definition entity.
+// The dashboard handler in v2_paths.go reads this property and renders one
+// row per parameter with the `In` chip set accordingly.
+//
+// We deliberately keep this layer string/regex-based (line-buffer parser
+// matching the existing #682/#683 fix) rather than reaching back into
+// tree-sitter — the param fragment we already capture in
+// buildMethodEndpointsWithAuth is sufficient for the annotation styles real
+// JAX-RS / Spring code uses. Multi-line parameter lists are rare in REST
+// controllers; when they occur we still capture the first-line parameters,
+// which is the dominant case for the Parameters table.
+package engine
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// JavaParam is the wire shape of one extracted parameter. The JSON tags are
+// the contract consumed by the dashboard (`internal/dashboard/v2_paths.go`
+// `handleV2PathDetail` → `parameters[]`). Stable across releases.
+type JavaParam struct {
+	Name         string   `json:"name"`
+	In           string   `json:"in"` // path|query|header|cookie|body|form|matrix
+	Type         string   `json:"type"`
+	Required     bool     `json:"required"`
+	DefaultValue string   `json:"default_value,omitempty"`
+	Annotations  []string `json:"annotations,omitempty"`
+}
+
+// extractJavaParameters parses a method parameter fragment (everything after
+// the opening `(` on the method declaration line, possibly truncated for
+// multi-line signatures) and the surrounding verb set, and returns one
+// JavaParam per parameter — including the implicit body param when the verb
+// allows it (the same heuristic used by inferRequestBodyParam from #1909).
+//
+// `verbs` is the deduplicated verb list for the endpoint. It controls whether
+// an unannotated parameter is treated as the implicit request body.
+//
+// The returned slice is order-preserving (matches source order) so the
+// rendered Parameters table reflects the method signature.
+func extractJavaParameters(paramFrag string, verbs []string) []JavaParam {
+	// The captured fragment includes everything from the opening '(' to the
+	// end of either a single-line signature ("…) { return null; }") or a
+	// multi-line one stitched by joinMultiLineParams. Cut at the matching
+	// close paren so the method body / brace / semicolon doesn't leak into
+	// the last parameter's type or name.
+	paramFrag = strings.TrimSpace(trimAtMatchingClose(paramFrag))
+	if paramFrag == "" {
+		return nil
+	}
+
+	hasBodyVerb := false
+	for _, v := range verbs {
+		if jaxrsVerbsThatHaveBody[strings.ToUpper(v)] {
+			hasBodyVerb = true
+			break
+		}
+	}
+
+	chunks := splitTopLevelCommas(paramFrag)
+	out := make([]JavaParam, 0, len(chunks))
+	implicitBodyTaken := false
+
+	for _, chunk := range chunks {
+		chunk = strings.TrimSpace(chunk)
+		if chunk == "" {
+			continue
+		}
+		// Framework-injected context objects never show up in the Parameters
+		// table (HttpServletRequest, UriInfo, Principal, …).
+		typGuess, _ := extractParamTypeAndName(chunk)
+		if typGuess != "" && isJavaNoisyType(typGuess) {
+			continue
+		}
+		// @Context-annotated parameters are framework injections — skip them.
+		if hasAnnotation(chunk, "@Context") {
+			continue
+		}
+
+		p, ok := classifyJavaParam(chunk, hasBodyVerb, &implicitBodyTaken)
+		if !ok {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// classifyJavaParam decides which `in` bucket a single parameter belongs to
+// and fills out the JavaParam record. Returns ok=false when the parameter
+// should be skipped (unparseable / framework injection / would-be implicit
+// body when the verb forbids it and no annotation steered it elsewhere).
+func classifyJavaParam(chunk string, hasBodyVerb bool, implicitBodyTaken *bool) (JavaParam, bool) {
+	annos := collectAnnotations(chunk)
+	typ, name := extractParamTypeAndName(chunk)
+	if typ == "" {
+		return JavaParam{}, false
+	}
+
+	// Required flag: any of @NotNull / @NotBlank / @NotEmpty / @Valid lifts
+	// `required` to true. Bean-Validation @Valid is a structural-validation
+	// marker but in practice it is only applied to required payloads.
+	required := false
+	for _, a := range annos {
+		switch annotationHead(a) {
+		case "@NotNull", "@NotBlank", "@NotEmpty", "@Valid":
+			required = true
+		}
+	}
+
+	// Try each location annotation in priority order. @PathParam / @PathVariable
+	// outranks everything else because path params are inherently required.
+	if v, ok := annotationValue(annos, "@PathParam", "@PathVariable"); ok {
+		return paramRecord(name, v, "path", typ, true, defaultValueFor(annos), annos), true
+	}
+	if v, ok := annotationValue(annos, "@QueryParam", "@RequestParam"); ok {
+		return paramRecord(name, v, "query", typ, requiredForRequestParam(annos, required), defaultValueFor(annos), annos), true
+	}
+	if v, ok := annotationValue(annos, "@HeaderParam", "@RequestHeader"); ok {
+		return paramRecord(name, v, "header", typ, requiredForRequestParam(annos, required), defaultValueFor(annos), annos), true
+	}
+	if v, ok := annotationValue(annos, "@CookieParam", "@CookieValue"); ok {
+		return paramRecord(name, v, "cookie", typ, requiredForRequestParam(annos, required), defaultValueFor(annos), annos), true
+	}
+	if v, ok := annotationValue(annos, "@FormParam", "@ModelAttribute"); ok {
+		return paramRecord(name, v, "form", typ, required, defaultValueFor(annos), annos), true
+	}
+	if v, ok := annotationValue(annos, "@MatrixParam"); ok {
+		return paramRecord(name, v, "matrix", typ, required, defaultValueFor(annos), annos), true
+	}
+	// Explicit Spring @RequestBody → body.
+	if hasAnnotation(chunk, "@RequestBody") {
+		return paramRecord(name, name, "body", typ, true, "", annos), true
+	}
+	// @BeanParam (JAX-RS) groups multiple sub-params; we cannot decompose without
+	// the target class. Surface as a single composite row tagged "query" — the
+	// most common case in real code — with the original annotation preserved so
+	// the row is informative.
+	if hasAnnotation(chunk, "@BeanParam") {
+		return paramRecord(name, name, "query", typ, required, "", annos), true
+	}
+	// No location annotation. Implicit body candidate when the verb allows it
+	// and we haven't already claimed an implicit body for this method.
+	if hasBodyVerb && !*implicitBodyTaken {
+		*implicitBodyTaken = true
+		return paramRecord(name, name, "body", typ, true, "", annos), true
+	}
+	return JavaParam{}, false
+}
+
+// paramRecord composes a JavaParam, using `paramName` (from @QueryParam("x"))
+// when present, falling back to the Java variable name. Annotation list is
+// emitted as the bare heads (`@QueryParam`, `@DefaultValue`, …) — sufficient
+// for the dashboard tooltip and avoids leaking full source fragments.
+func paramRecord(varName, paramName, in, typ string, required bool, def string, annos []string) JavaParam {
+	if paramName == "" {
+		paramName = varName
+	}
+	heads := make([]string, 0, len(annos))
+	for _, a := range annos {
+		h := annotationHead(a)
+		if h != "" {
+			heads = append(heads, h)
+		}
+	}
+	return JavaParam{
+		Name:         paramName,
+		In:           in,
+		Type:         typ,
+		Required:     required,
+		DefaultValue: def,
+		Annotations:  heads,
+	}
+}
+
+// requiredForRequestParam mirrors Spring's contract: @RequestParam /
+// @RequestHeader / @CookieValue parameters are required by default, unless
+// `required = false` is set or a `@DefaultValue` / Spring `defaultValue` is
+// provided (which implies optional). Bean-Validation @NotNull lifts back to
+// required.
+func requiredForRequestParam(annos []string, validationRequired bool) bool {
+	if validationRequired {
+		return true
+	}
+	for _, a := range annos {
+		// Spring style: @RequestParam(required = false) / defaultValue
+		if strings.Contains(a, "required") && strings.Contains(a, "false") {
+			return false
+		}
+		if strings.Contains(a, "defaultValue") {
+			return false
+		}
+		// JAX-RS: presence of @DefaultValue implies optional.
+		if strings.HasPrefix(strings.TrimSpace(a), "@DefaultValue") {
+			return false
+		}
+	}
+	return true
+}
+
+// defaultValueFor returns the JAX-RS @DefaultValue("…") string, or the
+// Spring defaultValue = "…" arg, or empty when neither is present.
+func defaultValueFor(annos []string) string {
+	for _, a := range annos {
+		if strings.HasPrefix(strings.TrimSpace(a), "@DefaultValue") {
+			if v := firstQuotedArg(a); v != "" {
+				return v
+			}
+		}
+		if strings.Contains(a, "defaultValue") {
+			if v := namedQuotedArg(a, "defaultValue"); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// namedQuotedArg returns the quoted argument associated with `key = "…"`
+// inside an annotation argument list, or empty when the key is absent.
+// Robust against the order of keyed args (`value = "x", defaultValue = "y"`).
+var javaNamedArgRe = map[string]*regexp.Regexp{}
+
+func namedQuotedArg(anno, key string) string {
+	re, ok := javaNamedArgRe[key]
+	if !ok {
+		re = regexp.MustCompile(key + `\s*=\s*"([^"]*)"`)
+		javaNamedArgRe[key] = re
+	}
+	if m := re.FindStringSubmatch(anno); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// firstQuotedArg returns the contents of the first "…"-delimited substring
+// inside `s`, or empty when there is none.
+func firstQuotedArg(s string) string {
+	if m := javaStringArgRe.FindStringSubmatch(s); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// hasAnnotation reports whether the parameter chunk contains a specific
+// annotation head (e.g. @RequestBody). Robust against trailing `(` arg lists.
+func hasAnnotation(chunk, head string) bool {
+	// Word-boundary check so @RequestBodyAdvice doesn't match @RequestBody.
+	idx := strings.Index(chunk, head)
+	if idx < 0 {
+		return false
+	}
+	end := idx + len(head)
+	if end >= len(chunk) {
+		return true
+	}
+	c := chunk[end]
+	return c == '(' || c == ' ' || c == '\t' || c == ',' || c == ')'
+}
+
+// annotationValue scans the annotation list for any of the candidate heads
+// and returns the first quoted argument (the "wire" param name) for the
+// first match. When the annotation is bare (no quoted arg) the returned
+// string is empty and ok=true — caller falls back to the Java variable name.
+func annotationValue(annos []string, candidates ...string) (string, bool) {
+	for _, a := range annos {
+		head := annotationHead(a)
+		for _, c := range candidates {
+			if head == c {
+				return firstQuotedArg(a), true
+			}
+		}
+	}
+	return "", false
+}
+
+// annotationHead extracts the leading @Name token from an annotation
+// fragment, stripping any argument list.
+func annotationHead(a string) string {
+	a = strings.TrimSpace(a)
+	if !strings.HasPrefix(a, "@") {
+		return ""
+	}
+	end := len(a)
+	for i := 1; i < len(a); i++ {
+		c := a[i]
+		if c == '(' || c == ' ' || c == '\t' {
+			end = i
+			break
+		}
+	}
+	return a[:end]
+}
+
+// javaParamAnnotationRe matches one annotation fragment in a parameter chunk:
+// either a marker (`@Foo`) or a parameterised form (`@Foo(args)`). Captures
+// the entire match. Arguments may contain nested parentheses with depth 1
+// (e.g. `@Pattern(regexp = "\\d+", message = "...")` is fine).
+var javaParamAnnotationRe = regexp.MustCompile(`@\w+(?:\s*\([^()]*(?:\([^()]*\)[^()]*)*\))?`)
+
+// collectAnnotations returns every `@Annotation(…)?` substring present in
+// the parameter chunk, in source order.
+func collectAnnotations(chunk string) []string {
+	return javaParamAnnotationRe.FindAllString(chunk, -1)
+}
+
+// trimAtMatchingClose returns the prefix of `s` up to (but not including)
+// the `)` that closes the parameter list. The opening `(` was already
+// consumed before `s` was handed to us, so depth starts at 0 and we walk
+// forward until depth would go negative.
+func trimAtMatchingClose(s string) string {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth == 0 {
+				return s[:i]
+			}
+			depth--
+		}
+	}
+	return s
+}
+
+// EncodeJavaParameters serialises a slice of JavaParam records into the
+// canonical JSON representation written to the `parameters` entity property.
+// Empty slice returns "" so the property is omitted entirely.
+func EncodeJavaParameters(ps []JavaParam) string {
+	if len(ps) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(ps)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// DecodeJavaParameters is the inverse of EncodeJavaParameters. Returns nil
+// on empty input or malformed JSON (consumers tolerate the absence).
+func DecodeJavaParameters(s string) []JavaParam {
+	if s == "" {
+		return nil
+	}
+	var out []JavaParam
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil
+	}
+	return out
+}

--- a/internal/engine/java_annotation_params_test.go
+++ b/internal/engine/java_annotation_params_test.go
@@ -1,0 +1,260 @@
+// Tests for #1936 Phase 1 — Java JAX-RS / Spring full parameter-location
+// coverage. Each test focuses on one annotation kind so a regression is
+// easy to localise. End-to-end coverage (`parameters` property attached to
+// the emitted endpoint entity) is exercised in
+// java_annotation_routes_params_test.go.
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// findParamByIn returns the first parameter with the given `in` location, or
+// nil. Used by every test below to assert specific rows.
+func findParamByIn(ps []JavaParam, in string) *JavaParam {
+	for i := range ps {
+		if ps[i].In == in {
+			return &ps[i]
+		}
+	}
+	return nil
+}
+
+// findParamByName returns the first parameter with the given wire name.
+func findParamByName(ps []JavaParam, name string) *JavaParam {
+	for i := range ps {
+		if ps[i].Name == name {
+			return &ps[i]
+		}
+	}
+	return nil
+}
+
+func TestExtractJavaParameters_JAXRSQueryParam(t *testing.T) {
+	frag := `@QueryParam("limit") @DefaultValue("20") int limit, @QueryParam("offset") @DefaultValue("0") int offset)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 query params, got %d (%+v)", len(got), got)
+	}
+	for _, p := range got {
+		if p.In != "query" {
+			t.Errorf("want in=query, got %q for %q", p.In, p.Name)
+		}
+		if p.Required {
+			t.Errorf("@DefaultValue should mark %q optional, got required=true", p.Name)
+		}
+	}
+	limit := findParamByName(got, "limit")
+	if limit == nil {
+		t.Fatalf("missing limit param")
+	}
+	if limit.DefaultValue != "20" {
+		t.Errorf("want default=20, got %q", limit.DefaultValue)
+	}
+	if limit.Type != "int" {
+		t.Errorf("want type=int, got %q", limit.Type)
+	}
+}
+
+func TestExtractJavaParameters_JAXRSHeaderParam(t *testing.T) {
+	frag := `@HeaderParam("X-Request-ID") String requestId, @HeaderParam("Authorization") @NotNull String auth)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 header params, got %d", len(got))
+	}
+	req := findParamByName(got, "X-Request-ID")
+	if req == nil || req.In != "header" {
+		t.Fatalf("want X-Request-ID as header, got %+v", req)
+	}
+	if !req.Required {
+		t.Errorf("@HeaderParam is required by default — got required=false")
+	}
+	auth := findParamByName(got, "Authorization")
+	if auth == nil || !auth.Required {
+		t.Errorf("@NotNull should keep Authorization required, got %+v", auth)
+	}
+}
+
+func TestExtractJavaParameters_JAXRSCookieParam(t *testing.T) {
+	frag := `@CookieParam("session") String session)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 1 {
+		t.Fatalf("want 1 cookie param, got %d", len(got))
+	}
+	if got[0].In != "cookie" {
+		t.Errorf("want in=cookie, got %q", got[0].In)
+	}
+	if got[0].Name != "session" {
+		t.Errorf("want name=session, got %q", got[0].Name)
+	}
+}
+
+func TestExtractJavaParameters_JAXRSFormParam(t *testing.T) {
+	frag := `@FormParam("username") String username, @FormParam("password") String password)`
+	got := extractJavaParameters(frag, []string{"POST"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 form params, got %d", len(got))
+	}
+	for _, p := range got {
+		if p.In != "form" {
+			t.Errorf("want in=form, got %q for %q", p.In, p.Name)
+		}
+	}
+}
+
+func TestExtractJavaParameters_JAXRSMatrixParam(t *testing.T) {
+	frag := `@MatrixParam("category") String category)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 1 || got[0].In != "matrix" {
+		t.Fatalf("want 1 matrix param, got %+v", got)
+	}
+	if got[0].Name != "category" {
+		t.Errorf("want name=category, got %q", got[0].Name)
+	}
+}
+
+func TestExtractJavaParameters_JAXRSMixedPathQueryBody(t *testing.T) {
+	// Realistic JAX-RS handler — path + query + implicit body.
+	frag := `@PathParam("id") String id, @QueryParam("limit") @DefaultValue("10") int limit, UpdateRequest payload)`
+	got := extractJavaParameters(frag, []string{"PUT"})
+	if len(got) != 3 {
+		t.Fatalf("want 3 params, got %d (%+v)", len(got), got)
+	}
+	if p := findParamByIn(got, "path"); p == nil || p.Name != "id" {
+		t.Errorf("want path id, got %+v", p)
+	}
+	if p := findParamByIn(got, "query"); p == nil || p.Name != "limit" {
+		t.Errorf("want query limit, got %+v", p)
+	}
+	if p := findParamByIn(got, "body"); p == nil || p.Type != "UpdateRequest" {
+		t.Errorf("want body UpdateRequest, got %+v", p)
+	}
+}
+
+func TestExtractJavaParameters_SpringRequestParamQuery(t *testing.T) {
+	frag := `@RequestParam("page") int page, @RequestParam(value = "size", defaultValue = "20") int size)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 query params, got %d", len(got))
+	}
+	page := findParamByName(got, "page")
+	if page == nil || page.In != "query" {
+		t.Fatalf("want page query, got %+v", page)
+	}
+	if !page.Required {
+		t.Errorf("Spring @RequestParam without defaultValue should be required, got %+v", page)
+	}
+	size := findParamByName(got, "size")
+	if size == nil || size.DefaultValue != "20" {
+		t.Errorf("want size default=20, got %+v", size)
+	}
+	if size.Required {
+		t.Errorf("Spring @RequestParam with defaultValue should be optional, got required=true")
+	}
+}
+
+func TestExtractJavaParameters_SpringRequestHeader(t *testing.T) {
+	frag := `@RequestHeader("X-Tenant") String tenant, @RequestHeader(value = "X-Trace", required = false) String trace)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 header params, got %d", len(got))
+	}
+	tenant := findParamByName(got, "X-Tenant")
+	if tenant == nil || !tenant.Required {
+		t.Errorf("want X-Tenant required, got %+v", tenant)
+	}
+	trace := findParamByName(got, "X-Trace")
+	if trace == nil || trace.Required {
+		t.Errorf("want X-Trace optional (required=false), got %+v", trace)
+	}
+}
+
+func TestExtractJavaParameters_SpringCookieValue(t *testing.T) {
+	frag := `@CookieValue("session") String session)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 1 || got[0].In != "cookie" || got[0].Name != "session" {
+		t.Fatalf("want cookie session, got %+v", got)
+	}
+}
+
+func TestExtractJavaParameters_SpringRequestBodyExplicit(t *testing.T) {
+	frag := `@RequestBody @Valid CreateOrderRequest req)`
+	got := extractJavaParameters(frag, []string{"POST"})
+	if len(got) != 1 {
+		t.Fatalf("want 1 body param, got %d", len(got))
+	}
+	if got[0].In != "body" {
+		t.Errorf("want in=body, got %q", got[0].In)
+	}
+	if got[0].Type != "CreateOrderRequest" {
+		t.Errorf("want type=CreateOrderRequest, got %q", got[0].Type)
+	}
+	if !got[0].Required {
+		t.Errorf("@RequestBody is required, got required=false")
+	}
+}
+
+func TestExtractJavaParameters_ContextInjectionsSkipped(t *testing.T) {
+	frag := `@Context UriInfo uriInfo, @Context HttpServletRequest req, @QueryParam("q") String q)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 1 {
+		t.Fatalf("want @Context params skipped, got %d (%+v)", len(got), got)
+	}
+	if got[0].In != "query" {
+		t.Errorf("want query q, got %+v", got[0])
+	}
+}
+
+func TestExtractJavaParameters_GetVerbDropsImplicitBody(t *testing.T) {
+	// A GET handler with an unannotated DTO param — must NOT surface as body.
+	frag := `@QueryParam("q") String q, FilterDTO filter)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 1 {
+		t.Fatalf("want only 1 param (no body on GET), got %d (%+v)", len(got), got)
+	}
+}
+
+func TestExtractJavaParameters_DefaultValueAndAnnotationsRecorded(t *testing.T) {
+	frag := `@QueryParam("limit") @DefaultValue("10") @Min(1) @Max(100) int limit)`
+	got := extractJavaParameters(frag, []string{"GET"})
+	if len(got) != 1 {
+		t.Fatalf("want 1 param, got %d", len(got))
+	}
+	p := got[0]
+	if p.DefaultValue != "10" {
+		t.Errorf("want default=10, got %q", p.DefaultValue)
+	}
+	heads := strings.Join(p.Annotations, ",")
+	for _, want := range []string{"@QueryParam", "@DefaultValue", "@Min", "@Max"} {
+		if !strings.Contains(heads, want) {
+			t.Errorf("annotations missing %s: %s", want, heads)
+		}
+	}
+}
+
+func TestEncodeDecodeJavaParameters_RoundTrip(t *testing.T) {
+	in := []JavaParam{
+		{Name: "limit", In: "query", Type: "int", Required: false, DefaultValue: "10", Annotations: []string{"@QueryParam", "@DefaultValue"}},
+		{Name: "X-Trace", In: "header", Type: "String", Required: true, Annotations: []string{"@HeaderParam"}},
+	}
+	enc := EncodeJavaParameters(in)
+	if enc == "" {
+		t.Fatalf("encode produced empty string")
+	}
+	out := DecodeJavaParameters(enc)
+	if len(out) != len(in) {
+		t.Fatalf("round trip length mismatch: in=%d out=%d", len(in), len(out))
+	}
+	for i := range in {
+		if in[i].Name != out[i].Name || in[i].In != out[i].In || in[i].Required != out[i].Required {
+			t.Errorf("round trip mismatch at %d: in=%+v out=%+v", i, in[i], out[i])
+		}
+	}
+}
+
+func TestEncodeJavaParameters_EmptyReturnsEmpty(t *testing.T) {
+	if got := EncodeJavaParameters(nil); got != "" {
+		t.Errorf("empty input should encode to \"\", got %q", got)
+	}
+}

--- a/internal/engine/java_annotation_routes.go
+++ b/internal/engine/java_annotation_routes.go
@@ -451,11 +451,15 @@ func extractJavaEndpointsWithAuth(src, relPath string, authCtx JavaAuthContext) 
 		if m := javaMethodDeclRe.FindStringSubmatch(line); m != nil {
 			methodName := m[1]
 			// m[2] is the rest of the line after the opening '(' — used for
-			// request body inference (#1909). May be empty for multi-line sigs.
+			// request body inference (#1909) and full parameter extraction
+			// (#1936 Phase 1). For multi-line signatures (one parameter per
+			// line, common in JAX-RS code), we splice subsequent lines until
+			// we hit the closing ')'.
 			paramFrag := ""
 			if len(m) > 2 {
 				paramFrag = m[2]
 			}
+			paramFrag = joinMultiLineParams(paramFrag, lines, idx)
 			methodAnnos := flushAnnoBuf()
 			if cur.name == "" {
 				// Method declared before any class header (shouldn't happen
@@ -634,6 +638,12 @@ func buildMethodEndpointsWithAuth(
 	// inferRequestBodyParam needs the full verb list to decide eligibility.
 	bodyType, bodyParamName := inferRequestBodyParam(paramFrag, uniqueVerbs)
 
+	// Issue #1936 Phase 1 — extract ALL parameter locations (query / header /
+	// cookie / form / matrix / path / body) for the Parameters table. The
+	// JSON-encoded slice is attached to every emitted endpoint entity below.
+	allParams := extractJavaParameters(paramFrag, uniqueVerbs)
+	paramsJSON := EncodeJavaParameters(allParams)
+
 	// #1942 Phase 1 — resolve auth_policy from class + method + Quarkus context.
 	policy := ResolveJavaAuthPolicy(
 		joined, methodLine,
@@ -684,6 +694,27 @@ func buildMethodEndpointsWithAuth(
 				props["request_body_param_name"] = bodyParamName
 			}
 		}
+		// Issue #1936 Phase 1 — emit the full parameter list (query / header /
+		// cookie / form / matrix / path / body) for the Parameters table. We
+		// trim the body row from the per-verb list when the verb cannot carry
+		// a body so a GET endpoint with `(@QueryParam String q, FooDTO maybeBody)`
+		// does not surface `maybeBody` as a body row.
+		if paramsJSON != "" {
+			if jaxrsVerbsThatHaveBody[strings.ToUpper(verb)] {
+				props["parameters"] = paramsJSON
+			} else {
+				filtered := make([]JavaParam, 0, len(allParams))
+				for _, pp := range allParams {
+					if pp.In == "body" || pp.In == "form" {
+						continue
+					}
+					filtered = append(filtered, pp)
+				}
+				if enc := EncodeJavaParameters(filtered); enc != "" {
+					props["parameters"] = enc
+				}
+			}
+		}
 
 		out = append(out, types.EntityRecord{
 			ID:                 id,
@@ -698,6 +729,39 @@ func buildMethodEndpointsWithAuth(
 		})
 	}
 	return out
+}
+
+// joinMultiLineParams splices subsequent source lines onto the captured
+// parameter fragment until the depth of unbalanced parentheses returns to
+// zero (meaning we have seen the closing `)`). Used for multi-line method
+// signatures where each parameter sits on its own line.
+//
+// The lines slice is the file split on "\n"; `startIdx` is the 0-based index
+// of the method-declaration line. Returns the accumulated fragment including
+// the closing `)` so existing trimming logic (`TrimRight ")}"`) still works.
+func joinMultiLineParams(firstLine string, lines []string, startIdx int) string {
+	depth := strings.Count(firstLine, "(") - strings.Count(firstLine, ")")
+	// The opening '(' was already consumed by the regex; depth here counts
+	// only what's INSIDE the param list. If we have already seen the closing
+	// ')' on the same line, depth will be -1 and we're done.
+	if depth < 0 {
+		return firstLine
+	}
+	if depth == 0 && strings.Contains(firstLine, ")") {
+		return firstLine
+	}
+	var sb strings.Builder
+	sb.WriteString(firstLine)
+	for i := startIdx + 1; i < len(lines); i++ {
+		next := lines[i]
+		sb.WriteByte(' ')
+		sb.WriteString(next)
+		depth += strings.Count(next, "(") - strings.Count(next, ")")
+		if depth < 0 {
+			break
+		}
+	}
+	return sb.String()
 }
 
 // parseRequestMappingMethods extracts every `method = RequestMethod.X` (or

--- a/internal/engine/java_annotation_routes_params_test.go
+++ b/internal/engine/java_annotation_routes_params_test.go
@@ -1,0 +1,196 @@
+// End-to-end test for #1936 Phase 1 — assert that ApplyJavaAnnotationRoutes
+// emits a `parameters` JSON property on the synthetic endpoint entity that
+// covers ALL parameter locations (path / query / header / cookie / form /
+// matrix / body) on a representative JAX-RS + Spring controller pair.
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestApplyJavaAnnotationRoutes_Issue1936_JAXRSAllLocations exercises a
+// fictional client-fixture-X JAX-RS resource that uses every supported
+// parameter location plus a body row.
+func TestApplyJavaAnnotationRoutes_Issue1936_JAXRSAllLocations(t *testing.T) {
+	src := `package com.client_fixture_x.banking;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Response;
+import jakarta.validation.Valid;
+
+@Path("/transfers")
+public class TransfersResource {
+
+    @PUT
+    @Path("/confirm/{transferId}")
+    public Response confirm(
+            @PathParam("transferId") String id,
+            @QueryParam("dryRun") @DefaultValue("false") boolean dryRun,
+            @HeaderParam("X-Request-ID") String requestId,
+            @CookieParam("session") String session,
+            @MatrixParam("priority") String priority,
+            @Valid ConfirmRequest body) {
+        return Response.ok().build();
+    }
+}
+`
+	got := collect(t, map[string]string{"TransfersResource.java": src})
+	var put *recordLike
+	for i := range got {
+		if got[i].ID == "http:PUT:/transfers/confirm/{transferId}" {
+			put = &got[i]
+			break
+		}
+	}
+	if put == nil {
+		t.Fatalf("[#1936] PUT endpoint missing; ids=%v", endpointIDs(got))
+	}
+	raw := put.Props["parameters"]
+	if raw == "" {
+		t.Fatalf("[#1936] expected parameters JSON, got empty")
+	}
+	params := DecodeJavaParameters(raw)
+	if len(params) < 6 {
+		t.Fatalf("[#1936] expected at least 6 param rows, got %d (%s)", len(params), raw)
+	}
+
+	wantByIn := map[string]string{
+		"path":   "transferId",
+		"query":  "dryRun",
+		"header": "X-Request-ID",
+		"cookie": "session",
+		"matrix": "priority",
+		"body":   "body",
+	}
+	for in, wantName := range wantByIn {
+		var found *JavaParam
+		for i := range params {
+			if params[i].In == in {
+				found = &params[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Errorf("[#1936] missing %s param row", in)
+			continue
+		}
+		if found.Name != wantName {
+			t.Errorf("[#1936] %s row name = %q, want %q", in, found.Name, wantName)
+		}
+	}
+	// Default value captured.
+	for _, p := range params {
+		if p.Name == "dryRun" && p.DefaultValue != "false" {
+			t.Errorf("[#1936] dryRun default = %q, want false", p.DefaultValue)
+		}
+	}
+}
+
+// TestApplyJavaAnnotationRoutes_Issue1936_SpringQueryHeaderRequired covers
+// Spring annotations (@RequestParam / @RequestHeader / @PathVariable /
+// @CookieValue) including the required-vs-optional semantics.
+func TestApplyJavaAnnotationRoutes_Issue1936_SpringQueryHeaderRequired(t *testing.T) {
+	src := `package com.client_fixture_x.api;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    @GetMapping("/{id}")
+    public OrderResponse get(
+            @PathVariable("id") String id,
+            @RequestParam(value = "expand", defaultValue = "false") boolean expand,
+            @RequestHeader("X-Tenant") String tenant,
+            @RequestHeader(value = "X-Trace", required = false) String trace,
+            @CookieValue("session") String session) {
+        return null;
+    }
+}
+`
+	got := collect(t, map[string]string{"OrderController.java": src})
+	var ep *recordLike
+	for i := range got {
+		if got[i].ID == "http:GET:/api/orders/{id}" {
+			ep = &got[i]
+			break
+		}
+	}
+	if ep == nil {
+		t.Fatalf("[#1936] GET endpoint missing; ids=%v", endpointIDs(got))
+	}
+	raw := ep.Props["parameters"]
+	if raw == "" {
+		t.Fatalf("[#1936] expected parameters JSON, got empty")
+	}
+	params := DecodeJavaParameters(raw)
+
+	byName := map[string]JavaParam{}
+	for _, p := range params {
+		byName[p.Name] = p
+	}
+	if p, ok := byName["id"]; !ok || p.In != "path" || !p.Required {
+		t.Errorf("[#1936] id row wrong: %+v", p)
+	}
+	if p, ok := byName["expand"]; !ok || p.In != "query" || p.Required || p.DefaultValue != "false" {
+		t.Errorf("[#1936] expand row wrong: %+v", p)
+	}
+	if p, ok := byName["X-Tenant"]; !ok || p.In != "header" || !p.Required {
+		t.Errorf("[#1936] X-Tenant row wrong: %+v", p)
+	}
+	if p, ok := byName["X-Trace"]; !ok || p.In != "header" || p.Required {
+		t.Errorf("[#1936] X-Trace should be optional: %+v", p)
+	}
+	if p, ok := byName["session"]; !ok || p.In != "cookie" {
+		t.Errorf("[#1936] session row wrong: %+v", p)
+	}
+}
+
+// TestApplyJavaAnnotationRoutes_Issue1936_BodyRowExcludedFromGet asserts that
+// a single controller class with both GET and POST handlers does not leak
+// the POST body row into the GET endpoint's parameter list when the body
+// param is an unannotated DTO that the GET would otherwise misclassify.
+func TestApplyJavaAnnotationRoutes_Issue1936_BodyRowExcludedFromGet(t *testing.T) {
+	src := `package com.client_fixture_x.api;
+import jakarta.ws.rs.*;
+
+@Path("/items")
+public class ItemsResource {
+
+    @GET
+    public Object list(@QueryParam("q") String q, FilterDTO filter) { return null; }
+
+    @POST
+    public Object create(CreateItemRequest req) { return null; }
+}
+`
+	got := collect(t, map[string]string{"ItemsResource.java": src})
+	for _, r := range got {
+		raw := r.Props["parameters"]
+		if raw == "" {
+			continue
+		}
+		params := DecodeJavaParameters(raw)
+		if strings.HasPrefix(r.ID, "http:GET:") {
+			for _, p := range params {
+				if p.In == "body" {
+					t.Errorf("[#1936] GET endpoint %s should not have body param: %+v", r.ID, p)
+				}
+			}
+		}
+		if strings.HasPrefix(r.ID, "http:POST:") {
+			hasBody := false
+			for _, p := range params {
+				if p.In == "body" {
+					hasBody = true
+					if p.Type != "CreateItemRequest" {
+						t.Errorf("[#1936] POST body type = %q, want CreateItemRequest", p.Type)
+					}
+				}
+			}
+			if !hasBody {
+				t.Errorf("[#1936] POST endpoint %s missing body param row", r.ID)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What this PR does

Closes #1936 (Phase 1). Extends the Java JAX-RS / Spring / Quarkus annotation-route extractor to extract EVERY parameter location from a handler signature — not just path + body. Each endpoint detail's Parameters table now renders one row per parameter with the correct `In` chip (`path` / `query` / `header` / `cookie` / `form` / `matrix` / `body`), default-value capture, required-vs-optional flag, and annotation hints.

## Why we needed it

The Phase 0 indexer wired path-param synthesis (URL template) and body-param inference (#1908 / #1909), but real REST endpoints take many more parameter kinds. Endpoints with `@QueryParam("limit") @DefaultValue("20")` or `@HeaderParam("Authorization")` previously surfaced only their path segments in the dashboard's Parameters table — half the story.

## Approach

1. New file `internal/engine/java_annotation_params.go` — line-oriented parser that walks the method parameter fragment (already captured by the #682/#683 fix) and emits one `JavaParam` per parameter with `name`, `in`, `type`, `required`, `default_value`, and `annotations[]`.
2. `internal/engine/java_annotation_routes.go` — `buildMethodEndpointsWithAuth` now also calls `extractJavaParameters` and serialises the result as a JSON `parameters` property on the synthetic endpoint entity. Body/form rows are pruned from the per-verb list when the verb cannot carry a body (so `GET` with an unannotated DTO does not leak a body row).
3. `internal/engine/java_annotation_routes.go` — new `joinMultiLineParams` helper stitches multi-line method signatures (one parameter per line) into a single fragment before extraction.
4. `internal/dashboard/v2_paths.go` — `handleV2PathDetail` decodes the `parameters` property and merges the rows into the existing `v2PathParameter` list. Verb sets are merged for parameters shared across verbs. Path rows from the URL template remain as a fallback when the extractor did not emit them. The existing #1909 body row is now only appended when the Phase 1 list did not already surface a body for that verb.

## How it was verified

- `go test ./internal/extractors/java/... ./internal/dashboard/... ./internal/engine/...` — all green.
- `go build ./...` — clean (only the upstream `tree-sitter/lua/parser.c` null-character warning, unchanged).
- New unit tests cover each annotation kind in isolation (JAX-RS query / header / cookie / form / matrix; Spring `@RequestParam` / `@RequestHeader` / `@PathVariable` / `@CookieValue` / `@RequestBody`), default-value capture, required-vs-optional semantics, `@Context` injection skipping, and the GET-drops-implicit-body invariant. Round-trip encode/decode test for the JSON wire shape.
- End-to-end test (`Issue1936_JAXRSAllLocations`) exercises a fictional `client-fixture-X` JAX-RS resource that uses every supported parameter location and asserts the emitted entity carries a `parameters` JSON payload covering all six locations.
- Dashboard handler test (`TestV2PathDetail_Issue1936_JavaParametersSurfaced`) seeds an endpoint entity with a hand-crafted `parameters` property and asserts the v2 detail response contains one row per parameter with the correct `In` chip and required flag.

## What this PR explicitly does NOT do

- No frontend changes. The Parameters table in webui-v2 already renders the `In` column with chip colouring — populating the data is the work; the UI was waiting.
- No changes outside Java. Phase 2 (Python), Phase 3 (TS/JS), Phase 4 (Go) are tracked under #1936 and will land separately.
- No body-shape expansion (#1935). Phase 1 emits parameter rows; turning an object-typed parameter into an expandable field subtree is orthogonal and remains scoped to #1935.
- No new entity kinds and no schema migrations. The `parameters` property is a stable JSON string on the existing `http_endpoint_definition` entity; older indexer outputs without it continue to work (the dashboard handler falls back to path-template extraction + the #1909 body row).
- No daemon ops. Coordinator handles `go install` / `launchctl kickstart` / `cp -R webui-v2/dist` post-merge.

## Follow-ups / known gaps

- Multi-line signatures with parameter-list comments between annotations are stitched but not parsed line-by-line; if a JavaDoc-style comment is inside the parameter list (`(/* note */ @QueryParam ...)`), the comment will leak into the parameter chunk. This is rare in REST code and the worst case is one row with a slightly noisy annotation list.
- `@BeanParam` (JAX-RS) groups multiple sub-params under one DTO. Without the target class we cannot decompose; the row is emitted with `in: query` and the original `@BeanParam` annotation preserved. A future Phase 1.5 could resolve the BeanParam class and expand its fields.
- The annotation list on each row is captured as bare heads only (e.g. `@DefaultValue`, `@Min`, `@Max`) without their argument literals. The dashboard tooltip remains informative; if richer detail is needed for the description column, a future enhancement can expand the captured tokens.

## Phasing & relationship to other tickets

- #1936 Phase 1 — Java (this PR).
- #1936 Phase 2 — Python (FastAPI / DRF / Django / Flask).
- #1936 Phase 3 — TS / JS (NestJS / Express / Fastify / Hono).
- #1936 Phase 4 — Go (net/http / gin / echo / chi).
- #1908 / #1909 — body-row inference (already shipped; preserved as fallback).
- #1935 — body-shape expansion (orthogonal; future composition with this ticket lets a `@QueryParam("filter") FilterDTO filter` row carry an expandable subtree).
- #1942 Phase 1 auth-policy resolver (last merge on `main` at `9811e8b`) was the immediate ancestor and is preserved intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
