### PR TITLE
fix(go-extractor): Windows build-tag variant entity receives caller edges via build_tag-aware merge (#1818)

### DIFF
--- a/internal/resolve/platform_variants_test.go
+++ b/internal/resolve/platform_variants_test.go
@@ -379,3 +379,200 @@ func TestBuildIndex_PlatformVariant_NoTags_StillAmbiguous(t *testing.T) {
 		t.Fatalf("regression: no-tag ambiguity should not resolve; ToID=%q", got)
 	}
 }
+
+// -----------------------------------------------------------------------
+// Issue #1818 — CALLS fan-out: both platform variants receive caller edges.
+// -----------------------------------------------------------------------
+
+// TestBuildIndex_PlatformVariant_BothVariantsReceiveCallerEdge is the primary
+// regression test for #1818. After #1815 the resolver correctly resolves a
+// CALLS stub to the canonical (Unix) variant, but the Windows variant ends up
+// with zero inbound edges so find_callers returns "no_incoming_edges" for it.
+//
+// After the fix, ReferencesEmbeddedWithAllowlist must clone the resolved CALLS
+// relationship so both the canonical AND every non-canonical variant ID appear
+// as ToID in at least one CALLS edge in the output.
+func TestBuildIndex_PlatformVariant_BothVariantsReceiveCallerEdge(t *testing.T) {
+	// Mirrors the live dogfood scenario from #1818:
+	//   read_source_unix.go    //go:build darwin || linux   ID=aaaa…
+	//   read_source_windows.go //go:build windows           ID=bbbb…
+	//   tools.go               (no build tag)  CALLS readSourceWindow
+	entities := []types.EntityRecord{
+		{
+			ID:         "aaaaaaaaaaaaaaaa",
+			Kind:       "SCOPE.Operation",
+			Name:       "readSourceWindow",
+			SourceFile: "internal/mcp/read_source_unix.go",
+			Language:   "go",
+			Properties: map[string]string{"build_tag": "darwin || linux"},
+		},
+		{
+			ID:         "bbbbbbbbbbbbbbbb",
+			Kind:       "SCOPE.Operation",
+			Name:       "readSourceWindow",
+			SourceFile: "internal/mcp/read_source_windows.go",
+			Language:   "go",
+			Properties: map[string]string{"build_tag": "windows"},
+		},
+		{
+			ID:         "cccccccccccccccc",
+			Kind:       "SCOPE.Operation",
+			Name:       "handleGetSource",
+			SourceFile: "internal/mcp/tools.go",
+			Language:   "go",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: "cccccccccccccccc",
+					ToID:   "scope:operation:method:go:internal/mcp/tools.go:readSourceWindow",
+					Kind:   "CALLS",
+					Properties: map[string]string{"language": "go"},
+				},
+			},
+		},
+	}
+	idx := BuildIndex(entities)
+	_ = ReferencesEmbedded(entities, idx)
+
+	// Collect all ToIDs emitted by the caller (entity index 2).
+	callerRels := entities[2].Relationships
+	toIDs := make(map[string]bool, len(callerRels))
+	for _, r := range callerRels {
+		toIDs[r.ToID] = true
+	}
+
+	// Both the canonical (unix) and the non-canonical (windows) variant must
+	// appear as a CALLS target. Before the fix, only one of them did.
+	if !toIDs["aaaaaaaaaaaaaaaa"] {
+		t.Errorf("#1818: unix variant aaaa… not present in caller's CALLS edges; toIDs=%v", toIDs)
+	}
+	if !toIDs["bbbbbbbbbbbbbbbb"] {
+		t.Errorf("#1818: windows variant bbbb… not present in caller's CALLS edges; toIDs=%v", toIDs)
+	}
+	if len(callerRels) < 2 {
+		t.Errorf("#1818: expected at least 2 CALLS relationships (one per variant), got %d", len(callerRels))
+	}
+}
+
+// TestBuildIndex_PlatformVariant_MultipleCallers_BothVariantsReceiveAll tests
+// that when there are MULTIPLE callers of a platform-split function, every
+// caller fans out its CALLS edge to both variants.
+func TestBuildIndex_PlatformVariant_MultipleCallers_BothVariantsReceiveAll(t *testing.T) {
+	entities := []types.EntityRecord{
+		{
+			ID:         "aaaaaaaaaaaaaaaa",
+			Kind:       "SCOPE.Operation",
+			Name:       "openPlatformFd",
+			SourceFile: "pkg/fd_unix.go",
+			Language:   "go",
+			Properties: map[string]string{"build_tag": "darwin || linux"},
+		},
+		{
+			ID:         "bbbbbbbbbbbbbbbb",
+			Kind:       "SCOPE.Operation",
+			Name:       "openPlatformFd",
+			SourceFile: "pkg/fd_windows.go",
+			Language:   "go",
+			Properties: map[string]string{"build_tag": "windows"},
+		},
+		// First caller.
+		{
+			ID:         "cccccccccccccccc",
+			Kind:       "SCOPE.Operation",
+			Name:       "callerA",
+			SourceFile: "pkg/caller_a.go",
+			Language:   "go",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: "cccccccccccccccc",
+					ToID:   "scope:operation:method:go:pkg/caller_a.go:openPlatformFd",
+					Kind:   "CALLS",
+					Properties: map[string]string{"language": "go"},
+				},
+			},
+		},
+		// Second caller.
+		{
+			ID:         "dddddddddddddddd",
+			Kind:       "SCOPE.Operation",
+			Name:       "callerB",
+			SourceFile: "pkg/caller_b.go",
+			Language:   "go",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: "dddddddddddddddd",
+					ToID:   "scope:operation:method:go:pkg/caller_b.go:openPlatformFd",
+					Kind:   "CALLS",
+					Properties: map[string]string{"language": "go"},
+				},
+			},
+		},
+	}
+	idx := BuildIndex(entities)
+	_ = ReferencesEmbedded(entities, idx)
+
+	// Both callers must have expanded their single stub into two CALLS edges.
+	for i, callerName := range []string{"callerA", "callerB"} {
+		rels := entities[2+i].Relationships
+		toIDs := make(map[string]bool, len(rels))
+		for _, r := range rels {
+			toIDs[r.ToID] = true
+		}
+		if !toIDs["aaaaaaaaaaaaaaaa"] || !toIDs["bbbbbbbbbbbbbbbb"] {
+			t.Errorf("#1818 multiple callers: %s missing variant edge; toIDs=%v", callerName, toIDs)
+		}
+	}
+}
+
+// TestBuildIndex_PlatformVariant_NoFanOutForAmbiguous verifies that the
+// platform-variant fan-out does NOT fire when the two definitions are
+// ambiguous (overlapping or missing build tags) — i.e. we never introduce
+// false caller edges for genuine same-name collisions.
+func TestBuildIndex_PlatformVariant_NoFanOutForAmbiguous(t *testing.T) {
+	// Two functions with no build tags — genuine ambiguity.
+	entities := []types.EntityRecord{
+		{
+			ID:         "aaaaaaaaaaaaaaaa",
+			Kind:       "SCOPE.Operation",
+			Name:       "doWork",
+			SourceFile: "pkg/a.go",
+			Language:   "go",
+		},
+		{
+			ID:         "bbbbbbbbbbbbbbbb",
+			Kind:       "SCOPE.Operation",
+			Name:       "doWork",
+			SourceFile: "pkg/b.go",
+			Language:   "go",
+		},
+		{
+			ID:         "cccccccccccccccc",
+			Kind:       "SCOPE.Operation",
+			Name:       "caller",
+			SourceFile: "pkg/caller.go",
+			Language:   "go",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: "cccccccccccccccc",
+					ToID:   "scope:operation:method:go:pkg/caller.go:doWork",
+					Kind:   "CALLS",
+					Properties: map[string]string{"language": "go"},
+				},
+			},
+		},
+	}
+	idx := BuildIndex(entities)
+	_ = ReferencesEmbedded(entities, idx)
+
+	// The stub must remain unresolved (ambiguous sentinel → no rewrite).
+	// Crucially, PlatformVariants must be empty so no fan-out occurs.
+	if len(idx.PlatformVariants) != 0 {
+		t.Errorf("#1818 fan-out guard: PlatformVariants must be empty for ambiguous pair, got %v", idx.PlatformVariants)
+	}
+	rels := entities[2].Relationships
+	if len(rels) != 1 {
+		t.Errorf("#1818 fan-out guard: caller should still have exactly 1 relationship, got %d", len(rels))
+	}
+	if rels[0].ToID == "aaaaaaaaaaaaaaaa" || rels[0].ToID == "bbbbbbbbbbbbbbbb" {
+		t.Errorf("#1818 fan-out guard: ambiguous doWork must not resolve; ToID=%q", rels[0].ToID)
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -481,6 +481,17 @@ type Index struct {
 	// instead of binding to an arbitrary same-named component in the same
 	// package (extremely rare in practice).
 	byPackageComponent map[string]map[string]string
+
+	// PlatformVariants maps a canonical platform-variant entity ID to the
+	// slice of non-canonical variant entity IDs that were merged into it
+	// during BuildIndex. Populated when byPackageOperation detects a
+	// mutually-exclusive build-tag pair (e.g. _unix.go "darwin||linux" vs
+	// _windows.go "windows") and keeps the alphabetically-first SourceFile
+	// as the canonical. The non-canonical IDs are stored here so that
+	// ReferencesEmbeddedWithAllowlist can clone resolved CALLS edges to
+	// point at both the canonical AND every non-canonical variant, giving
+	// each variant identical caller lists in the output graph (#1818).
+	PlatformVariants map[string][]string
 }
 
 // LocationIndex maps file_path -> name -> entity_id, retaining only entries
@@ -686,6 +697,7 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		byPackageOperation: make(map[string]map[string]string),
 		byPackageComponent: make(map[string]map[string]string),
 		byQualifiedName:    make(map[string]string),
+		PlatformVariants:   make(map[string][]string),
 	}
 
 	// Issue #1811 — build-tag tracking side-tables.
