### PR TITLE
fix(docgen): field_type + kwargs in class_manifest + synthetic Module manifest population (#1978 #1969)

### DIFF
--- a/internal/docgen/issue1969_synthetic_module_test.go
+++ b/internal/docgen/issue1969_synthetic_module_test.go
@@ -1,0 +1,426 @@
+package docgen_test
+
+// issue1969_synthetic_module_test.go — regression tests for #1969: synthetic
+// Module entities (aggregate containers from module/aggregate.go with
+// Properties["synthetic"]="true") should:
+//   - set gc.SyntheticModule = true
+//   - populate ModuleManifest from CONTAINS children when present
+//   - not set ModuleReadme / ModuleConfigs (no source file)
+//
+// Also verifies that SCOPE.Component(file) proxy entities are correctly skipped
+// from the Classes bucket in ModuleManifest so a module whose only CONTAINS
+// child is a file proxy doesn't return a non-nil manifest with a stale entry.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/docgen"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// issue1969SyntheticHarness builds a graph with a synthetic aggregate Module
+// entity (Kind="Module", Properties["synthetic"]="true", SourceFile="") and
+// CONTAINS children of varying kinds.
+//
+//   - funcID: SCOPE.Operation/function child
+//   - classID: SCOPE.Component/class child
+func issue1969SyntheticHarness(t *testing.T) (groupName, synthModuleID string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName = "issue-1969-synthetic-module-test"
+
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir fleet config dir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name":  groupName,
+		"repos": []map[string]interface{}{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write fleet config: %v", err)
+	}
+
+	// Synthetic aggregate module: no SourceFile, synthetic=true in Properties.
+	// This mirrors the output of internal/module/aggregate.go.
+	synthModID := graph.EntityID("repo", "Module", "myapp.services", "")
+	funcID := graph.EntityID("repo", "SCOPE.Operation", "do_work", "myapp/services/tasks.py")
+	classID := graph.EntityID("repo", "SCOPE.Component", "TaskQueue", "myapp/services/queue.py")
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Entities: []graph.Entity{
+			{
+				ID:         synthModID,
+				Name:       "myapp.services",
+				Kind:       "Module",
+				SourceFile: "", // synthetic: no source file
+				Properties: map[string]string{
+					"synthetic": "true",
+					"module":    "myapp.services",
+					"repo":      "repo",
+				},
+			},
+			{
+				ID:         funcID,
+				Name:       "do_work",
+				Kind:       "SCOPE.Operation",
+				Subtype:    "function",
+				SourceFile: "myapp/services/tasks.py",
+				StartLine:  10,
+				Language:   "python",
+				Properties: map[string]string{"module": "myapp.services"},
+			},
+			{
+				ID:         classID,
+				Name:       "TaskQueue",
+				Kind:       "SCOPE.Component",
+				Subtype:    "class",
+				SourceFile: "myapp/services/queue.py",
+				StartLine:  5,
+				Language:   "python",
+				Properties: map[string]string{"module": "myapp.services"},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{
+				ID:     graph.RelationshipID(synthModID, funcID, "CONTAINS"),
+				FromID: synthModID,
+				ToID:   funcID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(synthModID, classID, "CONTAINS"),
+				FromID: synthModID,
+				ToID:   classID,
+				Kind:   "CONTAINS",
+			},
+		},
+	}
+	docJSON, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	return groupName, synthModID
+}
+
+// TestBuildBundle_SyntheticModule_Flag verifies that gc.SyntheticModule is set
+// to true when the seed Module entity has Properties["synthetic"]="true" and
+// SourceFile="" (#1969).
+func TestBuildBundle_SyntheticModule_Flag(t *testing.T) {
+	groupName, modID := issue1969SyntheticHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: modID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	if !bundle.GraphContext.SyntheticModule {
+		t.Error("gc.SyntheticModule is false — expected true for synthetic aggregate module")
+	}
+}
+
+// TestBuildBundle_SyntheticModule_NoReadme verifies that gc.ModuleReadme is nil
+// for a synthetic aggregate module (no source file to look for README near) (#1969).
+func TestBuildBundle_SyntheticModule_NoReadme(t *testing.T) {
+	groupName, modID := issue1969SyntheticHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: modID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	if bundle.GraphContext.ModuleReadme != nil {
+		t.Errorf("gc.ModuleReadme is non-nil for synthetic module — expected nil: %+v", bundle.GraphContext.ModuleReadme)
+	}
+}
+
+// TestBuildBundle_SyntheticModule_ManifestFromContainsChildren verifies that
+// gc.ModuleManifest is populated from the CONTAINS children of a synthetic
+// aggregate module when those children are present (#1969).
+func TestBuildBundle_SyntheticModule_ManifestFromContainsChildren(t *testing.T) {
+	groupName, modID := issue1969SyntheticHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: modID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	mm := bundle.GraphContext.ModuleManifest
+	if mm == nil {
+		t.Fatal("gc.ModuleManifest is nil — expected non-nil: synthetic module has CONTAINS children that should populate the manifest")
+	}
+
+	// Should have a function from do_work.
+	if len(mm.Functions) == 0 {
+		t.Errorf("ModuleManifest.Functions is empty — expected do_work to appear")
+	}
+	foundFunc := false
+	for _, f := range mm.Functions {
+		if f.Name == "do_work" {
+			foundFunc = true
+			break
+		}
+	}
+	if !foundFunc {
+		t.Errorf("do_work not found in ModuleManifest.Functions: %+v", mm.Functions)
+	}
+
+	// Should have a class from TaskQueue.
+	if len(mm.Classes) == 0 {
+		t.Errorf("ModuleManifest.Classes is empty — expected TaskQueue to appear")
+	}
+	foundClass := false
+	for _, c := range mm.Classes {
+		if c.Name == "TaskQueue" {
+			foundClass = true
+			break
+		}
+	}
+	if !foundClass {
+		t.Errorf("TaskQueue not found in ModuleManifest.Classes: %+v", mm.Classes)
+	}
+}
+
+// TestBuildBundle_SyntheticModule_Flag_False_ForRealModule verifies that
+// gc.SyntheticModule is NOT set for a regular (non-synthetic) Module entity.
+func TestBuildBundle_SyntheticModule_Flag_False_ForRealModule(t *testing.T) {
+	// Re-use the moduleManifestHarness which builds a real SCOPE.Module entity
+	// with SourceFile and children.
+	groupName, moduleID := moduleManifestHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: moduleID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	if bundle.GraphContext.SyntheticModule {
+		t.Error("gc.SyntheticModule is true for a real (non-synthetic) module — should be false")
+	}
+}
+
+// TestBuildBundle_ModuleManifest_FileProxySkipped verifies that SCOPE.Component
+// entities with Subtype="file" are NOT counted in the Classes bucket of
+// ModuleManifest, so they don't pollute the manifest with proxy entities (#1969).
+func TestBuildBundle_ModuleManifest_FileProxySkipped(t *testing.T) {
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName := "issue-1969-file-proxy-test"
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name":  groupName,
+		"repos": []map[string]interface{}{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	moduleID := graph.EntityID("repo", "Module", "myapp.views", "myapp/views.py")
+	// This is the file-proxy entity emitted by the Python extractor (#2020).
+	fileProxyID := graph.EntityID("repo", "SCOPE.Component", "myapp/views.py", "myapp/views.py")
+	realClassID := graph.EntityID("repo", "SCOPE.Component", "HomeView", "myapp/views.py")
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Entities: []graph.Entity{
+			{
+				ID:         moduleID,
+				Name:       "myapp.views",
+				Kind:       "Module",
+				SourceFile: "myapp/views.py",
+				Language:   "python",
+			},
+			{
+				ID:         fileProxyID,
+				Name:       "myapp/views.py",
+				Kind:       "SCOPE.Component",
+				Subtype:    "file", // file proxy — should be skipped
+				SourceFile: "myapp/views.py",
+				StartLine:  1,
+				Language:   "python",
+			},
+			{
+				ID:         realClassID,
+				Name:       "HomeView",
+				Kind:       "SCOPE.Component",
+				Subtype:    "class", // real class — should appear in Classes bucket
+				SourceFile: "myapp/views.py",
+				StartLine:  10,
+				Language:   "python",
+			},
+		},
+		Relationships: []graph.Relationship{
+			{
+				ID:     graph.RelationshipID(moduleID, fileProxyID, "CONTAINS"),
+				FromID: moduleID,
+				ToID:   fileProxyID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(moduleID, realClassID, "CONTAINS"),
+				FromID: moduleID,
+				ToID:   realClassID,
+				Kind:   "CONTAINS",
+			},
+		},
+	}
+	docJSON, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: moduleID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	mm := bundle.GraphContext.ModuleManifest
+	if mm == nil {
+		t.Fatal("ModuleManifest is nil — expected non-nil since module has a real class child")
+	}
+
+	// Verify the file proxy is NOT in Classes.
+	for _, c := range mm.Classes {
+		if c.KindSubtype == "file" {
+			t.Errorf("file proxy entity found in ModuleManifest.Classes: %+v — file proxies should be skipped", c)
+		}
+	}
+
+	// Verify the real class IS in Classes.
+	found := false
+	for _, c := range mm.Classes {
+		if c.Name == "HomeView" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("HomeView not found in ModuleManifest.Classes: %+v — real class should be present", mm.Classes)
+	}
+
+	// Classes bucket should have exactly 1 entry (HomeView only, not the file proxy).
+	if len(mm.Classes) != 1 {
+		t.Errorf("ModuleManifest.Classes has %d entries, want 1 (file proxy must be excluded): %+v", len(mm.Classes), mm.Classes)
+	}
+}

--- a/internal/docgen/issue1978_field_type_test.go
+++ b/internal/docgen/issue1978_field_type_test.go
@@ -1,0 +1,280 @@
+package docgen_test
+
+// issue1978_field_type_test.go — regression tests for #1978: field_type and
+// kwargs must be populated in class_manifest.fields[] entries when the child
+// SCOPE.Schema field entity carries Properties["field_type"] and
+// Properties["kwarg.*"] stamped by django_relational.go.
+//
+// Verify on a Django-like Model with:
+//   - a CharField with kwarg.max_length
+//   - a ForeignKey with kwarg.to + kwarg.on_delete
+//   - a plain field (no Properties) that should still work (empty FieldType)
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/docgen"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// issue1978Harness sets up an isolated test environment with a Django-like
+// Model class entity that has SCOPE.Schema/field children carrying
+// Properties["field_type"] and Properties["kwarg.*"].
+func issue1978Harness(t *testing.T) (groupName, classEntityID string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName = "issue-1978-field-type-test"
+
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir fleet config dir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name":  groupName,
+		"repos": []map[string]interface{}{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write fleet config: %v", err)
+	}
+
+	// Entities.
+	modelID := graph.EntityID("repo", "SCOPE.Model", "Building", "models/building.py")
+	charFieldID := graph.EntityID("repo", "SCOPE.Schema", "Building.name", "models/building.py")
+	fkFieldID := graph.EntityID("repo", "SCOPE.Schema", "Building.client", "models/building.py")
+	plainFieldID := graph.EntityID("repo", "SCOPE.Schema", "Building.active", "models/building.py")
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Entities: []graph.Entity{
+			{
+				ID:         modelID,
+				Name:       "Building",
+				Kind:       "SCOPE.Model",
+				Subtype:    "model",
+				SourceFile: "models/building.py",
+				StartLine:  1,
+				Language:   "python",
+				Signature:  "class Building",
+			},
+			{
+				ID:         charFieldID,
+				Name:       "Building.name",
+				Kind:       "SCOPE.Schema",
+				Subtype:    "field",
+				SourceFile: "models/building.py",
+				StartLine:  5,
+				Language:   "python",
+				Properties: map[string]string{
+					"field_type":     "CharField",
+					"kwarg.max_length": "200",
+				},
+			},
+			{
+				ID:         fkFieldID,
+				Name:       "Building.client",
+				Kind:       "SCOPE.Schema",
+				Subtype:    "field",
+				SourceFile: "models/building.py",
+				StartLine:  6,
+				Language:   "python",
+				Properties: map[string]string{
+					"field_type":      "ForeignKey",
+					"kwarg.to":        "Client",
+					"kwarg.on_delete": "CASCADE",
+				},
+			},
+			{
+				ID:         plainFieldID,
+				Name:       "Building.active",
+				Kind:       "SCOPE.Schema",
+				Subtype:    "field",
+				SourceFile: "models/building.py",
+				StartLine:  7,
+				Language:   "python",
+				Signature:  "active: bool",
+				// No field_type / kwargs properties.
+			},
+		},
+		Relationships: []graph.Relationship{
+			{
+				ID:     graph.RelationshipID(modelID, charFieldID, "CONTAINS"),
+				FromID: modelID,
+				ToID:   charFieldID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(modelID, fkFieldID, "CONTAINS"),
+				FromID: modelID,
+				ToID:   fkFieldID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(modelID, plainFieldID, "CONTAINS"),
+				FromID: modelID,
+				ToID:   plainFieldID,
+				Kind:   "CONTAINS",
+			},
+		},
+	}
+	docJSON, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	return groupName, modelID
+}
+
+// TestBuildBundle_ClassManifest_FieldType verifies that class_manifest.fields
+// entries carry field_type when Properties["field_type"] is set on the child
+// SCOPE.Schema entity (#1978).
+func TestBuildBundle_ClassManifest_FieldType(t *testing.T) {
+	groupName, classID := issue1978Harness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: classID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	m := bundle.GraphContext.ClassManifest
+	if m == nil {
+		t.Fatal("class_manifest is nil — expected non-nil for model-like seed")
+	}
+	if len(m.Fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d: %+v", len(m.Fields), m.Fields)
+	}
+
+	// Find field entries by name.
+	byName := make(map[string]docgen.ClassFieldEntry, len(m.Fields))
+	for _, f := range m.Fields {
+		byName[f.Name] = f
+	}
+
+	// CharField: field_type must be "CharField", kwargs must have max_length.
+	nameField, ok := byName["name"]
+	if !ok {
+		t.Fatal("field 'name' not found in ClassManifest.Fields")
+	}
+	if nameField.FieldType != "CharField" {
+		t.Errorf("field 'name' FieldType: got %q, want %q", nameField.FieldType, "CharField")
+	}
+	if nameField.Kwargs == nil {
+		t.Error("field 'name' Kwargs is nil — expected map with max_length")
+	} else if nameField.Kwargs["max_length"] != "200" {
+		t.Errorf("field 'name' Kwargs[max_length]: got %q, want %q", nameField.Kwargs["max_length"], "200")
+	}
+
+	// ForeignKey: field_type must be "ForeignKey", kwargs must have to + on_delete.
+	clientField, ok := byName["client"]
+	if !ok {
+		t.Fatal("field 'client' not found in ClassManifest.Fields")
+	}
+	if clientField.FieldType != "ForeignKey" {
+		t.Errorf("field 'client' FieldType: got %q, want %q", clientField.FieldType, "ForeignKey")
+	}
+	if clientField.Kwargs == nil {
+		t.Error("field 'client' Kwargs is nil — expected map with to + on_delete")
+	} else {
+		if clientField.Kwargs["to"] != "Client" {
+			t.Errorf("field 'client' Kwargs[to]: got %q, want %q", clientField.Kwargs["to"], "Client")
+		}
+		if clientField.Kwargs["on_delete"] != "CASCADE" {
+			t.Errorf("field 'client' Kwargs[on_delete]: got %q, want %q", clientField.Kwargs["on_delete"], "CASCADE")
+		}
+	}
+
+	// Plain field (no field_type): FieldType must be empty, Kwargs must be nil.
+	activeField, ok := byName["active"]
+	if !ok {
+		t.Fatal("field 'active' not found in ClassManifest.Fields")
+	}
+	if activeField.FieldType != "" {
+		t.Errorf("field 'active' FieldType: got %q, want empty string (no field_type property)", activeField.FieldType)
+	}
+	if activeField.Kwargs != nil {
+		t.Errorf("field 'active' Kwargs: got %v, want nil (no kwarg.* properties)", activeField.Kwargs)
+	}
+}
+
+// TestBuildBundle_ClassManifest_Kwargs_NilWhenAbsent verifies that
+// ClassFieldEntry.Kwargs is nil (omitted from JSON) when the child entity has
+// no kwarg.* properties. Ensures omitempty contract is upheld (#1978).
+func TestBuildBundle_ClassManifest_Kwargs_NilWhenAbsent(t *testing.T) {
+	groupName, classID := issue1978Harness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: classID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	m := bundle.GraphContext.ClassManifest
+	if m == nil {
+		t.Fatal("class_manifest is nil")
+	}
+
+	for _, f := range m.Fields {
+		if f.Name == "active" {
+			if f.Kwargs != nil {
+				t.Errorf("ClassFieldEntry[active].Kwargs is non-nil (%v) for a field with no kwarg.* properties — omitempty contract broken", f.Kwargs)
+			}
+			return
+		}
+	}
+	t.Error("field 'active' not found in ClassManifest.Fields")
+}

