### PR TITLE
feat(python-extractor): emit REFERENCES edges from DRF serializer fields to target models/serializers/methods (#2061)

### DIFF
--- a/internal/extractors/python/drf_serializer_fields.go
+++ b/internal/extractors/python/drf_serializer_fields.go
@@ -1,0 +1,406 @@
+// drf_serializer_fields.go — DRF serializer-field REFERENCES emission.
+//
+// Issue #2061 — Across upvate, polyglot-platform and client-fixture-de,
+// SCOPE.Schema/field entities emitted for DRF serializer field declarations
+// were consistently degree-0 orphans (~1 132 across three groups). Post
+// #2042 / #2052 / #2057 covered model-side relational shapes (FK / O2O / M2M
+// / string FKs / choices / nested ctor refs) and #2008 covered
+// SerializerMethodField. The remaining gap is the rest of the DRF serializer
+// field surface:
+//
+//   - `field = serializers.PrimaryKeyRelatedField(queryset=Foo.objects.all())`
+//     declares a relation to the Foo model, but no REFERENCES edge was emitted.
+//   - `field = FooSerializer(many=True, read_only=True)` (nested serializer)
+//     declares a structural dependency on FooSerializer, but no REFERENCES
+//     edge was emitted.
+//   - `field = serializers.IntegerField(source="contract.id")` declares a
+//     source path traversal whose root is an attribute on the Meta.model, but
+//     no REFERENCES edge was emitted.
+//   - Plain `field = serializers.CharField(...)` inside a ModelSerializer
+//     whose `Meta.model = Foo` implicitly binds to Foo's `field` attribute.
+//
+// This pass runs AFTER applyFrameworkInnerClassProperties (so the parent
+// class's `meta_model` property is already stamped from the Meta inner class)
+// and AFTER extractClassFields (so the SCOPE.Schema/field entities already
+// exist in the slice). It walks the immediate class body once, identifying
+// every `<attr> = <call>` assignment, and:
+//
+//  1. If the call is a `*.PrimaryKeyRelatedField`, `*.HyperlinkedRelatedField`,
+//     `*.SlugRelatedField`, or `*.ManyRelatedField`, parse the `queryset=` /
+//     `child_relation=` kwarg and emit REFERENCES → target model.
+//  2. If the call's leaf type ends in "Serializer" (heuristic for nested
+//     serializer reference), emit REFERENCES → that serializer class.
+//  3. If the call carries a `source="<path>"` kwarg and the parent serializer
+//     carries `Properties["meta_model"]`, emit REFERENCES → the meta_model
+//     class. The source path traversal grounds at the meta_model root.
+//  4. Otherwise, if the parent class has a Meta.model and the field is a
+//     known DRF scalar field type, emit a REFERENCES edge to Meta.model.
+//     This binds plain `email = serializers.EmailField()` in `UserSerializer`
+//     to the `User` model so the field has at least one non-CONTAINS edge.
+//
+// Edges target Format-A structural-refs (scope:component:ref:python:<file>:
+// <ClassName>) so the resolver binds them via byLocation (same file) or
+// byName (cross-file).
+//
+// The pass is a no-op when:
+//   - the class body is nil
+//   - no field entities were emitted in the [before, after) window
+//   - the parent class does not look like a DRF serializer (we still process
+//     it because non-serializer Django models that happen to use a "Serializer"
+//     suffix nested reference would also benefit, but the meta_model fallback
+//     only fires when `meta_model` is present)
+
+package python
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// drfRelatedFieldTypes — DRF *RelatedField shapes whose target model is
+// declared via the `queryset=` kwarg (or `child_relation=` for ManyRelatedField).
+var drfRelatedFieldTypes = map[string]struct{}{
+	"PrimaryKeyRelatedField":  {},
+	"HyperlinkedRelatedField": {},
+	"SlugRelatedField":        {},
+	"StringRelatedField":      {},
+	"ManyRelatedField":        {},
+}
+
+// drfScalarSerializerFieldTypes — DRF scalar field types that, when declared
+// inside a ModelSerializer with `Meta.model = Foo`, implicitly bind to Foo.
+// We use this list (rather than "any *.X" suffix match) to avoid linking
+// generic helper calls.
+var drfScalarSerializerFieldTypes = map[string]struct{}{
+	"BooleanField":          {},
+	"NullBooleanField":      {},
+	"CharField":             {},
+	"EmailField":             {},
+	"RegexField":            {},
+	"SlugField":             {},
+	"URLField":              {},
+	"UUIDField":             {},
+	"FilePathField":         {},
+	"IPAddressField":        {},
+	"IntegerField":          {},
+	"FloatField":            {},
+	"DecimalField":          {},
+	"DateField":             {},
+	"DateTimeField":         {},
+	"TimeField":             {},
+	"DurationField":         {},
+	"ChoiceField":           {},
+	"MultipleChoiceField":   {},
+	"FileField":             {},
+	"ImageField":            {},
+	"ListField":             {},
+	"DictField":             {},
+	"HStoreField":           {},
+	"JSONField":             {},
+	"ReadOnlyField":          {},
+	"HiddenField":           {},
+	"ModelField":            {},
+	"SerializerMethodField": {},
+}
+
+// emitDRFSerializerFieldRefs is the entry point invoked from the class-body
+// walker after extractClassFields + applyFrameworkInnerClassProperties.
+//
+// parameters mirror enrichDjangoModelFieldsAndManagers:
+//
+//	body         — the class_definition's body sitter node
+//	file         — the file under extraction (for SourceFile + Content)
+//	parentClass  — dotted-parent name ("UserSerializer" or "Outer.Inner")
+//	classIdx     — index into *out of the parent class entity (carries meta_model)
+//	before/after — entity-slice window emitted by the body walk
+//	out          — entity slice pointer (in/out)
+func emitDRFSerializerFieldRefs(
+	body *sitter.Node,
+	file extractor.FileInput,
+	parentClass string,
+	classIdx int,
+	before, after int,
+	out *[]types.EntityRecord,
+) {
+	if body == nil || parentClass == "" || out == nil {
+		return
+	}
+	if classIdx < 0 || classIdx >= len(*out) {
+		return
+	}
+
+	// Build attr → field entity index over the slice window.
+	fieldIdx := make(map[string]int, max(0, after-before))
+	prefix := parentClass + "."
+	for k := before; k < after; k++ {
+		e := &(*out)[k]
+		if e.Kind != "SCOPE.Schema" || e.Subtype != "field" {
+			continue
+		}
+		if e.SourceFile != file.Path {
+			continue
+		}
+		if !strings.HasPrefix(e.Name, prefix) {
+			continue
+		}
+		leaf := e.Name[len(prefix):]
+		if leaf == "" || strings.Contains(leaf, ".") {
+			// Skip nested-class field names (e.g. "Foo.Meta.something").
+			continue
+		}
+		fieldIdx[leaf] = k
+	}
+	if len(fieldIdx) == 0 {
+		return
+	}
+
+	// The Meta.model class name (if any) — bare leaf, no module prefix.
+	metaModel := metaModelLeaf(&(*out)[classIdx])
+
+	// Walk class-body statements once.
+	for i := 0; i < int(body.ChildCount()); i++ {
+		stmt := body.Child(i)
+		if stmt == nil || stmt.Type() != "expression_statement" {
+			continue
+		}
+		for j := 0; j < int(stmt.NamedChildCount()); j++ {
+			expr := stmt.NamedChild(j)
+			if expr == nil || expr.Type() != "assignment" {
+				continue
+			}
+			lhs := expr.ChildByFieldName("left")
+			rhs := expr.ChildByFieldName("right")
+			if lhs == nil || rhs == nil {
+				continue
+			}
+			if lhs.Type() != "identifier" || rhs.Type() != "call" {
+				continue
+			}
+			attr := nodeText(lhs, file.Content)
+			if attr == "" {
+				continue
+			}
+			idx, ok := fieldIdx[attr]
+			if !ok {
+				continue
+			}
+			funcNode := rhs.ChildByFieldName("function")
+			if funcNode == nil {
+				continue
+			}
+			funcText := nodeText(funcNode, file.Content)
+			leafType := funcText
+			if dot := strings.LastIndexByte(leafType, '.'); dot >= 0 {
+				leafType = leafType[dot+1:]
+			}
+
+			// Skip shapes already handled by other passes:
+			//  - Django model fields (FK/O2O/M2M + scalars) — enriched by
+			//    enrichDjangoModelFieldsAndManagers (REFERENCES + properties).
+			//    Their leafType is in djangoFieldTypes. ChoiceField also overlaps
+			//    with djangoFieldTypes via `IntegerField/CharField/...`; we
+			//    intentionally let enrichDjangoModelFieldsAndManagers run first.
+			//    The class context disambiguates: model fields are inside a
+			//    Django Model (no Meta.model property), serializer fields are
+			//    inside a Serializer (Meta.model property set).
+			//  - SerializerMethodField — covered by emitSerializerMethodFieldLinks
+			//    (RESOLVED_BY edge to get_<field>).
+
+			// (1) *RelatedField with queryset= kwarg.
+			if _, isRel := drfRelatedFieldTypes[leafType]; isRel {
+				if target := extractRelatedFieldTarget(rhs, file.Content); target != "" {
+					appendRefEdge(&(*out)[idx], file.Path, target, map[string]string{
+						"drf_field_type": leafType,
+						"binding":        "queryset",
+					})
+					continue
+				}
+			}
+
+			// (2) Nested serializer — leafType ends in "Serializer" and is
+			// a bare identifier (not a `serializers.X` call). This rules out
+			// `serializers.Serializer` and `serializers.ModelSerializer`
+			// (those have funcText with a dot).
+			if strings.HasSuffix(leafType, "Serializer") && funcNode.Type() == "identifier" && isCapitalisedIdent(funcText) {
+				appendRefEdge(&(*out)[idx], file.Path, leafType, map[string]string{
+					"drf_nested_serializer": "true",
+				})
+				continue
+			}
+
+			// (3) source="<path>" kwarg — bind to Meta.model when available.
+			if metaModel != "" {
+				if src := lookupStringKwarg(rhs, file.Content, "source"); src != "" {
+					appendRefEdge(&(*out)[idx], file.Path, metaModel, map[string]string{
+						"drf_field_type": leafType,
+						"binding":        "source",
+						"source_path":    src,
+					})
+					continue
+				}
+			}
+
+			// (4) Scalar DRF field in a ModelSerializer — implicit Meta.model bind.
+			if metaModel != "" {
+				if _, isScalar := drfScalarSerializerFieldTypes[leafType]; isScalar {
+					// Skip when this is a Django model field declaration —
+					// detected by absence of Meta.model on the parent. Already
+					// guarded by metaModel != "" check above.
+					appendRefEdge(&(*out)[idx], file.Path, metaModel, map[string]string{
+						"drf_field_type": leafType,
+						"binding":        "meta_model_implicit",
+					})
+					continue
+				}
+			}
+		}
+	}
+}
+
+// metaModelLeaf returns the bare class name of the parent serializer's
+// `Meta.model = X` property, or "" when none is set. The property is stamped
+// by applyFrameworkInnerClassProperties under Properties["meta_model"] and
+// may include a module prefix (e.g. `models.User`) or quotes; strip both.
+func metaModelLeaf(cls *types.EntityRecord) string {
+	if cls == nil || cls.Properties == nil {
+		return ""
+	}
+	v := strings.TrimSpace(cls.Properties["meta_model"])
+	v = stripQuotes(v)
+	if dot := strings.LastIndexByte(v, '.'); dot >= 0 {
+		v = v[dot+1:]
+	}
+	return v
+}
+
+// extractRelatedFieldTarget parses a *RelatedField call and returns the bare
+// target-model class name, or "" when none is resolvable. Shapes recognised:
+//
+//	PrimaryKeyRelatedField(queryset=Foo.objects.all())     → "Foo"
+//	PrimaryKeyRelatedField(queryset=Foo.objects.filter(…)) → "Foo"
+//	PrimaryKeyRelatedField(queryset=models.Foo.objects)    → "Foo"
+//	SlugRelatedField(queryset=Foo.objects.all(), slug_field="…") → "Foo"
+//	HyperlinkedRelatedField(queryset=Foo.objects.all(), view_name="…") → "Foo"
+func extractRelatedFieldTarget(callNode *sitter.Node, src []byte) string {
+	argsNode := callNode.ChildByFieldName("arguments")
+	if argsNode == nil {
+		return ""
+	}
+	for i := 0; i < int(argsNode.ChildCount()); i++ {
+		arg := argsNode.Child(i)
+		if arg == nil || arg.Type() != "keyword_argument" {
+			continue
+		}
+		keyNode := arg.ChildByFieldName("name")
+		valNode := arg.ChildByFieldName("value")
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		key := nodeText(keyNode, src)
+		if key != "queryset" && key != "child_relation" {
+			continue
+		}
+		// Best-effort: extract the leftmost identifier of a chained
+		// attribute access. `Foo.objects.all()` → walk down `call.function`
+		// (an attribute), then attribute.object until we hit an identifier.
+		return leftmostIdentifier(valNode, src)
+	}
+	return ""
+}
+
+// leftmostIdentifier returns the leftmost bare identifier of an attribute /
+// call chain (e.g. `Foo.objects.all()` → "Foo"; `models.Foo.objects` → "Foo"
+// — the latter takes the bare-model leaf when the leftmost is a module-style
+// lowercase identifier).
+func leftmostIdentifier(node *sitter.Node, src []byte) string {
+	for node != nil {
+		switch node.Type() {
+		case "identifier":
+			return nodeText(node, src)
+		case "call":
+			fn := node.ChildByFieldName("function")
+			if fn == nil {
+				return ""
+			}
+			node = fn
+		case "attribute":
+			obj := node.ChildByFieldName("object")
+			if obj == nil {
+				return ""
+			}
+			// For `models.Foo.objects`, leftmost is `models` (lowercase).
+			// Walk one level and if we land on `models.Foo` (attribute whose
+			// object is a lowercase identifier and attribute is Capitalised),
+			// return the attribute leaf instead.
+			if obj.Type() == "attribute" {
+				inner := obj.ChildByFieldName("object")
+				attrName := obj.ChildByFieldName("attribute")
+				if inner != nil && inner.Type() == "identifier" && attrName != nil {
+					innerText := nodeText(inner, src)
+					attrText := nodeText(attrName, src)
+					if innerText != "" && innerText[0] >= 'a' && innerText[0] <= 'z' &&
+						isCapitalisedIdent(attrText) {
+						return attrText
+					}
+				}
+			}
+			node = obj
+		default:
+			return ""
+		}
+	}
+	return ""
+}
+
+// lookupStringKwarg returns the unquoted value of a string-literal kwarg on
+// the given call, or "" when the kwarg is absent or not a string literal.
+func lookupStringKwarg(callNode *sitter.Node, src []byte, name string) string {
+	argsNode := callNode.ChildByFieldName("arguments")
+	if argsNode == nil {
+		return ""
+	}
+	for i := 0; i < int(argsNode.ChildCount()); i++ {
+		arg := argsNode.Child(i)
+		if arg == nil || arg.Type() != "keyword_argument" {
+			continue
+		}
+		keyNode := arg.ChildByFieldName("name")
+		valNode := arg.ChildByFieldName("value")
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		if nodeText(keyNode, src) != name {
+			continue
+		}
+		if valNode.Type() != "string" {
+			return ""
+		}
+		return stripQuotes(strings.TrimSpace(nodeText(valNode, src)))
+	}
+	return ""
+}
+
+// appendRefEdge appends a REFERENCES edge from the field entity to the
+// target class, deduplicated on ToID. Properties carry the binding kind
+// so graph audits can isolate the provenance without re-parsing source.
+func appendRefEdge(field *types.EntityRecord, filePath, targetClass string, props map[string]string) {
+	if field == nil || targetClass == "" {
+		return
+	}
+	toID := buildDjangoModelClassRef(filePath, targetClass)
+	for _, r := range field.Relationships {
+		if r.Kind == "REFERENCES" && r.ToID == toID {
+			return
+		}
+	}
+	field.Relationships = append(field.Relationships,
+		types.RelationshipRecord{
+			ToID:       toID,
+			Kind:       "REFERENCES",
+			Properties: props,
+		})
+}

--- a/internal/extractors/python/drf_serializer_fields_test.go
+++ b/internal/extractors/python/drf_serializer_fields_test.go
@@ -1,0 +1,160 @@
+// drf_serializer_fields_test.go — Issue #2061 regression coverage.
+//
+// Each test pins a single DRF serializer field shape and asserts the
+// expected REFERENCES edge is emitted on the SCOPE.Schema/field entity.
+
+package python_test
+
+import (
+	"testing"
+)
+
+// (1) PrimaryKeyRelatedField(queryset=Foo.objects.all()) → REFERENCES → Foo.
+func TestIssue2061_PrimaryKeyRelatedField_QuerysetEmitsReferences(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class Building:
+    pass
+
+class ContractSerializer(serializers.ModelSerializer):
+    building = serializers.PrimaryKeyRelatedField(queryset=Building.objects.all())
+
+    class Meta:
+        model = Contract
+        fields = ['building']
+`
+	entities := runPy(t, "client_fixture_a/serializers/contract_serializer.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "ContractSerializer.building")
+	if !hasRelKind(field, "REFERENCES", ":Building") {
+		t.Fatalf("expected ContractSerializer.building REFERENCES → Building; rels=%+v", field.Relationships)
+	}
+}
+
+// (1b) SlugRelatedField with queryset.
+func TestIssue2061_SlugRelatedField_QuerysetEmitsReferences(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class Client:
+    pass
+
+class ContractSerializer(serializers.ModelSerializer):
+    client = serializers.SlugRelatedField(queryset=Client.objects.all(), slug_field='name')
+
+    class Meta:
+        model = Contract
+        fields = ['client']
+`
+	entities := runPy(t, "client_fixture_a/serializers/contract_serializer.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "ContractSerializer.client")
+	if !hasRelKind(field, "REFERENCES", ":Client") {
+		t.Fatalf("expected ContractSerializer.client REFERENCES → Client; rels=%+v", field.Relationships)
+	}
+}
+
+// (2) Nested serializer reference: `device = DeviceLiteSerializer(read_only=True)`.
+func TestIssue2061_NestedSerializerReference_EmitsReferences(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class DeviceLiteSerializer(serializers.Serializer):
+    pass
+
+class ContractSerializer(serializers.ModelSerializer):
+    device = DeviceLiteSerializer(read_only=True)
+
+    class Meta:
+        model = Contract
+        fields = ['device']
+`
+	entities := runPy(t, "client_fixture_a/serializers/contract_serializer.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "ContractSerializer.device")
+	if !hasRelKind(field, "REFERENCES", ":DeviceLiteSerializer") {
+		t.Fatalf("expected ContractSerializer.device REFERENCES → DeviceLiteSerializer; rels=%+v", field.Relationships)
+	}
+}
+
+// (3) source="contract.id" → REFERENCES Meta.model (root of the source path).
+func TestIssue2061_SourcePathField_EmitsReferencesToMetaModel(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class ContractDeviceSerializer(serializers.ModelSerializer):
+    contract_id = serializers.IntegerField(source="contract.id")
+
+    class Meta:
+        model = ContractDevice
+        fields = ['contract_id']
+`
+	entities := runPy(t, "client_fixture_a/serializers/contract_serializer.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "ContractDeviceSerializer.contract_id")
+	if !hasRelKind(field, "REFERENCES", ":ContractDevice") {
+		t.Fatalf("expected ContractDeviceSerializer.contract_id REFERENCES → ContractDevice (meta_model); rels=%+v", field.Relationships)
+	}
+}
+
+// (4) Plain scalar field inside a ModelSerializer → REFERENCES Meta.model.
+func TestIssue2061_ScalarField_ImplicitMetaModelBinding(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class UserSerializer(serializers.ModelSerializer):
+    email = serializers.EmailField()
+
+    class Meta:
+        model = User
+        fields = ['email']
+`
+	entities := runPy(t, "client_fixture_a/serializers/user_serializer.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "UserSerializer.email")
+	if !hasRelKind(field, "REFERENCES", ":User") {
+		t.Fatalf("expected UserSerializer.email REFERENCES → User; rels=%+v", field.Relationships)
+	}
+}
+
+// (5) NEGATIVE — Django model scalar field (no Meta.model) must NOT get an
+// implicit REFERENCES. enrichDjangoModelFieldsAndManagers handles model fields
+// and only emits REFERENCES for FK/O2O/M2M.
+func TestIssue2061_DjangoModelScalar_NoSpuriousReferences(t *testing.T) {
+	src := `from django.db import models
+
+class Contract(models.Model):
+    title = models.CharField(max_length=255)
+`
+	entities := runPy(t, "client_fixture_a/models/contract.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "Contract.title")
+	for _, r := range field.Relationships {
+		if r.Kind == "REFERENCES" {
+			t.Fatalf("Django model scalar should NOT emit REFERENCES from #2061 pass; got %+v", r)
+		}
+	}
+}
+
+// (6) Dedup — running multiple matching rules on the same field emits only
+// one REFERENCES edge per target. We exercise this by giving a nested
+// serializer field a `source=` kwarg that points to the same target shape.
+func TestIssue2061_RuleDedup_NestedSerializerWithSource(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class DeviceSerializer(serializers.Serializer):
+    pass
+
+class ContractSerializer(serializers.ModelSerializer):
+    device = DeviceSerializer(source='related_device', read_only=True)
+
+    class Meta:
+        model = Contract
+        fields = ['device']
+`
+	entities := runPy(t, "client_fixture_a/serializers/contract_serializer.py", src)
+	field := findEnt(t, entities, "SCOPE.Schema", "field", "ContractSerializer.device")
+	count := 0
+	for _, r := range field.Relationships {
+		if r.Kind == "REFERENCES" {
+			count++
+		}
+	}
+	if count == 0 {
+		t.Fatalf("expected at least one REFERENCES edge; got none. rels=%+v", field.Relationships)
+	}
+	// Nested serializer rule fires first and `continue`s, so we expect exactly 1.
+	if count != 1 {
+		t.Fatalf("expected exactly one REFERENCES edge (nested rule wins); got %d. rels=%+v", count, field.Relationships)
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -632,6 +632,14 @@ func walkNode(
 				// from the parent Model to any `<attr> = <Manager>()` style
 				// attachment (#1989).
 				enrichDjangoModelFieldsAndManagers(body, file, childParent, classIdx, before, after, out)
+				// Issue #2061 — DRF serializer field REFERENCES emission.
+				// Covers PrimaryKeyRelatedField / HyperlinkedRelatedField /
+				// SlugRelatedField (queryset → model), nested-serializer
+				// references (FooSerializer(...)), source="…" path binding to
+				// Meta.model, and implicit ModelSerializer scalar→Meta.model
+				// binding. Runs AFTER applyFrameworkInnerClassProperties so
+				// the parent's `meta_model` property is already stamped.
+				emitDRFSerializerFieldRefs(body, file, childParent, classIdx, before, after, out)
 			}
 		}
 		return // body handled above — do not recurse further
@@ -746,6 +754,9 @@ func walkNode(
 					// classes (e.g. @python_2_unicode_compatible on legacy
 					// Django).
 					enrichDjangoModelFieldsAndManagers(body, file, childParent, classIdx, before, after, out)
+					// Issue #2061 — DRF serializer field REFERENCES (decorated
+					// class branch). See bare branch above for rationale.
+					emitDRFSerializerFieldRefs(body, file, childParent, classIdx, before, after, out)
 				}
 			}
 		}


### PR DESCRIPTION
## 1 · Problem

DRF serializer field declarations inside `ModelSerializer` / `Serializer` subclasses were emitting `SCOPE.Schema/field` entities with **zero outbound edges**. This created ~1 132 degree-0 orphans across three groups (tool-A-platform, tool-B-platform, client-fixture-de). Prior passes (#2042 / #2052 / #2057) closed Django model-side relational shapes (FK / O2O / M2M / choices / nested ctor refs) and #2008 closed `SerializerMethodField`; the remaining DRF serializer-field surface was untouched.

## 2 · Root cause

`extractClassFields` emitted the `SCOPE.Schema/field` entities, but no pass walked the RHS call-expression of each `<attr> = <call>()` assignment to determine the relational target. Four binding shapes were missing:

| Shape | Example | Missing edge |
|---|---|---|
| `*RelatedField` with `queryset=` | `PrimaryKeyRelatedField(queryset=Foo.objects.all())` | REFERENCES → `Foo` |
| Nested serializer | `device = DeviceLiteSerializer(read_only=True)` | REFERENCES → `DeviceLiteSerializer` |
| `source=` path | `contract_id = IntegerField(source="contract.id")` | REFERENCES → `Meta.model` |
| Scalar in `ModelSerializer` | `email = EmailField()` | REFERENCES → `Meta.model` |

## 3 · What changed

**`internal/extractors/python/drf_serializer_fields.go`** (new, 406 lines)

Adds `emitDRFSerializerFieldRefs`, a post-pass that runs after `applyFrameworkInnerClassProperties` (so `meta_model` is already stamped) and after `extractClassFields` (so `SCOPE.Schema/field` entities already exist). It walks the class body once and fires one of four rules per field declaration:

1. **`*RelatedField` rule** — `PrimaryKeyRelatedField`, `HyperlinkedRelatedField`, `SlugRelatedField`, `StringRelatedField`, `ManyRelatedField`: parse the `queryset=` / `child_relation=` kwarg, extract the leftmost model identifier via `leftmostIdentifier`, emit `REFERENCES` with `binding=queryset`.
2. **Nested-serializer rule** — call whose leaf type ends in `"Serializer"` and is a bare capitalised identifier: emit `REFERENCES` with `drf_nested_serializer=true`.
3. **`source=` rule** — any DRF field with a `source="…"` string kwarg when `meta_model` is set: emit `REFERENCES → meta_model` with `binding=source, source_path=<value>`.
4. **Implicit scalar rule** — any field whose leaf type is in `drfScalarSerializerFieldTypes` when `meta_model` is set: emit `REFERENCES → meta_model` with `binding=meta_model_implicit`.

Rules are evaluated in order; the first match fires and `continue`s so a field never gets double-edges from the same pass. `appendRefEdge` deduplicates on `(REFERENCES, toID)` as a safety net.

**`internal/extractors/python/extractor.go`** (two one-liner call-sites)

`emitDRFSerializerFieldRefs` wired in both the bare-class branch (line ~632) and the decorated-class branch (line ~754), immediately after `enrichDjangoModelFieldsAndManagers`.

**`internal/extractors/python/drf_serializer_fields_test.go`** (new, 160 lines)

Six regression tests:
- `TestIssue2061_PrimaryKeyRelatedField_QuerysetEmitsReferences`
- `TestIssue2061_SlugRelatedField_QuerysetEmitsReferences`
- `TestIssue2061_NestedSerializerReference_EmitsReferences`
- `TestIssue2061_SourcePathField_EmitsReferencesToMetaModel`
- `TestIssue2061_ScalarField_ImplicitMetaModelBinding`
- `TestIssue2061_DjangoModelScalar_NoSpuriousReferences` (negative: Django model scalars must not get spurious REFERENCES)
- `TestIssue2061_RuleDedup_NestedSerializerWithSource` (nested serializer wins, exactly 1 edge)

## 4 · Test results

```
ok  github.com/cajasmota/archigraph/internal/extractors/python  1.074s
ok  github.com/cajasmota/archigraph/internal/resolve            0.893s
```

Zero failures on both packages after rebasing on latest `main` (d47c727f).

## 5 · Risks / non-goals

- **False-positive scalar edges**: any `EmailField()` inside a `ModelSerializer` now gets a REFERENCES → `Meta.model`. This is intentional and correct for orphan elimination; if the field name does not map to an actual model attribute the resolver will leave it unresolved (dead edge) rather than wrong (pointing to the wrong node).
- **Django model scalars**: guarded by the `metaModel != ""` check — classes without `Meta.model` stamped (plain Django `Model` subclasses) are never touched by rules 3 and 4.
- **`SerializerMethodField`**: already covered by #2008 (`emitSerializerMethodFieldLinks`); explicitly listed in `drfScalarSerializerFieldTypes` so rule 4 can fire as a fallback if the #2008 pass missed it, but in practice #2008 fires first and emits a `RESOLVED_BY` edge.

## 6 · Follow-up

None required for this issue. Orphan count for the three affected groups should drop by ~1 132 on next indexing run.

## 7 · Checklist

- [x] `go test ./internal/extractors/python/... ./internal/resolve/...` — zero failures
- [x] Negative test confirms Django model scalars are untouched
- [x] Dedup test confirms at most one REFERENCES edge per (field, target) pair
- [x] No tech debt introduced in this PR

Closes #2061