### PR TITLE
fix(daemon): admission control wedge — delta-based budget + dead-man switch (#1763)

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/agents"
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/process"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/dashboard"
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -42,11 +43,38 @@ var daemonProgressBroker = progress.NewBroker()
 // defaultDashboardPort is the default TCP port for the embedded dashboard.
 const defaultDashboardPort = 47274
 
-// defaultRSSBudgetMB is the production default for the concurrency
-// cap. Chosen to match the post-#639 single-reindex peak (343MB) plus
-// headroom for one small concurrent reindex: targets the 500MB cap
-// from the real-fixture benchmark.
-const defaultRSSBudgetMB = 500
+// defaultRSSBudgetMB returns the production default for the admission-control
+// budget (in MB). It auto-tunes based on available system memory so that
+// the daemon's idle RSS (heap inflation after graph load) does not cause the
+// scheduler to wedge when the user's repos are large.
+//
+// Formula: min(2048, systemMemoryMB / 8).  On a 16 GB machine this gives
+// 2 GB; on an 8 GB machine 1 GB; on a 4 GB machine 512 MB.  The env var
+// ARCHIGRAPH_MAX_RSS_BUDGET_MB and the --max-rss-budget flag both override
+// the result, so operators can tune down on constrained hardware.
+//
+// NOTE: this budget is for the ADDITIONAL predicted RSS of concurrently
+// running index jobs only — the daemon's idle RSS is never subtracted from
+// it (delta-based accounting).  See internal/daemon/sched for the admission
+// logic.
+func defaultRSSBudgetMB() int64 {
+	sysMB := systemTotalMemoryMB()
+	if sysMB <= 0 {
+		return 500 // safe fallback when sysinfo is unavailable
+	}
+	budget := sysMB / 8
+	const cap = 2048
+	if budget > cap {
+		budget = cap
+	}
+	return budget
+}
+
+// systemTotalMemoryMB returns total host physical memory in MB via the
+// process package's platform-specific sysinfo implementation.
+func systemTotalMemoryMB() int64 {
+	return process.TotalMemoryMB()
+}
 
 // defaultMaxConcurrentGroups is the production default for parallel group
 // indexing during a Rebuild RPC (#1276). With 2 concurrent group slots a
@@ -87,7 +115,7 @@ func runDaemon(argv []string) error {
 	// with a clear error rather than being silently ignored.
 	fs := flag.NewFlagSet("daemon", flag.ContinueOnError)
 	var maxRSSBudget int64
-	envBudget := int64(defaultRSSBudgetMB)
+	envBudget := defaultRSSBudgetMB()
 	if v := os.Getenv("ARCHIGRAPH_MAX_RSS_BUDGET_MB"); v != "" {
 		if parsed, perr := strconv.ParseInt(v, 10, 64); perr == nil && parsed >= 0 {
 			envBudget = parsed

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -72,20 +72,27 @@ func runStatus(w io.Writer, filter string) error {
 					st.QueueLen, len(st.IndexInFlight), len(st.PendingAlgo), len(st.PendingLinks))
 			}
 			if st.RSSBudgetMB > 0 {
-				headroom := st.RSSBudgetMB - st.RSSUsedMB
-				if headroom < 0 {
-					headroom = 0
+				// Two separate lines: daemon idle RSS (informational) vs.
+				// admission budget (delta-based predicted in-flight sum).
+				// These are intentionally distinct — idle RSS can exceed the
+				// budget without blocking jobs, because jobs are only blocked
+				// when sum(predicted_in_flight) + new_job_pred > budget.
+				fmt.Fprintf(w, "  rss: daemon=%dMB (actual process RSS)\n", st.RSSUsedMB)
+				admHeadroom := st.RSSBudgetMB - st.AdmissionUsedMB
+				if admHeadroom < 0 {
+					admHeadroom = 0
 				}
-				fmt.Fprintf(w, "  rss budget: used=%dMB / %dMB (headroom=%dMB) blocked=%d\n",
-					st.RSSUsedMB, st.RSSBudgetMB, headroom, len(st.BlockedJobs))
+				fmt.Fprintf(w, "  admission: queued=%d admitted=%d predicted=%dMB / budget=%dMB (headroom=%dMB)\n",
+					len(st.BlockedJobs), len(st.InFlightJobs),
+					st.AdmissionUsedMB, st.RSSBudgetMB, admHeadroom)
 				if len(st.InFlightJobs) > 0 {
 					for _, j := range st.InFlightJobs {
-						fmt.Fprintf(w, "    running: %s (predicted=%dMB)\n", j.Path, j.PredictedMB)
+						fmt.Fprintf(w, "    admitted: %s (predicted=%dMB)\n", j.Path, j.PredictedMB)
 					}
 				}
 				if len(st.BlockedJobs) > 0 {
 					for _, p := range st.BlockedJobs {
-						fmt.Fprintf(w, "    blocked: %s\n", p)
+						fmt.Fprintf(w, "    queued:   %s\n", p)
 					}
 				}
 			}

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -51,14 +51,22 @@ type StatusReply struct {
 	RecentLog      []SchedLogEntry    `json:"recent_log,omitempty"`
 
 	// Concurrency-cap additions. BudgetMB=0 means admission control is
-	// disabled. UsedMB is the sum of predicted RSS reserved by jobs
-	// currently running. InFlightJobs duplicates IndexInFlight with
-	// per-job predicted-MB so the status formatter can print headroom.
+	// disabled.
+	//
+	// RSSUsedMB is the ACTUAL daemon process RSS in MB — informational
+	// only; it is NOT used in admission math.
+	//
+	// AdmissionUsedMB is the sum of predicted MB reserved by currently-
+	// admitted jobs; this is what the scheduler compares against
+	// RSSBudgetMB (delta-based accounting).
+	//
+	// InFlightJobs duplicates IndexInFlight with per-job predicted-MB.
 	// BlockedJobs lists repos waiting for the budget to free.
-	RSSBudgetMB  int64              `json:"rss_budget_mb,omitempty"`
-	RSSUsedMB    int64              `json:"rss_used_mb,omitempty"`
-	InFlightJobs []InFlightJobState `json:"in_flight_jobs,omitempty"`
-	BlockedJobs  []string           `json:"blocked_jobs,omitempty"`
+	RSSBudgetMB     int64              `json:"rss_budget_mb,omitempty"`
+	RSSUsedMB       int64              `json:"rss_used_mb,omitempty"`
+	AdmissionUsedMB int64              `json:"admission_used_mb,omitempty"`
+	InFlightJobs    []InFlightJobState `json:"in_flight_jobs,omitempty"`
+	BlockedJobs     []string           `json:"blocked_jobs,omitempty"`
 
 	// DashboardPort is the TCP port the daemon's embedded dashboard HTTP
 	// server is bound to. Zero means the dashboard is not running.

--- a/internal/daemon/sched/admission_test.go
+++ b/internal/daemon/sched/admission_test.go
@@ -212,6 +212,175 @@ func TestRSSHistoryRoundTrip(t *testing.T) {
 	}
 }
 
+// TestAdmissionDeltaIgnoresProcessRSS is the regression test for #1763.
+// It verifies that admission control operates on the delta sum of predicted
+// in-flight jobs ONLY, and does not include the daemon's process-level RSS.
+//
+// Scenario: daemon idle RSS >> budget (simulated by a large-but-irrelevant
+// process memory baseline), but no jobs are in-flight. The next queued job
+// should still be admitted because the scheduler's usedMB counter (delta
+// ledger) starts at zero.
+//
+// Implementation note: the scheduler never reads process RSS for admission
+// decisions — it only uses s.usedMB (predicted in-flight sum). This test
+// confirms that a single job is admitted even when its prediction is just
+// under budget, regardless of what the OS reports as process RSS.
+func TestAdmissionDeltaIgnoresProcessRSS(t *testing.T) {
+	// Budget = 200 MB; single job predicted at 150 MB.
+	// The test passes if the job is admitted (delta 0+150 <= 200).
+	// If the scheduler were to include process RSS it would need to be
+	// mocked; since it doesn't, we just verify normal admission works.
+	var admitted atomic.Int32
+	gate := make(chan struct{})
+	s := New(Config{
+		Workers:  1,
+		BudgetMB: 200,
+		Predict:  func(_ string) int64 { return 150 },
+		Index: func(_ context.Context, _ string) error {
+			admitted.Add(1)
+			<-gate
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.Enqueue("/repo-a")
+	time.Sleep(200 * time.Millisecond)
+	if got := admitted.Load(); got != 1 {
+		t.Fatalf("expected job admitted (delta 0+150 <= 200); admitted=%d", got)
+	}
+	snap := s.Snapshot()
+	if snap.UsedMB != 150 {
+		t.Errorf("admission ledger: got UsedMB=%d, want 150", snap.UsedMB)
+	}
+	gate <- struct{}{}
+}
+
+// TestAdmissionMultipleJobsDeltaAccounting verifies that when two jobs are
+// in-flight their predictions are SUMMED (not replaced) in the admission
+// ledger, and a third job that would exceed the sum is deferred.
+func TestAdmissionMultipleJobsDeltaAccounting(t *testing.T) {
+	// Budget = 300, two jobs at 120 each = 240 ≤ 300 → both admitted.
+	// Third job at 120: 240+120=360 > 300 → deferred.
+	gate := make(chan struct{})
+	var admitted atomic.Int32
+	s := New(Config{
+		Workers:  3,
+		BudgetMB: 300,
+		Predict:  func(_ string) int64 { return 120 },
+		Index: func(_ context.Context, _ string) error {
+			admitted.Add(1)
+			<-gate
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.Enqueue("/a")
+	s.Enqueue("/b")
+	s.Enqueue("/c")
+	time.Sleep(250 * time.Millisecond)
+
+	snap := s.Snapshot()
+	if snap.UsedMB != 240 {
+		t.Errorf("admission ledger with 2 jobs at 120MB: got UsedMB=%d, want 240", snap.UsedMB)
+	}
+	if got := admitted.Load(); got != 2 {
+		t.Errorf("expected exactly 2 admitted (240 ≤ 300), got %d", got)
+	}
+	if len(snap.BlockedJobs) != 1 {
+		t.Errorf("expected 1 blocked job, got %v", snap.BlockedJobs)
+	}
+	// Release one — third should then be admitted.
+	gate <- struct{}{}
+	time.Sleep(200 * time.Millisecond)
+	if got := admitted.Load(); got != 3 {
+		t.Errorf("expected 3 admitted after releasing one, got %d", got)
+	}
+	gate <- struct{}{}
+	gate <- struct{}{}
+}
+
+// TestDeadManSwitchForceAdmits verifies that checkDeadMan force-admits the
+// smallest queued job when:
+//   - the pending queue is non-empty,
+//   - the inflight map is empty (nothing is running),
+//   - the dead-man clock has exceeded deadManTimeout.
+//
+// We construct this state directly by manipulating the scheduler's internal
+// fields under the mutex: inject a fake pending job, leave inflight empty,
+// pre-set usedMB high enough to block normal admission, and backdate deadManAt.
+// Then call checkDeadMan() directly to bypass the 30s ticker.
+func TestDeadManSwitchForceAdmits(t *testing.T) {
+	var admitted atomic.Int32
+	done := make(chan struct{})
+	s := New(Config{
+		Workers:  2,
+		BudgetMB: 100,
+		Predict:  func(_ string) int64 { return 50 },
+		Index: func(_ context.Context, _ string) error {
+			admitted.Add(1)
+			<-done
+			return nil
+		},
+	})
+	s.Start()
+	defer func() {
+		close(done) // unblock any in-flight index so Stop() can drain
+		s.Stop()
+	}()
+
+	// Directly inject a stuck state: /wedged is in the pending queue,
+	// inflight is empty, but usedMB is 999 so tryAdmit defers it, and
+	// deadManAt is past the timeout.
+	s.mu.Lock()
+	s.pendingQ = []string{"/wedged"}
+	s.pendingIndex["/wedged"] = true
+	s.queueLen = 1
+	s.usedMB = 999 // synthetic stuck ledger — no running job caused this
+	s.deadManAt = time.Now().Add(-(deadManTimeout + time.Second))
+	s.mu.Unlock()
+
+	// Sanity: normal admission should defer /wedged (usedMB > budget).
+	s.tryAdmit()
+	time.Sleep(50 * time.Millisecond)
+	if got := admitted.Load(); got != 0 {
+		t.Fatalf("expected /wedged deferred by admission; admitted=%d", got)
+	}
+
+	// Now call checkDeadMan — it should detect inflight==0 + expired clock
+	// and force-admit the job.
+	// checkDeadMan needs inflight to be empty; usedMB was synthetic so
+	// reset inflight to confirm the dead-man condition is met.
+	s.mu.Lock()
+	// inflight is already empty (we never put anything there); just
+	// re-backdate in case time moved forward.
+	s.deadManAt = time.Now().Add(-(deadManTimeout + time.Second))
+	s.mu.Unlock()
+
+	s.checkDeadMan()
+	time.Sleep(200 * time.Millisecond)
+
+	if got := admitted.Load(); got < 1 {
+		t.Errorf("expected dead-man to force-admit /wedged; admitted=%d", got)
+	}
+
+	// Verify the admit_deadman log entry.
+	snap := s.Snapshot()
+	var foundDeadMan bool
+	for _, e := range snap.RecentLog {
+		if e.Kind == "admit_deadman" {
+			foundDeadMan = true
+			break
+		}
+	}
+	if !foundDeadMan {
+		t.Errorf("expected admit_deadman log entry in recent log; got: %+v", snap.RecentLog)
+	}
+}
+
 // TestPredictRSSSmokeOnFakeRepo verifies the source-size predictor
 // returns a sensible MB number for a tiny fixture.
 func TestPredictRSSSmokeOnFakeRepo(t *testing.T) {

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -84,6 +84,12 @@ type Config struct {
 	History *RSSHistory
 }
 
+// deadManTimeout is how long the scheduler waits with a non-empty pending
+// queue and zero admitted jobs before force-admitting the smallest queued
+// job. This is the relief valve for admission-control wedge scenarios
+// (e.g. inflated RSS history predictions that exceed the budget).
+const deadManTimeout = 2 * time.Minute
+
 // Scheduler is constructed once per daemon. It owns:
 //   - a bounded job channel (per-repo dedup happens before enqueue),
 //   - a worker pool,
@@ -112,6 +118,11 @@ type Scheduler struct {
 	algoCancel   map[string]context.CancelFunc
 	indexedRepos map[string]repoStats
 	recentLog    []LogEntry
+
+	// deadManAt tracks when the pending queue became non-empty with no
+	// admitted jobs. The dead-man goroutine force-admits a job when this
+	// exceeds deadManTimeout. Zero means the clock is not running.
+	deadManAt time.Time
 }
 
 // jobToken couples a repo path with the predicted MB that admission
@@ -176,13 +187,15 @@ func New(cfg Config) *Scheduler {
 	}
 }
 
-// Start spins up the dedup goroutine + admission loop + worker pool.
-// Stop reverses it.
+// Start spins up the dedup goroutine + admission loop + worker pool +
+// dead-man switch. Stop reverses it.
 func (s *Scheduler) Start() {
 	s.wg.Add(1)
 	go s.dedupLoop()
 	s.wg.Add(1)
 	go s.admitLoop()
+	s.wg.Add(1)
+	go s.deadManLoop()
 	for i := 0; i < s.cfg.Workers; i++ {
 		s.wg.Add(1)
 		go s.workerLoop()
@@ -240,6 +253,11 @@ func (s *Scheduler) dedupLoop() {
 			s.pendingIndex[p] = true
 			s.pendingQ = append(s.pendingQ, p)
 			s.queueLen++
+			// Start the dead-man clock if nothing is currently
+			// running — otherwise there will be a poke on completion.
+			if len(s.inflight) == 0 && s.deadManAt.IsZero() {
+				s.deadManAt = time.Now()
+			}
 			s.mu.Unlock()
 			s.poke()
 		}
@@ -271,6 +289,84 @@ func (s *Scheduler) admitLoop() {
 		}
 		s.tryAdmit()
 	}
+}
+
+// deadManLoop runs a periodic check: if the pending queue has been non-empty
+// with zero admitted jobs for longer than deadManTimeout, it force-admits the
+// smallest predicted job so the daemon cannot wedge indefinitely. The
+// force-admit overrides the budget — it is the last-resort relief valve.
+//
+// The dead-man clock (deadManAt) is set when a job enters the pending queue
+// while the inflight map is empty, and cleared when any job is admitted.
+func (s *Scheduler) deadManLoop() {
+	defer s.wg.Done()
+	tick := time.NewTicker(30 * time.Second)
+	defer tick.Stop()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-tick.C:
+			s.checkDeadMan()
+		}
+	}
+}
+
+// checkDeadMan inspects the dead-man state and force-admits the smallest
+// pending job if the timeout has elapsed with no admitted jobs.
+func (s *Scheduler) checkDeadMan() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.pendingQ) == 0 || len(s.inflight) > 0 {
+		// Queue is clear OR jobs are running — reset the clock.
+		s.deadManAt = time.Time{}
+		return
+	}
+
+	now := time.Now()
+	if s.deadManAt.IsZero() {
+		// Start the clock: queue has jobs but nothing is running.
+		s.deadManAt = now
+		return
+	}
+
+	if now.Sub(s.deadManAt) < deadManTimeout {
+		return // not yet timed out
+	}
+
+	// Timeout elapsed: find the smallest predicted job and force-admit it.
+	// "Smallest" minimises the memory spike from the override.
+	smallestIdx := 0
+	smallestMB := s.predictedFor(s.pendingQ[0])
+	for i := 1; i < len(s.pendingQ); i++ {
+		if mb := s.predictedFor(s.pendingQ[i]); mb < smallestMB {
+			smallestMB = mb
+			smallestIdx = i
+		}
+	}
+	repo := s.pendingQ[smallestIdx]
+	// Remove from queue (preserve order for remaining entries).
+	s.pendingQ = append(s.pendingQ[:smallestIdx], s.pendingQ[smallestIdx+1:]...)
+	s.inflight[repo] = smallestMB
+	s.usedMB += smallestMB
+	stuckFor := now.Sub(s.deadManAt).Truncate(time.Second)
+	s.deadManAt = time.Time{} // reset clock; the job is now admitted
+	s.logEventLocked("admit_deadman", repo,
+		"force-admitted after "+stuckFor.String()+" with no progress; predicted="+formatMB(smallestMB))
+	s.logger.Printf("sched: dead-man: force-admitting %s (predicted=%dMB) after queue stuck %s",
+		repo, smallestMB, stuckFor)
+
+	tok := jobToken{repoPath: repo, predictedMB: smallestMB}
+	// Dispatch asynchronously so we don't hold the lock while blocking on
+	// the jobs channel. The worker pool is guaranteed to drain the channel
+	// because the pool size >= 1.
+	go func() {
+		select {
+		case s.jobs <- tok:
+		case <-s.stop:
+		}
+	}()
 }
 
 // tryAdmit walks the pending queue head-first and dispatches every job
@@ -307,6 +403,7 @@ func (s *Scheduler) tryAdmit() {
 		s.pendingQ = s.pendingQ[1:]
 		s.inflight[repo] = predicted
 		s.usedMB += predicted
+		s.deadManAt = time.Time{} // job admitted — reset dead-man clock
 		s.logEventLocked("admit_ok", repo,
 			"predicted="+formatMB(predicted)+" used="+formatMB(s.usedMB))
 		tok := jobToken{repoPath: repo, predictedMB: predicted}

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -205,10 +205,12 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 		reply.PendingAlgo = snap.PendingAlgo
 		reply.PendingLinks = snap.PendingLinks
 		reply.RSSBudgetMB = snap.BudgetMB
-		// RSSUsedMB reports actual measured daemon RSS (in MB), not predicted
-		// sum of in-flight jobs. This ensures the budget display shows the
-		// real memory pressure (#803).
+		// RSSUsedMB reports actual measured daemon process RSS (informational).
 		reply.RSSUsedMB = int64(reply.RSSBytes / (1024 * 1024))
+		// AdmissionUsedMB is the scheduler's delta ledger: sum of predicted
+		// MB reserved by currently-admitted jobs. This is what the admission
+		// logic compares against BudgetMB — not the process RSS.
+		reply.AdmissionUsedMB = snap.UsedMB
 		reply.BlockedJobs = snap.BlockedJobs
 		for _, j := range snap.InFlight {
 			reply.IndexInFlight = append(reply.IndexInFlight, j.Path)

--- a/internal/process/sysinfo_darwin.go
+++ b/internal/process/sysinfo_darwin.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package process
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// TotalMemoryMB returns the total physical memory of the host in megabytes.
+// On macOS it reads hw.memsize via sysctl. Returns 0 on failure.
+func TotalMemoryMB() int64 {
+	out, err := exec.Command("sysctl", "-n", "hw.memsize").Output()
+	if err != nil {
+		return 0
+	}
+	bytes, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil || bytes <= 0 {
+		return 0
+	}
+	return bytes / (1024 * 1024)
+}

--- a/internal/process/sysinfo_linux.go
+++ b/internal/process/sysinfo_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package process
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// TotalMemoryMB returns the total physical memory of the host in megabytes.
+// On Linux it reads MemTotal from /proc/meminfo. Returns 0 on failure.
+func TotalMemoryMB() int64 {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "MemTotal:") {
+			continue
+		}
+		// Format: "MemTotal:       16384000 kB"
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			break
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil || kb <= 0 {
+			break
+		}
+		return kb / 1024
+	}
+	return 0
+}

--- a/internal/process/sysinfo_other.go
+++ b/internal/process/sysinfo_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin
+
+package process
+
+// TotalMemoryMB returns 0 on unsupported platforms.
+// Callers that use this to compute a budget default should fall back to
+// their hard-coded safe value when 0 is returned.
+func TotalMemoryMB() int64 {
+	return 0
+}


### PR DESCRIPTION
## Summary

- **Root A — Budget accounting**: `RSSUsedMB` in `service.go` was incorrectly set to actual daemon process RSS (632MB on a loaded daemon) instead of the scheduler's delta ledger (sum of predicted in-flight jobs). Added `AdmissionUsedMB` to `StatusReply` to carry the correct scheduler-side value. Also replaced the fixed 500MB `defaultRSSBudgetMB` constant with an auto-tuning function: `min(2048, system_total_memory_MB/8)`, so large-graph deployments don't wedge on a budget too small for the daemon's idle heap inflation.
- **Root B — Dead-man switch**: Added a `deadManLoop` goroutine that fires every 30 seconds. If the pending queue has been non-empty with zero admitted jobs for more than 2 minutes (`deadManTimeout`), it force-admits the smallest predicted job and logs `admit_deadman`. This is the relief valve for any future regression in admission logic.
- **Root C — Status clarity**: The misleading `used=632MB / 500MB (headroom=0MB) blocked=0` line is replaced with two distinct lines: `rss: daemon=NMB (actual process RSS)` (informational) and `admission: queued=N admitted=M predicted=XMB / budget=YMB (headroom=ZMB)` (what actually gates jobs). `in_flight` disambiguated to `admitted`; `blocked` becomes `queued`.

## Investigation findings

**Q: Is the admission check delta-only or absolute?**
Delta-only. `tryAdmit` checks `s.usedMB + predicted <= s.cfg.BudgetMB` where `s.usedMB` is the sum of predicted MB for currently-running jobs only. The daemon's idle RSS is never included in admission math.

**Q: What does `headroom=0` mean in the old status output?**
`Budget - RSSUsedMB`, where `RSSUsedMB` was wired to **actual daemon process RSS** (632MB), not the scheduler's in-flight prediction sum. This made the display misleading — it showed negative headroom even when the scheduler's ledger was at 0. The real admission headroom (`Budget - AdmissionUsedMB`) would have been `500 - 0 = 500MB` with no jobs running.

**Q: Does `in_flight=4` count admitted (running) or queued (waiting) jobs?**
The top-level `in_flight` field in `StatusReply` is `s.inFlight` from the **service layer** (increments for every active Rebuild RPC), not the scheduler's admitted-jobs count. The scheduler's inflight map is exposed as `IndexInFlight`/`InFlightJobs`. The `in_flight=4` in the repro reflects 4 concurrent Rebuild RPC calls (groups), which go through `daemonRebuildFunc` entirely bypassing the scheduler — the scheduler is only for watcher-driven reactive reindexes.

## Changed files

- `cmd/archigraph/daemon.go` — auto-tuning `defaultRSSBudgetMB()` + `systemTotalMemoryMB()` helper
- `internal/process/sysinfo_{darwin,linux,other}.go` — new platform-specific `TotalMemoryMB()` 
- `internal/daemon/sched/scheduler.go` — `deadManLoop` + `checkDeadMan` + `deadManAt` clock tracking; `tryAdmit` clears clock on admission; `dedupLoop` starts clock when queue gains first job with empty inflight
- `internal/daemon/proto/proto.go` — `AdmissionUsedMB` field added to `StatusReply`
- `internal/daemon/service.go` — wire `reply.AdmissionUsedMB = snap.UsedMB`
- `internal/cli/status.go` — two-line RSS display; `admitted`/`queued` terminology
- `internal/daemon/sched/admission_test.go` — 3 new tests

## Test plan

- [x] `go test ./internal/daemon/sched/...` — all 13 tests pass including 3 new
- [x] `go test ./internal/daemon/... ./internal/cli/... ./internal/process/...` — all pass
- [x] `go build ./...` — clean (one pre-existing lua parser C warning, unrelated)
- [ ] Manual: start daemon on large-graph machine; verify `archigraph status` shows two-line RSS/admission output
- [ ] Manual: verify `archigraph status` shows `headroom>0` when no jobs are running (previously showed `headroom=0` due to process RSS > budget)

## Checklist

- [x] Worktree isolated at `archigraph-worktrees/fix-1763-admission-wedge`
- [x] No changes to main checkout, launchctl, or go install
- [x] No real client names in any artifact

Closes #1763

🤖 Generated with [Claude Code](https://claude.com/claude-code)