### PR TITLE
feat(python-extractor+docgen): enrichment cluster — @action on neighbour briefs + class typed deps + Class end_line + Schema type_hint + EXTENDS visibility + decorator generalization (#1862 #1867 #1868 #1877 #2012 #2016)

### DIFF
--- a/internal/docgen/llm_bundle.go
+++ b/internal/docgen/llm_bundle.go
@@ -427,6 +427,39 @@ type NeighbourBrief struct {
 	// Bundle C's dead-import detector stamps live=false on dead IMPORTS
 	// edges.
 	Live bool `json:"live,omitempty"`
+
+	// HTTPMethod is the canonical HTTP verb for a method neighbour decorated
+	// with `@action(methods=["..."])` (post-#2004), or any other framework
+	// decorator that surfaces a single verb. Sourced from the neighbour's
+	// entity Properties["http_method"]. Empty for non-HTTP neighbours.
+	// Surfaced on NeighbourBrief (#1862) so class-seed bundles can render
+	// a {method, verb, path} api table without an extra graph walk.
+	HTTPMethod string `json:"http_method,omitempty"`
+	// HTTPMethods is the comma-joined list of HTTP verbs when a single
+	// action declares multiple verbs. Sourced from
+	// Properties["http_methods"] (#1862).
+	HTTPMethods string `json:"http_methods,omitempty"`
+	// URLPath is the URL path pattern declared by an `@action(url_path=...)`
+	// decorator or equivalent (#1862). Sourced from Properties["url_path"].
+	URLPath string `json:"url_path,omitempty"`
+	// IsDetail mirrors Properties["is_detail"] == "true" for DRF actions.
+	// True for detail actions (operate on a single instance), false for
+	// list actions (#1862).
+	IsDetail bool `json:"is_detail,omitempty"`
+	// TypeHint surfaces type information for the neighbour (#1877). For
+	// SCOPE.Schema/field neighbours this is built from the entity's
+	// Properties["field_type"] + Properties["kwarg.<name>"] (Django Model
+	// fields stamped by django_relational.go) or from the Signature when
+	// the extractor recorded a Python type annotation. Empty for kinds
+	// where no meaningful type hint is available.
+	//
+	// Examples (Django fields):
+	//   "ForeignKey(Client) on_delete=CASCADE"
+	//   "CharField(max_length=10)"
+	//   "BooleanField default=False"
+	// Examples (Python type-annotated attributes):
+	//   "int", "list[str]", "Optional[User]"
+	TypeHint string `json:"type_hint,omitempty"`
 }
 
 // Canonical NeighbourBrief.Direction values.
@@ -744,6 +777,26 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 		if i < len(neighbourProperties) && neighbourProperties[i] != nil {
 			props = neighbourProperties[i]
 		}
+		// Issue #1862 — surface @action HTTP metadata (verb + path + detail)
+		// directly onto the NeighbourBrief so class-seed bundles can render
+		// {method, verb, path} api tables without an extra graph walk.
+		// Sourced from the NEIGHBOUR entity's Properties (stamped by
+		// internal/extractors/python/django_drf_actions.go), not from edge
+		// Properties.
+		// Issue #1877 — surface a compact TypeHint for SCOPE.Schema/field
+		// neighbours so the Schema section of Model pages becomes data-
+		// grounded. TypeHint is composed from Properties["field_type"] and
+		// the kwarg.<name> sidecars stamped by django_relational.go.
+		var httpMethod, httpMethods, urlPath, typeHint string
+		var isDetail bool
+		if n.Properties != nil {
+			httpMethod = n.Properties["http_method"]
+			httpMethods = n.Properties["http_methods"]
+			urlPath = n.Properties["url_path"]
+			isDetail = n.Properties["is_detail"] == "true"
+		}
+		typeHint = buildNeighbourTypeHint(&n)
+
 		briefs = append(briefs, NeighbourBrief{
 			EntityID:     n.ID,
 			Name:         n.Name,
@@ -760,7 +813,12 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 			// Live defaults to true when unset (existing edges with no
 			// dead-import pass coverage stay visible) and is false only
 			// when explicitly stamped live=false by the dead-import pass.
-			Live: props["live"] != "false",
+			Live:        props["live"] != "false",
+			HTTPMethod:  httpMethod,
+			HTTPMethods: httpMethods,
+			URLPath:     urlPath,
+			IsDetail:    isDetail,
+			TypeHint:    typeHint,
 		})
 	}
 
@@ -1186,6 +1244,118 @@ func typeHintFromSignature(sig string) string {
 		return parts[0]
 	}
 	return ""
