### PR TITLE
feat(dashboard+engine+extractors): per-status response tabs + ANY suppression + transfer-workflow process coverage (#1938 #1940 #2024)

### DIFF
--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -150,6 +150,17 @@ type v2ResponseShape struct {
 	HasChildren  bool   `json:"has_children,omitempty"`
 }
 
+// v2PerStatusResponse is one entry in the per-status-code tab strip
+// for the Response section (#1938 Phase 1). Each entry describes the
+// response shape for a specific HTTP status code extracted from
+// @APIResponse / @ApiResponse annotations.
+type v2PerStatusResponse struct {
+	StatusCode   int    `json:"status_code"`
+	TypeName     string `json:"type_name,omitempty"`
+	TypeEntityID string `json:"type_entity_id,omitempty"`
+	HasChildren  bool   `json:"has_children,omitempty"`
+}
+
 // v2HandlerDetail is one handler implementation in the detail pane.
 type v2HandlerDetail struct {
 	Verb          string `json:"verb"`
@@ -210,10 +221,15 @@ type v2PathDetail struct {
 	AuthPolicy   *v2AuthPolicy      `json:"auth_policy,omitempty"`
 	AuthChip     string             `json:"auth_chip,omitempty"`
 	AuthChipTone string             `json:"auth_chip_tone,omitempty"`
-	Description     v2DescriptionBlock `json:"description"`
-	Parameters      []v2PathParameter  `json:"parameters"`
-	ResponseShapes  []v2ResponseShape  `json:"response_shapes"`
-	Handlers        []v2HandlerDetail  `json:"handlers"`
+	Description     v2DescriptionBlock    `json:"description"`
+	Parameters      []v2PathParameter     `json:"parameters"`
+	ResponseShapes  []v2ResponseShape     `json:"response_shapes"`
+	// PerStatusResponses carries per-status-code response metadata extracted
+	// from @APIResponse / @ApiResponse annotations (#1938 Phase 1). Non-empty
+	// only for Java endpoints using MicroProfile OpenAPI or JAX-RS 2.x.
+	// The frontend renders a tab strip above the ShapeTree when this is non-empty.
+	PerStatusResponses []v2PerStatusResponse `json:"per_status_responses,omitempty"`
+	Handlers        []v2HandlerDetail     `json:"handlers"`
 	InboundFetches  []v2PathEntity     `json:"inbound_fetches"`
 	Outbound        v2OutboundQueries  `json:"outbound"`
 	SideEffects     []v2PathEntity     `json:"side_effects"`
@@ -417,6 +433,36 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 				AuthPolicy:     authPolicy,
 			})
 		}
+	}
+
+	// ---- Phase 1b: #1940 — suppress ANY-verb catch-all endpoints when
+	//      per-verb counterparts exist for the same (backend, path).
+	//
+	// Django URL-conf entries can emit method=ANY when the URL entry itself
+	// carries no verb restriction. When a per-verb route (GET, POST, etc.)
+	// exists for the same path (typically from DRF router expansion or a
+	// class-based view), the ANY entry is redundant and clutters the list.
+	// We mark it synthetic so the Endpoints tab hides it; it will instead
+	// appear under the "Catch-all" filter chip (frontend TODO: #1940).
+	{
+		type backendPathKey struct{ backend, path string }
+		nonAnyVerbs := map[backendPathKey]bool{}
+		for _, ep := range eps {
+			if ep.Verb != "ANY" {
+				nonAnyVerbs[backendPathKey{ep.OwningBackend, ep.Path}] = true
+			}
+		}
+		filtered := eps[:0:0]
+		for _, ep := range eps {
+			if ep.Verb == "ANY" &&
+				ep.Repo != "" &&
+				nonAnyVerbs[backendPathKey{ep.OwningBackend, ep.Path}] {
+				// A per-verb route exists — suppress this synthetic catch-all.
+				continue
+			}
+			filtered = append(filtered, ep)
+		}
+		eps = filtered
 	}
 
 	// ---- Phase 2: group by backend → controller → path ----
@@ -753,6 +799,10 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		// engine.extractJavaReturnType (e.g. "LoginResponse"). Used to
 		// surface a ShapeTree-expandable response row.
 		ResponseType string
+		// Issue #1938 Phase 1 — JSON-encoded []engine.APIResponseEntry extracted
+		// from @APIResponse / @ApiResponse annotations. Decoded below to build
+		// the PerStatusResponses tab strip.
+		APIResponsesJSON string
 		// #1942 Phase 1 — resolved auth_policy decoded from the endpoint's
 		// `auth_policy` property. Multiple `matched` entries for the same path
 		// are reduced to the strongest policy when building the response.
@@ -906,6 +956,8 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 				// Refs #1935 Phase 1 — handler return type for the
 				// Response ShapeTree subtree.
 				ResponseType: e.Properties["response_type"],
