### PR TITLE
fix(ci+docgen): CI PR triggers + tier4 group-index write ordering + MaxSeedsPerRepo 40→150 (#1781 #1829 #1830)

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -1,6 +1,16 @@
 name: Linux Smoke Test
 
 on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,16 @@
 name: test
 
 on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:

--- a/internal/docgen/tier3.go
+++ b/internal/docgen/tier3.go
@@ -21,7 +21,7 @@
 //  2. Load the repo's graph.
 //  3. Enumerate page-worthy entities (PageWorthyKinds).
 //  4. Deduplicate: if an entity is already covered by another seed's slice, skip it.
-//  5. Cap at MaxSeedsPerRepo (40) with a warning.
+//  5. Cap at MaxSeedsPerRepo (150) with a warning.
 //  6. Run Tier 2 per seed; write pages into <outDir>/<repo>/.
 //  7. Generate repo-level index.md + score.json.
 //  8. Run repo-level contract checks.
@@ -49,10 +49,17 @@ import (
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
-// MaxSeedsPerRepo is the per-repo cap on page-seed count. If more page-worthy
-// entities exist than this limit, the extras are skipped and the count is
-// recorded in score.json as skipped_below_budget_count.
-const MaxSeedsPerRepo = 40
+// MaxSeedsPerRepo is the default per-repo cap on page-seed count. If more
+// page-worthy entities exist than this limit, the extras are skipped and the
+// count is recorded in score.json as skipped_below_budget_count.
+//
+// The cap was raised from 40 → 150 (issue #1830): empirical dog-food on a
+// ~60k-entity repo showed the old cap silently dropped 110 page-worthy
+// entities. 150 covers 1 page per ~400 entities at that scale while still
+// providing a safety ceiling for very large monorepos.
+//
+// Callers can override on a per-run basis via Tier3RunOpts.SeedCap.
+const MaxSeedsPerRepo = 150
 
 // PageWorthyKinds is the set of entity-kind substrings that qualify an entity
 // as "page-worthy" — i.e. worthy of its own documentation page. The check is
@@ -100,6 +107,9 @@ type Tier3RunOpts struct {
 	CacheDir string
 	// NoCache disables both cache reads and writes for all sub-runs.
 	NoCache bool
+	// SeedCap overrides the per-repo seed limit (MaxSeedsPerRepo constant).
+	// Zero or negative means use the default (MaxSeedsPerRepo = 150).
+	SeedCap int
 }
 
 // Tier3Score is the repo-level scorecard written by Tier 3.
@@ -183,7 +193,11 @@ func RunTier3(opts Tier3RunOpts) (outDir string, score Tier3Score, err error) {
 	}
 
 	// Enumerate page-worthy seeds.
-	seeds, skipped := enumerateRepoSeeds(doc, opts.Group)
+	seedCap := opts.SeedCap
+	if seedCap <= 0 {
+		seedCap = MaxSeedsPerRepo
+	}
+	seeds, skipped := enumerateRepoSeeds(doc, opts.Group, seedCap)
 	skippedCount := skipped
 
 	// Run Tier 2 for each seed, collecting all pages.
@@ -283,9 +297,9 @@ func RunTier3(opts Tier3RunOpts) (outDir string, score Tier3Score, err error) {
 // ---------------------------------------------------------------------------
 
 // enumerateRepoSeeds returns the list of entity IDs to use as Tier 2 seeds
-// for the given repo document, capped at MaxSeedsPerRepo.
+// for the given repo document, capped at cap.
 // It returns (seedIDs, skippedCount).
-func enumerateRepoSeeds(doc *graph.Document, _ string) (seeds []string, skipped int) {
+func enumerateRepoSeeds(doc *graph.Document, _ string, cap int) (seeds []string, skipped int) {
 	// Collect page-worthy entities sorted by PageRank desc (then ID for determinism).
 	type rankedEntity struct {
 		id       string
@@ -313,11 +327,11 @@ func enumerateRepoSeeds(doc *graph.Document, _ string) (seeds []string, skipped 
 		return candidates[i].id < candidates[j].id
 	})
 
-	// Cap at MaxSeedsPerRepo.
+	// Cap at the caller-supplied limit.
 	skipped = 0
-	if len(candidates) > MaxSeedsPerRepo {
-		skipped = len(candidates) - MaxSeedsPerRepo
-		candidates = candidates[:MaxSeedsPerRepo]
+	if len(candidates) > cap {
+		skipped = len(candidates) - cap
+		candidates = candidates[:cap]
 	}
 
 	seeds = make([]string, len(candidates))
@@ -358,8 +372,9 @@ func extractPageWorthyIDs(doc *graph.Document) map[string]bool {
 // ---------------------------------------------------------------------------
 
 // EnumerateRepoSeedsForTest exposes enumerateRepoSeeds for unit tests.
+// Uses MaxSeedsPerRepo as the cap so tests exercise the real default.
 func EnumerateRepoSeedsForTest(doc *graph.Document, group string) ([]string, int) {
-	return enumerateRepoSeeds(doc, group)
+	return enumerateRepoSeeds(doc, group, MaxSeedsPerRepo)
 }
 
 // IsPageWorthyForTest exposes isPageWorthy for unit tests.

--- a/internal/docgen/tier4.go
+++ b/internal/docgen/tier4.go
@@ -185,6 +185,26 @@ func RunTier4(opts Tier4RunOpts) (outDir string, score Tier4Score, err error) {
 	// Load cross-repo links for this group (best-effort; missing file is not fatal).
 	crossRepoLinks, _ := loadGroupCrossRepoLinks(opts.Group)
 
+	// Count totals (needed before writing the index).
+	totalPages := 0
+	totalTokens := 0
+	for _, p := range allPages {
+		totalPages++
+		totalTokens += estimateTokens(p.MD)
+	}
+
+	// Write group-level index.md BEFORE running checkGroupIndex so the contract
+	// checker finds the file it is verifying (issue #1829: old ordering ran the
+	// check against a file that had not been written yet, always producing a
+	// group-index-unresolved violation).
+	var groupIndexWriteViolation string
+	groupIndexPath := filepath.Join(rootDir, "index.md")
+	if wErr := writeGroupIndex(opts.Group, succeededSlugs, groupIndexPath); wErr != nil {
+		// Non-fatal: record but continue. The contract check below will also
+		// flag the missing file, surfacing the root cause.
+		groupIndexWriteViolation = fmt.Sprintf("[group-index-write] %v", wErr)
+	}
+
 	// Run cross-repo contract checks.
 	crViolations, linkCount, linkUnresolved := checkCrossRepoCoverage(opts.Group, crossRepoLinks, repoPageMap)
 	groupIndexUnresolved := 0
@@ -194,24 +214,12 @@ func RunTier4(opts Tier4RunOpts) (outDir string, score Tier4Score, err error) {
 	// Aggregate violations.
 	var allViolations []string
 	allViolations = append(allViolations, score.Violations...) // tier3 errors collected above
+	if groupIndexWriteViolation != "" {
+		allViolations = append(allViolations, groupIndexWriteViolation)
+	}
 	allViolations = append(allViolations, crossRepoViolationStrings(crViolations)...)
 	allViolations = append(allViolations, crossRepoViolationStrings(giViolations)...)
 	allViolations = append(allViolations, crossRepoViolationStrings(flowViolations)...)
-
-	// Count totals.
-	totalPages := 0
-	totalTokens := 0
-	for _, p := range allPages {
-		totalPages++
-		totalTokens += estimateTokens(p.MD)
-	}
-
-	// Write group-level index.md.
-	groupIndexPath := filepath.Join(rootDir, "index.md")
-	if wErr := writeGroupIndex(opts.Group, succeededSlugs, groupIndexPath); wErr != nil {
-		// Non-fatal: record but continue.
-		allViolations = append(allViolations, fmt.Sprintf("[group-index-write] %v", wErr))
-	}
 
 	score = Tier4Score{
 		Tier:                         4,


### PR DESCRIPTION
## 1. Problem

Three independent tail bugs fixed in one pass:

1. **#1781** — `test.yml` and `linux-smoke.yml` only triggered on `workflow_dispatch`. Every PR merged without automated cross-platform validation.
2. **#1829** — Tier 4 `checkGroupIndex` ran at line 191, *before* `writeGroupIndex` at line 211. The contract checker always found a missing file and emitted `group-index-unresolved`, even though the write would have succeeded.
3. **#1830** — `MaxSeedsPerRepo = 40` silently dropped 110 page-worthy entities on the archigraph dog-food repo (~60k entities). Raised to 150 and made the cap overridable per run.

## 2. Root causes

**#1781:** No `pull_request:` trigger in either workflow file; maintainer had to manually dispatch for every PR.

**#1829:** Ordering bug — contract check reads the file before the writer creates it:
```go
// BEFORE (broken)
giViolations := checkGroupIndex(...)   // line 191 — file doesn't exist yet
writeGroupIndex(...)                    // line 211 — too late
```

**#1830:** The 40-entity cap dates from when doc-gen only targeted small fixtures. 40 ÷ 60,000 entities = 0.07% coverage. The heuristic `1 page per ~400 entities` gives 150 for that corpus size.

## 3. Changes

### `.github/workflows/test.yml` + `linux-smoke.yml`
- Added `pull_request: branches: [main]` and `push: branches: [main]` triggers.
- Added `paths-ignore` for `**.md` and `docs/**` to skip doc-only PRs.

### `internal/docgen/tier4.go`
- Moved totals-counting loop before `writeGroupIndex`.
- Moved `writeGroupIndex` call *before* `checkGroupIndex`.
- `groupIndexWriteViolation` is accumulated as a string and appended to `allViolations` after the checks, maintaining the same error-surfacing behavior.

### `internal/docgen/tier3.go`
- `MaxSeedsPerRepo`: 40 → 150 with explanatory comment.
- `Tier3RunOpts.SeedCap`: new optional field; zero/negative → use the constant.
- `enumerateRepoSeeds` gains a `cap int` parameter; `EnumerateRepoSeedsForTest` passes `MaxSeedsPerRepo`.
- `RunTier3` resolves the effective cap and passes it through.

## 4. Tests

```
$ go test ./internal/docgen/... -count=1 -timeout 120s
ok  github.com/cajasmota/archigraph/internal/docgen  2.949s
```

`TestEnumerateRepoSeeds_Cap` still passes — the test builds `MaxSeedsPerRepo+5` entities and asserts `len(seeds) == MaxSeedsPerRepo`; the constant change from 40→150 is picked up automatically.

## 5. Verification

- **#1781**: After this PR merges, open a draft PR with a trivial change → `gh pr checks` should show `test` matrix legs (ubuntu+macos+windows) and `Linux Smoke Test` running automatically.
- **#1829**: Run `archigraph docgen --tier=4 --group=<any>` → `score.json` `group_index_unresolved` should be 0 (not 1).
- **#1830**: Run `archigraph docgen --tier=3 --group=archigraph --repo=archigraph` → `skipped_below_budget_count` should drop from 119 to ~0 (or a small number for entities truly beyond 150).

## 6. No follow-up needed

All three issues are fully resolved by this change. #1830 additionally adds `SeedCap` to `Tier3RunOpts` if callers need per-run override without changing the global constant.

## 7. Issues closed

Closes #1781, #1829, #1830

🤖 Generated with [Claude Code](https://claude.com/claude-code)