### PR TITLE
feat(python-extractor): nested ctor REFERENCES + SerializerMethodField link + router.register edges + CBV inherited annotations (#1977 #2007 #2008 #2009 #2010 #2011)

### DIFF
--- a/internal/extractors/python/cbv_inherited_methods.go
+++ b/internal/extractors/python/cbv_inherited_methods.go
@@ -1,0 +1,190 @@
+// cbv_inherited_methods.go — Generic CBV inherited-method annotation.
+//
+// Issue #2011 — Django generic class-based views and DRF generic
+// viewsets/views inherit a fixed contract of HTTP method handlers from
+// their base classes. A `class PermitViewSet(ModelViewSet)` exposes
+// `list / retrieve / create / update / partial_update / destroy`
+// without declaring them. Earlier waves attempted to model this by
+// synthesizing fake SCOPE.Operation entities for the inherited methods,
+// which produced spurious "method exists but has no source" findings
+// in audits AND inflated entity counts on every DRF project.
+//
+// Option A (this implementation): annotate the SCOPE.Component/class
+// entity with an `inherited_methods` property listing every inherited
+// method name from each recognised base class, comma-joined and
+// deduplicated. Downstream tools that need to enumerate the class's
+// API surface read the property directly without us having to
+// fabricate operation entities or invent a synthetic provenance.
+//
+// We only handle the well-known generic CBV / DRF base classes
+// enumerated in `cbvBaseInheritedMethods` below. Anything else gets no
+// annotation — a deliberate trade-off: it's better to under-annotate
+// than to invent inheritance from arbitrary user-defined bases whose
+// method sets we don't know.
+
+package python
+
+import (
+	"sort"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// cbvBaseInheritedMethods maps the bare leaf name of each recognised
+// Django / DRF generic base class to the set of method names it
+// contributes to its subclass's HTTP surface.
+//
+// Source: Django docs (generic class-based views) + DRF docs (generic
+// viewsets / generic API views). The list intentionally covers ONLY
+// the canonical HTTP-handler methods — helpers like `get_queryset`,
+// `get_serializer_class`, `perform_create` etc. are excluded because
+// subclasses override them as customization hooks rather than treat
+// them as part of the public API contract.
+var cbvBaseInheritedMethods = map[string][]string{
+	// Django generic class-based views (django.views.generic.*).
+	"View":                {"get", "post", "put", "patch", "delete", "head", "options", "trace"},
+	"TemplateView":        {"get"},
+	"RedirectView":        {"get", "post", "put", "patch", "delete", "head", "options"},
+	"ListView":            {"get"},
+	"DetailView":          {"get"},
+	"FormView":            {"get", "post"},
+	"CreateView":          {"get", "post"},
+	"UpdateView":          {"get", "post"},
+	"DeleteView":          {"get", "post", "delete"},
+	"ArchiveIndexView":    {"get"},
+	"YearArchiveView":     {"get"},
+	"MonthArchiveView":    {"get"},
+	"DayArchiveView":      {"get"},
+	"WeekArchiveView":     {"get"},
+	"TodayArchiveView":    {"get"},
+	"DateDetailView":      {"get"},
+	"ProcessFormView":     {"get", "post"},
+	"BaseCreateView":      {"get", "post"},
+	"BaseUpdateView":      {"get", "post"},
+	"BaseDeleteView":      {"get", "post", "delete"},
+
+	// DRF generic API views (rest_framework.generics.*).
+	"GenericAPIView":      {},
+	"CreateAPIView":       {"post"},
+	"ListAPIView":         {"get"},
+	"RetrieveAPIView":     {"get"},
+	"DestroyAPIView":      {"delete"},
+	"UpdateAPIView":       {"put", "patch"},
+	"ListCreateAPIView":   {"get", "post"},
+	"RetrieveUpdateAPIView":         {"get", "put", "patch"},
+	"RetrieveDestroyAPIView":        {"get", "delete"},
+	"RetrieveUpdateDestroyAPIView":  {"get", "put", "patch", "delete"},
+
+	// DRF viewsets (rest_framework.viewsets.*).
+	"ViewSet":             {},
+	"GenericViewSet":      {},
+	"ReadOnlyModelViewSet": {"list", "retrieve"},
+	"ModelViewSet":        {"list", "retrieve", "create", "update", "partial_update", "destroy"},
+
+	// DRF mixins (rest_framework.mixins.*).
+	"CreateModelMixin":           {"create"},
+	"ListModelMixin":             {"list"},
+	"RetrieveModelMixin":         {"retrieve"},
+	"UpdateModelMixin":           {"update", "partial_update"},
+	"DestroyModelMixin":          {"destroy"},
+}
+
+// emitCBVInheritedMethodAnnotations walks every class entity in the
+// file's slice. For each class whose EXTENDS edges include one or more
+// recognised CBV / DRF base classes, it stamps an `inherited_methods`
+// property holding the comma-joined union of method names contributed
+// by those bases.
+//
+// We read EXTENDS edges (emitted by extractBaseClasses, #698) rather
+// than re-parse the class header, so the rule fires consistently
+// regardless of whether the base is `View`, `views.View`, or
+// `django.views.generic.View` — extractBaseClasses normalises the leaf.
+//
+// Mutates *entities in place. Safe with nil/empty inputs.
+func emitCBVInheritedMethodAnnotations(_ *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if entities == nil || len(*entities) == 0 {
+		return
+	}
+	for i := range *entities {
+		e := &(*entities)[i]
+		if e.SourceFile != file.Path {
+			continue
+		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "class" {
+			continue
+		}
+		seen := make(map[string]struct{})
+		hadBase := false
+		for _, r := range e.Relationships {
+			if r.Kind != "EXTENDS" {
+				continue
+			}
+			baseLeaf := r.Properties["base_name"]
+			if baseLeaf == "" {
+				baseLeaf = extractLeafFromExtendsToID(r.ToID)
+			}
+			if dot := strings.LastIndexByte(baseLeaf, '.'); dot >= 0 {
+				baseLeaf = baseLeaf[dot+1:]
+			}
+			methods, ok := cbvBaseInheritedMethods[baseLeaf]
+			if !ok {
+				continue
+			}
+			hadBase = true
+			for _, m := range methods {
+				seen[m] = struct{}{}
+			}
+		}
+		if !hadBase {
+			continue
+		}
+		// Sort for deterministic property values across runs.
+		ordered := make([]string, 0, len(seen))
+		for m := range seen {
+			ordered = append(ordered, m)
+		}
+		sort.Strings(ordered)
+		if e.Properties == nil {
+			e.Properties = make(map[string]string)
+		}
+		e.Properties["inherited_methods"] = strings.Join(ordered, ",")
+		// Bases tag is useful for downstream audit; comma-joined leaves.
+		bases := make([]string, 0)
+		for _, r := range e.Relationships {
+			if r.Kind != "EXTENDS" {
+				continue
+			}
+			baseLeaf := r.Properties["base_name"]
+			if baseLeaf == "" {
+				baseLeaf = extractLeafFromExtendsToID(r.ToID)
+			}
+			if dot := strings.LastIndexByte(baseLeaf, '.'); dot >= 0 {
+				baseLeaf = baseLeaf[dot+1:]
+			}
+			if _, ok := cbvBaseInheritedMethods[baseLeaf]; ok {
+				bases = append(bases, baseLeaf)
+			}
+		}
+		if len(bases) > 0 {
+			e.Properties["cbv_bases"] = strings.Join(bases, ",")
+		}
+	}
+}
+
+// extractLeafFromExtendsToID returns the trailing colon-separated
+// segment of an EXTENDS edge ToID. The structural-ref shape used by
+// extractBaseClasses ends with the bare class name. Empty input yields
+// "".
+func extractLeafFromExtendsToID(toID string) string {
+	if toID == "" {
+		return ""
+	}
+	if idx := strings.LastIndexByte(toID, ':'); idx >= 0 {
+		return toID[idx+1:]
+	}
+	return toID
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -324,6 +324,44 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		applyCeleryAnnotations(file, &entities)
 	}()
 
+	// Issues #2007 / #2009 — supplemental REFERENCES emission for
+	// shapes the primary `emitReferences` walker excludes: nested
+	// constructor calls inside method bodies (`SerializerClass()` in
+	// `get_<field>`) and capitalised attribute receivers inside
+	// class-body assignment RHSs (`choices=User.TYPE_CHOICES`). Runs
+	// after the primary REFERENCES pass and after the Django relational
+	// pass so the class-target table observes the full entity list.
+	func() {
+		defer func() { _ = recover() }()
+		emitNestedConstructorRefs(root, file, &entities)
+	}()
+
+	// Issue #2008 — DRF SerializerMethodField → method link. For every
+	// `<field> = serializers.SerializerMethodField(...)` declaration
+	// emit a RESOLVED_BY edge from the field entity to the sibling
+	// `get_<field>` (or `method_name=` kwarg) operation entity.
+	func() {
+		defer func() { _ = recover() }()
+		emitSerializerMethodFieldLinks(root, file, &entities)
+	}()
+
+	// Issue #2010 — DRF router.register(prefix, ViewSet, ...). Emit
+	// REFERENCES from urls.py / routers.py file entities to each
+	// registered ViewSet class, capturing url_prefix + basename props.
+	func() {
+		defer func() { _ = recover() }()
+		emitRouterRegisterEdges(root, file, &entities)
+	}()
+
+	// Issue #2011 — Generic CBV / DRF viewset inherited-method
+	// annotation (option A). Stamp `inherited_methods` and `cbv_bases`
+	// properties on each subclass of a recognised generic base, rather
+	// than synthesising fake Operation entities for inherited handlers.
+	func() {
+		defer func() { _ = recover() }()
+		emitCBVInheritedMethodAnnotations(root, file, &entities)
+	}()
+
 	// Issue #1991 — __init__.py re-export annotation.
 	// Stamps re_export / package_init / public / alias properties on
 	// IMPORTS edges of package __init__.py files. Returns the public

--- a/internal/extractors/python/nested_ctor_refs.go
+++ b/internal/extractors/python/nested_ctor_refs.go
@@ -1,0 +1,411 @@
+// nested_ctor_refs.go — supplemental REFERENCES emission for two
+// adjacent shapes the primary `emitReferences` walker leaves on the
+// table:
+//
+//   - #2007 — `SerializerClass()` (or `Helper()`) construction *inside*
+//     a method body. The primary `emitReferences` already walks method
+//     bodies, but identifiers that are the `function` child of a `call`
+//     node are routed to the CALLS extractor (extractCallRelationships).
+//     CALLS only resolves bare-name callees that match a known function
+//     in the file; a Capitalised identifier used as a constructor where
+//     the class lives in another file (or is an imported symbol) falls
+//     through both the CALLS extractor (no in-file function match) and
+//     the REFERENCES extractor (the identifier is excluded by
+//     isPyCallCallee). The result: the cross-class composition between
+//     `MyView.get_<field>()` and `SerializerClass` is invisible in the
+//     graph.
+//
+//   - #2009 — `choices=User.TYPE_CHOICES` and similar shapes inside
+//     class-attribute initializer kwargs. The Django relational pass
+//     (#1977 / #1978) captures the raw kwarg value text but does not
+//     emit a REFERENCES edge to the referenced class. The constructor
+//     RHS lives in a class body (not a method body), which the primary
+//     `emitReferences` walker doesn't descend into — its function-frame
+//     stack only pushes inside function_definition / lambda. So a
+//     module-level `models.IntegerField(choices=User.TYPE_CHOICES)`
+//     never references `User`.
+//
+// Implementation strategy:
+//
+//   - Build a single name → class-entity table (mirrors the bareSymbols
+//     table in references.go, but limited to SCOPE.Component/class plus
+//     module-import bindings — we only want REFERENCES that resolve to a
+//     declared class entity or an external symbol from an import). Then
+//     walk every method body AND every class-body assignment RHS, looking
+//     for Capitalised identifiers in either:
+//
+//       (a) the `function` field of a `call` node, or
+//       (b) the `object` field of an `attribute` access (e.g.
+//           `User.TYPE_CHOICES`).
+//
+//     For each, look up the bare name and, if the table has an entry,
+//     emit a REFERENCES edge from the enclosing entity (the method, or
+//     the parent class when at class-body scope) to the resolved class.
+//
+//   - The edge is deduplicated by (from_id, to_id) so a method that
+//     references the same class three times produces a single edge.
+//
+//   - The walker filters out bare-name self-references (a method that
+//     constructs its own enclosing class — rare but legal — does not
+//     get an edge back to itself).
+//
+// This file is intentionally narrow: it ONLY emits the *missing* edges
+// that the primary REFERENCES walker excludes. It does not duplicate or
+// re-emit any edge that the primary walker already produced.
+
+package python
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// classRefTarget is one row of the class-target lookup table assembled
+// by emitNestedConstructorRefs. emittedName is the value placed in the
+// structural-ref ToID; fromImport indicates whether the lookup hit was
+// produced by a file-level IMPORTS edge (vs. a same-file class entity).
+type classRefTarget struct {
+	emittedName string
+	fromImport  bool
+}
+
+// nestedEdgeKey deduplicates (from_id, to_id) pairs across the pass so
+// repeated references inside the same method body or class body produce
+// a single REFERENCES edge.
+type nestedEdgeKey struct{ from, to string }
+
+// emitNestedConstructorRefs runs AFTER the primary REFERENCES pass so
+// it can observe the file-scope symbol table the primary walker would
+// have built. We re-derive the class-only symbol view here rather than
+// share state with emitReferences — the two passes have different
+// criteria (REFERENCES skips call-callee identifiers; we only fire on
+// call-callee + attribute-receiver shapes that REFERENCES skipped).
+//
+// Safe to call with nil/empty inputs.
+func emitNestedConstructorRefs(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	// Build the class-target table. We index bare class names (declared
+	// in this file as SCOPE.Component/class) AND import bindings whose
+	// local_name starts with an upper-case letter (the universal Python
+	// convention for class-like imports). The latter lets a method that
+	// constructs an imported class trigger a REFERENCES edge whose
+	// target resolves via the existing structural-ref → ext: fallback.
+	classTargets := make(map[string]classRefTarget)
+
+	for i := range *entities {
+		e := &(*entities)[i]
+		if e.SourceFile != file.Path {
+			continue
+		}
+		if e.Kind == "SCOPE.Component" && e.Subtype == "class" {
+			leaf := e.Name
+			if dot := strings.LastIndexByte(leaf, '.'); dot >= 0 {
+				leaf = leaf[dot+1:]
+			}
+			if leaf == "" {
+				continue
+			}
+			if _, exists := classTargets[leaf]; !exists {
+				classTargets[leaf] = classRefTarget{emittedName: e.Name}
+			}
+			// Also index the dotted name for nested classes.
+			if e.Name != leaf {
+				if _, exists := classTargets[e.Name]; !exists {
+					classTargets[e.Name] = classRefTarget{emittedName: e.Name}
+				}
+			}
+			continue
+		}
+		// Pull import bindings out of the file entity's IMPORTS edges.
+		if e.Kind == "SCOPE.Component" && e.Subtype == "file" {
+			for _, r := range e.Relationships {
+				if r.Kind != "IMPORTS" {
+					continue
+				}
+				local := r.Properties["local_name"]
+				if local == "" {
+					continue
+				}
+				// Skip lower-case bindings (functions / modules / vars).
+				if !isCapitalisedIdent(local) {
+					continue
+				}
+				imported := r.Properties["imported_name"]
+				if imported == "" {
+					imported = local
+				}
+				if _, exists := classTargets[local]; !exists {
+					classTargets[local] = classRefTarget{emittedName: imported, fromImport: true}
+				}
+			}
+		}
+	}
+
+	if len(classTargets) == 0 {
+		return
+	}
+
+	seen := make(map[nestedEdgeKey]bool)
+
+	// emitEdge appends a REFERENCES edge from the entity at entityIdx
+	// to the resolved class target. fromName is the enclosing entity's
+	// emitted Name (used for self-reference filtering). The edge
+	// carries a `nested_ctor` property to make the provenance
+	// inspectable in graph audits.
+	emitEdge := func(entityIdx int, fromName, leaf string, t classRefTarget) {
+		_ = leaf // leaf retained for future self-ref refinement; current guard is name-based
+		if entityIdx < 0 || entityIdx >= len(*entities) {
+			return
+		}
+		// Self-reference guard: only suppress when the resolved target
+		// IS the enclosing entity itself (a method body that references
+		// its own enclosing class would still be a real edge, but a
+		// class body that references itself via the bare class name
+		// would not be — handled below by comparing against the entity's
+		// emitted Name).
+		if t.emittedName == fromName {
+			return
+		}
+		toID := buildDjangoModelClassRef(file.Path, t.emittedName)
+		key := nestedEdgeKey{fromName, toID}
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		(*entities)[entityIdx].Relationships = append((*entities)[entityIdx].Relationships,
+			types.RelationshipRecord{
+				ToID: toID,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"nested_ctor":  "true",
+					"target_class": t.emittedName,
+				},
+			})
+	}
+
+	// Walk every class definition. Inside a class we visit:
+	//   1. each class-body assignment's RHS (#2009 shape: kwargs of a
+	//      field constructor like `choices=User.TYPE_CHOICES`); the
+	//      enclosing entity is the parent class.
+	//   2. each method body (function_definition inside the class
+	//      body); the enclosing entity is the method.
+	//
+	// Nested classes recurse with the dotted parent name.
+	var walkClass func(classNode *sitter.Node, parentClass string)
+	walkClass = func(classNode *sitter.Node, parentClass string) {
+		if classNode == nil {
+			return
+		}
+		nameNode := classNode.ChildByFieldName("name")
+		cls := ""
+		if nameNode != nil {
+			cls = nodeText(nameNode, file.Content)
+		}
+		dottedClass := cls
+		if parentClass != "" && cls != "" {
+			dottedClass = parentClass + "." + cls
+		}
+		body := classNode.ChildByFieldName("body")
+		if body == nil {
+			return
+		}
+
+		// Locate the enclosing class entity index for class-body refs.
+		classIdx := -1
+		for i := range *entities {
+			if (*entities)[i].Kind == "SCOPE.Component" &&
+				(*entities)[i].Subtype == "class" &&
+				(*entities)[i].Name == dottedClass &&
+				(*entities)[i].SourceFile == file.Path {
+				classIdx = i
+				break
+			}
+		}
+
+		for i := 0; i < int(body.ChildCount()); i++ {
+			stmt := body.Child(i)
+			if stmt == nil {
+				continue
+			}
+			switch stmt.Type() {
+			case "expression_statement":
+				// Class-body assignment: walk its RHS for capitalised
+				// callees / attribute receivers. Enclosing entity is
+				// the parent class itself (#2009 surface).
+				if classIdx >= 0 {
+					scanNodeForClassRefs(stmt, file.Content, classTargets, func(leaf string, t classRefTarget) {
+						emitEdge(classIdx, dottedClass, leaf, t)
+					})
+				}
+			case "function_definition":
+				scanMethodForClassRefs(stmt, file, dottedClass, classTargets, entities, seen, emitEdge)
+			case "decorated_definition":
+				inner := stmt.ChildByFieldName("definition")
+				if inner == nil {
+					continue
+				}
+				switch inner.Type() {
+				case "function_definition":
+					scanMethodForClassRefs(inner, file, dottedClass, classTargets, entities, seen, emitEdge)
+				case "class_definition":
+					walkClass(inner, dottedClass)
+				}
+			case "class_definition":
+				walkClass(stmt, dottedClass)
+			}
+		}
+	}
+
+	// Top-level walk: find every class_definition (including those
+	// wrapped in a decorated_definition) and process it.
+	var walkTop func(n *sitter.Node)
+	walkTop = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_definition":
+			walkClass(n, "")
+			return
+		case "decorated_definition":
+			inner := n.ChildByFieldName("definition")
+			if inner != nil && inner.Type() == "class_definition" {
+				walkClass(inner, "")
+				return
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walkTop(n.Child(i))
+		}
+	}
+	walkTop(root)
+}
+
+// scanMethodForClassRefs walks a function_definition body looking for
+// capitalised-identifier callees (#2007) and capitalised-identifier
+// attribute receivers (#2009 — defensive: same shape can also appear
+// inside method bodies). The enclosing entity is the method itself,
+// looked up by emitted Name "<parentClass>.<methodLeaf>".
+func scanMethodForClassRefs(
+	fnNode *sitter.Node,
+	file extractor.FileInput,
+	parentClass string,
+	classTargets map[string]classRefTarget,
+	entities *[]types.EntityRecord,
+	seen map[nestedEdgeKey]bool,
+	emitEdge func(entityIdx int, fromName, leaf string, t classRefTarget),
+) {
+	_ = seen // edge-key dedup is owned by emitEdge's closure
+	nameNode := fnNode.ChildByFieldName("name")
+	if nameNode == nil {
+		return
+	}
+	leafName := nodeText(nameNode, file.Content)
+	emittedName := leafName
+	if parentClass != "" {
+		emittedName = parentClass + "." + leafName
+	}
+
+	// Find the method entity index by Name + SourceFile.
+	methodIdx := -1
+	for i := range *entities {
+		if (*entities)[i].Kind == "SCOPE.Operation" &&
+			(*entities)[i].Name == emittedName &&
+			(*entities)[i].SourceFile == file.Path {
+			methodIdx = i
+			break
+		}
+	}
+	if methodIdx < 0 {
+		return
+	}
+
+	body := fnNode.ChildByFieldName("body")
+	if body == nil {
+		return
+	}
+	scanNodeForClassRefs(body, file.Content, classTargets, func(leaf string, t classRefTarget) {
+		emitEdge(methodIdx, emittedName, leaf, t)
+	})
+}
+
+// scanNodeForClassRefs recursively visits node and invokes onMatch for
+// every Capitalised identifier that:
+//
+//   - is the `function` child of a `call` node (constructor call), OR
+//   - is the `object` child of an `attribute` node (class-qualified
+//     attribute access like `User.TYPE_CHOICES`).
+//
+// Capitalised is the conservative gate: it filters out the common
+// lower-case-callable case (function calls) that the CALLS pass owns
+// and avoids spurious REFERENCES to local variables.
+func scanNodeForClassRefs(
+	node *sitter.Node,
+	src []byte,
+	classTargets map[string]classRefTarget,
+	onMatch func(leaf string, t classRefTarget),
+) {
+	if node == nil {
+		return
+	}
+	switch node.Type() {
+	case "call":
+		fn := node.ChildByFieldName("function")
+		if fn != nil {
+			tryEmitClassRef(fn, src, classTargets, onMatch)
+		}
+	case "attribute":
+		obj := node.ChildByFieldName("object")
+		if obj != nil {
+			tryEmitClassRef(obj, src, classTargets, onMatch)
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		scanNodeForClassRefs(node.Child(i), src, classTargets, onMatch)
+	}
+}
+
+// tryEmitClassRef looks up the leaf identifier of fnOrObj in
+// classTargets. fnOrObj may be an `identifier` node (bare class name)
+// or an `attribute` node whose final leaf is the class name. Anything
+// else (subscripts, lambdas, conditional_expression, etc.) is ignored.
+func tryEmitClassRef(
+	fnOrObj *sitter.Node,
+	src []byte,
+	classTargets map[string]classRefTarget,
+	onMatch func(leaf string, t classRefTarget),
+) {
+	if fnOrObj == nil {
+		return
+	}
+	var leaf string
+	switch fnOrObj.Type() {
+	case "identifier":
+		leaf = nodeText(fnOrObj, src)
+	case "attribute":
+		// Take the trailing leaf — `mod.Sub.User` → `User`.
+		txt := nodeText(fnOrObj, src)
+		if dot := strings.LastIndexByte(txt, '.'); dot >= 0 {
+			leaf = txt[dot+1:]
+		} else {
+			leaf = txt
+		}
+	default:
+		return
+	}
+	if leaf == "" || !isCapitalisedIdent(leaf) {
+		return
+	}
+	t, ok := classTargets[leaf]
+	if !ok {
+		return
+	}
+	onMatch(leaf, t)
+}

--- a/internal/extractors/python/python_relational_bundle_test.go
+++ b/internal/extractors/python/python_relational_bundle_test.go
@@ -1,0 +1,339 @@
+// python_relational_bundle_test.go — coverage for the Python relational
+// edges bundle (#1977 retest + #2007 / #2008 / #2009 / #2010 / #2011).
+//
+// All fixtures use the `client-fixture-a` naming convention per the
+// standing rule — no real client names appear.
+
+package python_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/extractors/python"
+)
+
+// runPy is a small helper that runs the Python extractor on a snippet
+// at the supplied file path and returns the entities slice.
+func runPy(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parse(t, []byte(src))
+	ext, ok := extractor.Get("python")
+	if !ok {
+		t.Fatal("python extractor not registered")
+	}
+	fi := extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "python",
+		Tree:     tree,
+	}
+	entities, err := ext.Extract(context.Background(), fi)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return entities
+}
+
+// findEnt returns the first entity matching kind+subtype+name. Fails the
+// test when no match is found.
+func findEnt(t *testing.T, entities []types.EntityRecord, kind, subtype, name string) types.EntityRecord {
+	t.Helper()
+	for _, e := range entities {
+		if e.Kind == kind && e.Subtype == subtype && e.Name == name {
+			return e
+		}
+	}
+	t.Fatalf("entity %s/%s %q not found", kind, subtype, name)
+	return types.EntityRecord{}
+}
+
+// hasRelKind reports whether e has a relationship of kind k whose ToID
+// contains substr.
+func hasRelKind(e types.EntityRecord, k, substr string) bool {
+	for _, r := range e.Relationships {
+		if r.Kind == k && strings.Contains(r.ToID, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// #1977 retest — ForeignKey REFERENCES is emitted post-bundle-A. W6R2 had
+// flagged the surface as still broken, but Bundle A's enrich pass already
+// stamps the edge; this test pins the behaviour so a future regression
+// shows up here, and documents that any downstream surface gap (e.g. the
+// NeighbourBrief Properties surface in #2025) is not an extractor bug.
+// ============================================================================
+
+func TestIssue1977_ForeignKey_References_StillEmitted(t *testing.T) {
+	src := `from django.db import models
+
+class Jurisdiction(models.Model):
+    name = models.CharField(max_length=100)
+
+class Building(models.Model):
+    jurisdiction = models.ForeignKey(Jurisdiction, on_delete=models.CASCADE)
+`
+	entities := runPy(t, "client_fixture_a/buildings/models.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "Building.jurisdiction")
+	if !hasRelKind(field, "REFERENCES", ":Jurisdiction") {
+		t.Fatalf("expected Building.jurisdiction REFERENCES → Jurisdiction; rels=%+v", field.Relationships)
+	}
+}
+
+// ============================================================================
+// #2007 — Nested constructor call inside a method body emits REFERENCES.
+// ============================================================================
+
+func TestIssue2007_NestedConstructorInMethodEmitsReferences(t *testing.T) {
+	src := `class WidgetSerializer:
+    pass
+
+class ParentSerializer:
+    def get_widget(self, obj):
+        return WidgetSerializer().data
+
+    def get_thing(self, obj):
+        helper = WidgetSerializer()
+        return helper
+`
+	entities := runPy(t, "client_fixture_a/api/serializers.py", src)
+	method := findEnt(t, entities, "SCOPE.Operation", "method", "ParentSerializer.get_widget")
+	if !hasRelKind(method, "REFERENCES", ":WidgetSerializer") {
+		t.Fatalf("expected ParentSerializer.get_widget REFERENCES → WidgetSerializer; rels=%+v", method.Relationships)
+	}
+	// nested_ctor provenance property is stamped.
+	found := false
+	for _, r := range method.Relationships {
+		if r.Kind == "REFERENCES" && r.Properties["nested_ctor"] == "true" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected at least one REFERENCES edge with nested_ctor=true; rels=%+v", method.Relationships)
+	}
+
+	// Dedup: get_thing also constructs WidgetSerializer — should be one edge.
+	thing := findEnt(t, entities, "SCOPE.Operation", "method", "ParentSerializer.get_thing")
+	count := 0
+	for _, r := range thing.Relationships {
+		if r.Kind == "REFERENCES" && strings.Contains(r.ToID, ":WidgetSerializer") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 nested_ctor REFERENCES to WidgetSerializer from get_thing, got %d", count)
+	}
+}
+
+// ============================================================================
+// #2008 — SerializerMethodField → get_<field> RESOLVED_BY edge.
+// ============================================================================
+
+func TestIssue2008_SerializerMethodFieldImplicitName(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class FooSerializer(serializers.ModelSerializer):
+    full_name = serializers.SerializerMethodField()
+
+    def get_full_name(self, obj):
+        return obj.name
+`
+	entities := runPy(t, "client_fixture_a/api/serializers.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "FooSerializer.full_name")
+	if !hasRelKind(field, "RESOLVED_BY", "FooSerializer.get_full_name") {
+		t.Fatalf("expected FooSerializer.full_name RESOLVED_BY → get_full_name; rels=%+v", field.Relationships)
+	}
+}
+
+func TestIssue2008_SerializerMethodFieldExplicitName(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class FooSerializer(serializers.ModelSerializer):
+    full_name = serializers.SerializerMethodField(method_name="compute_full")
+
+    def compute_full(self, obj):
+        return obj.name
+`
+	entities := runPy(t, "client_fixture_a/api/serializers.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "FooSerializer.full_name")
+	if !hasRelKind(field, "RESOLVED_BY", "FooSerializer.compute_full") {
+		t.Fatalf("expected explicit method_name link; rels=%+v", field.Relationships)
+	}
+}
+
+func TestIssue2008_SerializerMethodField_MissingMethodNoEdge(t *testing.T) {
+	// The implementing method doesn't exist — the pass must NOT
+	// fabricate the edge.
+	src := `from rest_framework import serializers
+
+class FooSerializer(serializers.ModelSerializer):
+    full_name = serializers.SerializerMethodField()
+`
+	entities := runPy(t, "client_fixture_a/api/serializers.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "FooSerializer.full_name")
+	for _, r := range field.Relationships {
+		if r.Kind == "RESOLVED_BY" {
+			t.Fatalf("did not expect RESOLVED_BY edge when implementor is absent; got %+v", r)
+		}
+	}
+}
+
+// ============================================================================
+// #2009 — Indirect Model refs (`choices=User.TYPE_CHOICES`) emit REFERENCES.
+// ============================================================================
+
+func TestIssue2009_ChoicesAttributeEmitsReferences(t *testing.T) {
+	src := `from django.db import models
+
+class User(models.Model):
+    TYPE_CHOICES = [("a", "A"), ("b", "B")]
+
+class Profile(models.Model):
+    user_type = models.IntegerField(choices=User.TYPE_CHOICES)
+`
+	entities := runPy(t, "client_fixture_a/accounts/models.py", src)
+	profile := findEnt(t, entities, "SCOPE.Component", "class", "Profile")
+	if !hasRelKind(profile, "REFERENCES", ":User") {
+		t.Fatalf("expected Profile class REFERENCES → User from choices attribute; rels=%+v", profile.Relationships)
+	}
+	found := false
+	for _, r := range profile.Relationships {
+		if r.Kind == "REFERENCES" && r.Properties["nested_ctor"] == "true" && strings.Contains(r.ToID, ":User") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected REFERENCES edge with nested_ctor=true and target_class=User; rels=%+v", profile.Relationships)
+	}
+}
+
+// ============================================================================
+// #2010 — router.register(prefix, ViewSet, ...) REFERENCES from urls.py.
+// ============================================================================
+
+func TestIssue2010_RouterRegisterEmitsEdge(t *testing.T) {
+	src := `from rest_framework.routers import DefaultRouter
+from .views import PermitViewSet, JurisdictionViewSet
+
+router = DefaultRouter()
+router.register(r"permits", PermitViewSet, basename="permit")
+router.register(r"jurisdictions", JurisdictionViewSet)
+`
+	entities := runPy(t, "client_fixture_a/api/urls.py", src)
+	// File entity carries the REFERENCES edges.
+	fileEnt := findEnt(t, entities, "SCOPE.Component", "file", "client_fixture_a/api/urls.py")
+	if !hasRelKind(fileEnt, "REFERENCES", ":PermitViewSet") {
+		t.Fatalf("expected REFERENCES → PermitViewSet on urls.py; rels=%+v", fileEnt.Relationships)
+	}
+	if !hasRelKind(fileEnt, "REFERENCES", ":JurisdictionViewSet") {
+		t.Fatalf("expected REFERENCES → JurisdictionViewSet on urls.py; rels=%+v", fileEnt.Relationships)
+	}
+	// Property check: url_prefix + basename are stamped on the
+	// PermitViewSet edge.
+	var permitEdge types.RelationshipRecord
+	for _, r := range fileEnt.Relationships {
+		if r.Kind == "REFERENCES" && strings.Contains(r.ToID, ":PermitViewSet") {
+			permitEdge = r
+			break
+		}
+	}
+	if permitEdge.Properties["url_prefix"] != "permits" {
+		t.Errorf("url_prefix = %q, want permits", permitEdge.Properties["url_prefix"])
+	}
+	if permitEdge.Properties["basename"] != "permit" {
+		t.Errorf("basename = %q, want permit", permitEdge.Properties["basename"])
+	}
+	if permitEdge.Properties["router_register"] != "true" {
+		t.Errorf("router_register property missing")
+	}
+}
+
+func TestIssue2010_NonUrlsFileIsNoOp(t *testing.T) {
+	// Same call shape in a non-urls module must NOT emit the edge.
+	src := `from rest_framework.routers import DefaultRouter
+router = DefaultRouter()
+router.register(r"permits", PermitViewSet)
+`
+	entities := runPy(t, "client_fixture_a/api/handlers.py", src)
+	fileEnt := findEnt(t, entities, "SCOPE.Component", "file", "client_fixture_a/api/handlers.py")
+	for _, r := range fileEnt.Relationships {
+		if r.Kind == "REFERENCES" && r.Properties["router_register"] == "true" {
+			t.Fatalf("router_register edge emitted from non-urls file: %+v", r)
+		}
+	}
+}
+
+// ============================================================================
+// #2011 — CBV inherited methods annotation.
+// ============================================================================
+
+func TestIssue2011_ModelViewSetInheritedMethods(t *testing.T) {
+	src := `from rest_framework import viewsets
+
+class PermitViewSet(viewsets.ModelViewSet):
+    pass
+`
+	entities := runPy(t, "client_fixture_a/api/views.py", src)
+	cls := findEnt(t, entities, "SCOPE.Component", "class", "PermitViewSet")
+	got := cls.Properties["inherited_methods"]
+	want := "create,destroy,list,partial_update,retrieve,update"
+	if got != want {
+		t.Errorf("inherited_methods = %q, want %q", got, want)
+	}
+	if cls.Properties["cbv_bases"] != "ModelViewSet" {
+		t.Errorf("cbv_bases = %q, want ModelViewSet", cls.Properties["cbv_bases"])
+	}
+}
+
+func TestIssue2011_ListViewInheritedMethods(t *testing.T) {
+	src := `from django.views.generic import ListView
+
+class PermitListView(ListView):
+    pass
+`
+	entities := runPy(t, "client_fixture_a/web/views.py", src)
+	cls := findEnt(t, entities, "SCOPE.Component", "class", "PermitListView")
+	if cls.Properties["inherited_methods"] != "get" {
+		t.Errorf("ListView subclass inherited_methods = %q, want get", cls.Properties["inherited_methods"])
+	}
+}
+
+func TestIssue2011_UnknownBaseIsNoOp(t *testing.T) {
+	// User-defined base class that we don't recognise: no annotation.
+	src := `class MyBase:
+    pass
+
+class MySub(MyBase):
+    pass
+`
+	entities := runPy(t, "client_fixture_a/random.py", src)
+	cls := findEnt(t, entities, "SCOPE.Component", "class", "MySub")
+	if _, exists := cls.Properties["inherited_methods"]; exists {
+		t.Errorf("unknown-base subclass should not carry inherited_methods; got %q", cls.Properties["inherited_methods"])
+	}
+}
+
+func TestIssue2011_MultipleBasesUnion(t *testing.T) {
+	src := `from rest_framework import mixins
+from rest_framework.viewsets import GenericViewSet
+
+class CustomViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, GenericViewSet):
+    pass
+`
+	entities := runPy(t, "client_fixture_a/api/views.py", src)
+	cls := findEnt(t, entities, "SCOPE.Component", "class", "CustomViewSet")
+	got := cls.Properties["inherited_methods"]
+	want := "list,retrieve"
+	if got != want {
+		t.Errorf("multi-mixin inherited_methods = %q, want %q", got, want)
+	}
+}

--- a/internal/extractors/python/router_register.go
+++ b/internal/extractors/python/router_register.go
@@ -1,0 +1,235 @@
+// router_register.go — DRF `router.register(prefix, ViewSetClass, ...)`
+// REFERENCES edge emission from urls.py to the registered ViewSet class.
+//
+// Issue #2010 — A canonical DRF urls.py looks like:
+//
+//	from rest_framework.routers import DefaultRouter
+//	from .views import PermitViewSet, JurisdictionViewSet
+//
+//	router = DefaultRouter()
+//	router.register(r"permits", PermitViewSet, basename="permit")
+//	router.register(r"jurisdictions", JurisdictionViewSet)
+//
+//	urlpatterns = [path("api/", include(router.urls))]
+//
+// Before this pass the urls.py file entity (#577) carried IMPORTS edges
+// to PermitViewSet / JurisdictionViewSet but no edge that captured the
+// *routing* relationship: which ViewSet is mounted at which URL prefix.
+// Downstream tools that walk "what code does this URL hit?" stop dead.
+//
+// We emit a REFERENCES edge from the urls.py file entity to a
+// structural-ref of the ViewSet class. The edge carries:
+//
+//	router_register = "true"
+//	url_prefix       = "<prefix>"            (raw text of the first arg)
+//	basename         = "<basename>"          (if the kwarg is present)
+//	router_var       = "<routerVarName>"     (the variable the call lives on)
+//
+// Detection is intentionally syntactic — we match ANY `<x>.register(`
+// call where the first positional arg is a string literal and the
+// second positional arg is a Capitalised identifier. The DefaultRouter
+// / SimpleRouter import binding is not strictly required: in practice
+// any `register(prefix, ViewSet, ...)` shape in a urls/routes file is
+// route registration.
+//
+// Filtering by file name (urls.py / routers.py / api_urls.py) keeps
+// the false-positive surface low — a generic `.register(name, cls)` in
+// a non-urls module won't be misinterpreted as DRF routing.
+
+package python
+
+import (
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitRouterRegisterEdges scans the file for `<x>.register(<str>, <ViewSet>,
+// ...)` call sites and appends REFERENCES edges from the file entity to
+// each ViewSet's structural-ref. Safe with nil/empty inputs and non-urls
+// files (no-op).
+func emitRouterRegisterEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	if !isRouterRegisterCandidateFile(file.Path) {
+		return
+	}
+	// Locate the file entity index — the REFERENCES from-side.
+	fileIdx := -1
+	for i := range *entities {
+		if (*entities)[i].Kind == "SCOPE.Component" &&
+			(*entities)[i].Subtype == "file" &&
+			(*entities)[i].SourceFile == file.Path {
+			fileIdx = i
+			break
+		}
+	}
+	if fileIdx < 0 {
+		return
+	}
+
+	// Dedup: a single ViewSet may be re-registered with different
+	// prefixes (rare but legal). We emit one edge per unique ViewSet
+	// per file to avoid inflating REFERENCES counts; the url_prefix
+	// property captures the first prefix seen.
+	emitted := make(map[string]bool)
+
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "call" {
+			tryEmitRegisterEdge(n, file, fileIdx, entities, emitted)
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+}
+
+// isRouterRegisterCandidateFile gates the pass to files where DRF
+// router-registration is plausible. We accept any of:
+//
+//	urls.py, api_urls.py, urlpatterns.py, routers.py, router.py
+//
+// or any file under a `urls/` or `routers/` package. The set is
+// intentionally inclusive — false positives in non-DRF urls modules
+// fail later (no second-arg identifier → no edge).
+func isRouterRegisterCandidateFile(path string) bool {
+	if path == "" {
+		return false
+	}
+	clean := filepath.ToSlash(path)
+	base := filepath.Base(clean)
+	switch base {
+	case "urls.py", "api_urls.py", "urlpatterns.py", "routers.py", "router.py":
+		return true
+	}
+	// Sub-package shapes.
+	if strings.Contains(clean, "/urls/") || strings.Contains(clean, "/routers/") {
+		return true
+	}
+	return false
+}
+
+// tryEmitRegisterEdge inspects a `call` node. If it matches
+// `<receiver>.register(<string>, <Ident>, ...)` it emits a REFERENCES
+// edge from the file entity to a structural-ref of the second argument
+// (treated as the ViewSet class). Non-matching calls return silently.
+func tryEmitRegisterEdge(
+	callNode *sitter.Node,
+	file extractor.FileInput,
+	fileIdx int,
+	entities *[]types.EntityRecord,
+	emitted map[string]bool,
+) {
+	fn := callNode.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "attribute" {
+		return
+	}
+	attrNode := fn.ChildByFieldName("attribute")
+	if attrNode == nil || nodeText(attrNode, file.Content) != "register" {
+		return
+	}
+	recvNode := fn.ChildByFieldName("object")
+	routerVar := ""
+	if recvNode != nil && recvNode.Type() == "identifier" {
+		routerVar = nodeText(recvNode, file.Content)
+	}
+	argsNode := callNode.ChildByFieldName("arguments")
+	if argsNode == nil {
+		return
+	}
+
+	// Collect positional args (skipping punctuation) and capture the
+	// `basename=` kwarg when present.
+	var positional []*sitter.Node
+	basename := ""
+	for i := 0; i < int(argsNode.ChildCount()); i++ {
+		arg := argsNode.Child(i)
+		if arg == nil {
+			continue
+		}
+		switch arg.Type() {
+		case "(", ")", ",", "comment":
+			continue
+		case "keyword_argument":
+			keyNode := arg.ChildByFieldName("name")
+			valNode := arg.ChildByFieldName("value")
+			if keyNode == nil || valNode == nil {
+				continue
+			}
+			if nodeText(keyNode, file.Content) == "basename" && valNode.Type() == "string" {
+				basename = stripQuotes(strings.TrimSpace(nodeText(valNode, file.Content)))
+			}
+			continue
+		default:
+			positional = append(positional, arg)
+		}
+	}
+	if len(positional) < 2 {
+		return
+	}
+	prefixNode := positional[0]
+	viewSetNode := positional[1]
+
+	// First positional must be a string literal (URL prefix).
+	if prefixNode.Type() != "string" {
+		return
+	}
+	prefix := strings.TrimSpace(nodeText(prefixNode, file.Content))
+	// Strip leading raw-string `r` prefix and surrounding quotes.
+	prefix = strings.TrimPrefix(prefix, "r")
+	prefix = strings.TrimPrefix(prefix, "R")
+	prefix = strings.Trim(prefix, "\"'")
+
+	// Second positional must be a Capitalised identifier — the ViewSet.
+	var viewSetName string
+	switch viewSetNode.Type() {
+	case "identifier":
+		viewSetName = nodeText(viewSetNode, file.Content)
+	case "attribute":
+		// `views.PermitViewSet` — take the trailing leaf.
+		txt := nodeText(viewSetNode, file.Content)
+		if dot := strings.LastIndexByte(txt, '.'); dot >= 0 {
+			viewSetName = txt[dot+1:]
+		} else {
+			viewSetName = txt
+		}
+	default:
+		return
+	}
+	if !isCapitalisedIdent(viewSetName) {
+		return
+	}
+	if emitted[viewSetName] {
+		return
+	}
+	emitted[viewSetName] = true
+
+	toID := buildDjangoModelClassRef(file.Path, viewSetName)
+	props := map[string]string{
+		"router_register": "true",
+		"url_prefix":      prefix,
+		"viewset":         viewSetName,
+	}
+	if routerVar != "" {
+		props["router_var"] = routerVar
+	}
+	if basename != "" {
+		props["basename"] = basename
+	}
+	(*entities)[fileIdx].Relationships = append((*entities)[fileIdx].Relationships,
+		types.RelationshipRecord{
+			ToID:       toID,
+			Kind:       "REFERENCES",
+			Properties: props,
+		})
+}

--- a/internal/extractors/python/serializer_method_field.go
+++ b/internal/extractors/python/serializer_method_field.go
@@ -1,0 +1,239 @@
+// serializer_method_field.go — DRF SerializerMethodField → method link.
+//
+// Issue #2008 — When a DRF serializer declares
+//
+//	class FooSerializer(serializers.ModelSerializer):
+//	    full_name = serializers.SerializerMethodField()
+//	    def get_full_name(self, obj):
+//	        return f"{obj.first} {obj.last}"
+//
+// the per-attribute SCOPE.Schema/field entity ("FooSerializer.full_name")
+// has no typed edge to the implementing method ("FooSerializer.get_full_name").
+// Without that link the docgen / NeighbourBrief pass can't enumerate the
+// field's computation source, and graph queries against the field never
+// reach the method that produces its value.
+//
+// DRF supports two forms:
+//
+//  1. Implicit naming: `<field> = SerializerMethodField()` resolves to
+//     a sibling method `get_<field>(self, obj)`.
+//  2. Explicit naming: `<field> = SerializerMethodField(method_name="custom")`
+//     resolves to a sibling method `custom(self, obj)`.
+//
+// This pass walks every class body, looking for the SerializerMethodField
+// shape at top-level (class-body) assignments, then emits a RESOLVED_BY
+// edge from the field entity to the sibling method's structural-ref.
+//
+// "RESOLVED_BY" is consistent with edge nomenclature used by the
+// engine layer for "this node's value is produced by that node"
+// relationships. The edge carries `serializer_method_field=true` so
+// graph audits can isolate this provenance without parsing source.
+//
+// Cap: at most one RESOLVED_BY edge per (field, method) pair. If the
+// declared method does not exist as a sibling, the pass emits nothing
+// (we don't fabricate the method; the absence is itself signal).
+
+package python
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitSerializerMethodFieldLinks walks every class_definition once and,
+// for every `<field> = serializers.SerializerMethodField(...)` (or a
+// suffix match — `*.SerializerMethodField`) declared in the class body,
+// emits a RESOLVED_BY edge from the field's SCOPE.Schema entity to the
+// matching method's structural-ref.
+//
+// Mutates *entities in place; safe with nil/empty inputs.
+func emitSerializerMethodFieldLinks(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	var walk func(n *sitter.Node, parentClass string)
+	walk = func(n *sitter.Node, parentClass string) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "class_definition":
+			nameNode := n.ChildByFieldName("name")
+			cls := ""
+			if nameNode != nil {
+				cls = nodeText(nameNode, file.Content)
+			}
+			dotted := cls
+			if parentClass != "" && cls != "" {
+				dotted = parentClass + "." + cls
+			}
+			body := n.ChildByFieldName("body")
+			if body != nil {
+				scanSerializerBody(body, file, dotted, entities)
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), dotted)
+				}
+			}
+			return
+		case "decorated_definition":
+			inner := n.ChildByFieldName("definition")
+			if inner != nil {
+				walk(inner, parentClass)
+			}
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), parentClass)
+		}
+	}
+	walk(root, "")
+}
+
+// scanSerializerBody iterates immediate class-body statements, detects
+// SerializerMethodField declarations, resolves the implementing method
+// name (`method_name=` kwarg or default `get_<field>`), confirms the
+// sibling method exists as a SCOPE.Operation entity, and stamps the
+// RESOLVED_BY edge.
+func scanSerializerBody(body *sitter.Node, file extractor.FileInput, parentClass string, entities *[]types.EntityRecord) {
+	if body == nil || parentClass == "" {
+		return
+	}
+	// Index this class's operation method names once; cheap linear pass.
+	methodNames := make(map[string]bool)
+	prefix := parentClass + "."
+	for i := range *entities {
+		e := &(*entities)[i]
+		if e.SourceFile != file.Path {
+			continue
+		}
+		if e.Kind != "SCOPE.Operation" {
+			continue
+		}
+		if !strings.HasPrefix(e.Name, prefix) {
+			continue
+		}
+		leaf := e.Name[len(prefix):]
+		if leaf == "" || strings.Contains(leaf, ".") {
+			// Skip methods of nested classes that share the prefix
+			// (e.g. "FooSerializer.Meta.something").
+			continue
+		}
+		methodNames[leaf] = true
+	}
+
+	for i := 0; i < int(body.ChildCount()); i++ {
+		stmt := body.Child(i)
+		if stmt == nil || stmt.Type() != "expression_statement" {
+			continue
+		}
+		for j := 0; j < int(stmt.NamedChildCount()); j++ {
+			expr := stmt.NamedChild(j)
+			if expr == nil || expr.Type() != "assignment" {
+				continue
+			}
+			lhs := expr.ChildByFieldName("left")
+			rhs := expr.ChildByFieldName("right")
+			if lhs == nil || rhs == nil || lhs.Type() != "identifier" || rhs.Type() != "call" {
+				continue
+			}
+			attr := nodeText(lhs, file.Content)
+			if attr == "" {
+				continue
+			}
+			funcNode := rhs.ChildByFieldName("function")
+			if funcNode == nil {
+				continue
+			}
+			funcText := nodeText(funcNode, file.Content)
+			leafType := funcText
+			if dot := strings.LastIndexByte(leafType, '.'); dot >= 0 {
+				leafType = leafType[dot+1:]
+			}
+			if leafType != "SerializerMethodField" {
+				continue
+			}
+			methodName := lookupSerializerMethodName(rhs, file.Content)
+			if methodName == "" {
+				methodName = "get_" + attr
+			}
+			if !methodNames[methodName] {
+				// The declared method doesn't exist in this class —
+				// don't fabricate the edge. The pass stays a no-op
+				// here; the absence remains signal.
+				continue
+			}
+			// Locate the field entity ("<parentClass>.<attr>") to mutate.
+			fieldName := parentClass + "." + attr
+			fieldIdx := -1
+			for k := range *entities {
+				e := &(*entities)[k]
+				if e.SourceFile == file.Path &&
+					e.Kind == "SCOPE.Schema" &&
+					e.Subtype == "field" &&
+					e.Name == fieldName {
+					fieldIdx = k
+					break
+				}
+			}
+			if fieldIdx < 0 {
+				continue
+			}
+			methodEmitted := parentClass + "." + methodName
+			toID := extractor.BuildOperationStructuralRef("python", file.Path, methodEmitted)
+			// Dedup: only emit one RESOLVED_BY per (field, method) pair.
+			already := false
+			for _, r := range (*entities)[fieldIdx].Relationships {
+				if r.Kind == "RESOLVED_BY" && r.ToID == toID {
+					already = true
+					break
+				}
+			}
+			if already {
+				continue
+			}
+			(*entities)[fieldIdx].Relationships = append((*entities)[fieldIdx].Relationships,
+				types.RelationshipRecord{
+					ToID: toID,
+					Kind: "RESOLVED_BY",
+					Properties: map[string]string{
+						"serializer_method_field": "true",
+						"method_name":             methodName,
+					},
+				})
+		}
+	}
+}
+
+// lookupSerializerMethodName returns the value of the `method_name=`
+// kwarg of a SerializerMethodField call, with surrounding quotes
+// stripped. Returns "" when the kwarg is absent or its value isn't a
+// string literal.
+func lookupSerializerMethodName(callNode *sitter.Node, src []byte) string {
+	argsNode := callNode.ChildByFieldName("arguments")
+	if argsNode == nil {
+		return ""
+	}
+	for i := 0; i < int(argsNode.ChildCount()); i++ {
+		arg := argsNode.Child(i)
+		if arg == nil || arg.Type() != "keyword_argument" {
+			continue
+		}
+		keyNode := arg.ChildByFieldName("name")
+		valNode := arg.ChildByFieldName("value")
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		if nodeText(keyNode, src) != "method_name" {
+			continue
+		}
+		if valNode.Type() != "string" {
+			return ""
+		}
+		return stripQuotes(strings.TrimSpace(nodeText(valNode, src)))
+	}
+	return ""
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -403,6 +403,15 @@ const (
 	//                       config's directory contains downstream modules).
 	RelationshipKindDependsOnConfig RelationshipKind = "DEPENDS_ON_CONFIG"
 	RelationshipKindConfigures      RelationshipKind = "CONFIGURES"
+
+	// #2008: DRF SerializerMethodField → method link.
+	//   RESOLVED_BY : SCOPE.Schema/field → SCOPE.Operation/method
+	// Emitted for `<field> = serializers.SerializerMethodField(...)`
+	// declarations, pointing at the sibling `get_<field>` (or
+	// `method_name=` kwarg) operation that produces the field's value.
+	// Generalisable to any "value resolved by another entity" shape;
+	// kept narrow today to the DRF extractor producer.
+	RelationshipKindResolvedBy RelationshipKind = "RESOLVED_BY"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -480,6 +489,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		// #1885 first-class config entities:
 		RelationshipKindDependsOnConfig,
 		RelationshipKindConfigures,
+		// #2008 DRF SerializerMethodField → method link:
+		RelationshipKindResolvedBy,
 	}
 }
 