@@ -1045,8 +1057,10 @@ func BuildIndex(entities []types.EntityRecord) Index {
 						// update it to the incoming ID if the incoming file
 						// sorts earlier.
 						canonicalID := existing
+						nonCanonicalID := e.ID
 						if sourceFile < srcBucket[e.Name] {
 							canonicalID = e.ID
+							nonCanonicalID = existing
 							srcBucket[e.Name] = sourceFile
 						}
 						pkgBucket[e.Name] = canonicalID
@@ -1054,6 +1068,12 @@ func BuildIndex(entities []types.EntityRecord) Index {
 						// so a third variant (if ever present) can extend
 						// the same mutual-exclusion check.
 						tagBucket[e.Name] = mergePlatformVariantTags(existingTag, incomingTag)
+						// Issue #1818 — record the non-canonical variant so
+						// ReferencesEmbeddedWithAllowlist can clone CALLS edges
+						// to both the canonical and every non-canonical variant,
+						// giving each platform-split function identical caller
+						// lists in the output graph.
+						idx.PlatformVariants[canonicalID] = append(idx.PlatformVariants[canonicalID], nonCanonicalID)
 					} else {
 						pkgBucket[e.Name] = "" // blank sentinel → ambiguous
 					}
@@ -1107,12 +1127,17 @@ func BuildIndex(entities []types.EntityRecord) Index {
 					existingTag := tagBucket[e.Name]
 					if buildTagsMutuallyExclusive(existingTag, incomingTag) {
 						canonicalID := existing
+						nonCanonicalID := e.ID
 						if sourceFile < srcBucket[e.Name] {
 							canonicalID = e.ID
+							nonCanonicalID = existing
 							srcBucket[e.Name] = sourceFile
 						}
 						pkgBucket[e.Name] = canonicalID
 						tagBucket[e.Name] = mergePlatformVariantTags(existingTag, incomingTag)
+						// Issue #1818 — mirror PlatformVariants tracking for
+						// Component-family platform splits (struct/interface).
+						idx.PlatformVariants[canonicalID] = append(idx.PlatformVariants[canonicalID], nonCanonicalID)
 					} else {
 						pkgBucket[e.Name] = "" // blank sentinel → ambiguous
 					}
@@ -5158,6 +5183,48 @@ func ReferencesEmbeddedWithAllowlist(records []types.EntityRecord, idx Index, al
 			}
 		}
 	}