+				// Issue #1938 Phase 1 — per-status @APIResponse annotations.
+				APIResponsesJSON: e.Properties["api_responses"],
 				// #1942 Phase 1 — auth_policy decoded from the endpoint entity.
 				AuthPolicy: readAuthPolicyFromEntity(e.Properties),
 			})
@@ -1205,6 +1257,42 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Issue #1938 Phase 1 — build per-status-code response tab data.
+	// Merge @APIResponse entries across all matched handlers; deduplicate by
+	// status code (first-wins). Resolve type names to in-group class entities
+	// so the frontend can request ShapeTree expansion.
+	var perStatusResponses []v2PerStatusResponse
+	{
+		seenStatus := map[int]bool{}
+		for _, h := range hits {
+			if h.APIResponsesJSON == "" {
+				continue
+			}
+			entries := engine.DecodeAPIResponses(h.APIResponsesJSON)
+			for _, entry := range entries {
+				if seenStatus[entry.StatusCode] {
+					continue
+				}
+				seenStatus[entry.StatusCode] = true
+				psr := v2PerStatusResponse{StatusCode: entry.StatusCode}
+				if entry.TypeName != "" {
+					psr.TypeName = entry.TypeName
+					resolveT := unwrapElementType(entry.TypeName)
+					if target := findClassEntityByName(grp, resolveT); target != nil {
+						if slug, _ := findRepoForEntity(grp, target.ID); slug != "" {
+							psr.TypeEntityID = dashPrefixedID(slug, target.ID)
+							psr.HasChildren = classHasFieldChildren(grp, target)
+						}
+					}
+				}
+				perStatusResponses = append(perStatusResponses, psr)
+			}
+		}
+		sort.Slice(perStatusResponses, func(i, j int) bool {
+			return perStatusResponses[i].StatusCode < perStatusResponses[j].StatusCode
+		})
+	}
+
 	// Description block from docgen.
 	var description v2DescriptionBlock
 	if len(hits) > 0 && hits[0].HasDocs {
@@ -1239,25 +1327,26 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeV2JSON(w, http.StatusOK, v2OK(v2PathDetail{
-		PathHash:        pathHash,
-		Path:            pathStr,
-		Verbs:           verbs,
-		Repos:           repos,
-		IsWebhook:       isWebhook,
-		WebhookProvider: webhookProv,
-		Auth:            auth,
-		AuthPolicy:      authPolicyWire,
-		AuthChip:        authChip,
-		AuthChipTone:    authChipTone,
-		AuthScheme:      authScheme,
-		Description:     description,
-		Parameters:      params,
-		ResponseShapes:  responseShapes,
-		Handlers:        handlers,
-		InboundFetches:  inboundFetches,
-		Outbound:        outbound,
-		SideEffects:     sideEffectEntities,
-		Tests:           testEntities,
+		PathHash:           pathHash,
+		Path:               pathStr,
+		Verbs:              verbs,
+		Repos:              repos,
+		IsWebhook:          isWebhook,
+		WebhookProvider:    webhookProv,
+		Auth:               auth,
+		AuthPolicy:         authPolicyWire,
+		AuthChip:           authChip,
+		AuthChipTone:       authChipTone,
+		AuthScheme:         authScheme,
+		Description:        description,
+		Parameters:         params,
+		ResponseShapes:     responseShapes,
+		PerStatusResponses: perStatusResponses,
+		Handlers:           handlers,
+		InboundFetches:     inboundFetches,
+		Outbound:           outbound,
+		SideEffects:        sideEffectEntities,
+		Tests:              testEntities,
 	}))
 }
 