+}
+
+// buildNeighbourTypeHint computes a compact type-hint string for a neighbour
+// entity suitable for surfacing on NeighbourBrief.TypeHint (#1877).
+//
+// For SCOPE.Schema/field neighbours stamped by the Python Django relational
+// pass (django_relational.go) we synthesise an ORM-aware hint from
+// Properties["field_type"] + Properties["kwarg.<name>"]:
+//
+//	field_type=ForeignKey kwarg.to=Client kwarg.on_delete=CASCADE
+//	  → "ForeignKey(Client) on_delete=CASCADE"
+//
+//	field_type=CharField kwarg.max_length=10 kwarg.choices=STATUS_CHOICES
+//	  → "CharField(max_length=10, choices=STATUS_CHOICES)"
+//
+//	field_type=BooleanField kwarg.default=False
+//	  → "BooleanField default=False"
+//
+// For other SCOPE.Schema/field kinds (Python type-annotated assignments,
+// TypeScript class properties) we fall back to typeHintFromSignature which
+// parses the Signature ("x: int" → "int", "private String name" → "String").
+//
+// Returns "" for non-field kinds (Operation, Component, Module, ...) so the
+// JSON field stays absent (omitempty) and bundle size doesn't grow for the
+// 80% case.
+func buildNeighbourTypeHint(n *graph.Entity) string {
+	if n == nil {
+		return ""
+	}
+	// Only field-shaped Schema entities carry a meaningful type hint.
+	// Non-field kinds are returned with empty hint so the JSON field is
+	// elided via omitempty.
+	if n.Kind != "SCOPE.Schema" || n.Subtype != "field" {
+		return ""
+	}
+
+	// Django Model field: build a structured hint from field_type + kwargs.
+	if n.Properties != nil {
+		if ft := strings.TrimSpace(n.Properties["field_type"]); ft != "" {
+			return composeDjangoFieldTypeHint(ft, n.Properties)
+		}
+	}
+
+	// Fallback: parse the Signature for "name: Type" or "Type name" forms.
+	return typeHintFromSignature(n.Signature)
+}
+
+// composeDjangoFieldTypeHint builds the canonical TypeHint string for a
+// Django Model field given its field_type and kwarg.<name> property sidecars.
+//
+// Format conventions (kept stable so docgen prompt templates can rely on them):
+//
+//   - Relational fields (ForeignKey, OneToOneField, ManyToManyField) render
+//     with the target model in parens, then on_delete after a space:
+//     "ForeignKey(Client) on_delete=CASCADE"
+//
+//   - Length/max-aware fields render kwargs in parens, comma-joined:
+//     "CharField(max_length=10, choices=STATUS_CHOICES)"
+//
+//   - Boolean/Default-only fields render kwargs after a space:
+//     "BooleanField default=False"
+//
+// Kwargs are iterated in a deterministic key order (`to`, `on_delete`,
+// `max_length`, `default`, `choices`, `null`, `blank`, then the rest sorted)
+// so the rendered string is stable across runs / map iteration orders.
+func composeDjangoFieldTypeHint(fieldType string, props map[string]string) string {
+	// Canonical kwarg keys to surface (in this order) and the bucket each
+	// renders into: parens vs trailing space-separated.
+	parenKeys := []string{"max_length", "max_digits", "decimal_places", "choices"}
+	trailingKeys := []string{"on_delete", "default", "null", "blank", "related_name", "unique", "db_index"}
+
+	collect := func(keys []string) []string {
+		var out []string
+		for _, k := range keys {
+			if v, ok := props["kwarg."+k]; ok && v != "" {
+				out = append(out, k+"="+v)
+			}
+		}
+		return out
+	}
+
+	// Relational field: render target in parens, on_delete on the trailing
+	// side. Target is the `to` kwarg (django_relational.go captures the
+	// positional model as Properties["kwarg.to"] when expressed as keyword,
+	// and as REFERENCES edge when positional — for the hint we surface only
+	// the kwarg form to keep things deterministic; positional callers can
+	// inspect the REFERENCES edge separately).
+	isRelational := fieldType == "ForeignKey" || fieldType == "OneToOneField" || fieldType == "ManyToManyField"
+	if isRelational {
+		target := strings.TrimSpace(props["kwarg.to"])
+		head := fieldType
+		if target != "" {
+			head = fieldType + "(" + target + ")"
+		}
+		trailing := collect(trailingKeys)
+		if len(trailing) == 0 {
+			return head
+		}
+		return head + " " + strings.Join(trailing, " ")
+	}
+
+	parens := collect(parenKeys)
+	trailing := collect(trailingKeys)
+
+	head := fieldType
+	if len(parens) > 0 {
+		head = fieldType + "(" + strings.Join(parens, ", ") + ")"
+	}
+	if len(trailing) == 0 {
+		return head
+	}
+	return head + " " + strings.Join(trailing, " ")
 }
 
 // buildClassManifest constructs a ClassManifest for the seed entity by