+	// Issue #1818 — platform-variant CALLS fan-out.
+	//
+	// After the main resolution pass every CALLS edge whose ToID was resolved
+	// to the canonical platform-variant entity (e.g. the Unix variant that
+	// sorts alphabetically first) has been rewritten in place. The non-canonical
+	// variant (e.g. the Windows function) therefore still has zero inbound edges
+	// in the output graph, which makes find_callers return "no_incoming_edges"
+	// for it.
+	//
+	// For every entity that owns at least one CALLS relationship whose ToID is
+	// a canonical platform-variant entity, clone that relationship for each
+	// non-canonical sibling. The clone is appended to the calling entity's
+	// Relationships slice so the output graph carries identical caller lists
+	// for both the canonical and all non-canonical variants.
+	//
+	// We only do this when idx.PlatformVariants is non-empty (the vast majority
+	// of codebases have no platform splits — no-op path has no cost).
+	if len(idx.PlatformVariants) > 0 {
+		for k := range records {
+			rels := records[k].Relationships
+			var extras []types.RelationshipRecord
+			for j := range rels {
+				r := &rels[j]
+				if strings.ToUpper(r.Kind) != "CALLS" {
+					continue
+				}
+				nonCanonicals, ok := idx.PlatformVariants[r.ToID]
+				if !ok || len(nonCanonicals) == 0 {
+					continue
+				}
+				for _, ncID := range nonCanonicals {
+					clone := *r
+					clone.ToID = ncID
+					extras = append(extras, clone)
+				}
+			}
+			if len(extras) > 0 {
+				records[k].Relationships = append(records[k].Relationships, extras...)
+			}
+		}
+	}
+
 	stats.finalizeDispositions()
 	return stats
 }