--- a/internal/engine/issue1938_api_response_test.go
+++ b/internal/engine/issue1938_api_response_test.go
@@ -1,0 +1,154 @@
+// Tests for #1938 Phase 1 — @APIResponse per-status-code extraction.
+//
+// Verifies that the java_annotation_routes pass correctly extracts
+// @APIResponse / @ApiResponse annotations and emits the api_responses
+// property on the http_endpoint_definition entities.
+package engine
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractAPIResponseAnnotations_MicroProfile(t *testing.T) {
+	// MicroProfile OpenAPI @APIResponse with responseCode + implementation
+	joined := `
+@GET
+@Path("/items/{sku}")
+@APIResponse(responseCode = "200", description = "Item found", content = @Content(schema = @Schema(implementation = CatalogItem.class)))
+@APIResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+@APIResponse(responseCode = "500", description = "Server error")
+`
+	entries := extractAPIResponseAnnotations(joined)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %+v", len(entries), entries)
+	}
+	wantCodes := []int{200, 404, 500}
+	for i, want := range wantCodes {
+		if entries[i].StatusCode != want {
+			t.Errorf("[%d] status_code: want %d, got %d", i, want, entries[i].StatusCode)
+		}
+	}
+	if entries[0].TypeName != "CatalogItem" {
+		t.Errorf("[0] type_name: want CatalogItem, got %q", entries[0].TypeName)
+	}
+	if entries[1].TypeName != "ErrorResponse" {
+		t.Errorf("[1] type_name: want ErrorResponse, got %q", entries[1].TypeName)
+	}
+	if entries[2].TypeName != "" {
+		t.Errorf("[2] type_name: want empty (no implementation), got %q", entries[2].TypeName)
+	}
+}
+
+func TestExtractAPIResponseAnnotations_JAXRSLegacy(t *testing.T) {
+	// JAX-RS 2.x / Swagger @ApiResponse with code (int) + response class
+	joined := `
+@GET
+@ApiResponse(code = 200, message = "OK", response = LoginResponse.class)
+@ApiResponse(code = 401, message = "Unauthorized", response = ErrorDTO.class)
+`
+	entries := extractAPIResponseAnnotations(joined)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].StatusCode != 200 {
+		t.Errorf("status 0: want 200, got %d", entries[0].StatusCode)
+	}
+	if entries[0].TypeName != "LoginResponse" {
+		t.Errorf("type 0: want LoginResponse, got %q", entries[0].TypeName)
+	}
+	if entries[1].StatusCode != 401 {
+		t.Errorf("status 1: want 401, got %d", entries[1].StatusCode)
+	}
+}
+
+func TestExtractAPIResponseAnnotations_Deduplication(t *testing.T) {
+	// Duplicate status codes should be collapsed (first-wins).
+	joined := `
+@APIResponse(responseCode = "200", description = "first")
+@APIResponse(responseCode = "200", description = "second")
+@APIResponse(responseCode = "404", description = "not found")
+`
+	entries := extractAPIResponseAnnotations(joined)
+	if len(entries) != 2 {
+		t.Fatalf("dedup: want 2 entries, got %d", len(entries))
+	}
+	if entries[0].StatusCode != 200 || entries[1].StatusCode != 404 {
+		t.Errorf("dedup: want [200 404], got [%d %d]", entries[0].StatusCode, entries[1].StatusCode)
+	}
+}
+
+func TestEncodeDecodeAPIResponses_RoundTrip(t *testing.T) {
+	entries := []APIResponseEntry{
+		{StatusCode: 200, TypeName: "LoginResponse"},
+		{StatusCode: 404, TypeName: "ErrorDTO", TypeEntityID: "myrepo:abc123", HasChildren: true},
+		{StatusCode: 500},
+	}
+	encoded := EncodeAPIResponses(entries)
+	if encoded == "" {
+		t.Fatal("EncodeAPIResponses returned empty string")
+	}
+	decoded := DecodeAPIResponses(encoded)
+	if len(decoded) != 3 {
+		t.Fatalf("DecodeAPIResponses: want 3 entries, got %d", len(decoded))
+	}
+	if decoded[1].TypeEntityID != "myrepo:abc123" {
+		t.Errorf("type_entity_id round-trip failed: %q", decoded[1].TypeEntityID)
+	}
+	if !decoded[1].HasChildren {
+		t.Error("has_children round-trip failed")
+	}
+}
+
+func TestAPIResponseAnnotations_EmittedOnEndpointEntity(t *testing.T) {
+	// End-to-end: the api_responses property is set on the emitted entity.
+	src := `package com.example;
+import jakarta.ws.rs.*;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Path("/transfers")
+public class TransfersController {
+    @PUT
+    @Path("/confirm")
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = TransferResult.class)))
+    @APIResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    public TransferResult confirmTransfer() { return null; }
+}
+`
+	recs := collect(t, map[string]string{"TransfersController.java": src})
+	var ep *recordLike
+	for i := range recs {
+		if recs[i].Props["path"] == "/transfers/confirm" {
+			ep = &recs[i]
+			break
+		}
+	}
+	if ep == nil {
+		t.Fatal("no endpoint entity found for /transfers/confirm")
+	}
+	raw := ep.Props["api_responses"]
+	if raw == "" {
+		t.Fatal("api_responses property is empty — annotation extraction did not fire")
+	}
+	var entries []APIResponseEntry
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		t.Fatalf("failed to decode api_responses: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %d: %+v", len(entries), entries)
+	}
+	if entries[0].StatusCode != 200 {
+		t.Errorf("entry[0].StatusCode: want 200, got %d", entries[0].StatusCode)
+	}
+	if entries[0].TypeName != "TransferResult" {
+		t.Errorf("entry[0].TypeName: want TransferResult, got %q", entries[0].TypeName)
+	}
+	if entries[1].StatusCode != 404 {
+		t.Errorf("entry[1].StatusCode: want 404, got %d", entries[1].StatusCode)
+	}
+	if entries[1].TypeName != "ErrorResponse" {
+		t.Errorf("entry[1].TypeName: want ErrorResponse, got %q", entries[1].TypeName)
+	}
+}

