### PR TITLE
feat(testmap): detect Go testify suite receiver-method test functions (#2076)

### DIFF
--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -351,6 +351,132 @@ func TestMockOnly(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Go testify suite (#2076)
+// ---------------------------------------------------------------------------
+
+// TestGoTestifySuite_BasicMethod verifies that a receiver-method test on a
+// testify suite struct emits a TESTS edge and carries the correct framework /
+// confidence properties.
+func TestGoTestifySuite_BasicMethod(t *testing.T) {
+	src := `package user
+
+import (
+	"testing"
+	"github.com/stretchr/testify/suite"
+)
+
+type UserSuite struct{ suite.Suite }
+
+func (s *UserSuite) TestGetUser() {
+	u := s.repo.GetUser(1)
+	s.Require().NotNil(u)
+}
+
+func TestRunUserSuite(t *testing.T) {
+	suite.Run(t, new(UserSuite))
+}
+`
+	recs := runExtract(t, "user_test.go", "go", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected >=1 entity, got 0")
+	}
+	// TestGetUser must appear as a test_function.
+	found := false
+	for _, r := range recs {
+		if r.Properties["test_function"] == "TestGetUser" {
+			found = true
+			if r.Properties["test_framework"] != "go_testing" {
+				t.Errorf("framework=%q, want go_testing", r.Properties["test_framework"])
+			}
+			hasTestsEdge := false
+			for _, rel := range r.Relationships {
+				if rel.Kind == "TESTS" {
+					hasTestsEdge = true
+				}
+			}
+			if !hasTestsEdge {
+				t.Errorf("TestGetUser entity has no TESTS edge")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no entity with test_function=TestGetUser (got %d entities)", len(recs))
+		for _, r := range recs {
+			t.Logf("  entity: test_function=%q tested_function=%q", r.Properties["test_function"], r.Properties["tested_function"])
+		}
+	}
+}
+
+// TestGoTestifySuite_DirectCallHighConfidence verifies that a direct production
+// call inside a suite method is resolved at high confidence.
+func TestGoTestifySuite_DirectCallHighConfidence(t *testing.T) {
+	src := `package svc
+
+import (
+	"github.com/stretchr/testify/suite"
+)
+
+type RepoSuite struct{ suite.Suite }
+
+func (s *RepoSuite) TestFindOrder() {
+	order := FindOrder(42)
+	s.NotNil(order)
+}
+`
+	recs := runExtract(t, "repo_test.go", "go", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected entities")
+	}
+	rec := findByTested(t, recs, "TestFindOrder", "FindOrder")
+	if rec.Properties["confidence"] != "high" {
+		t.Errorf("confidence=%q, want high", rec.Properties["confidence"])
+	}
+	if !hasEdge(recs, "TestFindOrder", "FindOrder") {
+		t.Errorf("missing TESTS edge TestFindOrder→FindOrder")
+	}
+}
+
+// TestGoTestifySuite_NonSuiteReceiverSkipped ensures that receiver methods on
+// structs that do NOT embed suite.Suite are not falsely detected as tests.
+func TestGoTestifySuite_NonSuiteReceiverSkipped(t *testing.T) {
+	src := `package svc
+
+type MyHandler struct{}
+
+func (h *MyHandler) TestHelper() {
+	doInternal()
+}
+`
+	recs := runExtract(t, "helper_test.go", "go", src)
+	for _, r := range recs {
+		if r.Properties["test_function"] == "TestHelper" {
+			t.Errorf("non-suite receiver method should not be detected as a test")
+		}
+	}
+}
+
+// TestGoTestifySuite_StandardTestsUnaffected ensures legacy top-level tests
+// continue to work correctly alongside suite-method detection.
+func TestGoTestifySuite_StandardTestsUnaffected(t *testing.T) {
+	src := `package p
+import "testing"
+func TestStandard(t *testing.T) {
+	DoWork()
+}
+`
+	recs := runExtract(t, "p_test.go", "go", src)
+	found := false
+	for _, r := range recs {
+		if r.Properties["test_function"] == "TestStandard" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("standard top-level test was not detected")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Python pytest
 // ---------------------------------------------------------------------------
 

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -213,12 +213,56 @@ var goTestFuncRE = regexp.MustCompile(
 	`(?m)^\s*func\s+(Test\w+)\s*\(\s*\w+\s+\*testing\.T\s*\)\s*{`,
 )
 
+// goTestSuiteMethodRE matches testify suite receiver-method test functions of
+// the form: func (s *MySuite) TestFoo() {
+// The receiver type name is captured in group 1, the test name in group 2.
+var goTestSuiteMethodRE = regexp.MustCompile(
+	`(?m)^\s*func\s+\(\s*\w+\s+\*(\w+)\s*\)\s+(Test\w+)\s*\([^)]*\)\s*{`,
+)
+
+// goSuiteEmbedRE detects whether a named struct embeds suite.Suite from the
+// testify package. It matches: suite.Suite as a field in the struct body.
+// We use a simple source-level search rather than full AST parsing.
+var goSuiteEmbedRE = regexp.MustCompile(
+	`(?m)\bsuite\.Suite\b`,
+)
+
+// isSuiteStruct reports whether structName appears to be a testify suite struct
+// by checking whether the source contains a struct definition for structName
+// that embeds suite.Suite.
+func isSuiteStruct(source, structName string) bool {
+	// Fast path: source must reference suite.Suite at all.
+	if !goSuiteEmbedRE.MatchString(source) {
+		return false
+	}
+	// Build a regex: type <structName> struct { ... suite.Suite ... }
+	// We accept any ordering / whitespace between the struct open brace and the
+	// embed, covering single-field and multi-field structs.
+	structRE := regexp.MustCompile(
+		`(?ms)\btype\s+` + regexp.QuoteMeta(structName) + `\s+struct\s*\{[^}]*\bsuite\.Suite\b`,
+	)
+	return structRE.MatchString(source)
+}
+
 func detectGoTest(source string) []testFunction {
 	var out []testFunction
+	// Standard top-level test functions: func TestFoo(t *testing.T) { … }
 	for _, m := range goTestFuncRE.FindAllStringSubmatchIndex(source, -1) {
 		name := source[m[2]:m[3]]
 		body := extractBraceBody(source, m[1]-1)
 		out = append(out, testFunction{qname: name, body: body})
+	}
+	// Testify suite receiver-method tests: func (s *MySuite) TestFoo() { … }
+	// Only emit when the receiver type looks like a testify suite struct (embeds
+	// suite.Suite), to avoid false-positive matches on unrelated receiver methods.
+	for _, m := range goTestSuiteMethodRE.FindAllStringSubmatchIndex(source, -1) {
+		receiverType := source[m[2]:m[3]]
+		testName := source[m[4]:m[5]]
+		if !isSuiteStruct(source, receiverType) {
+			continue
+		}
+		body := extractBraceBody(source, m[1]-1)
+		out = append(out, testFunction{qname: testName, body: body})
 	}
 	return out
 }


### PR DESCRIPTION
## Problem

`goTestFuncRE` in `internal/extractors/cross/testmap/frameworks.go` only matches top-level `func TestFoo(t *testing.T)` functions. Testify suite tests use receiver methods (`func (s *MySuite) TestFoo()`) — no `*testing.T` parameter, the suite struct holds it — so they were silently skipped and no TESTS edges were emitted.

## Root cause

```go
var goTestFuncRE = regexp.MustCompile(
    `(?m)^\s*func\s+(Test\w+)\s*\(\s*\w+\s+\*testing\.T\s*\)\s*{`,
)
```

The regex requires `*testing.T` as the only parameter. Receiver-method forms never match.

## Solution

- Added `goTestSuiteMethodRE` that matches `func (s *MySuite) TestFoo() {` capturing both the receiver type name and the test name.
- Added `isSuiteStruct(source, structName)` which verifies the receiver type actually embeds `suite.Suite` before emitting — prevents false-positive matches on unrelated receiver methods that happen to start with `Test`.
- Updated `detectGoTest` to union both regex passes; matched suite methods emit `testFunction` records with the same body-extraction path as top-level functions.
- No changes to the framework registry, import hints, or edge-building pipeline — the fix is entirely within `detectGoTest`.

## Tests

Four new tests in `extractor_test.go`:

| Test | What it checks |
|---|---|
| `TestGoTestifySuite_BasicMethod` | `func (s *UserSuite) TestGetUser()` detected, TESTS edge emitted, framework=`go_testing` |
| `TestGoTestifySuite_DirectCallHighConfidence` | Direct production call inside suite method → confidence=`high` |
| `TestGoTestifySuite_NonSuiteReceiverSkipped` | Receiver on struct that does NOT embed `suite.Suite` is not detected |
| `TestGoTestifySuite_StandardTestsUnaffected` | Legacy `func TestFoo(t *testing.T)` still detected correctly |

`go test ./internal/extractors/cross/testmap/...` — zero failures (62 tests total).

## Acceptance checklist

- [x] `func (s *UserSuite) TestGetUser()` in a `_test.go` file is detected and emits a TESTS edge with `test_framework=go_testing`
- [x] The test function name (`TestGetUser`) is used as `test_function` on the entity
- [x] Standard `func TestFoo(t *testing.T)` tests are unaffected
- [x] Non-suite receiver methods beginning with `Test` are not falsely detected
- [x] `extractor_test.go` has four new tests covering testify suite method form

## Files changed

- `internal/extractors/cross/testmap/frameworks.go` — `goTestSuiteMethodRE`, `goSuiteEmbedRE`, `isSuiteStruct`, updated `detectGoTest`
- `internal/extractors/cross/testmap/extractor_test.go` — four new regression tests

Closes #2076

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)