### PR DESCRIPTION
## 1. What

Bundle of six related Python extractor graph-edge gaps surfaced by W6R2 / docgen audits.

Closes #1977
Closes #2007
Closes #2008
Closes #2009
Closes #2010
Closes #2011

All five new passes are post-passes that observe the entity slice after the primary walk and append edges/properties in place; none modify or remove existing entities.

1. **#1977 retest** — pin ForeignKey/O2O/M2M REFERENCES emission with a Building→Jurisdiction unit test. Bundle A's enrich pass already stamps the edge; the W6R2 "still broken" report was a downstream surface gap (NeighbourBrief Properties, composes with #2025) rather than an extractor bug. The new test guards against regression.
2. **#2007** — `nested_ctor_refs.go` walks every method body looking for capitalised-identifier callees (`SerializerClass()`) that the primary REFERENCES walker excludes via `isPyCallCallee`. Emits REFERENCES from the enclosing method entity with `nested_ctor=true` provenance.
3. **#2008** — `serializer_method_field.go` detects `<f> = serializers.SerializerMethodField(...)` declarations, resolves the implementor name (`method_name=` kwarg, else `get_<f>`), and emits a `RESOLVED_BY` edge from the field entity to the sibling method when the method actually exists. New `RelationshipKindResolvedBy` added to `internal/types/kinds.go`.
4. **#2009** — same pass: extends the walker to scan class-body assignment RHSs for capitalised attribute receivers (`User.TYPE_CHOICES`). Edge attaches to the parent class entity (not the field) because the constructor's kwarg lives in class-body scope.
5. **#2010** — `router_register.go` scans urls.py / routers.py / `urls/` / `routers/` packages for `<x>.register(prefix, ViewSetClass, ...)` calls. Emits REFERENCES from the file entity to each ViewSet with `router_register=true`, `url_prefix`, `basename`, `router_var` properties.
6. **#2011** — `cbv_inherited_methods.go` — Option A annotation. When a class extends a recognised Django/DRF generic base (`ModelViewSet`, `ListView`, `ListCreateAPIView`, mixins) stamps `inherited_methods` (comma-joined sorted) and `cbv_bases` properties. Unknown bases are a deliberate no-op.