--- a/internal/docgen/llm_bundle.go
+++ b/internal/docgen/llm_bundle.go
@@ -148,6 +148,13 @@ type LLMGraphContext struct {
 	// start_line or end_line. Tracked so downstream consumers can audit
 	// how often the extractors emit broken positions (issue #1964).
 	SourceWindowFallback bool `json:"source_window_fallback,omitempty"`
+	// SyntheticModule is true when the seed Module entity is a synthetic
+	// aggregation container produced by the module aggregation layer
+	// (Properties["synthetic"]="true"). Synthetic modules have no source file
+	// of their own; module_readme and module_configs will be absent. The
+	// module_manifest is built from the module's CONTAINS children when they
+	// are present in the graph (#1969).
+	SyntheticModule bool `json:"synthetic_module,omitempty"`
 }
 
 // ModuleReadme holds the README content embedded into a Module bundle (#1880).
@@ -248,6 +255,16 @@ type ClassFieldEntry struct {
 	// TypeHint is the declared type of the field as inferred from the Signature
 	// (e.g. "UserRepository", "str", "List<String>"). Empty when not available.
 	TypeHint string `json:"type_hint,omitempty"`
+	// FieldType is the ORM/framework field type copied from the child entity's
+	// Properties["field_type"] (e.g. "CharField", "ForeignKey", "IntegerField").
+	// Populated only when the extractor stamped the field_type property (Django
+	// Model fields via django_relational.go). Empty for other field kinds (#1978).
+	FieldType string `json:"field_type,omitempty"`
+	// Kwargs is the map of kwarg.* property sidecars from the child entity's
+	// Properties (keys have the "kwarg." prefix stripped). For a ForeignKey field
+	// this carries {"to": "Client", "on_delete": "CASCADE"}; for a CharField it
+	// carries {"max_length": "200"}. Nil when no kwarg.* properties exist (#1978).
+	Kwargs map[string]string `json:"kwargs,omitempty"`
 	// DefaultValue is the literal default value when the extractor captured one.
 	// Empty for computed or unknown defaults.
 	DefaultValue string `json:"default_value,omitempty"`
@@ -1025,9 +1042,25 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 
 		// Populate ModuleReadme and ModuleConfigs for Module-kind seeds (#1880).
 		// Also populate ModuleManifest (#1881) — both coexist.
+		//
+		// Issue #1969 — synthetic Module entities (produced by the module
+		// aggregation layer, Properties["synthetic"]="true") have no
+		// SourceFile and no README on disk. Their CONTAINS children are real
+		// code entities, so ModuleManifest is still built from those children
+		// when they are present. ModuleReadme and ModuleConfigs are skipped
+		// because there is no source directory to scan. SyntheticModule is
+		// set so the LLM can reason about the absence of file-level metadata.
 		if isModuleKind(entity.Kind) {
-			gc.ModuleReadme, gc.ModuleConfigs = buildModuleSupplements(entity, seedRepo, neighbours, neighbourKinds)
-			gc.ModuleManifest = buildModuleManifest(entity, neighbours, neighbourKinds)
+			isSynthetic := entity.Properties["synthetic"] == "true" && entity.SourceFile == ""
+			if isSynthetic {
+				gc.SyntheticModule = true
+				// For synthetic aggregate modules: skip README/config discovery
+				// (no source directory); build ModuleManifest from CONTAINS children.
+				gc.ModuleManifest = buildModuleManifest(entity, neighbours, neighbourKinds)
+			} else {
+				gc.ModuleReadme, gc.ModuleConfigs = buildModuleSupplements(entity, seedRepo, neighbours, neighbourKinds)
+				gc.ModuleManifest = buildModuleManifest(entity, neighbours, neighbourKinds)
+			}
 		}
 	}
 
