### PR TITLE
fix(orphan-probe): exclude Lombok-synth generated entities from orphan classifier (#2071)

### DIFF
--- a/cmd/orphan-probe/main.go
+++ b/cmd/orphan-probe/main.go
@@ -191,6 +191,13 @@ func probeGroup(cfg *registry.GroupConfig, topN int) GroupResult {
 			if e.Kind == "Module" && e.SourceFile == "" {
 				continue
 			}
+			// Exclude Lombok-synthesized and generated entities from orphan count.
+			// These are intentionally generated dead code (e.g. getters/setters from @Data/@Builder)
+			// that no caller invokes. They exist in the graph but don't count toward orphan metrics
+			// (Issue #2071).
+			if isLombokSynthesized(e) {
+				continue
+			}
 			nOrphans++
 			allOrphans = append(allOrphans, orphanEntry{
 				id:       e.ID,
@@ -493,6 +500,25 @@ func printTextReport(report ProbeReport) {
 		}
 		fmt.Println()
 	}
+}
+
+// isLombokSynthesized checks if an entity is a generated/synthesized entity
+// that should be excluded from orphan classification.
+func isLombokSynthesized(e *graph.Entity) bool {
+	if e.Properties == nil {
+		return false
+	}
+	// Check synthesized_from property for Lombok synthesis markers.
+	if synthesizedFrom, ok := e.Properties["synthesized_from"]; ok {
+		if strings.HasPrefix(synthesizedFrom, "lombok_") {
+			return true
+		}
+	}
+	// Check generated property.
+	if generated, ok := e.Properties["generated"]; ok && generated == "true" {
+		return true
+	}
+	return false
 }
 
 // suppress unused warning for reDigits (used for possible future deduplication).


### PR DESCRIPTION
## Summary

Exclude entities with `synthesized_from` starting with `lombok_` or `generated=true` from orphan classification. These are intentionally generated dead code (e.g. getters/setters from `@Data`/`@Builder`) that no caller invokes. They exist in the graph but don't count toward orphan metrics.

## Problem

The orphan classifier was counting Lombok-synthesized methods as real orphans. After the fix in #2062 (which avoids inventing fake edges), approximately 390 of the 405 Lombok-synth orphans on client-fixture-de are getters/setters that never have inbound calls in Java code. These are DTO construction patterns where instances are created via `new ProductDTO(...)` and then JSON-serialized.

## Solution

Added `isLombokSynthesized()` helper function that checks entity properties and skips classification of:
- Entities where `properties["synthesized_from"]` starts with `lombok_`
- Entities where `properties["generated"] == "true"`

Same approach as #2064 empty-SourceFile Module suppression.

## Expected Impact

- client-fixture-d orphan rate: 56.3% → likely ~10-15% (drops ~390 Lombok-synth getters/setters)
- archigraph + upvate + polyglot-platform: minimal change (don't use Lombok)

## Test Status

- Java extractor tests: ✓ PASS
- No regressions in internal/extractors tests

Closes #2071

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>