--- a/internal/docgen/llm_bundle_python_enrichment_test.go
+++ b/internal/docgen/llm_bundle_python_enrichment_test.go
@@ -1,0 +1,420 @@
+package docgen_test
+
+// llm_bundle_python_enrichment_test.go — regression tests for the Python
+// enrichment cluster (#1862, #1867, #1877, #2012).
+//
+// Each test builds an isolated fleet group with a single repo whose graph
+// is hand-written to mimic the post-extractor shape the Python extractor
+// would produce. The bundle assertions exercise the wiring on the docgen
+// side without depending on the full extractor pipeline (covered by the
+// extractor-side tests in internal/extractors/python).
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/docgen"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// writeGroupGraph is a small harness that builds an isolated archigraph
+// group whose only repo contains the supplied graph document. Returns the
+// group name and the chosen seed entity ID.
+func writeGroupGraph(t *testing.T, groupName, seedID string, doc graph.Document) string {
+	t.Helper()
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "myrepo")
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir fleet config dir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name": groupName,
+		"repos": []map[string]interface{}{
+			{"path": repoPath, "slug": "myrepo"},
+		},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write fleet config: %v", err)
+	}
+
+	doc.Repo = repoPath
+	doc.Version = 1
+	if doc.GeneratedAt.IsZero() {
+		doc.GeneratedAt = time.Now().UTC()
+	}
+	if doc.IndexerVersion == "" {
+		doc.IndexerVersion = "test"
+	}
+	doc.Stats = graph.Stats{
+		Files:         1,
+		Entities:      len(doc.Entities),
+		Relationships: len(doc.Relationships),
+	}
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	docJSON, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal graph doc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	_ = seedID
+	return groupName
+}
+
+// TestNeighbourBrief_1862_ActionDecoratorMetadata asserts that HTTP metadata
+// stamped on a method entity by the DRF @action pass (#2004) surfaces on
+// the corresponding NeighbourBrief for a class-seed bundle (#1862).
+//
+// Fixture: a ContractViewSet with one CONTAINS-child method `.approve`
+// carrying http_method=post, http_methods="post,put", url_path="approve",
+// is_detail="true" on the method entity Properties.
+func TestNeighbourBrief_1862_ActionDecoratorMetadata(t *testing.T) {
+	seedID := "1111111111111111"
+	methodID := "2222222222222222"
+
+	doc := graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: seedID, Name: "ContractViewSet",
+				Kind: "SCOPE.Component", Subtype: "class",
+				SourceFile: "core/views/contract_viewset.py",
+				Language:   "python",
+				StartLine:  10, EndLine: 80,
+			},
+			{
+				ID: methodID, Name: "ContractViewSet.approve",
+				Kind: "SCOPE.Operation", Subtype: "method",
+				SourceFile: "core/views/contract_viewset.py",
+				Language:   "python",
+				StartLine:  40, EndLine: 55,
+				Properties: map[string]string{
+					"drf_action":   "true",
+					"http_method":  "post",
+					"http_methods": "post,put",
+					"url_path":     "approve",
+					"is_detail":    "true",
+				},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: seedID, ToID: methodID, Kind: "CONTAINS"},
+		},
+	}
+
+	group := writeGroupGraph(t, "issue-1862-group", seedID, doc)
+
+	bundle, err := docgen.BuildBundle(context.Background(), docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        group,
+			SeedEntityID: seedID,
+			Section:      "api",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	var brief *docgen.NeighbourBrief
+	for i, b := range bundle.GraphContext.NeighbourBriefs {
+		if b.Name == "ContractViewSet.approve" {
+			brief = &bundle.GraphContext.NeighbourBriefs[i]
+			break
+		}
+	}
+	if brief == nil {
+		t.Fatalf("approve neighbour brief missing — got %d briefs", len(bundle.GraphContext.NeighbourBriefs))
+	}
+	if brief.HTTPMethod != "post" {
+		t.Errorf("HTTPMethod = %q, want %q", brief.HTTPMethod, "post")
+	}
+	if brief.HTTPMethods != "post,put" {
+		t.Errorf("HTTPMethods = %q, want %q", brief.HTTPMethods, "post,put")
+	}
+	if brief.URLPath != "approve" {
+		t.Errorf("URLPath = %q, want %q", brief.URLPath, "approve")
+	}
+	if !brief.IsDetail {
+		t.Errorf("IsDetail = false, want true")
+	}
+}
+
+// TestNeighbourBrief_1877_SchemaTypeHint asserts that SCOPE.Schema/field
+// neighbours surface a structured TypeHint built from their entity
+// Properties (field_type + kwarg.*), composing the Django Model field
+// summary documented on composeDjangoFieldTypeHint (#1877).
+func TestNeighbourBrief_1877_SchemaTypeHint(t *testing.T) {
+	classID := "1111111111111111"
+	fkFieldID := "2222222222222222"
+	charFieldID := "3333333333333333"
+	boolFieldID := "4444444444444444"
+
+	doc := graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: classID, Name: "Contract",
+				Kind: "SCOPE.Component", Subtype: "class",
+				SourceFile: "core/models/contract.py", Language: "python",
+				StartLine: 10, EndLine: 90,
+			},
+			{
+				ID: fkFieldID, Name: "Contract.client",
+				Kind: "SCOPE.Schema", Subtype: "field",
+				SourceFile: "core/models/contract.py", Language: "python",
+				StartLine: 12, EndLine: 12,
+				Properties: map[string]string{
+					"field_type":      "ForeignKey",
+					"kwarg.to":        "Client",
+					"kwarg.on_delete": "CASCADE",
+				},
+			},
+			{
+				ID: charFieldID, Name: "Contract.status",
+				Kind: "SCOPE.Schema", Subtype: "field",
+				SourceFile: "core/models/contract.py", Language: "python",
+				StartLine: 13, EndLine: 13,
+				Properties: map[string]string{
+					"field_type":       "CharField",
+					"kwarg.max_length": "10",
+					"kwarg.choices":    "STATUS_CHOICES",
+				},
+			},
+			{
+				ID: boolFieldID, Name: "Contract.is_active",
+				Kind: "SCOPE.Schema", Subtype: "field",
+				SourceFile: "core/models/contract.py", Language: "python",
+				StartLine: 14, EndLine: 14,
+				Properties: map[string]string{
+					"field_type":    "BooleanField",
+					"kwarg.default": "False",
+				},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: classID, ToID: fkFieldID, Kind: "CONTAINS"},
+			{ID: "r2", FromID: classID, ToID: charFieldID, Kind: "CONTAINS"},
+			{ID: "r3", FromID: classID, ToID: boolFieldID, Kind: "CONTAINS"},
+		},
+	}
+
+	group := writeGroupGraph(t, "issue-1877-group", classID, doc)
+
+	bundle, err := docgen.BuildBundle(context.Background(), docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        group,
+			SeedEntityID: classID,
+			Section:      "reference-config",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	byName := map[string]docgen.NeighbourBrief{}
+	for _, b := range bundle.GraphContext.NeighbourBriefs {
+		byName[b.Name] = b
+	}
+	wants := map[string]string{
+		"Contract.client":    "ForeignKey(Client) on_delete=CASCADE",
+		"Contract.status":    "CharField(max_length=10, choices=STATUS_CHOICES)",
+		"Contract.is_active": "BooleanField default=False",
+	}
+	for name, want := range wants {
+		b, ok := byName[name]
+		if !ok {
+			t.Errorf("neighbour %q missing", name)
+			continue
+		}
+		if b.TypeHint != want {
+			t.Errorf("neighbour %q TypeHint = %q, want %q", name, b.TypeHint, want)
+		}
+	}
+}
+
+// TestNeighbourBrief_1867_ClassMethodHopExpansion asserts that for a Class
+// seed, the bundle surfaces depth-2 typed dependencies reached through the
+// class's contained methods. Specifically: a foreign Model that one of the
+// class methods REFERENCES must appear as a NeighbourBrief on the class.
+func TestNeighbourBrief_1867_ClassMethodHopExpansion(t *testing.T) {
+	classID := "1111111111111111"
+	methodAID := "2222222222222222"
+	methodBID := "3333333333333333"
+	foreignModelID := "4444444444444444"
+	foreignServiceID := "5555555555555555"
+
+	doc := graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: classID, Name: "ContractViewSet",
+				Kind: "SCOPE.Component", Subtype: "class",
+				SourceFile: "core/views/contract_viewset.py",
+				Language:   "python",
+				StartLine:  10, EndLine: 100,
+			},
+			{
+				ID: methodAID, Name: "ContractViewSet.list",
+				Kind: "SCOPE.Operation", Subtype: "method",
+				SourceFile: "core/views/contract_viewset.py", Language: "python",
+				StartLine: 20, EndLine: 30,
+			},
+			{
+				ID: methodBID, Name: "ContractViewSet.create",
+				Kind: "SCOPE.Operation", Subtype: "method",
+				SourceFile: "core/views/contract_viewset.py", Language: "python",
+				StartLine: 32, EndLine: 50,
+			},
+			// Foreign Model referenced by a method body.
+			{
+				ID: foreignModelID, Name: "Building",
+				Kind: "SCOPE.Component", Subtype: "class",
+				SourceFile: "core/models/building.py", Language: "python",
+				StartLine: 1, EndLine: 40,
+			},
+			// External service called by a method body.
+			{
+				ID: foreignServiceID, Name: "send_notification",
+				Kind: "SCOPE.Operation", Subtype: "function",
+				SourceFile: "core/services/notify.py", Language: "python",
+				StartLine: 5, EndLine: 12,
+			},
+		},
+		Relationships: []graph.Relationship{
+			// Direct CONTAINS children (methods).
+			{ID: "r1", FromID: classID, ToID: methodAID, Kind: "CONTAINS"},
+			{ID: "r2", FromID: classID, ToID: methodBID, Kind: "CONTAINS"},
+			// Method bodies touch foreign entities — these are the
+			// depth-2 typed deps that should bubble up to the class.
+			{ID: "r3", FromID: methodAID, ToID: foreignModelID, Kind: "REFERENCES"},
+			{ID: "r4", FromID: methodBID, ToID: foreignServiceID, Kind: "CALLS"},
+		},
+	}
+
+	group := writeGroupGraph(t, "issue-1867-group", classID, doc)
+
+	bundle, err := docgen.BuildBundle(context.Background(), docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        group,
+			SeedEntityID: classID,
+			Section:      "flows",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	byName := map[string]docgen.NeighbourBrief{}
+	for _, b := range bundle.GraphContext.NeighbourBriefs {
+		byName[b.Name] = b
+	}
+
+	// Foreign Model and foreign Service must appear via the method hop.
+	building, ok := byName["Building"]
+	if !ok {
+		t.Fatalf("Building (depth-2 typed dep) missing from neighbour_briefs; "+
+			"got %d briefs", len(bundle.GraphContext.NeighbourBriefs))
+	}
+	if building.Relationship != "REFERENCES" {
+		t.Errorf("Building Relationship = %q, want REFERENCES", building.Relationship)
+	}
+	if v := building.Properties["via_method_hop"]; v != "true" {
+		t.Errorf("Building Properties[via_method_hop] = %q, want \"true\"", v)
+	}
+	send, ok := byName["send_notification"]
+	if !ok {
+		t.Fatalf("send_notification (depth-2 CALL) missing from neighbour_briefs")
+	}
+	if send.Relationship != "CALLS" {
+		t.Errorf("send_notification Relationship = %q, want CALLS", send.Relationship)
+	}
+}
+
+// TestNeighbourBrief_2012_ExtendsVisible asserts that an EXTENDS edge from
+// the class seed to a base class surfaces in NeighbourBriefs with
+// Relationship="EXTENDS" (verifying that the edge kind is preserved
+// post-#1879 / #2025 — see #2012).
+func TestNeighbourBrief_2012_ExtendsVisible(t *testing.T) {
+	seedID := "1111111111111111"
+	baseID := "2222222222222222"
+
+	doc := graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: seedID, Name: "ReportViewSet",
+				Kind: "SCOPE.Component", Subtype: "class",
+				SourceFile: "core/views/report.py", Language: "python",
+				StartLine: 10, EndLine: 50,
+			},
+			{
+				ID: baseID, Name: "BaseAuditedViewSet",
+				Kind: "SCOPE.Component", Subtype: "class",
+				SourceFile: "core/views/base.py", Language: "python",
+				StartLine: 1, EndLine: 30,
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: seedID, ToID: baseID, Kind: "EXTENDS"},
+		},
+	}
+	group := writeGroupGraph(t, "issue-2012-group", seedID, doc)
+	bundle, err := docgen.BuildBundle(context.Background(), docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        group,
+			SeedEntityID: seedID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	var rel string
+	for _, b := range bundle.GraphContext.NeighbourBriefs {
+		if b.Name == "BaseAuditedViewSet" {
+			rel = b.Relationship
+			break
+		}
+	}
+	if rel == "" {
+		t.Fatalf("BaseAuditedViewSet missing from neighbour_briefs — EXTENDS edge dropped (issue #2012)")
+	}
+	if !strings.EqualFold(rel, "EXTENDS") {
+		t.Errorf("base-class neighbour Relationship = %q, want EXTENDS — issue #2012 still broken", rel)
+	}
+}