@@ -1218,6 +1251,26 @@ func inferVisibility(sig string) string {
 		return "public"
 	}
 	return ""
+}
+
+// extractKwargs extracts the "kwarg.*" property sidecars from an entity
+// Properties map into a plain string→string map with the "kwarg." prefix
+// stripped (#1978). Returns nil when no kwarg.* keys are present so the
+// ClassFieldEntry.Kwargs JSON field is elided via omitempty.
+func extractKwargs(props map[string]string) map[string]string {
+	if len(props) == 0 {
+		return nil
+	}
+	var out map[string]string
+	for k, v := range props {
+		if strings.HasPrefix(k, "kwarg.") {
+			if out == nil {
+				out = make(map[string]string)
+			}
+			out[k[len("kwarg."):]] = v
+		}
+	}
+	return out
 }
 
 // typeHintFromSignature extracts the declared type from a field signature.
@@ -1433,6 +1486,16 @@ func buildClassManifest(entity *graph.Entity, neighbours []graph.Entity, neighbo
 						StartLine: n.StartLine,
 					}
 					entry.Visibility = inferVisibility(n.Signature)
+					// Issue #1978 — copy field_type and kwarg.* properties from
+					// the child entity's Properties map so that class_manifest
+					// field entries carry the same ORM metadata that
+					// NeighbourBrief.TypeHint surfaces for Schema neighbours.
+					// This lets docgen render a schema table directly from
+					// class_manifest without an extra neighbour-brief lookup.
+					if n.Properties != nil {
+						entry.FieldType = strings.TrimSpace(n.Properties["field_type"])
+						entry.Kwargs = extractKwargs(n.Properties)
+					}
 					m.Fields = append(m.Fields, entry)
 				}
 			}
