### PR TITLE
feat(testmap): add Playwright framework entry (#2074)

### DIFF
--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -493,6 +493,59 @@ func TestJest_E2EPath(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Playwright
+// ---------------------------------------------------------------------------
+
+func TestPlaywright_ImportHintsDetection(t *testing.T) {
+	src := `import { test, expect } from '@playwright/test';
+
+test('logs in successfully', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[name="user"]', 'alice');
+});`
+	recs := runExtract(t, "tests/login.spec.ts", "typescript", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected playwright entities")
+	}
+	// Import hint should win over filename match, identifying as playwright not jest
+	if recs[0].Properties["test_framework"] != "playwright" {
+		t.Errorf("framework=%q, want playwright", recs[0].Properties["test_framework"])
+	}
+	// When no direct production calls are found, fallback uses filename convention
+	// to infer the tested_file (tests/login.spec.ts -> tests/login.ts)
+	if recs[0].Properties["tested_function"] != "login" {
+		t.Errorf("tested_function=%q, want login (from filename convention)", recs[0].Properties["tested_function"])
+	}
+}
+
+func TestPlaywright_PwExtensionDetection(t *testing.T) {
+	src := `import { test } from '@playwright/test';
+test('visit home', async ({ page }) => { await page.goto('/'); });`
+	recs := runExtract(t, "e2e/home.pw.ts", "typescript", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected entities from .pw.ts file")
+	}
+	if recs[0].Properties["test_framework"] != "playwright" {
+		t.Errorf("framework=%q, want playwright", recs[0].Properties["test_framework"])
+	}
+}
+
+func TestPlaywright_SpecFileWithoutPlaywrightImportIsJest(t *testing.T) {
+	// .spec.ts file without @playwright/test import should be detected as Jest
+	src := `import { describe, it, expect } from 'vitest';
+describe('test', () => {
+  it('works', () => { doWork(); });
+});`
+	recs := runExtract(t, "src/test.spec.ts", "typescript", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected entities")
+	}
+	if recs[0].Properties["test_framework"] != "jest" {
+		t.Errorf("framework=%q, want jest (not playwright)", recs[0].Properties["test_framework"])
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Ruby RSpec
 // ---------------------------------------------------------------------------
 

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -498,6 +498,14 @@ var frameworkOrder = []frameworkEntry{
 		detect: detectPytest,
 	},
 	{
+		name:        "playwright",
+		importHints: []string{"@playwright/test", "playwright"},
+		filenameHints: []*regexp.Regexp{
+			regexp.MustCompile(`\.pw\.(?:ts|tsx|js|jsx)$`),
+		},
+		detect: detectJest,
+	},
+	{
 		name:        "jest",
 		importHints: []string{"jest", "@jest", "vitest", "mocha", "chai", "jasmine"},
 		filenameHints: []*regexp.Regexp{


### PR DESCRIPTION
## Summary
Add a new Playwright framework entry to the testmap detector that properly identifies and tags Playwright test files with `test_framework=playwright` (not jest).

## Problem
- Files importing `@playwright/test` but without `.pw.*` naming convention were skipped or tagged as Jest
- No separate Playwright framework entry existed — requests merged into Jest's importHints
- This degraded filtering and reporting accuracy for Playwright-specific test analysis

## Solution
- Added new `playwright` frameworkEntry in `frameworks.go` that fires before Jest in `frameworkOrder`
- `importHints: ["@playwright/test", "playwright"]` — Playwright imports take priority
- `filenameHints: [\.pw\.(ts|tsx|js|jsx)$]` — `.pw.ts` / `.pw.js` files as fallback
- Reuses `detectJest` (same `test(...) / it(...)` syntax)
- Emits `test_framework=playwright` (not jest)

## Test Plan
- [x] `go test ./internal/extractors/cross/testmap/...` — zero failures (61 tests pass)
- [x] `TestPlaywright_ImportHintsDetection` — `.spec.ts` file with `@playwright/test` import correctly tagged as playwright
- [x] `TestPlaywright_PwExtensionDetection` — `.pw.ts` file detected via filename hint
- [x] `TestPlaywright_SpecFileWithoutPlaywrightImportIsJest` — `.spec.ts` without playwright import falls back to jest
- [x] Regression test: existing Jest tests unaffected (all Jest tests still pass)

## Acceptance
- [x] A Playwright test file with `import { test } from '@playwright/test'` produces `test_framework=playwright`
- [x] Files with `test("visits home page", async ({ page }) => { ... })` properly tagged
- [x] Existing Jest tests remain unaffected
- [x] `extractor_test.go` includes 3 new Playwright-specific test cases

Closes #2074

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>