--- a/internal/docgen/tier0.go
+++ b/internal/docgen/tier0.go
@@ -398,6 +398,21 @@ func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.E
 		seen[seed.ID] = true
 		collect(seed.ID)
 
+		// Issue #1867 — Class seeds: surface typed dependencies from method
+		// bodies as 1-hop neighbours. Direct CONTAINS children (methods)
+		// dominate the raw 1-hop neighbourhood, but the LLM-useful
+		// neighbours for a ViewSet/Model class are the foreign Models +
+		// services its methods touch (REFERENCES / CALLS / DEPENDS_ON
+		// targets reachable through a method). We walk one extra hop
+		// through each contained Operation to surface those typed
+		// dependencies on the class's neighbour_briefs. Cap the total
+		// expansion at classMethodHopCap so a god-class with hundreds of
+		// methods doesn't blow up the bundle.
+		if seed != nil && isClassSeedForMethodHop(seed) {
+			classMethodHopExpand(seed.ID, allRels, byID,
+				&neighbours, &neighbourKinds, &neighbourDirections, &neighbourProperties, seen)
+		}
+
 		// Issue #2020 — Python Module entities are dual-emitted alongside a
 		// parallel SCOPE.Component(file) entity for the same __init__.py
 		// source file. IMPORTS / CONTAINS edges attach to the file entity,
@@ -444,6 +459,148 @@ func isPythonModuleEntity(e *graph.Entity) bool {
 		return false
 	}
 	return e.Language == "python" || e.Language == ""
+}
+
+// classMethodHopCap bounds the number of depth-2 neighbours added by
+// classMethodHopExpand so a god-class with hundreds of methods cannot
+// produce a runaway bundle. Tuned to keep the neighbour_briefs payload
+// within the same ~25-entry visual budget the dogfood evidence
+// referenced in #1867.
+const classMethodHopCap = 25
+
+// isClassSeedForMethodHop reports whether seed should trigger the
+// #1867 method-body typed-dependency expansion. Class-like entities
+// across languages are recognised:
+//
+//   - SCOPE.Component subtype=class / view / viewset / model / controller / service / repository
+//   - Top-level Class / Model / View / Controller / Service kinds (other extractors)
+//
+// Module / file / function / operation kinds are intentionally excluded
+// so the second-hop walk runs only where the dogfood evidence found
+// useful: per-class api/flows/patterns sections.
+func isClassSeedForMethodHop(seed *graph.Entity) bool {
+	if seed == nil {
+		return false
+	}
+	switch seed.Kind {
+	case "SCOPE.Component":
+		switch seed.Subtype {
+		case "class", "view", "viewset", "model", "controller", "service", "repository":
+			return true
+		}
+	case "Class", "Model", "View", "Controller", "Service":
+		return true
+	}
+	return false
+}
+
+// classMethodHopExpand adds depth-2 neighbours reachable through any of
+// the seed's CONTAINS-children that are SCOPE.Operation entities. It
+// follows OUTBOUND REFERENCES / CALLS / DEPENDS_ON / FK_TO / IMPLEMENTS
+// edges from each contained method and surfaces the targets as
+// inbound-to-class neighbours so the LLM sees typed deps directly on the
+// class's neighbour_briefs.
+//
+// The expansion respects the shared `seen` map (so a target already
+// present as a direct child is not duplicated), caps total additions at
+// classMethodHopCap, and preserves the per-edge Properties map (so any
+// annotations the extractor stamped — disposition_hint, cross_repo,
+// import_alias, etc. — survive onto the depth-2 NeighbourBrief).
+//
+// Direction is recorded as outbound because, conceptually, the class
+// "depends on" the target (seed → target via its method body). Edge kind
+// is preserved verbatim so docgen can render the typed relationship.
+func classMethodHopExpand(
+	seedID string,
+	allRels []graph.Relationship,
+	byID map[string]*graph.Entity,
+	neighbours *[]graph.Entity,
+	neighbourKinds *[]string,
+	neighbourDirections *[]string,
+	neighbourProperties *[]map[string]string,
+	seen map[string]bool,
+) {
+	// 1. Collect the method/operation IDs contained by the class.
+	methodIDs := make([]string, 0, 16)
+	for _, rel := range allRels {
+		if rel.Kind != "CONTAINS" || rel.FromID != seedID {
+			continue
+		}
+		child, ok := byID[rel.ToID]
+		if !ok {
+			continue
+		}
+		if child.Kind != "SCOPE.Operation" {
+			continue
+		}
+		methodIDs = append(methodIDs, child.ID)
+	}
+	if len(methodIDs) == 0 {
+		return
+	}
+
+	// Build a set for O(1) source-id lookup.
+	methodSet := make(map[string]bool, len(methodIDs))
+	for _, id := range methodIDs {
+		methodSet[id] = true
+	}
+
+	// 2. Walk outbound REFERENCES / CALLS / DEPENDS_ON / FK_TO / IMPLEMENTS
+	//    edges from any contained method. Cap total additions.
+	added := 0
+	for _, rel := range allRels {
+		if added >= classMethodHopCap {
+			return
+		}
+		if !methodSet[rel.FromID] {
+			continue
+		}
+		if !isTypedDepKind(rel.Kind) {
+			continue
+		}
+		if seen[rel.ToID] {
+			continue
+		}
+		target, ok := byID[rel.ToID]
+		if !ok {
+			continue
+		}
+		// Skip targets that are themselves the seed or any of the seed's
+		// own contained methods — those are already in the bundle as
+		// direct CONTAINS children.
+		if target.ID == seedID || methodSet[target.ID] {
+			continue
+		}
+		seen[target.ID] = true
+		*neighbours = append(*neighbours, *target)
+		*neighbourKinds = append(*neighbourKinds, rel.Kind)
+		*neighbourDirections = append(*neighbourDirections, NeighbourDirectionOutbound)
+		// Clone+stamp a `via_method_hop=true` marker so consumers can
+		// distinguish a depth-2 typed-dep from a depth-1 direct child.
+		// Preserve any existing per-edge Properties stamped by the
+		// extractor (#2018 carries cross_repo / import_alias / etc.).
+		props := map[string]string{"via_method_hop": "true"}
+		for k, v := range rel.Properties {
+			props[k] = v
+		}
+		*neighbourProperties = append(*neighbourProperties, props)
+		added++
+	}
+}
+
+// isTypedDepKind reports whether edgeKind expresses a typed dependency
+// the #1867 method-hop expansion should surface. CONTAINS / IMPORTS /
+// EXTENDS are intentionally excluded — CONTAINS is the seed's own
+// container relationship, IMPORTS is already a direct 1-hop file/module
+// neighbour, and EXTENDS sits on the class itself rather than its
+// methods.
+func isTypedDepKind(edgeKind string) bool {
+	switch edgeKind {
+	case "REFERENCES", "CALLS", "DEPENDS_ON", "FK_TO", "IMPLEMENTS",
+		"DEPENDS_ON_CONFIG", "RESOLVED_BY":
+		return true
+	}
+	return false
 }
 
 // repoEntry pairs a graph state directory with its absolute repo path from the

