### PR TITLE
fix(install): add missing skill names — archigraph-aware-review + archigraph-test-page + using-archigraph (#1855)

### DIFF
--- a/internal/install/skilllink/skilllink.go
+++ b/internal/install/skilllink/skilllink.go
@@ -1,7 +1,7 @@
 // Package skilllink handles symlinking archigraph skills into Claude Code's
 // discovery directories.
 //
-// The 6 archigraph skills are distributed with the binary and must be
+// The 9 archigraph skills are distributed with the binary and must be
 // symlinked into ~/.claude/skills/, ~/.claude-*/skills/, etc. so that
 // Claude Code's skill discovery mechanism can find them.
 //
@@ -18,17 +18,20 @@ import (
 	"strings"
 )
 
-// SkillNames lists the 6 archigraph skills in canonical order.
+// SkillNames lists the 9 archigraph skills in canonical order.
 var SkillNames = []string{
-	"archigraph-quality-check",
+	"archigraph-aware-review",
 	"archigraph-patterns-discover",
 	"archigraph-patterns-sync",
+	"archigraph-quality-check",
 	"archigraph-repair",
+	"archigraph-test-page",
 	"extend-convention",
 	"generate-docs",
+	"using-archigraph",
 }
 
-// DiscoverSkillsDir finds the source directory containing the 6 archigraph
+// DiscoverSkillsDir finds the source directory containing the 9 archigraph
 // skills. It tries these locations in order:
 //
 // 1. If skillsSourceDir is non-empty, use it as-is (no validation)
@@ -76,7 +79,7 @@ func DiscoverSkillsDir(binPath, skillsSourceDir string) string {
 	return ""
 }
 
-// InstallSkillsInClaudeConfigs symlinks the 6 archigraph skills into every
+// InstallSkillsInClaudeConfigs symlinks the 9 archigraph skills into every
 // detected Claude Code config directory's skills/ subdirectory.
 //
 // claudeConfigDirs: list of ~/.claude.json paths (typically from mcpreg.DetectClaudeConfigDirs)


### PR DESCRIPTION
## Summary
Update `SkillNames` array in `skilllink.go` to include all 9 shipped skills.
Previously listed only 6 skills; added archigraph-aware-review, archigraph-test-page, and using-archigraph.
Updated comments to reflect the actual count.

## Fixes
- #1855 archigraph install should publish skills globally

## Test Plan
- Build succeeds: `go build ./...`
- SkillNames array now matches `skills/` directory contents (9 entries)
- Alphabetical sort applied for consistency

Closes #1855

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>