### PR TITLE
fix(mcp+resolver): reverse traversal of file-entity-sourced REFERENCES/IMPORTS edges in find_callers + neighbourhood (#2039)

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -85,8 +85,19 @@ func (s *Server) handleFindCallers(_ context.Context, req mcpapi.CallToolRequest
 		// a module/file that CONTAINS an entity is not a caller. Without this
 		// filter find_callers was returning CONTAINS-linked parent nodes and
 		// other structural edges as fake "callers" (#1915).
+		//
+		// #2039: track the edge kind that *discovered* each node. When the
+		// discovering edge is REFERENCES or IMPORTS, a file/module CONTAINER
+		// source is a legitimate caller — post-#2020 file entities own these
+		// edges (e.g. `core/admin.py` REFERENCES Models, `views.py` IMPORTS
+		// HasPermission, `__init__.py` IMPORTS a re-exported module). The
+		// noiseContainer filter below must NOT drop those.
 		adj := r.Adjacency
 		visited := map[string]int{target: 0}
+		// discoveredVia[id] = edge kind via which `id` was first reached on
+		// the inbound BFS. Used below to decide whether to allow file/module
+		// container sources through the noise filter.
+		discoveredVia := map[string]string{}
 		frontier := []string{target}
 		for d := 0; d < depth; d++ {
 			next := []string{}
@@ -99,6 +110,7 @@ func (s *Server) handleFindCallers(_ context.Context, req mcpapi.CallToolRequest
 						continue
 					}
 					visited[e.target] = d + 1
+					discoveredVia[e.target] = e.kind
 					next = append(next, e.target)
 				}
 			}
@@ -120,9 +132,19 @@ func (s *Server) handleFindCallers(_ context.Context, req mcpapi.CallToolRequest
 			// #1614: drop file/module CONTAINER components and inferred
 			// shadows. Callers should be operation/component-level referencers,
 			// not the synthetic file node that "contains" the call. (q02/q03/q10)
+			//
+			// #2039: exception — when the discovering inbound edge is
+			// REFERENCES or IMPORTS, a file/module container IS the legitimate
+			// caller (file-level reference / import edges live on the file
+			// entity post-#2020). Keep noiseShadow filtered unconditionally.
 			switch classifyNoise(e) {
-			case noiseContainer, noiseShadow:
+			case noiseShadow:
 				continue
+			case noiseContainer:
+				dk := discoveredVia[id]
+				if dk != "REFERENCES" && dk != "IMPORTS" {
+					continue
+				}
 			}
 			c := caller{
 				EntityID:   prefixedID(r.Repo, e.ID),
@@ -861,6 +883,7 @@ func isStdlibEntity(e *graph.Entity) bool {
 var inboundRefKinds = map[string]bool{
 	"CALLS":           true,
 	"REFERENCES":      true,
+	"IMPORTS":         true, // #2039: file/module → symbol or re-exported module
 	"TESTS":           true,
 	"ROUTES_TO":       true,
 	"IMPLEMENTS":      true,

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -280,6 +280,138 @@ func TestFindCallers_ExcludesContainsEdges(t *testing.T) {
 	}
 }
 
+// TestFindCallers_FileEntityReferencesSource verifies that a file/module
+// CONTAINER entity is surfaced as a caller when the inbound edge is REFERENCES
+// — post-#2020 file entities legitimately own REFERENCES edges to the targets
+// they reference (e.g. `core/admin.py` REFERENCES Models / ModelAdmin classes
+// via admin.site.register(...)). Before #2039 the noiseContainer filter
+// silently dropped these, so find_callers returned 0. (#2039 / closes #2015)
+func TestFindCallers_FileEntityReferencesSource(t *testing.T) {
+	// Topology:
+	//   adminFile (Component, subtype=file) --REFERENCES--> ContractModel
+	doc := minDoc(
+		[]graph.Entity{
+			{
+				ID: "admin-file", Name: "core/admin.py",
+				Kind: "SCOPE.Component", SourceFile: "core/admin.py",
+				Properties: map[string]string{"subtype": "file"},
+			},
+			{
+				ID: "contract-model", Name: "ContractModel",
+				Kind: "SCOPE.Schema", SourceFile: "core/models.py", StartLine: 42,
+			},
+		},
+		[]graph.Relationship{
+			{FromID: "admin-file", ToID: "contract-model", Kind: "REFERENCES"},
+		},
+	)
+	srv := newTestServerWithDoc(t, doc)
+
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "contract-model",
+		"depth":     float64(1),
+	})
+	callers, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array, got %T", out["callers"])
+	}
+	if len(callers) != 1 {
+		t.Fatalf("expected 1 caller (core/admin.py via REFERENCES), got %d: %v", len(callers), callers)
+	}
+	first := callers[0].(map[string]any)
+	if first["name"] != "core/admin.py" {
+		t.Errorf("expected caller=core/admin.py, got %v", first["name"])
+	}
+}
+
+// TestFindCallers_FileEntityImportsSource verifies that a file/module CONTAINER
+// entity is surfaced as a caller when the inbound edge is IMPORTS — file-level
+// import edges live on the file entity post-#2020. (#2039 / closes #1985)
+func TestFindCallers_FileEntityImportsSource(t *testing.T) {
+	// Topology:
+	//   viewsetFile --IMPORTS--> HasPermission
+	doc := minDoc(
+		[]graph.Entity{
+			{
+				ID: "viewset-file", Name: "building_alternate_address_viewset.py",
+				Kind: "SCOPE.Component", SourceFile: "viewsets/building_alternate_address_viewset.py",
+				Properties: map[string]string{"subtype": "file"},
+			},
+			{
+				ID: "has-permission", Name: "HasPermission",
+				Kind: "SCOPE.Operation", SourceFile: "permissions.py", StartLine: 10,
+			},
+		},
+		[]graph.Relationship{
+			{FromID: "viewset-file", ToID: "has-permission", Kind: "IMPORTS"},
+		},
+	)
+	srv := newTestServerWithDoc(t, doc)
+
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "has-permission",
+		"depth":     float64(1),
+	})
+	callers, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array, got %T", out["callers"])
+	}
+	if len(callers) != 1 {
+		t.Fatalf("expected 1 caller (viewset file via IMPORTS), got %d: %v", len(callers), callers)
+	}
+	first := callers[0].(map[string]any)
+	if first["name"] != "building_alternate_address_viewset.py" {
+		t.Errorf("expected caller=building_alternate_address_viewset.py, got %v", first["name"])
+	}
+}
+
+// TestFindCallers_ModuleInitReExports verifies that an __init__.py module
+// entity surfaces as a caller of a re-exported module via the IMPORTS edge
+// emitted by #2026. Before #2039 the noiseContainer filter dropped it.
+// (#2039 / closes #1991)
+func TestFindCallers_ModuleInitReExports(t *testing.T) {
+	// Topology:
+	//   upvate_core/__init__.py (Component, subtype=module) --IMPORTS--> upvate_core.celery
+	doc := minDoc(
+		[]graph.Entity{
+			{
+				ID: "init-module", Name: "upvate_core/__init__.py",
+				Kind: "SCOPE.Component", SourceFile: "upvate_core/__init__.py",
+				Properties: map[string]string{"subtype": "module"},
+			},
+			{
+				ID:   "celery-module",
+				Name: "upvate_core.celery",
+				Kind: "SCOPE.Component", SourceFile: "upvate_core/celery.py",
+				Properties: map[string]string{"subtype": "module"},
+			},
+			// Target needs a real referencable entity; the test entity itself is
+			// a module container — find_callers operates on the target as a
+			// pure id (no noise filter on the target). Walk from celery-module.
+		},
+		[]graph.Relationship{
+			{FromID: "init-module", ToID: "celery-module", Kind: "IMPORTS"},
+		},
+	)
+	srv := newTestServerWithDoc(t, doc)
+
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "celery-module",
+		"depth":     float64(1),
+	})
+	callers, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array, got %T", out["callers"])
+	}
+	if len(callers) != 1 {
+		t.Fatalf("expected 1 caller (__init__.py via IMPORTS), got %d: %v", len(callers), callers)
+	}
+	first := callers[0].(map[string]any)
+	if first["name"] != "upvate_core/__init__.py" {
+		t.Errorf("expected caller=upvate_core/__init__.py, got %v", first["name"])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TestFindCallees
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2039

Likely also closes (or substantially closes): #1985, #1991, #2015. Will verify on those tickets after merge once the daemon is rebuilt.

## 1. Problem

`archigraph_find_callers` returned 0 callers for any target whose only inbound reference edges originate from a **file/module CONTAINER** entity. Verified failure modes:

- `core/admin.py` REFERENCES `ContractModel` / `ModelAdmin` (17 edges) — `find_callers(ContractModel)` → 0
- `building_alternate_address_viewset.py` IMPORTS `HasPermission` — `find_callers(HasPermission)` → 0
- `upvate_core/__init__.py` IMPORTS re-exported modules (post-#2026) — `find_callers(<re-exported module>)` → 0

This is the single root cause behind three open tickets (#1985 dead-imports surface, #1991 init.py re-exports, #2015 admin.site.register downstream).

## 2. Root cause

Two compounding gaps in `internal/mcp/flow_tools.go::handleFindCallers`:

### Gap A — `IMPORTS` missing from `inboundRefKinds`

```go
var inboundRefKinds = map[string]bool{
    "CALLS": true, "REFERENCES": true, "TESTS": true, "ROUTES_TO": true,
    "IMPLEMENTS": true, "HANDLES": true, "ENTRY_POINT_OF": true, ...
    // IMPORTS was absent — file-level import edges were dropped in BFS.
}
```

The post-#2020 ownership model puts file-level import edges on the file entity (`file --IMPORTS--> Symbol`). The kind allowlist filtered them out at BFS time, so they never even reached the result-formatting stage.

### Gap B — `noiseContainer` filter over-broad post-#1614

After the BFS, results are filtered through `classifyNoise`:

```go
switch classifyNoise(e) {
case noiseContainer, noiseShadow:
    continue
}
```

`noiseContainer` is the file/module CONTAINER bucket. The filter was introduced for #1614/#1915 when files were showing up as "fake callers" via CONTAINS edges. But CONTAINS is **already excluded** by `inboundRefKinds`, so the only way a file/module CONTAINER reaches results today is via a real REFERENCES/IMPORTS edge — which is exactly the call site we want to surface, not suppress.

## 3. Fix

1. Add `"IMPORTS": true` to `inboundRefKinds`.
2. Track the **discovering edge kind** per visited node during BFS (`discoveredVia[id]`).
3. Allow `noiseContainer` entities through the noise filter when the discovering edge is `REFERENCES` or `IMPORTS`. `noiseShadow` continues to be filtered unconditionally.

## 4. Why this surface only

- `handleFindCallees` (outbound BFS) — file/module targets were never the bug surface; no change needed.
- `handleSubgraph` markdown / `subgraphMarkdown` — does **not** apply `classifyNoise` to inbound callers, so this path already surfaces file callers correctly.
- `handleGetNeighbors` (archigraph_expand) — no noise filter applied, already correct.
- `internal/dashboard/handlers_topology_detail.go` — operates directly on relationships, no noise classification, already correct.

So `flow_tools.go::handleFindCallers` was the only handler that needed code changes. Other call sites that traverse `inboundRefKinds` (notably `handleFindDeadCode`) now also benefit from the IMPORTS allowlist addition — an operation whose only inbound reference is via a file IMPORTS edge will no longer be misclassified as dead.

## 5. Regression tests

`internal/mcp/flow_tools_test.go`:

- `TestFindCallers_FileEntityReferencesSource` — file Component (subtype=file) --REFERENCES--> Model (admin.site.register pattern, #2015)
- `TestFindCallers_FileEntityImportsSource` — file Component --IMPORTS--> Operation (dead-imports pattern, #1985)
- `TestFindCallers_ModuleInitReExports` — __init__.py module --IMPORTS--> sibling module (re-export pattern, post-#2026, #1991)

All three failed before the fix (0 callers returned), pass after. The existing `TestFindCallers_ExcludesContainsEdges` continues to pass — CONTAINS still correctly excluded.

## 6. Test verification

```
$ go test ./internal/mcp/ -run 'TestFindCallers' -count=1
ok  github.com/cajasmota/archigraph/internal/mcp 0.614s

$ go test ./internal/mcp/... ./internal/dashboard/...
ok  github.com/cajasmota/archigraph/internal/dashboard
```

Four `internal/mcp` failures are observed (`TestToolNameSurface`, `TestElapsedMSCoverageAllTools`, `TestMCPHandshakeBudget`, `TestMCPToolDescriptions`) — all unrelated to this change. Verified by stashing the patch and running the same tests on `origin/main`: identical failures. They reference `archigraph_status` (handshake budget + description length + tool count = 29 vs 30) and are pre-existing tech debt to be addressed separately.

## 7. Follow-up

- After merge + daemon rebuild, re-run the three verification scenarios (admin.py, viewset import, __init__.py re-export) and post the evidence on #1985, #1991, #2015 before closing.
- Consider auditing other tools that read `inboundRefKinds` to confirm the addition of IMPORTS is wanted everywhere (find_dead_code is the main one — adding IMPORTS makes its "used" signal slightly more permissive, which is the correct direction; no false-dead reduction expected to introduce false-live regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)