@@ -1742,6 +1805,15 @@ func buildModuleManifest(entity *graph.Entity, neighbours []graph.Entity, neighb
 			}
 
 			// --- Classes (other class-like kinds, after model filter) ---
+			// Issue #1969 — skip SCOPE.Component(file) proxy entities: these are
+			// intermediate file containers emitted by extractors to bridge Module
+			// → file-body CONTAINS edges. They are not real classes and adding
+			// them to the Classes bucket would pollute the manifest and prevent
+			// the nil-return guard from emitting a useful manifest for modules
+			// whose only CONTAINS child is such a proxy entity.
+			if n.Kind == "SCOPE.Component" && n.Subtype == "file" {
+				continue
+			}
 			if isClassLikeKind(n.Kind) {
 				totalClasses++
 				if totalClasses <= ModuleManifestBucketCap {


### PR DESCRIPTION
## 1. Problem

**#1978 — class_manifest fields missing ORM type metadata**

`buildClassManifest` (#1925) built `ClassFieldEntry` with only `{name, type_hint, start_line, visibility}`. The `Properties["field_type"]` (e.g. "CharField", "ForeignKey") and `Properties["kwarg.*"]` sidecars stamped by `django_relational.go` on `SCOPE.Schema/field` children were present on the entity graph but never copied into the manifest. This meant docgen LLM sections couldn't render a Django Model field table from `class_manifest` alone.

**#1969 — synthetic Module entities: NULL module_manifest/configs/readme**

Synthetic aggregate Module entities (`Kind="Module"`, `Properties["synthetic"]="true"`, `SourceFile=""`) produced by `internal/module/aggregate.go` had NULL manifests because:
1. `buildModuleSupplements` found no README (no source directory) — silently returning nil.
2. `buildModuleManifest` was polluted by `SCOPE.Component(subtype="file")` proxy entities (from the Python `#2020` dual-entity shape) appearing in the Classes bucket — which could mask real children or prevent the non-nil return path from firing.

No `SyntheticModule` indicator existed, so docgen LLM had no way to distinguish "manifest deliberately absent" from "extractor hasn't run yet".

## 2. Fix

### #1978 — field_type + kwargs on ClassFieldEntry

- Add `FieldType string` and `Kwargs map[string]string` (both omitempty) to `ClassFieldEntry`.
- Add `extractKwargs(props map[string]string) map[string]string` helper — strips `"kwarg."` prefix, returns nil when no kwarg.* keys exist (preserves omitempty).
- In the `isField` branch of `buildClassManifest`, copy `n.Properties["field_type"]` → `entry.FieldType` and `extractKwargs(n.Properties)` → `entry.Kwargs`.

### #1969 — synthetic Module manifest population

- Add `SyntheticModule bool` (omitempty) to `LLMGraphContext`.
- In `BuildBundle`, detect `Properties["synthetic"]=="true" && SourceFile==""` → set `gc.SyntheticModule = true`; skip README/config discovery; still build `ModuleManifest` from `CONTAINS` children when present.
- In `buildModuleManifest`, skip `SCOPE.Component(subtype="file")` proxy entities from the Classes bucket so they don't pollute the manifest.

## 3. Verification

```
go test ./internal/docgen/...   # zero failures before and after
```

New regression test files:
- `internal/docgen/issue1978_field_type_test.go` — CharField/max_length, ForeignKey/to+on_delete, plain field (empty FieldType, nil Kwargs)
- `internal/docgen/issue1969_synthetic_module_test.go` — SyntheticModule flag set/unset, no readme for synthetic, manifest populated from CONTAINS children, file proxy skipped

## 4. Risk

Additive schema changes (`FieldType`, `Kwargs`, `SyntheticModule` all `omitempty`). Existing consumers that don't read these new fields are unaffected. No changes to relationship traversal or section rendering logic.

## 5. Test plan

- [x] `go test ./internal/docgen/...` — zero failures
- [x] `TestBuildBundle_ClassManifest_FieldType` — CharField + ForeignKey field_type/kwargs populated
- [x] `TestBuildBundle_ClassManifest_Kwargs_NilWhenAbsent` — plain field has nil Kwargs
- [x] `TestBuildBundle_SyntheticModule_Flag` — SyntheticModule=true for aggregate module
- [x] `TestBuildBundle_SyntheticModule_NoReadme` — ModuleReadme=nil for synthetic
- [x] `TestBuildBundle_SyntheticModule_ManifestFromContainsChildren` — manifest has Functions+Classes from CONTAINS children
- [x] `TestBuildBundle_SyntheticModule_Flag_False_ForRealModule` — real module not flagged
- [x] `TestBuildBundle_ModuleManifest_FileProxySkipped` — file proxy excluded, real class included

## 6. Closes

Closes #1978
Closes #1969

## 7. Notes

The `extractKwargs` helper mirrors the same kwarg.* extraction already performed by `composeDjangoFieldTypeHint` / `buildNeighbourTypeHint` for `NeighbourBrief.TypeHint`. The class_manifest now carries the same ORM field metadata surface so LLM section renderers don't need two code paths for the same data shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)