--- a/internal/extractors/python/decorators_generic.go
+++ b/internal/extractors/python/decorators_generic.go
@@ -1,0 +1,197 @@
+// decorators_generic.go — issue #2016: generalize Python decorator capture
+// beyond DRF @action / Celery @shared_task.
+//
+// For every decorator on a function_definition (top-level or method inside a
+// class body), stamp a `decorator_<name>` property on the matching
+// SCOPE.Operation entity. The value is the raw decorator source snippet
+// (capped) when the decorator is a call form, or the literal "true" for a
+// bare decorator.
+//
+// Recognised forms:
+//
+//	@property                           → decorator_property = "true"
+//	@cached_property                    → decorator_cached_property = "true"
+//	@staticmethod                       → decorator_staticmethod = "true"
+//	@classmethod                        → decorator_classmethod = "true"
+//	@contextmanager                     → decorator_contextmanager = "true"
+//	@functools.wraps(other)             → decorator_wraps = "@functools.wraps(other)"
+//	@cache(ttl=300)                     → decorator_cache = "@cache(ttl=300)"
+//	@<name>.setter / @<name>.getter     → decorator_setter = "<name>" / decorator_getter = "<name>"
+//	@<name>.deleter                     → decorator_deleter = "<name>"
+//
+// The pass runs AFTER the primary walk (and after the DRF / Celery passes),
+// so:
+//   - Operation entities exist and are looked up by SourceFile + Name.
+//   - Existing `drf_action` / `is_task` / kwarg-derived properties are
+//     preserved (this pass only writes keys that don't already exist).
+//
+// The pass is intentionally simple and never modifies existing properties.
+// Decorator-specific passes that already know how to parse their kwargs
+// (DRF @action, Celery @shared_task) continue to own their structured
+// extraction; this pass adds the COVERAGE so every decorator becomes a
+// queryable graph signal, satisfying the W8 evidence in #2016.
+
+package python
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitGenericDecoratorProperties walks every decorated_definition in root,
+// resolves the wrapped operation entity by SourceFile + Name, and stamps
+// `decorator_<name>` properties on it for each decorator on the definition.
+//
+// Mutates *entities in place. Safe to call with nil/empty input.
+func emitGenericDecoratorProperties(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+	walkDecoratedDefs(root, "", file, entities)
+}
+
+func walkDecoratedDefs(n *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if n == nil {
+		return
+	}
+	switch n.Type() {
+	case "class_definition":
+		nameNode := n.ChildByFieldName("name")
+		cls := ""
+		if nameNode != nil {
+			cls = nodeText(nameNode, file.Content)
+		}
+		childCls := cls
+		if parentClass != "" && cls != "" {
+			childCls = parentClass + "." + cls
+		}
+		body := n.ChildByFieldName("body")
+		if body != nil {
+			for i := 0; i < int(body.ChildCount()); i++ {
+				walkDecoratedDefs(body.Child(i), childCls, file, entities)
+			}
+		}
+		return
+	case "decorated_definition":
+		inner := n.ChildByFieldName("definition")
+		if inner != nil && inner.Type() == "function_definition" {
+			stampDecoratorsOnOperation(n, inner, parentClass, file, entities)
+		}
+		// Recurse so a decorated class wrapping methods is visited.
+		if inner != nil {
+			walkDecoratedDefs(inner, parentClass, file, entities)
+		}
+		return
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		walkDecoratedDefs(n.Child(i), parentClass, file, entities)
+	}
+}
+
+// stampDecoratorsOnOperation scans every decorator child of decoratedNode and
+// stamps a `decorator_<leaf>` property on the matching SCOPE.Operation entity
+// found by SourceFile + qualified Name.
+func stampDecoratorsOnOperation(decoratedNode, fnNode *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+	methodNameNode := fnNode.ChildByFieldName("name")
+	if methodNameNode == nil {
+		return
+	}
+	methodName := nodeText(methodNameNode, file.Content)
+	if methodName == "" {
+		return
+	}
+	emittedName := methodName
+	if parentClass != "" {
+		emittedName = parentClass + "." + methodName
+	}
+	op := findOpByName(*entities, file.Path, emittedName)
+	if op == nil {
+		return
+	}
+
+	for i := 0; i < int(decoratedNode.ChildCount()); i++ {
+		ch := decoratedNode.Child(i)
+		if ch == nil || ch.Type() != "decorator" {
+			continue
+		}
+		// Walk named children of the decorator to find either:
+		//   - a call    → `@foo(...)`           leaf = "foo"
+		//   - attribute → `@a.b.c` (rare) or `@<name>.setter`
+		//   - identifier→ `@foo` bare
+		// We capture the LEAF identifier as the decorator name (matching the
+		// existing convention in django_drf_actions.go decoratorLeaf).
+		var leaf string
+		var snippet string
+		var isCall bool
+		// setterTarget captures the LHS of `@<name>.setter` and friends so we
+		// can stamp `decorator_setter = "<name>"` instead of just "true".
+		var setterTarget string
+		var setterKind string // "setter" | "getter" | "deleter"
+		for j := 0; j < int(ch.NamedChildCount()); j++ {
+			inner := ch.NamedChild(j)
+			if inner == nil {
+				continue
+			}
+			switch inner.Type() {
+			case "call":
+				isCall = true
+				fn := inner.ChildByFieldName("function")
+				leaf = decoratorLeaf(fn, file.Content)
+				snippet = strings.TrimSpace(nodeText(ch, file.Content))
+				if len(snippet) > 200 {
+					snippet = snippet[:200] + "…"
+				}
+			case "attribute":
+				// Could be `@x.setter` / `@x.getter` / `@x.deleter` (property
+				// triad), or a dotted bare reference like `@a.b`.
+				if attr := inner.ChildByFieldName("attribute"); attr != nil {
+					attrText := nodeText(attr, file.Content)
+					switch attrText {
+					case "setter", "getter", "deleter":
+						setterKind = attrText
+						if obj := inner.ChildByFieldName("object"); obj != nil {
+							setterTarget = strings.TrimSpace(nodeText(obj, file.Content))
+						}
+						leaf = attrText
+					default:
+						leaf = attrText
+					}
+				}
+			case "identifier":
+				leaf = nodeText(inner, file.Content)
+			case "dotted_name":
+				if c := inner.NamedChild(int(inner.NamedChildCount()) - 1); c != nil {
+					leaf = nodeText(c, file.Content)
+				}
+			}
+		}
+		if leaf == "" {
+			continue
+		}
+		if op.Properties == nil {
+			op.Properties = map[string]string{}
+		}
+		key := "decorator_" + leaf
+		// Don't overwrite a value already set by a specialised pass
+		// (e.g. DRF @action stamped a structured kwarg snippet onto
+		// `decorator_<methodName>` on the parent class; that's different,
+		// scoped to the class. Here we write per-Operation keys which the
+		// specialised passes don't touch.)
+		if _, exists := op.Properties[key]; exists {
+			continue
+		}
+		switch {
+		case setterKind != "" && setterTarget != "":
+			// `@x.setter` → decorator_setter = "x"
+			op.Properties[key] = setterTarget
+		case isCall && snippet != "":
+			op.Properties[key] = snippet
+		default:
+			op.Properties[key] = "true"
+		}
+	}
+}

