### PR TITLE
fix(orphan-probe): exclude synthetic empty-SourceFile Modules from orphan classifier (#2064)

### DIFF
--- a/cmd/orphan-probe/main.go
+++ b/cmd/orphan-probe/main.go
@@ -185,6 +185,12 @@ func probeGroup(cfg *registry.GroupConfig, topN int) GroupResult {
 			if _, ok := connected[e.ID]; ok {
 				continue
 			}
+			// Exclude synthetic empty-SourceFile Module entities from orphan count.
+			// These are structural grouping nodes created by the module-grouping pass
+			// and don't represent real code constructs (Issue #2064).
+			if e.Kind == "Module" && e.SourceFile == "" {
+				continue
+			}
 			nOrphans++
 			allOrphans = append(allOrphans, orphanEntry{
 				id:       e.ID,


### PR DESCRIPTION
## Summary
Module entities with empty SourceFile are synthetic grouping nodes created by the module-grouping pass (Epic #1380). These structural markers have no incoming/outgoing semantic edges and were incorrectly counted as degree-0 orphans. Fixed by excluding Kind=Module with empty SourceFile from the orphan classifier.

## Root cause
The orphan-probe counted all degree-0 entities as orphans, but Module entities with empty SourceFile are intentional synthetic containers for grouping purposes, not real code constructs. This resulted in 17 false-positive orphans in the polyglot-platform group.

## Fix
Updated cmd/orphan-probe/main.go to skip Module entities where SourceFile is empty during orphan detection and clustering. These nodes remain in the graph (they serve a structural purpose) but are excluded from orphan metrics.

## Measurement
- polyglot-platform orphan count: 539 → 522 (reduction of 17)
- polyglot-platform orphan rate: 28.3% → 27.4%
- No other groups affected (Module orphans were polyglot-platform-only)

## Testing
- go test ./internal/extractors/... — all passed
- Manual validation: orphan-probe output confirms Module/(empty) cluster is no longer reported

## Impact
- Orphan rate metrics now accurately reflect real code connectivity issues
- Synthetic structural nodes no longer inflate false-positive orphan count

Closes #2064