## 2. Why

Python extractor REFERENCES coverage on DRF/Django corpora was leaving ViewSet→Serializer composition, SerializerMethodField→impl, and router→ViewSet edges unwalkable. Generic CBV/ViewSet subclasses appeared methodless in audits even when the framework provides a fixed HTTP-handler contract.

## 3. Where

- `internal/extractors/python/nested_ctor_refs.go` (new) — #2007 + #2009
- `internal/extractors/python/serializer_method_field.go` (new) — #2008
- `internal/extractors/python/router_register.go` (new) — #2010
- `internal/extractors/python/cbv_inherited_methods.go` (new) — #2011
- `internal/extractors/python/python_relational_bundle_test.go` (new, 13 unit tests)
- `internal/extractors/python/extractor.go` — 4 new defer-recover hooks slotted after celery, before re_exports
- `internal/types/kinds.go` — `RelationshipKindResolvedBy` + `AllRelationshipKinds` entry

## 4. How tested

- `go test ./internal/extractors/python/... ./internal/docgen/... ./internal/types/...` — all green.
- 13 new unit tests covering: ForeignKey REFERENCES regression-pin (#1977), nested ctor in two methods + dedup (#2007), implicit + explicit + missing-impl SerializerMethodField (#2008), `choices=User.TYPE_CHOICES` (#2009), urls.py + non-urls negative case (#2010), ModelViewSet + ListView + Mixin union + unknown-base no-op (#2011).
- All pre-existing python and docgen tests remain green.
- Pre-existing MCP test failures (`archigraph_status` description budget) are unrelated and present on origin/main.

## 5. Tradeoffs / non-goals

- CBV inherited-methods stays annotation-only (option A). Synthetic Operation entities for inherited handlers were explicitly rejected to avoid fabricated provenance.
- `router.register` pass gates on file path to keep false positives near zero. A `.register()` call in a non-routing file is intentionally ignored.
- `nested_ctor` pass uses a Capitalised-identifier heuristic. Lower-case constructors (`my_factory()`) are owned by the CALLS extractor.
- Did NOT touch the resolver. The new structural-ref ToIDs reuse `scope:component:ref:python:` which is already widened by `structuralKindFamilies`.

## 6. Followups

- The downstream NeighbourBrief surface gap referenced in W6R2 for #1977 belongs to docgen/MCP rendering (composes with #2025), not the extractor — tracked separately.
- `RESOLVED_BY` is currently DRF-specific. Generalising to Pydantic / dataclass computed fields is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)