### PR TITLE
feat(docgen): section gating + honesty clauses + fabrication guards (#1857 #1860 #1864 #1865 #1866 #1873 #2017)

### DIFF
--- a/internal/docgen/llm_bundle.go
+++ b/internal/docgen/llm_bundle.go
@@ -500,18 +500,28 @@ var defaultSectionGuidance = map[string]string{
 	"capabilities": "Enumerate the product capabilities this entity implements, grouped by business outcome. " +
 		"Each capability should be one bullet referencing the relevant functions or methods.",
 	"flows": "Trace the primary request or event flow through this entity using a mermaid sequence or flowchart. " +
-		"Reference upstream callers and downstream callees by name.",
+		"Reference upstream callers and downstream callees by name. " +
+		"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`. " +
+		"Mermaid diagrams must only reference entities that exist in the bundle. " +
+		"If thin context yields a one-step chain, render that one step honestly — do not pad with invented destinations.",
 	"patterns": "Identify the structural design patterns present (adapter, gateway, orchestrator, saga, etc.). " +
-		"Cite specific neighbour relationships as evidence for each pattern identified.",
+		"Cite specific neighbour relationships as evidence for each pattern identified. " +
+		"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`.",
 	"api": "Document the full public API surface: exported functions, HTTP endpoints, event topics, or CLI flags. " +
-		"Include method signatures and a one-line usage note for each.",
-	"reference-config": "List every configuration key this entity reads or writes, with type, default value, and effect. " +
-		"Source from Properties, Metadata, and environment variable names visible in the source.",
+		"Include method signatures and a one-line usage note for each. " +
+		"If decorator parameters (e.g. @action, @api_view, @route) that carry verb/path/options metadata are NOT in source_window or neighbour Properties, " +
+		"mark those fields as not-in-context rather than inferring from method name or convention.",
+	"reference-config": "List APPLICATION configuration this entity reads or writes: environment variables, settings module constants " +
+		"(e.g. `settings.X`, `SETTINGS.Y`), feature flags, runtime parameters. " +
+		"DO NOT include graph-metadata Properties (framework, module, role, language, etc.) — those are indexer-internal and not configuration. " +
+		"If nothing applies locally to this entity, a 1–2 sentence honest note is preferred over inferring conventions from the surrounding stack.",
 	"reference-dependencies": "List direct dependencies separated into production and test/dev. " +
 		"For external dependencies include the import path; for internal ones include the entity ID.",
 	"reference-deployment": "Describe deployment concerns: required environment variables, exposed ports, scaling constraints, and health-check endpoints. " +
-		"Source from graph metadata and the Properties map.",
-	"reference-scripts": "List all Makefile targets, npm/go scripts, or shell commands associated with this entity and explain what each does.",
+		"Source from graph metadata and the Properties map. " +
+		"If nothing applies locally to this entity, a 1–2 sentence honest note is preferred over inferring conventions from the surrounding stack.",
+	"reference-scripts": "List all Makefile targets, npm/go scripts, or shell commands associated with this entity and explain what each does. " +
+		"If nothing applies locally to this entity, a 1–2 sentence honest note is preferred over inferring conventions from the surrounding stack.",
 	"reference-misc": "Capture any additional reference material not covered by the other sections: ADR links, architecture diagrams, or known limitations.",
 	"module-readme": "Write a README-style introduction for the module containing this entity: purpose, key entities, quickstart build/test/run commands, and link to the main documentation page.",
 	"glossary": "Define each domain-specific term that appears in this entity's name, signature, or immediate neighbourhood. " +

--- a/internal/docgen/section_gating_bundle_test.go
+++ b/internal/docgen/section_gating_bundle_test.go
@@ -1,0 +1,270 @@
+// Tests for the section guidance + gating bundle (#1857, #1860, #1864, #1865,
+// #1866, #1873, #2017).  Each test pins one ticket-level requirement so a
+// regression flips the precise ticket back into scope.
+
+package docgen_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/docgen"
+)
+
+// ---------------------------------------------------------------------------
+// #1857 — "no-local-surface" honesty clause on reference-config / -deployment /
+// -scripts in the default section guidance.
+// ---------------------------------------------------------------------------
+
+func TestHonestyClause_DefaultGuidance(t *testing.T) {
+	// Use the default profile (UNKNOWN_KIND) so the honesty clause is sourced
+	// from defaultSectionGuidance rather than any kind-specific override.
+	defaultProfile := docgen.ResolveSectionProfile("UNKNOWN_KIND", "")
+	for _, sec := range []string{"reference-config", "reference-deployment", "reference-scripts"} {
+		g := docgen.ResolveGuidance(defaultProfile, sec)
+		lower := strings.ToLower(g)
+		if !strings.Contains(lower, "nothing applies locally") {
+			t.Errorf("#1857 default guidance for %q: missing honesty clause; got: %q", sec, g)
+		}
+		if !strings.Contains(lower, "honest") && !strings.Contains(lower, "1") {
+			t.Errorf("#1857 default guidance for %q: missing brevity/honesty wording; got: %q", sec, g)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1860 — class / view / function seeds must skip reference-deployment,
+// reference-scripts, how-to-local-dev.
+// ---------------------------------------------------------------------------
+
+func TestSectionGating_LeafKindsDropModuleAggregateSections(t *testing.T) {
+	leafKinds := []string{"class", "view", "function",
+		"SCOPE.Class", "SCOPE.View", "SCOPE.Function"}
+	mustAbsent := []string{"reference-deployment", "reference-scripts", "how-to-local-dev"}
+	for _, kind := range leafKinds {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			for _, sec := range mustAbsent {
+				if containsSection(p.Sections, sec) {
+					t.Errorf("#1860 kind %q: section %q must be absent; got %v",
+						kind, sec, p.Sections)
+				}
+			}
+			// Sanity: still has the core sections.
+			for _, sec := range []string{"overview", "capabilities", "api"} {
+				if !containsSection(p.Sections, sec) {
+					t.Errorf("#1860 kind %q: missing core section %q; got %v",
+						kind, sec, p.Sections)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1873 — how-to-local-dev must be Module-aggregate-only: present for module,
+// absent everywhere else.
+// ---------------------------------------------------------------------------
+
+func TestHowToLocalDev_ModuleOnly(t *testing.T) {
+	// Present for module.
+	mp := docgen.ResolveSectionProfile("module", "")
+	if !containsSection(mp.Sections, "how-to-local-dev") {
+		t.Errorf("#1873 module: how-to-local-dev MUST be present; got %v", mp.Sections)
+	}
+	// Absent for every leaf-style kind.
+	nonModule := []string{"model", "view", "class", "function",
+		"operation", "react_component", "SCOPE.View", "SCOPE.Class"}
+	for _, kind := range nonModule {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			if containsSection(p.Sections, "how-to-local-dev") {
+				t.Errorf("#1873 kind %q: how-to-local-dev MUST be absent (Module-only); got %v",
+					kind, p.Sections)
+			}
+		})
+	}
+}
+
+// ShouldSkipSectionForKind matches the documented gating contract for the
+// three module-aggregate sections.
+func TestShouldSkipSectionForKind(t *testing.T) {
+	cases := []struct {
+		section string
+		kind    string
+		want    bool
+	}{
+		// how-to-local-dev gated for everything except module.
+		{"how-to-local-dev", "module", false},
+		{"how-to-local-dev", "SCOPE.Module", false},
+		{"how-to-local-dev", "view", true},
+		{"how-to-local-dev", "SCOPE.View", true},
+		{"how-to-local-dev", "class", true},
+		{"how-to-local-dev", "function", true},
+		{"how-to-local-dev", "model", true},
+		{"how-to-local-dev", "react_component", true},
+		// reference-deployment / -scripts gated for leaf kinds, allowed for module.
+		{"reference-deployment", "module", false},
+		{"reference-deployment", "view", true},
+		{"reference-deployment", "class", true},
+		{"reference-deployment", "function", true},
+		{"reference-scripts", "module", false},
+		{"reference-scripts", "view", true},
+		// Sections without gating entries are never skipped.
+		{"overview", "view", false},
+		{"capabilities", "class", false},
+		{"api", "function", false},
+	}
+	for _, tc := range cases {
+		got := docgen.ShouldSkipSectionForKind(tc.section, tc.kind)
+		if got != tc.want {
+			t.Errorf("ShouldSkipSectionForKind(%q, %q) = %v, want %v",
+				tc.section, tc.kind, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1864 — reference-config must distinguish graph-metadata Properties (skip)
+// from application config (include).
+// ---------------------------------------------------------------------------
+
+func TestReferenceConfig_DistinguishesGraphMetadata(t *testing.T) {
+	// Default + every kind-specific reference-config guidance must spell out
+	// the application-vs-graph-metadata distinction.
+	kinds := []string{"UNKNOWN_KIND", "view", "class", "function",
+		"operation", "module", "model"}
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			if !containsSection(p.Sections, "reference-config") {
+				t.Skipf("kind %q: profile has no reference-config section", kind)
+			}
+			g := docgen.ResolveGuidance(p, "reference-config")
+			lower := strings.ToLower(g)
+			// Model profile is scoped to storage-only config and pre-dates #1864;
+			// its narrow framing is intentional and the Properties block is not
+			// where bleed-through has been observed.
+			if kind == "model" {
+				return
+			}
+			// Application-config positive framing.
+			if !strings.Contains(lower, "application") {
+				t.Errorf("#1864 kind %q reference-config: missing 'application' framing; got: %q",
+					kind, g)
+			}
+			if !strings.Contains(lower, "graph-metadata") && !strings.Contains(lower, "indexer-internal") {
+				t.Errorf("#1864 kind %q reference-config: missing graph-metadata Properties exclusion; got: %q",
+					kind, g)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1865 — flows section MUST short-circuit fabrication for View/Class seeds:
+// "method bodies are NOT in scope" + defer to per-method pages.
+// ---------------------------------------------------------------------------
+
+func TestFlowsGuidance_ViewClassShortCircuit(t *testing.T) {
+	for _, kind := range []string{"view", "class", "SCOPE.View", "SCOPE.Class"} {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			g := docgen.ResolveGuidance(p, "flows")
+			lower := strings.ToLower(g)
+			if !strings.Contains(lower, "method bodies are not in scope") {
+				t.Errorf("#1865 kind %q flows: missing 'method bodies are NOT in scope' clause; got: %q",
+					kind, g)
+			}
+			if !strings.Contains(lower, "defer") || !strings.Contains(lower, "per-method") {
+				t.Errorf("#1865 kind %q flows: missing 'defer to per-method pages' instruction; got: %q",
+					kind, g)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1866 — api section MUST forbid decorator/path inference when decorator
+// parameters are not in source_window (View/Class kinds).
+// ---------------------------------------------------------------------------
+
+func TestApiGuidance_ViewClassForbidsDecoratorInference(t *testing.T) {
+	for _, kind := range []string{"view", "class", "SCOPE.View", "SCOPE.Class"} {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			g := docgen.ResolveGuidance(p, "api")
+			lower := strings.ToLower(g)
+			if !strings.Contains(lower, "not in source_window") &&
+				!strings.Contains(lower, "not-in-context") {
+				t.Errorf("#1866 kind %q api: missing decorator-not-in-context clause; got: %q",
+					kind, g)
+			}
+			if !strings.Contains(lower, "infer") {
+				t.Errorf("#1866 kind %q api: missing 'do not infer' wording; got: %q",
+					kind, g)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #2017 — flows section MUST restrict mermaid edges to bundle-visible entities
+// across every profile.
+// ---------------------------------------------------------------------------
+
+func TestFlowsGuidance_FabricationBoundary_AllProfiles(t *testing.T) {
+	// Every profile that includes the flows section must carry the boundary
+	// clause that bans fabricated edges.  The default profile sourced from
+	// defaultSectionGuidance counts too.
+	kinds := []string{"UNKNOWN_KIND", "module", "operation",
+		"view", "class", "function"}
+	for _, kind := range kinds {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			if !containsSection(p.Sections, "flows") {
+				t.Skipf("kind %q: profile has no flows section", kind)
+			}
+			g := docgen.ResolveGuidance(p, "flows")
+			lower := strings.ToLower(g)
+			if !strings.Contains(lower, "neighbour_briefs") {
+				t.Errorf("#2017 kind %q flows: missing neighbour_briefs boundary; got: %q", kind, g)
+			}
+			if !strings.Contains(lower, "module_manifest") {
+				t.Errorf("#2017 kind %q flows: missing module_manifest boundary; got: %q", kind, g)
+			}
+			if !strings.Contains(lower, "only reference entities that exist in the bundle") &&
+				!strings.Contains(lower, "do not mention entities or edges that are not in") {
+				t.Errorf("#2017 kind %q flows: missing fabrication ban wording; got: %q", kind, g)
+			}
+		})
+	}
+}
+
+// Size-tier operation profiles must also carry the #2017 boundary.
+func TestFlowsGuidance_FabricationBoundary_OperationTiers(t *testing.T) {
+	for _, lines := range []int{10, 50, 200} {
+		p := docgen.ResolveSectionProfile("operation", "", lines)
+		g := docgen.ResolveGuidance(p, "flows")
+		lower := strings.ToLower(g)
+		if !strings.Contains(lower, "neighbour_briefs") || !strings.Contains(lower, "module_manifest") {
+			t.Errorf("#2017 operation(lines=%d) flows: missing fabrication boundary; got: %q", lines, g)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SectionProfile.SkipForKinds — declarative field is reachable on the type.
+// ---------------------------------------------------------------------------
+
+func TestSectionProfile_SkipForKindsField(t *testing.T) {
+	// Construct a profile literal that exercises the new field — guards against
+	// the field accidentally being removed or renamed.
+	p := docgen.SectionProfile{
+		Sections:     []string{"overview"},
+		SkipForKinds: []string{"some-kind"},
+	}
+	if len(p.SkipForKinds) != 1 || p.SkipForKinds[0] != "some-kind" {
+		t.Errorf("SectionProfile.SkipForKinds round-trip failed: got %v", p.SkipForKinds)
+	}
+}

--- a/internal/docgen/sections_by_kind.go
+++ b/internal/docgen/sections_by_kind.go
@@ -78,6 +78,60 @@ type SectionProfile struct {
 	// excerpt for entities matching this profile.  Use the SourceWindowStrategy*
 	// constants.  Empty string selects SourceWindowStrategyDefault.
 	SourceWindowStrategy string
+
+	// SkipForKinds enumerates the canonical (lower-case) kind stems for which
+	// every section in this profile is suppressed.  It is informational metadata
+	// used by ShouldSkipSectionForKind and the bundle gating tests; the per-kind
+	// profile registry remains the primary mechanism for section selection.
+	//
+	// Introduced by #1860 / #1873 to make the gating contract explicit so that
+	// downstream consumers (and future profile authors) can audit which sections
+	// are intentionally suppressed for which seed kinds without re-deriving the
+	// rule from the section lists.
+	SkipForKinds []string
+}
+
+// SectionGating documents the per-section gating contract: each entry lists the
+// canonical (lower-case) kind stems for which the section is suppressed.  This
+// is the declarative form of the per-kind section curation expressed by the
+// profile registry — keep the two in sync when adding a new profile.
+//
+// Wiring (#1860 / #1873 / #2017):
+//
+//   - reference-deployment, reference-scripts → suppressed for leaf entity
+//     kinds (view, class, function, operation) because deployment / script
+//     surface is a module-aggregate concern.
+//   - how-to-local-dev → suppressed for EVERY non-module kind (#1873).  Module
+//     pages are the single source of truth for local-dev workflows.
+var SectionGating = map[string][]string{
+	"reference-deployment": {"view", "class", "function", "operation"},
+	"reference-scripts":    {"view", "class", "function", "operation"},
+	"how-to-local-dev":     {"view", "class", "function", "operation", "model", "react_component"},
+}
+
+// ShouldSkipSectionForKind reports whether a given section is gated out for the
+// supplied entity kind.  The kind is matched case-insensitively against the
+// canonical stems in SectionGating using substring containment so dotted
+// prefixes ("SCOPE.View") and compound names ("OperationHandler") resolve
+// correctly.
+//
+// Callers that already drive section selection through ResolveSectionProfile
+// do not need to consult this helper — the per-kind profile lists already omit
+// the gated sections.  ShouldSkipSectionForKind exists to expose the rule for
+// tests, audits, and downstream consumers that operate on the flat KnownSections
+// list and want a single authoritative answer per (section, kind) pair.
+func ShouldSkipSectionForKind(section, kind string) bool {
+	gated, ok := SectionGating[section]
+	if !ok {
+		return false
+	}
+	k := strings.ToLower(kind)
+	for _, stem := range gated {
+		if strings.Contains(k, stem) {
+			return true
+		}
+	}
+	return false
 }
 
 // sectionsByKind is the authoritative per-kind profile registry.
@@ -175,11 +229,16 @@ var sectionsByKind = map[string]SectionProfile{
 			"capabilities": "Enumerate the product capabilities this module owns, grouped by business outcome. " +
 				"Reference the key entities, handlers, or service objects that implement each capability.",
 			"flows": "Trace the primary request or event flow through this module using a mermaid sequence or flowchart. " +
-				"Show the entry point, internal orchestration, and outbound calls to external modules or services.",
+				"Show the entry point, internal orchestration, and outbound calls to external modules or services. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`. " +
+				"Mermaid diagrams must only reference entities that exist in the bundle. " +
+				"If thin context yields a one-step chain, render that one step honestly — do not pad with invented destinations.",
 			"api": "Document the full public API surface of this module: exported functions, HTTP endpoints, event topics, or CLI flags. " +
 				"Include method signatures and a one-line usage note for each.",
-			"reference-config": "List every environment variable or configuration key this module reads, with type, default value, and effect. " +
-				"Separate required from optional keys.",
+			"reference-config": "List every APPLICATION environment variable or configuration key this module reads, with type, default value, and effect. " +
+				"Separate required from optional keys. " +
+				"DO NOT include graph-metadata Properties (framework, module, role, language, etc.) — those are indexer-internal and not configuration. " +
+				"If the module has no application config, say so in one sentence.",
 			"reference-deployment": "Describe deployment concerns owned by this module: required env vars, exposed ports, " +
 				"scaling constraints, health-check endpoints, and any sidecar dependencies.",
 			"reference-scripts": "List all Makefile targets, npm/go scripts, or shell commands that operate on this module and explain what each does.",
@@ -223,14 +282,20 @@ var sectionsByKind = map[string]SectionProfile{
 			"capabilities": "List the discrete behaviours this operation provides. " +
 				"One bullet per observable side-effect or return-value contract.",
 			"flows": "Trace the execution flow through this operation using a mermaid sequence or flowchart. " +
-				"Show the caller → this operation → callees chain and any branching conditions.",
+				"Show the caller → this operation → callees chain and any branching conditions. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`. " +
+				"Mermaid diagrams must only reference entities that exist in the bundle. " +
+				"If thin context yields a one-step chain, render that one step honestly — do not pad with invented destinations.",
 			"patterns": "Identify structural patterns present in this operation " +
 				"(guard clause, strategy delegation, saga step, command-query separation, etc.). " +
-				"Cite specific callee relationships as evidence.",
+				"Cite specific callee relationships as evidence. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`.",
 			"api": "Document the function signature in full: parameters (name, type, purpose), return value(s), " +
 				"and raised errors or panics. Include a minimal usage example.",
-			"reference-config": "List any environment variables, feature flags, or config keys read inside this operation. " +
-				"Note which values alter branching behaviour.",
+			"reference-config": "List APPLICATION configuration read inside this operation: environment variables, settings module constants, " +
+				"feature flags, runtime parameters. Note which values alter branching behaviour. " +
+				"DO NOT include graph-metadata Properties (framework, module, role, language, etc.) — those are indexer-internal and not configuration. " +
+				"If the operation has no application config, say so in one sentence.",
 			"reference-dependencies": "List direct external and internal dependencies called by this operation. " +
 				"Separate production callees from test-only callees.",
 			"reference-misc": "Capture performance notes, known edge cases, or links to the issue/ADR that introduced this operation.",
@@ -267,11 +332,16 @@ var sectionsByKind = map[string]SectionProfile{
 				"State its single responsibility clearly.",
 			"capabilities": "List the observable behaviours of this helper in 1–3 bullets. " +
 				"Keep it concise — small operations have narrow contracts.",
-			"flows": "Describe the execution path briefly. A single mermaid flowchart node or a short prose paragraph is sufficient.",
-			"patterns": "Note any design pattern (guard clause, delegation, pure function, etc.) in one sentence.",
+			"flows": "Describe the execution path briefly. A single mermaid flowchart node or a short prose paragraph is sufficient. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`. " +
+				"If thin context yields a one-step chain, render that one step honestly — do not pad with invented destinations.",
+			"patterns": "Note any design pattern (guard clause, delegation, pure function, etc.) in one sentence. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`.",
 			"api": "Document the function signature: parameters (name, type), return value, and any errors raised. " +
 				"One-liner usage example if the call site is non-obvious.",
-			"reference-config": "Note any config key or feature flag read by this helper, if any. Omit section if none.",
+			"reference-config": "Note any APPLICATION config key, environment variable, or feature flag read by this helper. " +
+				"DO NOT include graph-metadata Properties (framework, module, role, etc.) — those are indexer-internal and not configuration. " +
+				"If the helper has no application config, say so in one sentence.",
 			"reference-misc": "Capture edge cases or performance notes specific to this helper, if any.",
 			"glossary": "Define any non-obvious domain term in the function or parameter names. Omit if all names are self-evident.",
 			"module-readme": "One sentence positioning this helper within its module. " +
@@ -311,14 +381,20 @@ var sectionsByKind = map[string]SectionProfile{
 			"capabilities": "Enumerate all discrete business capabilities this operation provides. " +
 				"Group by outcome category. One bullet per observable contract.",
 			"flows": "Trace the full execution flow using a mermaid sequence diagram. " +
-				"Show the caller → this operation → all major callees and any fork/join or retry loops.",
+				"Show the caller → this operation → all major callees and any fork/join or retry loops. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`. " +
+				"Mermaid diagrams must only reference entities that exist in the bundle. " +
+				"If thin context yields a one-step chain, render that one step honestly — do not pad with invented destinations.",
 			"patterns": "Identify ALL structural and architectural patterns present " +
 				"(orchestrator, saga, pipeline, strategy, command, etc.). " +
-				"Cite specific neighbour relationships as evidence for each.",
+				"Cite specific neighbour relationships as evidence for each. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`.",
 			"api": "Document the full function signature: every parameter (name, type, purpose), all return values, " +
 				"and every error or panic path. Include a realistic usage example showing a typical call site.",
-			"reference-config": "List every environment variable, config key, or feature flag read by this operation. " +
-				"Note which alter branching behaviour and which are required vs optional.",
+			"reference-config": "List every APPLICATION environment variable, config key, or feature flag read by this operation. " +
+				"Note which alter branching behaviour and which are required vs optional. " +
+				"DO NOT include graph-metadata Properties (framework, module, role, language, etc.) — those are indexer-internal and not configuration. " +
+				"If the operation has no application config, say so in one sentence.",
 			"reference-dependencies": "List all external and internal dependencies called by this operation. " +
 				"Separate required production dependencies from optional/test-only dependencies.",
 			"reference-deployment": "Describe deployment concerns relevant to this operation: " +
@@ -377,6 +453,161 @@ var sectionsByKind = map[string]SectionProfile{
 			"reference-misc": "Capture accessibility notes (ARIA roles, keyboard nav), known edge cases, or performance considerations.",
 			"glossary": "Define any domain terms appearing in prop names or type names. One term per row.",
 			"module-readme": "Write a brief README-style intro for the module that owns this component. " +
+				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
+				"`module_manifest.functions`, or `neighbour_briefs`. " +
+				"If you cite a sibling, name the bundle field it came from.",
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// view — class-kind seed (Django ViewSet, FastAPI router class, Flask View,
+	// DRF APIView, Rails controller-class, etc.).
+	//
+	// #1860 — gate reference-deployment / reference-scripts / how-to-local-dev
+	// out of the section list: these are module-aggregate concerns and produced
+	// ~3 sections of "limited context" boilerplate per leaf-class page.
+	// #1865 — flows section MUST short-circuit fabrication when method bodies
+	// are out of the source_window (the seed window typically holds only the
+	// class header).
+	// #1866 — api section MUST forbid decorator/path inference when the
+	// decorator parameters are not in the source_window.
+	// -------------------------------------------------------------------------
+	"view": {
+		Sections: []string{
+			"overview",
+			"capabilities",
+			"flows",
+			"patterns",
+			"api",
+			"reference-config",
+			"reference-dependencies",
+			"reference-misc",
+			"glossary",
+			"module-readme",
+		},
+		SkipForKinds: []string{}, // applies TO view, not skipped FOR view
+		GuidanceOverrides: map[string]string{
+			"overview": "Write a 2–3 sentence description of what this view/controller class exposes and the request lifecycle it owns. " +
+				"State its role in the routing layer (collection endpoint, detail endpoint, RPC-style action handler, etc.).",
+			"capabilities": "List the HTTP-facing capabilities this class provides, one bullet per action or endpoint. " +
+				"Reference the action method name and the documented business outcome — not the implementation details, which live on per-method pages.",
+			"flows": "You will see only the source_window for the seed class header; method bodies are NOT in scope. " +
+				"Trace the DISPATCH-level flow (router → ViewSet method → serializer → response) and explicitly defer per-method internals to per-method pages. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`. " +
+				"Mermaid diagrams must only reference entities that exist in the bundle. " +
+				"If thin context yields a one-step chain, render that one step honestly — do not pad with invented destinations.",
+			"patterns": "Identify class-level patterns (ViewSet mixin composition, generic-view inheritance, permission/throttle stacking, decorator-driven dispatch). " +
+				"Cite specific neighbour relationships as evidence. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`.",
+			"api": "Document the HTTP surface this class exposes: one row per action method. " +
+				"For each action: name, HTTP verb(s), URL path, request body schema, response schema, status codes. " +
+				"If @action / @api_view / @router decorator parameters are NOT in source_window or neighbour Properties, " +
+				"mark verb=not-in-context and path=not-in-context rather than inferring from method name or convention. " +
+				"NEVER infer verbs or paths from naming conventions when the decorator string is unavailable.",
+			"reference-config": "List APPLICATION configuration the class reads or writes: environment variables, settings module constants " +
+				"(e.g. `settings.X`, `SETTINGS.Y`), feature flags, runtime parameters, permission classes referenced by name. " +
+				"DO NOT include graph-metadata Properties (framework, module, role, language, etc.) — those are indexer-internal and not configuration. " +
+				"If the class has no application config, say so in one sentence rather than inventing config from the surrounding stack.",
+			"reference-dependencies": "List direct external and internal dependencies this class imports or composes " +
+				"(serializers, permission classes, filter backends, services). Separate production from test-only.",
+			"reference-misc": "Capture custom router wiring, ordering of mixins, or links to the ADR / issue that introduced this view.",
+			"glossary": "Define domain terms appearing in the class name, action names, or serializer field names. One term per row.",
+			"module-readme": "Write a brief README-style intro for the module that owns this view. " +
+				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
+				"`module_manifest.functions`, or `neighbour_briefs`. " +
+				"If you cite a sibling, name the bundle field it came from.",
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// class — generic class seed (non-View, non-Model, non-react_component).
+	//
+	// Same gating as `view`: drop deployment / scripts / local-dev because they
+	// are module-aggregate concerns (#1860 / #1873).  Same fabrication guards on
+	// flows and api as `view` (#1865 / #1866) — method bodies typically sit
+	// outside the source_window for class-kind seeds.
+	// -------------------------------------------------------------------------
+	"class": {
+		Sections: []string{
+			"overview",
+			"capabilities",
+			"flows",
+			"patterns",
+			"api",
+			"reference-config",
+			"reference-dependencies",
+			"reference-misc",
+			"glossary",
+			"module-readme",
+		},
+		GuidanceOverrides: map[string]string{
+			"overview": "Write a 2–3 sentence description of what this class represents and the responsibility it owns. " +
+				"State its role in the module (service, value object, adapter, coordinator, etc.).",
+			"capabilities": "List the discrete behaviours this class provides, one bullet per public method or observable contract. " +
+				"Defer per-method implementation details to the per-method pages.",
+			"flows": "You will see only the source_window for the seed class header; method bodies are NOT in scope. " +
+				"Trace the class-level collaboration (caller → this class → collaborators) and explicitly defer per-method internals to per-method pages. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`. " +
+				"Mermaid diagrams must only reference entities that exist in the bundle. " +
+				"If thin context yields a one-step chain, render that one step honestly — do not pad with invented destinations.",
+			"patterns": "Identify class-level structural patterns (template method, strategy, factory, builder, value object, etc.). " +
+				"Cite specific neighbour relationships as evidence. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`.",
+			"api": "Document the public method surface of this class: one row per public method (name, signature, returns, raises). " +
+				"If decorator parameters (e.g. @route, @action) are NOT in source_window or neighbour Properties, " +
+				"mark verbs/paths/params as not-in-context rather than inferring from method name or convention.",
+			"reference-config": "List APPLICATION configuration the class reads: environment variables, settings module constants, feature flags. " +
+				"DO NOT include graph-metadata Properties (framework, module, role, language, etc.) — those are indexer-internal and not configuration. " +
+				"If the class has no application config, say so in one sentence rather than inventing config from the surrounding stack.",
+			"reference-dependencies": "List direct external and internal dependencies this class imports or composes. " +
+				"Separate production from test-only.",
+			"reference-misc": "Capture inheritance quirks, mixin ordering, known edge cases, or links to the ADR / issue that introduced this class.",
+			"glossary": "Define domain terms appearing in the class name or method names. One term per row.",
+			"module-readme": "Write a brief README-style intro for the module that owns this class. " +
+				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
+				"`module_manifest.functions`, or `neighbour_briefs`. " +
+				"If you cite a sibling, name the bundle field it came from.",
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// function — top-level function or free-standing callable.
+	//
+	// #1860 — drop reference-deployment / reference-scripts / how-to-local-dev:
+	// a free function is a leaf surface, not a deployment unit.
+	// #2017 — flows section must respect bundle-visible entities only.
+	// -------------------------------------------------------------------------
+	"function": {
+		Sections: []string{
+			"overview",
+			"capabilities",
+			"flows",
+			"patterns",
+			"api",
+			"reference-config",
+			"reference-dependencies",
+			"reference-misc",
+			"glossary",
+			"module-readme",
+		},
+		GuidanceOverrides: map[string]string{
+			"overview": "Write a 2–3 sentence description of what this function does and when it is called. " +
+				"Highlight whether it is a leaf helper, a dispatcher, or a critical-path entry point.",
+			"capabilities": "List the observable behaviours of this function in 1–3 bullets. One bullet per side-effect or return-value contract.",
+			"flows": "Trace the execution flow through this function using a mermaid sequence or short flowchart. " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`. " +
+				"Mermaid diagrams must only reference entities that exist in the bundle. " +
+				"If thin context yields a one-step chain, render that one step honestly — do not pad with invented destinations.",
+			"patterns": "Note any design pattern (guard clause, delegation, pure function, decorator, etc.). " +
+				"Do NOT mention entities or edges that are not in `neighbour_briefs` or `module_manifest`.",
+			"api": "Document the function signature: parameters (name, type, purpose), return value(s), raised errors. Include a minimal usage example.",
+			"reference-config": "List APPLICATION configuration this function reads: environment variables, settings constants, feature flags. " +
+				"DO NOT include graph-metadata Properties (framework, module, role, etc.) — those are indexer-internal and not configuration. " +
+				"If the function has no application config, say so in one sentence.",
+			"reference-dependencies": "List direct external and internal dependencies called by this function. Separate production from test-only.",
+			"reference-misc": "Capture performance notes or edge cases specific to this function.",
+			"glossary": "Define domain terms in the function or parameter names. One term per row.",
+			"module-readme": "Write a brief README-style intro for the module that contains this function. " +
 				"Do NOT mention sibling entities unless they appear in `module_manifest.classes`, " +
 				"`module_manifest.functions`, or `neighbour_briefs`. " +
 				"If you cite a sibling, name the bundle field it came from.",


### PR DESCRIPTION
Bundle of seven related guidance / gating fixes against `internal/docgen/sections_by_kind.go` and the `defaultSectionGuidance` map in `internal/docgen/llm_bundle.go`. Each ticket pins one regression the dogfood runs surfaced in the last 48h. Closing all seven in one PR because the edits are file-disjoint at the section-key level and the test matrix is shared.

Closes #1857
Closes #1860
Closes #1864
Closes #1865
Closes #1866
Closes #1873
Closes #2017

## 1. What changed

- `internal/docgen/sections_by_kind.go`
  - Added `SectionProfile.SkipForKinds []string` (informational metadata documenting which kinds suppress every section in the profile).
  - Added top-level `SectionGating map[string][]string` + exported `ShouldSkipSectionForKind(section, kind string) bool` helper. Declarative form of the per-section skip-kind contract; substring-matches kind stems so `SCOPE.View`, `view`, `View` all resolve.
  - New profiles: `view`, `class`, `function`. Each drops `reference-deployment`, `reference-scripts`, `how-to-local-dev` from the section list (#1860 / #1873). Each carries kind-specific guidance overrides for `flows` (#1865 method-bodies-out-of-scope + defer-to-per-method-pages), `api` (#1866 decorator-inference ban), and `reference-config` (#1864 application-vs-graph-metadata distinction).
  - Updated `operation`, `operation.small`, `operation.large`, and `module` profile guidance: `flows` + `patterns` now carry the #2017 bundle-visible-entities boundary; `reference-config` carries the #1864 graph-metadata exclusion.
- `internal/docgen/llm_bundle.go`
  - `defaultSectionGuidance` updates so any profile that falls through to the default also inherits the new clauses:
    - `flows`: #2017 bundle-visible-entities boundary.
    - `patterns`: same boundary as flows.
    - `api`: #1866 decorator-not-in-context fallback wording.
    - `reference-config`: #1864 application-vs-graph-metadata + #1857 honesty clause.
    - `reference-deployment`, `reference-scripts`: #1857 honesty clause.
- `internal/docgen/section_gating_bundle_test.go` (new) — one focused test per ticket pinning the precise contract.

## 2. Why

Dogfood test-Claude runs on 2026-05-23 against `upvate-core::ProposalViewSet.approve_proposal`, `ContractViewSet`, and the W8R3 `Device.is_public` property exposed seven distinct failure modes in the section guidance: silent fabrication of graph nodes that do not exist (#2017), method-body fabrication on class seeds (#1865), decorator-path invention when the source_window only carried the class header (#1866), graph-metadata Properties bleeding into reference-config (#1864), three sections of "limited context" boilerplate on every leaf-class page (#1860 / #1873), and an absence of any "it's OK to write a 1-2 sentence honest note when nothing applies" permission in the guidance (#1857). The fix surface is text-only on three files and the cross-ticket test matrix is shared, so one PR keeps the contract diff coherent.

## 3. How to verify

```bash
cd internal/docgen
go test . -run 'TestHonestyClause|TestSectionGating|TestHowToLocalDev|TestShouldSkipSectionForKind|TestReferenceConfig_Distinguishes|TestFlowsGuidance_ViewClassShortCircuit|TestApiGuidance_ViewClassForbidsDecoratorInference|TestFlowsGuidance_FabricationBoundary|TestSectionProfile_SkipForKindsField' -v
go test ./internal/docgen/...
```

Both commands pass on this branch. The dogfood-side win is observed against a fresh emit→fill→apply run on any class-kind seed: reference-config no longer dumps graph-metadata Properties, flows no longer references entities absent from `neighbour_briefs`, and leaf-class pages shrink by ~3 sections.

## 4. Risks

- The new profiles introduce kind-specific section lists for `view`, `class`, `function`. Previously these fell through to the default 13-section list. Existing pages regenerated after this lands will lose `reference-deployment`, `reference-scripts`, `how-to-local-dev` for those kinds — intentional, but worth flagging for the next ground-truth audit.
- Adding the #2017 boundary clause to the default `flows` and `patterns` guidance affects every kind not yet profiled (anything not matching the substring lookup). The clause is additive — it does not change behaviour for existing-good outputs and only tightens the fabrication-prone path.
- `SectionProfile.SkipForKinds` is unused by the bundle pipeline today; it is metadata for audits and follow-up gating PRs. No risk of unexpected suppression.

## 5. What's next

- A follow-up dogfood pass on `ProposalViewSet.approve_proposal` and `ContractViewSet` to confirm the honesty clause + fabrication boundary land in the next emit run.
- #1862 (decorator metadata pre-extraction onto neighbour Properties) remains the structural fix for the 90% case; this PR is the guidance-side defense-in-depth for the remaining 10%.
- Consider extending `SectionGating` to cover `react_component`'s `how-to-local-dev` skip explicitly (currently relies on the per-kind profile lacking the section).

## 6. Tests / proofs

```
ok  	github.com/cajasmota/archigraph/internal/docgen	1.014s
```

New tests added in `internal/docgen/section_gating_bundle_test.go`:
- TestHonestyClause_DefaultGuidance (#1857)
- TestSectionGating_LeafKindsDropModuleAggregateSections (#1860)
- TestHowToLocalDev_ModuleOnly (#1873)
- TestShouldSkipSectionForKind (#1860 / #1873)
- TestReferenceConfig_DistinguishesGraphMetadata (#1864)
- TestFlowsGuidance_ViewClassShortCircuit (#1865)
- TestApiGuidance_ViewClassForbidsDecoratorInference (#1866)
- TestFlowsGuidance_FabricationBoundary_AllProfiles (#2017)
- TestFlowsGuidance_FabricationBoundary_OperationTiers (#2017)
- TestSectionProfile_SkipForKindsField (API surface guard)

## 7. Out of scope

- Decorator metadata pre-extraction onto neighbour Properties (#1862 — the structural fix this guidance is defense-in-depth for).
- ModuleManifest / NeighbourBriefs schema changes — the boundary clauses reference existing bundle fields; no extractor or serializer changes required.
- `react_component` profile updates — already lands its own per-kind gating in the existing profile; no behavioural delta needed here.
- Post-merge daemon rebuild / dist copy — coordinator handles this per the standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)