### PR DESCRIPTION
## Problem

After #1815 landed, `byPackageOperation` correctly merges platform-variant function pairs into a single canonical entity (alphabetically-first source file wins). All callers' CALLS edges resolve to that canonical ID.

However the **non-canonical variant** (the Windows function, whose file sorts after the Unix one) ends up with **zero inbound edges** in the output graph. `find_callers` does a BFS on `adj.in[entity_id]` — if that slice is empty, it returns `"no_incoming_edges"`.

Live dogfood reproduction from #1818:
- `archigraph::4dad42008147580f` (`read_source_unix.go`) → 5 callers ✅
- `archigraph::3da01299a609c577` (`read_source_windows.go`) → `no_incoming_edges` ❌

## Root cause

`BuildIndex` selects a canonical entity ID and stores it in `byPackageOperation[pkgDir][name]`. `ReferencesEmbeddedWithAllowlist` rewrites each caller's CALLS stub to that one canonical ID. The non-canonical variant's entity ID never appears as a `ToID` in any relationship, so `buildAdjacency` produces an empty `adj.in` for it.

## Fix

Two-part change, both in `internal/resolve/refs.go`:

**1. Track non-canonical variant IDs during `BuildIndex`**

Added `PlatformVariants map[string][]string` field to `Index` (canonical ID → slice of non-canonical IDs). Populated in both the `byPackageOperation` and `byPackageComponent` merge paths whenever `buildTagsMutuallyExclusive` fires.

**2. Fan out resolved CALLS edges in `ReferencesEmbeddedWithAllowlist`**

After the main resolution loop, a second pass walks every entity's resolved CALLS relationships. For each relationship whose `ToID` is a canonical platform variant, it appends a cloned relationship pointing to each non-canonical variant. Both variants now appear as `ToID` in the output graph and get identical inbound edge lists.

The fan-out pass is gated on `len(idx.PlatformVariants) > 0` so codebases with no platform splits pay zero cost.

## Tests

Added three tests in `internal/resolve/platform_variants_test.go`:

| Test | Covers |
|---|---|
| `TestBuildIndex_PlatformVariant_BothVariantsReceiveCallerEdge` | Primary #1818 scenario: single caller of `readSourceWindow` must emit CALLS to both `unix` and `windows` entity IDs |
| `TestBuildIndex_PlatformVariant_MultipleCallers_BothVariantsReceiveAll` | Multiple callers — each must fan out independently |
| `TestBuildIndex_PlatformVariant_NoFanOutForAmbiguous` | Guard: genuinely ambiguous (no build tags) pair must NOT fan out |

All existing `#1811` tests continue to pass unchanged.

## Verification

```
go test ./internal/extractors/golang/... ./internal/mcp/... ./internal/resolve/...
ok   github.com/cajasmota/archigraph/internal/extractors/golang
ok   github.com/cajasmota/archigraph/internal/mcp
ok   github.com/cajasmota/archigraph/internal/resolve
```

Zero failures.

## Scope

- `internal/resolve/refs.go` — `Index` struct + `BuildIndex` + `ReferencesEmbeddedWithAllowlist`
- `internal/resolve/platform_variants_test.go` — 3 new regression tests

No changes to the extractor, MCP server, or graph serialisation.

Closes #1818