--- a/internal/engine/issue1940_any_suppression_test.go
+++ b/internal/engine/issue1940_any_suppression_test.go
@@ -1,0 +1,68 @@
+// Tests for #1940 ANY-verb suppression and #2024 process-flow helpers.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func TestIsPascalCaseIdentifier(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"TransferReceive", true},
+		{"PaymentForm", true},
+		{"App", true},
+		{"confirmTransfer", false}, // camelCase, not PascalCase
+		{"CONSTANT_STYLE", false},  // ALL_CAPS — no lowercase
+		{"_private", false},        // leading underscore
+		{"", false},                // empty
+		{"A", false},               // single uppercase char, no lowercase
+	}
+	for _, c := range cases {
+		got := isPascalCaseIdentifier(c.name)
+		if got != c.want {
+			t.Errorf("isPascalCaseIdentifier(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsJSXSourceFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"src/components/TransferReceive.jsx", true},
+		{"src/pages/Checkout.tsx", true},
+		{"src/utils/helpers.ts", false},
+		{"src/index.js", false},
+		{"TransferReceive.JSX", false}, // case-sensitive
+	}
+	for _, c := range cases {
+		got := isJSXSourceFile(c.path)
+		if got != c.want {
+			t.Errorf("isJSXSourceFile(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestIsEntryCandidate_IncludesSCOPEJSX(t *testing.T) {
+	// SCOPE.JSX must now be recognized as an entry candidate (fix #2024).
+	if !isEntryCandidate(&graph.Entity{Kind: "SCOPE.JSX"}) {
+		t.Error("isEntryCandidate: SCOPE.JSX should be accepted after #2024 fix")
+	}
+	// Prior kinds must still be accepted.
+	for _, k := range []string{"SCOPE.Function", "SCOPE.Operation", "SCOPE.Component", "SCOPE.Class"} {
+		if !isEntryCandidate(&graph.Entity{Kind: k}) {
+			t.Errorf("isEntryCandidate: %q should remain accepted", k)
+		}
+	}
+	// Non-entry kinds should remain rejected.
+	for _, k := range []string{"Route", "http_endpoint_definition", "SCOPE.Schema"} {
+		if isEntryCandidate(&graph.Entity{Kind: k}) {
+			t.Errorf("isEntryCandidate: %q should remain rejected", k)
+		}
+	}
+}

--- a/internal/engine/java_annotation_routes.go
+++ b/internal/engine/java_annotation_routes.go
@@ -56,6 +56,7 @@
 package engine
 
 import (
+	"encoding/json"
 	"regexp"
 	"strings"
 
@@ -738,6 +739,13 @@ func buildMethodEndpointsWithAuth(
 	allParams := extractJavaParameters(paramFrag, uniqueVerbs)
 	paramsJSON := EncodeJavaParameters(allParams)
 
+	// Issue #1938 Phase 1 — extract @APIResponse / @ApiResponse per-status-code
+	// metadata from the method's annotation block. The JSON-encoded slice is
+	// attached to every emitted endpoint entity so the dashboard can render a
+	// per-status tab strip with ShapeTree expansion for resolved DTOs.
+	apiResponses := extractAPIResponseAnnotations(joined)
+	apiResponsesJSON := EncodeAPIResponses(apiResponses)
+
 	// #1942 Phase 1 — resolve auth_policy from class + method + Quarkus context.
 	policy := ResolveJavaAuthPolicy(
 		joined, methodLine,
@@ -810,6 +818,11 @@ func buildMethodEndpointsWithAuth(
 			}
 		}
 
+		// Issue #1938 Phase 1 — attach the per-status @APIResponse list.
+		if apiResponsesJSON != "" {
+			props["api_responses"] = apiResponsesJSON
+		}
+
 		out = append(out, types.EntityRecord{
 			ID:                 id,
 			Name:               id,
@@ -872,3 +885,159 @@ func parseRequestMappingMethods(args string) []string {
 
 // joinPathFragments is shared with http_endpoint_synthesis.go (defined
 // there). We do not redefine it here.
+
+// ---------------------------------------------------------------------------
+// #1938 Phase 1 — @APIResponse per-status-code extraction
+// ---------------------------------------------------------------------------
+
+// javaAPIResponseCodeStringRe matches the responseCode = "NNN" form used by
+// MicroProfile OpenAPI: @APIResponse(responseCode = "200", ...).
+var javaAPIResponseCodeStringRe = regexp.MustCompile(`responseCode\s*=\s*"(\d{3})"`)
+
+// javaAPIResponseCodeIntRe matches the code = NNN (integer) form used by
+// JAX-RS 2.x / Swagger: @ApiResponse(code = 404, ...).
+// The word-boundary lookahead ensures we don't match "response_code = 404".
+var javaAPIResponseCodeIntRe = regexp.MustCompile(`(?:^|[\s,(])code\s*=\s*(\d{3})\b`)
+
+// javaAPIResponseSchemaRe captures `implementation = Foo.class` or
+// `response = Foo.class` inside an @APIResponse / @Content(...) block.
+var javaAPIResponseSchemaRe = regexp.MustCompile(
+	`(?:implementation|response)\s*=\s*([A-Z][A-Za-z0-9_]*)\s*\.class`)
+
+// javaAPIResponseAnnotationRe detects both @APIResponse (MicroProfile) and
+// @ApiResponse (Swagger / JAX-RS 2.x). The annotation opens with a '('.
+//   - @APIResponse(responseCode = "200", ...)    — MicroProfile OpenAPI
+//   - @ApiResponse(code = 404, ...)              — Swagger / Jakarta RS
+// The case-insensitive prefix `(?i)API` matches both `API` and `Api`.
+var javaAPIResponseAnnotationRe = regexp.MustCompile(`@(?i:API)Response\s*\(`)
+
+// APIResponseEntry holds one parsed @APIResponse annotation.
+type APIResponseEntry struct {
+	StatusCode     int    `json:"status_code"`
+	TypeEntityID   string `json:"type_entity_id,omitempty"`
+	TypeName       string `json:"type_name,omitempty"`
+	HasChildren    bool   `json:"has_children,omitempty"`
+}
+
+// extractAPIResponseAnnotations scans the joined annotation block for all
+// @APIResponse / @ApiResponse annotations and returns the parsed list.
+//
+// Strategy: split the joined text into per-annotation segments by finding each
+// @APIResponse( / @ApiResponse( occurrence, then scan forward to find the
+// balanced-paren closing ')'. This handles nested @Content(@Schema(...))
+// without requiring a [^)]* inner pattern that would fail on nested parens.
+//
+// The list is order-preserving (annotation declaration order). A status code
+// that appears more than once is collapsed to the first occurrence.
+func extractAPIResponseAnnotations(joined string) []APIResponseEntry {
+	if !strings.Contains(joined, "@APIResponse") && !strings.Contains(joined, "@ApiResponse") &&
+		!strings.Contains(joined, "@Apiresponse") {
+		return nil
+	}
+
+	// Find all annotation start positions.
+	locs := javaAPIResponseAnnotationRe.FindAllStringIndex(joined, -1)
+	if len(locs) == 0 {
+		return nil
+	}
+
+	seen := map[int]bool{}
+	var out []APIResponseEntry
+
+	for _, loc := range locs {
+		// loc[1] is the position after the opening '(' of the annotation.
+		openAt := loc[1] - 1 // position of the '('
+		if openAt >= len(joined) {
+			continue
+		}
+		// Find the matching closing ')' walking forward.
+		closeAt := findMatchingClose(joined, openAt)
+		var block string
+		if closeAt > openAt {
+			block = joined[openAt : closeAt+1]
+		} else {
+			// Unbalanced — take the rest of the line.
+			lineEnd := strings.IndexByte(joined[loc[0]:], '\n')
+			if lineEnd < 0 {
+				block = joined[loc[0]:]
+			} else {
+				block = joined[loc[0] : loc[0]+lineEnd]
+			}
+		}
+
+		// Extract status code from this annotation block.
+		code := 0
+		if m := javaAPIResponseCodeStringRe.FindStringSubmatch(block); len(m) >= 2 {
+			code = parseDigits(m[1])
+		} else if m := javaAPIResponseCodeIntRe.FindStringSubmatch(block); len(m) >= 2 {
+			code = parseDigits(m[1])
+		}
+		if code == 0 || seen[code] {
+			continue
+		}
+		seen[code] = true
+
+		entry := APIResponseEntry{StatusCode: code}
+		// Extract DTO type from implementation=Foo.class or response=Foo.class.
+		if sm := javaAPIResponseSchemaRe.FindStringSubmatch(block); len(sm) >= 2 {
+			entry.TypeName = sm[1]
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// findMatchingClose walks forward from position `open` (a '(') and returns the
+// index of the matching ')'. Returns -1 when the input is unbalanced.
+func findMatchingClose(s string, open int) int {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// parseDigits converts a pure-ASCII decimal string to int. Returns 0 on error.
+func parseDigits(s string) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+// EncodeAPIResponses serialises the []APIResponseEntry slice to JSON for
+// storage in entity Properties["api_responses"]. Returns "" when empty.
+func EncodeAPIResponses(entries []APIResponseEntry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(entries)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// DecodeAPIResponses deserialises the value of Properties["api_responses"].
+func DecodeAPIResponses(raw string) []APIResponseEntry {
+	if raw == "" {
+		return nil
+	}
+	var out []APIResponseEntry
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil
+	}
+	return out
+}

--- a/internal/engine/process_flow_entry.go
+++ b/internal/engine/process_flow_entry.go
@@ -117,6 +117,24 @@ func rankEntryPoints(doc *graph.Document, byID map[string]*graph.Entity, adj *ca
 			score += 1.0
 		case "SCOPE.Component":
 			score += 0.5
+		case "SCOPE.JSX":
+			// Issue #2024 — JSX component entities are UI entry points;
+			// give them a modest boost so React component render functions
+			// (e.g. TransferReceive) seed process-flow chains even when
+			// their name doesn't match the entryNameRE suffix list.
+			score += 2.0
+			if entryKind == "" {
+				entryKind = "ui_component"
+			}
+		}
+
+		// Issue #2024 — bonus for PascalCase function names in JSX/TSX source
+		// files (React component pattern: TransferReceive, PaymentForm, etc.).
+		// These are exported components that drive UI workflows and should seed
+		// the BFS even without an HTTP boundary signal.
+		if entryKind == "" && isPascalCaseIdentifier(local) && isJSXSourceFile(e.SourceFile) {
+			score += 2.0
+			entryKind = "ui_component"
 		}
 
 		if score <= 0 {
@@ -194,9 +212,15 @@ func buildBrokerBoundarySet(doc *graph.Document) map[string]string {
 // Routes and Endpoints themselves are targets of IMPLEMENTS edges, not
 // origins of CALLS; the handler entity (Function/Method/Operation) is what
 // actually emits the CALLS chain.
+//
+// Issue #2024 — SCOPE.JSX (React/Vue component entities emitted by the
+// JS/TS extractor) are now included so that frontend component render
+// functions like TransferReceive can seed a process-flow chain when they
+// call a service function that eventually reaches an HTTP endpoint.
 func isEntryCandidate(e *graph.Entity) bool {
 	switch e.Kind {
-	case "SCOPE.Function", "SCOPE.Operation", "SCOPE.Component", "SCOPE.Class":
+	case "SCOPE.Function", "SCOPE.Operation", "SCOPE.Component", "SCOPE.Class",
+		"SCOPE.JSX":
 		return true
 	}
 	return false
@@ -254,4 +278,34 @@ func isExportedName(name, language string) bool {
 	default:
 		return first != '_'
 	}
+}
+
+// isPascalCaseIdentifier returns true when name starts with an uppercase
+// letter and contains at least one lowercase letter — the standard PascalCase
+// React component naming convention (e.g. "TransferReceive", "PaymentForm").
+// Pure ALL_CAPS names (like constants) are excluded.
+func isPascalCaseIdentifier(name string) bool {
+	if len(name) < 2 {
+		return false
+	}
+	first := name[0]
+	if first < 'A' || first > 'Z' {
+		return false
+	}
+	// Require at least one lowercase character so CONSTANT_STYLE names
+	// are not mistaken for React components.
+	hasLower := false
+	for _, c := range name {
+		if c >= 'a' && c <= 'z' {
+			hasLower = true
+			break
+		}
+	}
+	return hasLower
+}
+
+// isJSXSourceFile returns true when path has a .jsx or .tsx extension,
+// indicating the file contains JSX syntax and is likely a React component.
+func isJSXSourceFile(path string) bool {
+	return strings.HasSuffix(path, ".jsx") || strings.HasSuffix(path, ".tsx")
 }

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -832,6 +832,20 @@ export interface PathParameter {
   has_children?: boolean;
 }
 
+/**
+ * #1938 Phase 1 — per-status-code response entry extracted from
+ * @APIResponse / @ApiResponse annotations (Java MicroProfile / JAX-RS).
+ * Populated only when the Java annotation extractor found explicit status
+ * codes on the handler. The frontend renders a tab strip above the ShapeTree
+ * when this array is non-empty. Default-selected tab = lowest 2xx code.
+ */
+export interface PerStatusResponse {
+  status_code: number;
+  type_name?: string;
+  type_entity_id?: string;
+  has_children?: boolean;
+}
+
 /** Response shape per verb in the detail pane. */
 export interface ResponseShape {
   verb: HttpVerb;
@@ -916,6 +930,8 @@ export interface PathDetail {
   };
   parameters: PathParameter[];
   response_shapes: ResponseShape[];
+  /** #1938 Phase 1 — per-status response tabs (Java @APIResponse only). */
+  per_status_responses?: PerStatusResponse[];
   handlers: HandlerDetail[];
   inbound_fetches: PathEntity[];
   outbound: {

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -33,7 +33,7 @@ import { usePaths, usePathDetail, useOrphans } from "@/hooks/use-paths";
 import type {
   PathBackend, ControllerGroupShape, PathRoute, PathDetail,
   OrphanCaller, HttpVerb, OrphanReason, PathEntity, HandlerDetail,
-  PathParameter, ResponseShape,
+  PathParameter, ResponseShape, PerStatusResponse,
 } from "@/data/types";
 
 /* ============================================================
@@ -493,6 +493,109 @@ function HandlerRefLine({ handler }: { handler: HandlerDetail }) {
 }
 
 /**
+ * #1938 Phase 1 — per-status-code tab strip above the Response ShapeTree.
+ * Renders one chip per status code; clicking selects it and re-renders the
+ * ShapeTree for that status's type. Default-selected = lowest 2xx code.
+ */
+function StatusCodeChip({
+  code,
+  selected,
+  onClick,
+}: {
+  code: number;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const tone =
+    code >= 200 && code < 300
+      ? { bg: "bg-[var(--pastel-2)]", text: "text-[var(--pastel-2-ink)]", border: "border-[var(--pastel-2)]" }
+      : code >= 400 && code < 500
+        ? { bg: "bg-[var(--pastel-4)]", text: "text-[var(--pastel-4-ink)]", border: "border-[var(--pastel-4)]" }
+        : code >= 500
+          ? { bg: "bg-danger-soft", text: "text-danger", border: "border-danger-soft" }
+          : { bg: "bg-surface-2", text: "text-text-3", border: "border-border" };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center justify-center h-5 px-2 rounded text-[11px] font-mono font-semibold border select-none transition-all",
+        tone.bg, tone.text, tone.border,
+        selected ? "ring-2 ring-accent ring-offset-1" : "opacity-70 hover:opacity-100",
+      )}
+    >
+      {code}
+    </button>
+  );
+}
+
+function PerStatusResponseStrip({
+  entries,
+  groupId,
+}: {
+  entries: PerStatusResponse[];
+  groupId: string;
+}) {
+  // Default to lowest 2xx code, or first entry if no 2xx.
+  const defaultCode = entries.find((e) => e.status_code >= 200 && e.status_code < 300)?.status_code
+    ?? entries[0]?.status_code;
+  const [selected, setSelected] = useState<number | undefined>(defaultCode);
+  const activeEntry = entries.find((e) => e.status_code === selected);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div data-testid="per-status-strip">
+      {/* Tab strip */}
+      <div className="flex items-center gap-1.5 px-4 py-2 border-b border-border-soft">
+        <span className="text-[10px] text-text-4 font-medium mr-1">Status</span>
+        {entries.map((e) => (
+          <StatusCodeChip
+            key={e.status_code}
+            code={e.status_code}
+            selected={selected === e.status_code}
+            onClick={() => setSelected(e.status_code)}
+          />
+        ))}
+      </div>
+      {/* ShapeTree for the selected status */}
+      {activeEntry && (
+        <ShapeTree
+          groupId={groupId}
+          rows={
+            activeEntry.has_children && activeEntry.type_entity_id
+              ? [
+                  {
+                    key: `status-${activeEntry.status_code}`,
+                    name: "response",
+                    inLabel: String(activeEntry.status_code),
+                    inTone: "status" as ShapeTreeRow["inTone"],
+                    type: activeEntry.type_name ?? "—",
+                    type_entity_id: activeEntry.type_entity_id,
+                    type_name_fallback: activeEntry.type_name,
+                    has_children: true,
+                  },
+                ]
+              : activeEntry.type_name
+                ? [
+                    {
+                      key: `status-${activeEntry.status_code}`,
+                      name: "response",
+                      inLabel: String(activeEntry.status_code),
+                      inTone: "status" as ShapeTreeRow["inTone"],
+                      type: activeEntry.type_name,
+                      has_children: false,
+                    },
+                  ]
+                : []
+          }
+        />
+      )}
+    </div>
+  );
+}
+
+/**
  * Refs #1935 Phase 1 — project a PathParameter onto the ShapeTree's
  * top-level row shape. Body params whose type resolves to a known
  * class entity carry `type_entity_id` + `has_children=true` so the
@@ -730,21 +833,37 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
         {/* 3. Response — ShapeTree subtree (#1935 Phase 1). Replaces the
             former "Response shapes" table. Each response shape becomes a
             top-level row; expandable when the return type resolves to a
-            user-defined DTO. */}
+            user-defined DTO.
+            #1938 Phase 1 — when per_status_responses is non-empty (Java
+            @APIResponse annotations present), render a per-status tab strip
+            above the ShapeTree; the strip defaults to the lowest 2xx tab. */}
         <div>
           <SectionHeader
             icon={<Box size={14} />}
             title="Response"
-            count={filteredShapes.length}
+            count={
+              (detail.per_status_responses?.length ?? 0) > 0
+                ? detail.per_status_responses!.length
+                : filteredShapes.length
+            }
             infoText="Response body types per HTTP status code, derived from handler return types + framework annotations. Expandable when the return type is a user-defined DTO."
             open={openSections.response}
             onToggle={() => toggleSection("response")}
           />
           {openSections.response && (
-            <ShapeTree
-              groupId={groupId}
-              rows={filteredShapes.flatMap((s, idx) => responseToShapeTreeRows(s, idx))}
-            />
+            (detail.per_status_responses?.length ?? 0) > 0
+              ? (
+                <PerStatusResponseStrip
+                  entries={detail.per_status_responses!}
+                  groupId={groupId}
+                />
+              )
+              : (
+                <ShapeTree
+                  groupId={groupId}
+                  rows={filteredShapes.flatMap((s, idx) => responseToShapeTreeRows(s, idx))}
+                />
+              )
           )}
         </div>
 


### PR DESCRIPTION
## What

Three related improvements to the dashboard endpoint detail panel, the Java annotation extractor, and the process-flow walker.

## Why

- **#1938** — Endpoints with multiple `@APIResponse` annotations showed a single fallback response type, losing per-status-code schema info (404 → `ErrorResponse`, 200 → `TransferResult`, etc.).
- **#1940** — ANY-verb synthetic routes (Django `url()` catch-alls) polluted the Endpoints tab for paths that already had concrete GET/POST/PUT/DELETE entries.
- **#2024** — The process-flow walker never seeded from `.jsx`/`.tsx` UI components, so the `TransferReceive → confirmTransfer → PUT /transfers/confirm → TransfersController` chain was invisible in the Flows view.

## How

### #1938 — Per-status response tabs (Java Phase 1)

**Extractor (`internal/engine/java_annotation_routes.go`)**
- Added `APIResponseEntry` struct and four regex vars for MicroProfile `responseCode="NNN"` and JAX-RS `code=NNN` forms.
- Added `extractAPIResponseAnnotations` which: (1) finds each `@APIResponse`/`@ApiResponse` start position, (2) uses a new `findMatchingClose` balanced-paren scanner to extract the full annotation body (handles nested `@Content(@Schema(...))` without stopping early), (3) parses status code and `implementation`/`response` class name, (4) deduplicates by first-wins.
- Added `EncodeAPIResponses`/`DecodeAPIResponses` JSON round-trip helpers.
- `buildMethodEndpointsWithAuth` now writes `api_responses` property JSON onto every emitted `http_endpoint_definition` entity.

**Dashboard (`internal/dashboard/v2_paths.go`)**
- Added `v2PerStatusResponse` struct and `PerStatusResponses []v2PerStatusResponse` on `v2PathDetail`.
- `handleV2PathDetail` reads `api_responses` from matched endpoints, calls `engine.DecodeAPIResponses`, resolves each `TypeName` → class entity → repo slug (same path as existing response-type resolution), deduplicates across multiple matched endpoints, sorts ascending by status code, and attaches as `per_status_responses`.

**Frontend (`webui-v2/src/routes/paths.tsx`, `webui-v2/src/data/types.ts`)**
- Added `PerStatusResponse` interface to `types.ts`.
- Added `StatusCodeChip` (color-coded: green 2xx, amber 4xx, red 5xx) and `PerStatusResponseStrip` (tab strip with `useState`, defaults to lowest 2xx code, each tab renders a `ShapeTree` for its type).
- `DetailPane` Response section: renders `PerStatusResponseStrip` when `per_status_responses?.length > 0`, otherwise falls back to the existing single-type `ShapeTree`.

### #1940 — ANY-verb suppression

**Dashboard (`internal/dashboard/v2_paths.go`)**
- Added Phase 1b pass in `handleV2PathsList`: builds a `map[(backend,path)]bool` of pairs that have at least one non-ANY verb, then filters out ANY-verb endpoints whose pair is in that map.

### #2024 — JSX/TSX entry-point seeding for process flows

**Engine (`internal/engine/process_flow_entry.go`)**
- `isEntryCandidate` now accepts `SCOPE.JSX` in addition to the existing four kinds.
- `rankEntryPoints` gives `SCOPE.JSX` entities +2.0 score and `ui_component` entry kind.
- A secondary bonus (+2.0, `ui_component`) is applied to plain `SCOPE.Function` entities whose name is PascalCase and whose source file ends in `.jsx`/`.tsx` — covers extractors that emit `SCOPE.Function` instead of `SCOPE.JSX` for React components.
- Added `isPascalCaseIdentifier` and `isJSXSourceFile` helpers (also unit-tested).

## Tests

- `internal/engine/issue1938_api_response_test.go` — 5 cases: MicroProfile extraction, JAX-RS legacy `code=`, deduplication, encode/decode round-trip, E2E `api_responses` property on emitted entity.
- `internal/engine/issue1940_any_suppression_test.go` — 3 cases: `isPascalCaseIdentifier`, `isJSXSourceFile`, `isEntryCandidate` includes `SCOPE.JSX`.

```
ok  github.com/cajasmota/archigraph/internal/dashboard
ok  github.com/cajasmota/archigraph/internal/extractors/java
ok  github.com/cajasmota/archigraph/internal/engine
ok  github.com/cajasmota/archigraph/internal/engine/httproutes
```

TypeScript: `tsc -b` — zero errors. Vite: `vite build` — zero errors, built in ~7s.

## Checklist

- [x] `go test ./internal/dashboard/... ./internal/extractors/java/... ./internal/engine/...` — zero failures
- [x] `tsc -b` — zero errors
- [x] `vite build` — zero errors
- [x] No changes to main checkout, no `go install`, no daemon restart

Closes #1938
Closes #1940
Closes #2024