--- a/internal/extractors/python/decorators_generic_test.go
+++ b/internal/extractors/python/decorators_generic_test.go
@@ -1,0 +1,199 @@
+package python
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// TestEmitGenericDecoratorProperties_2016 asserts that the generic decorator
+// capture pass stamps `decorator_<name>` properties on every decorated
+// Operation entity, covering the W8R1-R3 evidence in issue #2016:
+//
+//   - @property                  → decorator_property = "true"
+//   - @cached_property           → decorator_cached_property = "true"
+//   - @staticmethod              → decorator_staticmethod = "true"
+//   - @classmethod               → decorator_classmethod = "true"
+//   - @contextmanager            → decorator_contextmanager = "true"
+//   - @functools.wraps(fn)       → decorator_wraps = "<call snippet>"
+//   - @full_name.setter          → decorator_setter = "full_name"
+//
+// The pass MUST not clobber the specialised stamps produced by the DRF
+// @action pass (#2004) — `decorator_action` is the only key the generic
+// pass would write for an action, but the structured `drf_action=true`
+// + `http_method=...` properties from the action pass must survive.
+func TestEmitGenericDecoratorProperties_2016(t *testing.T) {
+	src := `from contextlib import contextmanager
+from functools import cached_property, wraps
+
+
+class UserProfile:
+    @property
+    def full_name(self):
+        return self.first + " " + self.last
+
+    @full_name.setter
+    def full_name(self, value):
+        self.first, self.last = value.split(" ", 1)
+
+    @cached_property
+    def avatar_url(self):
+        return "/static/" + self.id
+
+    @staticmethod
+    def banner_default():
+        return "default-banner.png"
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls()
+
+    @contextmanager
+    def transactional(self):
+        yield
+
+
+def memoize(fn):
+    @wraps(fn)
+    def inner(*a, **kw):
+        return fn(*a, **kw)
+    return inner
+`
+
+	e := &Extractor{}
+	out, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "fixture/userprofile.py",
+		Content:  []byte(src),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	findOp := func(name string) map[string]string {
+		for _, ent := range out {
+			if ent.Kind == "SCOPE.Operation" && ent.Name == name {
+				return ent.Properties
+			}
+		}
+		return nil
+	}
+
+	cases := []struct {
+		opName    string
+		wantKey   string
+		wantValue string // "" means we only check presence (key set to any non-empty)
+		wantExact bool   // when true, value must match exactly
+	}{
+		{"UserProfile.full_name", "decorator_property", "true", true},
+		// The setter is emitted as a same-named Operation; check that
+		// decorator_setter survives with the property-target name as value.
+		// Both entries have the same Name in the entity stream because Python
+		// allows the property/setter pair to share the method name; the
+		// stamping pass writes whichever it walks first. We assert at least
+		// one of the two carries decorator_setter.
+		{"UserProfile.avatar_url", "decorator_cached_property", "true", true},
+		{"UserProfile.banner_default", "decorator_staticmethod", "true", true},
+		{"UserProfile.from_dict", "decorator_classmethod", "true", true},
+		{"UserProfile.transactional", "decorator_contextmanager", "true", true},
+	}
+
+	for _, tc := range cases {
+		props := findOp(tc.opName)
+		if props == nil {
+			t.Errorf("operation %q not emitted", tc.opName)
+			continue
+		}
+		got, ok := props[tc.wantKey]
+		if !ok {
+			t.Errorf("operation %q missing property %q (got props=%v)", tc.opName, tc.wantKey, props)
+			continue
+		}
+		if tc.wantExact && got != tc.wantValue {
+			t.Errorf("operation %q property %q = %q, want %q",
+				tc.opName, tc.wantKey, got, tc.wantValue)
+		}
+	}
+
+	// Setter pair: walk all operations named "UserProfile.full_name" and
+	// assert that decorator_setter = "full_name" is present on at least one.
+	foundSetter := false
+	for _, ent := range out {
+		if ent.Kind != "SCOPE.Operation" || ent.Name != "UserProfile.full_name" {
+			continue
+		}
+		if v, ok := ent.Properties["decorator_setter"]; ok && v == "full_name" {
+			foundSetter = true
+			break
+		}
+	}
+	if !foundSetter {
+		t.Errorf("expected at least one UserProfile.full_name operation with decorator_setter=full_name")
+	}
+
+	// @wraps(fn) on inner: the inner function lives inside the `memoize`
+	// outer body. The current extractor emits nested functions as
+	// Operations too (no parent class) — check that `decorator_wraps`
+	// carries the call-form snippet.
+	innerProps := findOp("inner")
+	if innerProps == nil {
+		// Tolerate: the extractor may not surface deeply-nested helpers.
+		t.Logf("inner not emitted as a top-level Operation (expected for nested helpers); skipping @wraps assertion")
+	} else if got, ok := innerProps["decorator_wraps"]; !ok || got == "" {
+		t.Errorf("expected decorator_wraps on inner (got props=%v)", innerProps)
+	}
+}
+
+// TestEmitGenericDecoratorProperties_2016_DoesNotOverwriteDRF asserts that the
+// generic decorator pass does NOT overwrite structured properties stamped by
+// the DRF @action pass. The action pass writes `drf_action`, `http_method`,
+// `http_methods`, `is_detail`, `url_path` on the method Operation; those keys
+// must survive untouched.
+func TestEmitGenericDecoratorProperties_2016_DoesNotOverwriteDRF(t *testing.T) {
+	src := `from rest_framework.decorators import action
+
+
+class ContractViewSet:
+    @action(detail=True, methods=["post"], url_path="approve")
+    def approve(self, request, pk=None):
+        return {"ok": True}
+`
+
+	e := &Extractor{}
+	out, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "fixture/contract_viewset.py",
+		Content:  []byte(src),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	var props map[string]string
+	for _, ent := range out {
+		if ent.Kind == "SCOPE.Operation" && ent.Name == "ContractViewSet.approve" {
+			props = ent.Properties
+			break
+		}
+	}
+	if props == nil {
+		t.Fatalf("ContractViewSet.approve not emitted")
+	}
+	// DRF-pass keys must survive.
+	wants := map[string]string{
+		"drf_action":  "true",
+		"http_method": "post",
+		"is_detail":   "true",
+		"url_path":    "approve",
+	}
+	for k, want := range wants {
+		if got := props[k]; got != want {
+			t.Errorf("property %q = %q, want %q (full props=%v)", k, got, want, props)
+		}
+	}
+	// And the generic pass must additionally stamp `decorator_action`
+	// (a call-form snippet starting with "@action").
+	if got, ok := props["decorator_action"]; !ok || got == "" {
+		t.Errorf("expected decorator_action call-form snippet, got %q", got)
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -362,6 +362,20 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		emitCBVInheritedMethodAnnotations(root, file, &entities)
 	}()
 
+	// Issue #2016 — generic decorator capture. For every decorated
+	// function/method, stamp `decorator_<name>` properties on the
+	// matching Operation entity. Generalises the pattern established
+	// by DRF @action (#2004) and Celery @shared_task (#2006) so that
+	// @property, @cached_property, @staticmethod, @classmethod,
+	// @contextmanager, @<name>.setter/.getter/.deleter, and arbitrary
+	// decorator factories become queryable graph signals. Runs last
+	// among the decorator-aware passes so specialised stamps from
+	// DRF / Celery / admin / signal passes win on key collisions.
+	func() {
+		defer func() { _ = recover() }()
+		emitGenericDecoratorProperties(root, file, &entities)
+	}()
+
 	// Issue #1991 — __init__.py re-export annotation.
 	// Stamps re_export / package_init / public / alias properties on
 	// IMPORTS edges of package __init__.py files. Returns the public

--- a/internal/extractors/python/issue1868_class_endline_test.go
+++ b/internal/extractors/python/issue1868_class_endline_test.go
@@ -1,0 +1,162 @@
+package python
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// Issue #1868 — Class/View entities still showed `end_line=0` sentinels in
+// production reindex output (dogfood R1 2026-05-23 on ContractViewSet:
+// "Source: core/views/contract_viewset.py (lines 1575-0)") even after the
+// #1964 fix landed. The fix targeted Operations + Modules; this regression
+// test pins down the Class/View cases the #1964 test fixture did not cover.
+//
+// Pinned shapes:
+//
+//  1. Decorated class (`@decorator class Foo:`) — the inner class_definition
+//     node is reached via decorated_definition.definition. Verifies that
+//     buildClass uses the inner node's EndPoint regardless of the wrapper.
+//
+//  2. Large class with multi-statement methods — verifies the end_line is
+//     the line of the LAST statement of the LAST method (the dedent line),
+//     not an early-truncated value.
+//
+//  3. Nested class — both outer and inner classes carry non-zero end_line
+//     that bracket their respective bodies.
+//
+//  4. Class with NO body (just `class Empty: pass` or `class Empty: ...`)
+//     — must still emit end_line ≥ start_line (no 0 sentinel).
+func TestPython_Issue1868_ClassEndLine_DecoratedAndLargeAndNested(t *testing.T) {
+	src := `# Issue #1868 fixture
+import logging
+
+
+@register("v1")
+class DecoratedView:
+    """Decorated class declared in the same file as a large class.
+
+    The decorated_definition wrapper must not cause the inner
+    class_definition's EndPoint to be lost.
+    """
+
+    def list(self, request):
+        return {"ok": True}
+
+    def create(self, request):
+        log = logging.getLogger(__name__)
+        log.info("creating")
+        return {"id": 1}
+
+
+class LargeViewSet:
+    """Multi-method class — end_line must reach the LAST statement of the
+    LAST method, not an early-truncated value."""
+
+    queryset = None
+    serializer_class = None
+
+    def list(self, request):
+        return self.queryset
+
+    def retrieve(self, request, pk=None):
+        obj = self.queryset.filter(pk=pk).first()
+        return obj
+
+    def create(self, request):
+        return {"created": True}
+
+    def update(self, request, pk=None):
+        obj = self.queryset.filter(pk=pk).first()
+        return obj
+
+    def destroy(self, request, pk=None):
+        return {"deleted": True}
+
+
+class Outer:
+    class Inner:
+        def inner_method(self):
+            return 42
+
+    def outer_method(self):
+        return Outer.Inner()
+
+
+class Empty:
+    pass
+
+
+class EllipsisOnly:
+    ...
+`
+
+	e := &Extractor{}
+	out, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "fixture/issue1868.py",
+		Content:  []byte(src),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	// Total file line count (used as the upper-bound sanity check — no
+	// class's end_line should exceed the file length).
+	fileLineCount := strings.Count(src, "\n") + 1
+
+	type want struct {
+		minStart int
+		maxEnd   int
+		minSpan  int // end - start
+	}
+	wants := map[string]want{
+		// Decorated class spans roughly the docstring + 2 methods.
+		"DecoratedView": {minStart: 1, maxEnd: fileLineCount, minSpan: 8},
+		// Large class spans many methods.
+		"LargeViewSet": {minStart: 1, maxEnd: fileLineCount, minSpan: 20},
+		// Outer class wraps Inner + outer_method.
+		"Outer": {minStart: 1, maxEnd: fileLineCount, minSpan: 6},
+		// Nested classes are emitted with dotted names.
+		"Outer.Inner": {minStart: 1, maxEnd: fileLineCount, minSpan: 2},
+		// Empty classes must still have end_line ≥ start_line.
+		"Empty":         {minStart: 1, maxEnd: fileLineCount, minSpan: 0},
+		"EllipsisOnly":  {minStart: 1, maxEnd: fileLineCount, minSpan: 0},
+	}
+
+	seen := map[string]bool{}
+	for _, ent := range out {
+		if ent.Kind != "SCOPE.Component" || ent.Subtype != "class" {
+			continue
+		}
+		w, ok := wants[ent.Name]
+		if !ok {
+			continue
+		}
+		seen[ent.Name] = true
+		if ent.StartLine < w.minStart {
+			t.Errorf("class %q: start_line=%d < minStart=%d", ent.Name, ent.StartLine, w.minStart)
+		}
+		if ent.EndLine <= 0 {
+			t.Errorf("class %q: end_line=%d — issue #1868 sentinel re-introduced", ent.Name, ent.EndLine)
+		}
+		if ent.EndLine > w.maxEnd {
+			t.Errorf("class %q: end_line=%d > maxEnd=%d (file length)", ent.Name, ent.EndLine, w.maxEnd)
+		}
+		if ent.EndLine < ent.StartLine {
+			t.Errorf("class %q: end_line(%d) < start_line(%d)", ent.Name, ent.EndLine, ent.StartLine)
+		}
+		span := ent.EndLine - ent.StartLine
+		if span < w.minSpan {
+			t.Errorf("class %q: span=%d (start=%d end=%d) < minSpan=%d — body likely truncated",
+				ent.Name, span, ent.StartLine, ent.EndLine, w.minSpan)
+		}
+	}
+	for name := range wants {
+		if !seen[name] {
+			t.Errorf("class %q not emitted", name)
+		}
+	}
+}


### PR DESCRIPTION
## What

Six-ticket Python extractor + docgen enrichment cluster, scoped to the
dogfood R1-R3 + W7-W8 evidence gathered 2026-05-23.

Closes #1862
Closes #1867
Closes #1868
Closes #1877
Closes #2012
Closes #2016

## Why

Class-seed and Model-seed docgen quality was bottlenecked by six related
gaps in the Python extractor's graph signal — `@action` HTTP metadata
invisible on method neighbours, foreign-Model typed dependencies not
reaching 1-hop, Class `end_line=0` sentinels mid-source, Schema fields
typeless on neighbour briefs, EXTENDS edges dropped from
`neighbour_briefs`, and decorator capture limited to DRF/Celery. Each
on its own is small; together they were the single biggest cause of
"limited source" hedging in dogfood class pages.

## How

### Indexer side (`internal/extractors/python`)

`decorators_generic.go` (new, #2016). Post-pass that walks every
`decorated_definition` and stamps `decorator_<leaf>` properties on the
matching `SCOPE.Operation`:

- `@property` / `@cached_property` / `@staticmethod` / `@classmethod` /
  `@contextmanager` → `"true"`
- `@<x>.setter` / `@<x>.getter` / `@<x>.deleter` → `"<x>"`
- `@cache(ttl=300)` / `@functools.wraps(fn)` / arbitrary call-form
  decorators → full snippet (capped 200 chars)
- Never overwrites a property already set by a specialised pass — DRF
  `@action`'s structured `http_method`/`is_detail`/`url_path` survives
  untouched.

Wired as the last decorator-aware pass in `Extract`.

### Docgen side (`internal/docgen`)

`NeighbourBrief` extended with:

- `HTTPMethod` / `HTTPMethods` / `URLPath` / `IsDetail` (#1862) —
  copied from neighbour entity Properties.
- `TypeHint` (#1877) — built by `buildNeighbourTypeHint` /
  `composeDjangoFieldTypeHint`. Render conventions:
  - `ForeignKey(Client) on_delete=CASCADE`
  - `CharField(max_length=10, choices=STATUS_CHOICES)`
  - `BooleanField default=False`
  - Falls back to `typeHintFromSignature` for Python type-annotated
    attributes (`x: int` → `"int"`).

`loadEntityContext` (`tier0.go`) extended (#1867). When seed is a
class-shaped entity (`isClassSeedForMethodHop`), walk one extra hop
through each contained `SCOPE.Operation` along outbound REFERENCES /
CALLS / DEPENDS_ON / FK_TO / IMPLEMENTS / DEPENDS_ON_CONFIG /
RESOLVED_BY edges and surface the targets as neighbours stamped with
`via_method_hop=true`. Total second-hop additions capped at
`classMethodHopCap = 25`.

### Coverage tests

- `internal/extractors/python/decorators_generic_test.go` (#2016) —
  property/cached_property/staticmethod/classmethod/contextmanager
  all stamp `decorator_<leaf>`; DRF @action specialised properties
  survive intact alongside `decorator_action`.
- `internal/extractors/python/issue1868_class_endline_test.go`
  (#1868) — decorated class, large multi-method class, nested
  Outer.Inner, `class Empty: pass`, `class EllipsisOnly: ...` all
  carry non-zero end_line that bracket the body.
- `internal/docgen/llm_bundle_python_enrichment_test.go` (#1862,
  #1867, #1877, #2012) — four bundle assertions on hand-built graph
  fixtures: HTTP metadata propagation, depth-2 class-method hop,
  Django field TypeHint composition, EXTENDS edge visibility.

## Sequencing notes

`#1868` and `#2012` are closed by verification (no production code
change). Investigation showed:

- `#1868`: `buildClass` already sets `EndLine = node.EndPoint().Row+1`
  (line 773) for both bare and decorated branches, and the line-bound
  safety net at line 421 catches escapees. The dogfood `1575-0`
  evidence was against a pre-#1964 graph state. The new test pins
  down the corner cases the existing #1964 test fixture did not cover
  so a future regression cannot reintroduce the sentinel.
- `#2012`: `extractBaseClasses` already emits EXTENDS edges from both
  bare (line 522) and decorated (line 680) class branches, and
  `NeighbourBrief.Relationship` preserves the edge kind verbatim
  post-#1879. The new test pins down that EXTENDS surfaces with the
  literal kind.

## Risks

- `classMethodHopCap=25` is a heuristic. A god-class with many tiny
  methods touching many foreign models could overflow before
  reaching every typed dep; the existing direct-child briefs still
  surface so the LLM can drill in via the MCP.
- `composeDjangoFieldTypeHint` only renders `kwarg.to` for relational
  fields (positional `ForeignKey(Building, ...)` doesn't stamp
  `kwarg.to` — the target is recorded as a separate REFERENCES edge
  instead). Mitigated: the LLM still sees the target via the
  REFERENCES edge on the same field's brief; the TypeHint
  degrades to bare `ForeignKey on_delete=CASCADE` in that case.

## Verification

```
go build ./...                                                    # clean
go vet ./internal/extractors/python/... ./internal/docgen/...     # clean
go test ./internal/extractors/python/... ./internal/docgen/...    # PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)