### PR TITLE
feat(testmap): add Cypress framework entry (#2075)

### DIFF
--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -619,6 +619,69 @@ func TestJest_E2EPath(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Cypress
+// ---------------------------------------------------------------------------
+
+func TestCypress_CyTsFileDetection(t *testing.T) {
+	src := `import { HomePage } from '../pages/HomePage'
+
+describe('Home page', () => {
+  it('loads successfully', () => {
+    cy.visit('/')
+    HomePage.assertTitle()
+  })
+})`
+	recs := runExtract(t, "cypress/e2e/login.cy.ts", "typescript", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected cypress entities")
+	}
+	if recs[0].Properties["test_framework"] != "cypress" {
+		t.Errorf("framework=%q, want cypress", recs[0].Properties["test_framework"])
+	}
+	if recs[0].Properties["test_type"] != "e2e" {
+		t.Errorf("test_type=%q, want e2e", recs[0].Properties["test_type"])
+	}
+}
+
+func TestCypress_DirectCallToProduction(t *testing.T) {
+	src := `import { getUser } from '../app/user';
+describe('User page', () => {
+  it('should load user data', () => {
+    const u = getUser(1);
+    cy.wrap(u).should('exist');
+  })
+})`
+	recs := runExtract(t, "cypress/e2e/user.cy.ts", "typescript", src)
+	found := false
+	for _, r := range recs {
+		if r.Properties["tested_function"] == "getUser" && r.Properties["confidence"] == "high" {
+			found = true
+			if r.Properties["test_framework"] != "cypress" {
+				t.Errorf("framework=%q, want cypress", r.Properties["test_framework"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected getUser high-confidence entity from cypress test")
+	}
+}
+
+func TestCypress_CyGlobalNotATarget(t *testing.T) {
+	src := `describe('App', () => {
+  it('navigates', () => {
+    cy.visit('/');
+    cy.get('.button').click();
+  })
+})`
+	recs := runExtract(t, "cypress/e2e/app.cy.ts", "typescript", src)
+	for _, r := range recs {
+		if strings.HasPrefix(r.Properties["tested_function"], "cy.") {
+			t.Errorf("cy.* call should be filtered as stopword: %q", r.Properties["tested_function"])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Playwright
 // ---------------------------------------------------------------------------
 

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -542,6 +542,16 @@ var frameworkOrder = []frameworkEntry{
 		detect: detectPytest,
 	},
 	{
+		name:        "cypress",
+		importHints: []string{"cypress", "cy.", "@cypress/"},
+		filenameHints: []*regexp.Regexp{
+			regexp.MustCompile(`\.cy\.(?:ts|tsx|js|jsx)$`),
+			regexp.MustCompile(`cypress/e2e/`),
+			regexp.MustCompile(`cypress/integration/`),
+		},
+		detect: detectJest,
+	},
+	{
 		name:        "playwright",
 		importHints: []string{"@playwright/test", "playwright"},
 		filenameHints: []*regexp.Regexp{

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -82,6 +82,8 @@ var stopwords = map[string]bool{
 	"jest.fn": true, "jest.mock": true, "jest.spyon": true,
 	"beforeeach": true, "aftereach": true, "beforeall": true, "afterall": true,
 	"it": true, "test": true, "describe": true,
+	// Cypress
+	"cy": true,
 	// JUnit
 	"assertions.assertequals": true, "assertequals": true,
 	"assertnull": true, "assertnotnull": true,
@@ -112,6 +114,10 @@ func isStopword(id string) bool {
 	// Any identifier that starts with "test" or "mock" is not a production
 	// call for mapping purposes.
 	if strings.HasPrefix(low, "test") || strings.HasPrefix(low, "mock") {
+		return true
+	}
+	// Cypress global object — cy.visit(), cy.get(), etc.
+	if strings.HasPrefix(low, "cy.") {
 		return true
 	}
 	// Anything that looks like an assertion on a method (`.should`, `.toBe`,


### PR DESCRIPTION
## Summary

Add Cypress test framework detection to archigraph's testmap extractor. Cypress test files (`.cy.ts`, `.cy.js`) with `describe()`/`it()` blocks will now emit `test_framework=cypress` tags and resolve TESTS edges to production calls.

## Changes

- **frameworks.go**: Add `cypress` entry to `frameworkOrder` (before Jest for precedence)
  - Import hints: `cypress`, `cy.`, `@cypress/`
  - Filename patterns: `.cy.ts`, `.cy.js`, `.cy.tsx`, `.cy.jsx`
  - Directory hints: `cypress/e2e/`, `cypress/integration/`
  - Reuses `detectJest()` for body parsing (same test syntax)

- **resolver.go**: Add `cy.` prefix filtering
  - Prevent `cy.visit()`, `cy.get()`, etc. from appearing as production targets
  - Added to `isStopword()` function alongside Cypress stopword entry

- **extractor_test.go**: Add regression tests
  - `TestCypress_CyTsFileDetection`: Verify framework detection
  - `TestCypress_DirectCallToProduction`: Verify TESTS edges to real calls
  - `TestCypress_CyGlobalNotATarget`: Verify `cy.*` filtering

## Acceptance

- [x] `.cy.ts` files with `describe()`/`it()` detected as `test_framework=cypress`
- [x] Direct production calls in test body emit high-confidence TESTS edges
- [x] `cy.visit()`, `cy.get()` etc. NOT emitted as production targets
- [x] Existing Jest/Playwright tests unaffected
- [x] All 76 testmap tests pass

Closes #2075.

🤖 Generated with Claude Code