### PR TITLE
feat(gitmeta): record HEAD ref + SHA in graph metadata (#2088)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
 	idiff "github.com/cajasmota/archigraph/internal/indexer/diff"
 	"github.com/cajasmota/archigraph/internal/install/detect"
+	"github.com/cajasmota/archigraph/internal/gitmeta"
 	"github.com/cajasmota/archigraph/internal/module"
 	"github.com/cajasmota/archigraph/internal/progress"
 	"github.com/cajasmota/archigraph/internal/resolve"
@@ -347,6 +348,27 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 	doc, err := idx.Run(context.Background(), absRepo)
 	if err != nil {
 		return err
+	}
+
+	// Phase 0 git metadata (#2088). Capture HEAD ref + SHA + worktree flag
+	// and stamp them onto the document BEFORE the rename-detect pass so
+	// all on-disk representations (graph.fb and graph.json) carry them.
+	// Non-git directories return a zero-value Info; the Document fields stay
+	// empty, which is the correct default for old readers.
+	{
+		gi := gitmeta.Capture(absRepo)
+		doc.IndexedRef = gi.Ref
+		doc.IndexedSHA = gi.SHA
+		doc.IsWorktree = gi.IsWorktree
+		if gi.SHA != "" {
+			fmt.Fprintf(os.Stderr, "archigraph: git HEAD %s @ %s (worktree=%v)\n",
+				gi.SHA, func() string {
+					if gi.Ref == "" {
+						return "detached"
+					}
+					return gi.Ref
+				}(), gi.IsWorktree)
+		}
 	}
 
 	// Pass 5.5 — rename detection (#1344). Load the previous graph from disk

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -43,6 +43,12 @@ type RepoStatus struct {
 	Files          int
 	LastIndexed    time.Time
 	LastIndexedAge string // formatted duration like "5m ago"
+
+	// Phase 0 git metadata (#2088). Empty when the graph predates this
+	// feature or was built from a non-git directory.
+	IndexedRef string // branch name, or "" for detached HEAD / non-git
+	IndexedSHA string // 12-char abbreviated commit hash, or ""
+	IsWorktree bool   // true when the repo was a linked git worktree at index time
 }
 
 // ComputeStatusSummary loads the per-repo graph-stats.json files and enrichment
@@ -106,6 +112,10 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 			doc, err := graph.LoadGraphFromDir(stateDir)
 			if err == nil && doc != nil {
 				rs.Files = doc.Stats.Files
+				// Phase 0 git metadata (#2088).
+				rs.IndexedRef = doc.IndexedRef
+				rs.IndexedSHA = doc.IndexedSHA
+				rs.IsWorktree = doc.IsWorktree
 				for _, e := range doc.Entities {
 					// #1217: count all three http endpoint kind strings.
 					if e.Kind == "http_endpoint" || e.Kind == "http_endpoint_definition" || e.Kind == "http_endpoint_call" {
@@ -167,6 +177,23 @@ func formatTimeSince(t time.Time) string {
 	return fmt.Sprintf("%dd ago", d)
 }
 
+// formatGitRef builds the "@ main (abc12345)" suffix for a repo status line.
+// Returns "" when no SHA is available (pre-#2088 graph or non-git repo).
+func formatGitRef(ref, sha string, isWorktree bool) string {
+	if sha == "" {
+		return ""
+	}
+	label := ref
+	if label == "" {
+		label = "detached"
+	}
+	s := fmt.Sprintf(" @ %s (%s)", label, sha)
+	if isWorktree {
+		s += " [worktree]"
+	}
+	return s
+}
+
 // PrintStatusSummary writes the per-group and per-repo statistics to w.
 // The format includes per-repo statistics aligned in columns, followed by aggregated totals.
 func PrintStatusSummary(w io.Writer, s *StatusSummary) {
@@ -194,12 +221,14 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 	// Print each repo on one line.
 	for _, slug := range slugs {
 		rs := s.RepoStats[slug]
-		fmt.Fprintf(w, "  %-*s  %5s files  %6s entities  %6s rels  indexed %s\n",
+		gitSuffix := formatGitRef(rs.IndexedRef, rs.IndexedSHA, rs.IsWorktree)
+		fmt.Fprintf(w, "  %-*s  %5s files  %6s entities  %6s rels  indexed %s%s\n",
 			maxSlugLen, slug,
 			fmtInt(rs.Files),
 			fmtInt(rs.Entities),
 			fmtInt(rs.Relationships),
-			rs.LastIndexedAge)
+			rs.LastIndexedAge,
+			gitSuffix)
 	}
 
 	// Print aggregated totals.

--- a/internal/cli/status_stats_test.go
+++ b/internal/cli/status_stats_test.go
@@ -12,6 +12,29 @@ import (
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
+func TestFormatGitRef(t *testing.T) {
+	tests := []struct {
+		ref        string
+		sha        string
+		isWorktree bool
+		want       string
+	}{
+		{"main", "abc12345678", false, " @ main (abc12345678)"},
+		{"feat/my-feature", "def56789012", false, " @ feat/my-feature (def56789012)"},
+		{"", "abc12345678", false, " @ detached (abc12345678)"},
+		{"main", "abc12345678", true, " @ main (abc12345678) [worktree]"},
+		{"", "", false, ""},
+		{"main", "", false, ""},
+	}
+	for _, tt := range tests {
+		got := formatGitRef(tt.ref, tt.sha, tt.isWorktree)
+		if got != tt.want {
+			t.Errorf("formatGitRef(%q, %q, %v) = %q, want %q",
+				tt.ref, tt.sha, tt.isWorktree, got, tt.want)
+		}
+	}
+}
+
 func TestComputeStatusSummary(t *testing.T) {
 	// Create temporary directory structure for testing.
 	tmpDir := t.TempDir()

--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -43,6 +43,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph/fbreader"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
@@ -79,6 +80,12 @@ type v2SettingsRepo struct {
 	Entities  int             `json:"entities"`
 	IndexedAt *int64          `json:"indexedAt"`
 	Monorepo  *v2MonorepoInfo `json:"monorepo"`
+
+	// Phase 0 git metadata (#2088). Omitted when the graph predates this
+	// feature or the repo is not a git repository.
+	IndexedRef string `json:"indexed_ref,omitempty"`
+	IndexedSHA string `json:"indexed_sha,omitempty"`
+	IsWorktree bool   `json:"is_worktree,omitempty"`
 }
 
 // v2MonorepoInfo matches the SettingsRepo.monorepo shape.
@@ -186,6 +193,8 @@ func loadV2SettingsGroup(groupName, histRoot string) (*v2SettingsGroup, error) {
 			ms := idxAt.UnixMilli()
 			sr.IndexedAt = &ms
 		}
+		// Phase 0 git metadata (#2088). Read cheaply from graph.fb header.
+		sr.IndexedRef, sr.IndexedSHA, sr.IsWorktree = repoGitMeta(stateDir)
 		// Monorepo: if the repo has Modules, surface them as a stub MonorepoInfo.
 		if len(r.Modules) > 0 {
 			pkgs := make([]v2MonorepoPkg, 0, len(r.Modules))
@@ -231,6 +240,20 @@ func loadV2SettingsGroup(groupName, histRoot string) (*v2SettingsGroup, error) {
 
 // repoStats reads graph-stats.json for a repo's state dir and returns
 // (files, entities, lastIndexed). Zero values on any read error.
+// repoGitMeta reads the Phase-0 git metadata from graph.fb cheaply using
+// fbreader (no entity/relationship decode). Returns zero values for non-git
+// repos or graphs written before #2088.
+func repoGitMeta(stateDir string) (ref, sha string, isWorktree bool) {
+	fbPath := filepath.Join(stateDir, "graph.fb")
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		return "", "", false
+	}
+	defer r.Close()
+	meta := r.LoadGraphMeta()
+	return meta.IndexedRef, meta.IndexedSHA, meta.IsWorktree
+}
+
 func repoStats(stateDir string) (files, entities int, lastIndexed time.Time) {
 	type statsShape struct {
 		TotalEntities int       `json:"total_entities"`

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -1,0 +1,69 @@
+// Package gitmeta captures lightweight git HEAD metadata (ref name, commit
+// SHA, worktree flag) for a given repository path at index time.
+//
+// The information is stored in the graph metadata so downstream tools
+// (status, dashboard, MCP) can show which branch a graph was built from
+// without re-running git. This is Phase 0 of epic #2087.
+package gitmeta
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Info holds the git HEAD metadata captured at index time.
+type Info struct {
+	// Ref is the branch/tag name ("main", "feat/X"). Empty for a detached HEAD.
+	Ref string
+	// SHA is the abbreviated (12-char) commit hash, or "" if not a git repo.
+	SHA string
+	// IsWorktree is true when repoPath is a linked worktree (not the main
+	// checkout). Determined by comparing git-dir vs git-common-dir.
+	IsWorktree bool
+	// TopLevel is the output of git rev-parse --show-toplevel, or "" if not
+	// a git repo.
+	TopLevel string
+}
+
+// Capture runs a small set of git commands against repoPath and returns the
+// HEAD metadata. All git calls use a 2-second timeout; any failure (non-git
+// directory, git not on PATH, etc.) returns the zero-value Info with no error.
+func Capture(repoPath string) Info {
+	run := func(args ...string) string {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = repoPath
+		out, err := cmd.Output()
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	// Sanity-check: is this a git repo at all?
+	topLevel := run("rev-parse", "--show-toplevel")
+	if topLevel == "" {
+		return Info{}
+	}
+
+	// Abbreviated SHA (12 chars matches GitHub's default).
+	sha := run("rev-parse", "--short=12", "HEAD")
+
+	// Symbolic ref — fails for detached HEAD; that's fine, Ref stays "".
+	ref := run("symbolic-ref", "--short", "HEAD")
+
+	// Worktree detection: linked worktree ↔ git-dir != git-common-dir.
+	gitDir := run("rev-parse", "--git-dir")
+	gitCommonDir := run("rev-parse", "--git-common-dir")
+	isWorktree := gitDir != "" && gitCommonDir != "" && gitDir != gitCommonDir
+
+	return Info{
+		Ref:        ref,
+		SHA:        sha,
+		IsWorktree: isWorktree,
+		TopLevel:   topLevel,
+	}
+}

--- a/internal/gitmeta/gitmeta_test.go
+++ b/internal/gitmeta/gitmeta_test.go
@@ -1,0 +1,132 @@
+package gitmeta_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/gitmeta"
+)
+
+// initBareRepo creates a temp dir with a git repo, an initial commit on
+// the given branch name, and returns the repo path.
+func initBareRepo(t *testing.T, branch string) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "--initial-branch="+branch)
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+
+	// Write a file and commit so HEAD is not empty.
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "init")
+	return dir
+}
+
+func TestCapture_mainBranch(t *testing.T) {
+	dir := initBareRepo(t, "main")
+	info := gitmeta.Capture(dir)
+
+	if info.Ref != "main" {
+		t.Errorf("Ref = %q, want %q", info.Ref, "main")
+	}
+	if len(info.SHA) != 12 {
+		t.Errorf("SHA len = %d, want 12 (got %q)", len(info.SHA), info.SHA)
+	}
+	if info.IsWorktree {
+		t.Error("IsWorktree should be false for a regular checkout")
+	}
+	if !strings.HasSuffix(info.TopLevel, dir) && info.TopLevel != dir {
+		t.Errorf("TopLevel = %q, want suffix %q", info.TopLevel, dir)
+	}
+}
+
+func TestCapture_featureBranch(t *testing.T) {
+	dir := initBareRepo(t, "main")
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("checkout", "-b", "feat/my-feature")
+
+	info := gitmeta.Capture(dir)
+	if info.Ref != "feat/my-feature" {
+		t.Errorf("Ref = %q, want %q", info.Ref, "feat/my-feature")
+	}
+}
+
+func TestCapture_detachedHEAD(t *testing.T) {
+	dir := initBareRepo(t, "main")
+
+	// Get SHA to detach at.
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sha := strings.TrimSpace(string(out))
+
+	cmd := exec.Command("git", "checkout", "--detach", sha)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git checkout --detach: %v\n%s", err, out)
+	}
+
+	info := gitmeta.Capture(dir)
+	if info.Ref != "" {
+		t.Errorf("Ref = %q, want empty for detached HEAD", info.Ref)
+	}
+	if len(info.SHA) != 12 {
+		t.Errorf("SHA len = %d, want 12 (got %q)", len(info.SHA), info.SHA)
+	}
+}
+
+func TestCapture_nonGitDir(t *testing.T) {
+	dir := t.TempDir() // plain dir, no .git
+	info := gitmeta.Capture(dir)
+
+	if info.SHA != "" || info.Ref != "" || info.IsWorktree || info.TopLevel != "" {
+		t.Errorf("expected zero-value Info for non-git dir, got %+v", info)
+	}
+}
+
+func TestCapture_worktree(t *testing.T) {
+	main := initBareRepo(t, "main")
+	wtDir := t.TempDir()
+
+	// Remove the auto-created dir so git worktree add can use it.
+	os.RemoveAll(wtDir)
+
+	cmd := exec.Command("git", "worktree", "add", "-b", "wt-branch", wtDir)
+	cmd.Dir = main
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("git worktree add failed (old git?): %v\n%s", err, out)
+	}
+
+	info := gitmeta.Capture(wtDir)
+	if !info.IsWorktree {
+		t.Errorf("IsWorktree = false, want true for linked worktree")
+	}
+	if info.Ref != "wt-branch" {
+		t.Errorf("Ref = %q, want %q", info.Ref, "wt-branch")
+	}
+	if len(info.SHA) != 12 {
+		t.Errorf("SHA len = %d, want 12 (got %q)", len(info.SHA), info.SHA)
+	}
+}

--- a/internal/graph/fbgraph/Graph.go
+++ b/internal/graph/fbgraph/Graph.go
@@ -210,8 +210,36 @@ func (rcv *Graph) MutateDenoisedCommunities(n int32) bool {
 	return rcv._tab.MutateInt32Slot(26, n)
 }
 
+func (rcv *Graph) IndexedRef() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func (rcv *Graph) IndexedSha() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(30))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func (rcv *Graph) IsWorktree() bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(32))
+	if o != 0 {
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
+	}
+	return false
+}
+
+func (rcv *Graph) MutateIsWorktree(n bool) bool {
+	return rcv._tab.MutateBoolSlot(32, n)
+}
+
 func GraphStart(builder *flatbuffers.Builder) {
-	builder.StartObject(12)
+	builder.StartObject(15)
 }
 func GraphAddVersion(builder *flatbuffers.Builder, version int32) {
 	builder.PrependInt32Slot(0, version, 2)
@@ -257,6 +285,15 @@ func GraphAddAlgoRuntimeMs(builder *flatbuffers.Builder, algoRuntimeMs int64) {
 }
 func GraphAddDenoisedCommunities(builder *flatbuffers.Builder, denoisedCommunities int32) {
 	builder.PrependInt32Slot(11, denoisedCommunities, 0)
+}
+func GraphAddIndexedRef(builder *flatbuffers.Builder, indexedRef flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(12, flatbuffers.UOffsetT(indexedRef), 0)
+}
+func GraphAddIndexedSha(builder *flatbuffers.Builder, indexedSha flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(13, flatbuffers.UOffsetT(indexedSha), 0)
+}
+func GraphAddIsWorktree(builder *flatbuffers.Builder, isWorktree bool) {
+	builder.PrependBoolSlot(14, isWorktree, false)
 }
 func GraphEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/internal/graph/fbreader/reader.go
+++ b/internal/graph/fbreader/reader.go
@@ -178,6 +178,12 @@ type GraphMeta struct {
 	Version    int
 	ComputedAt string
 	RepoTag    string
+
+	// Phase 0 git metadata (#2088). Empty/false for graphs written before
+	// this field was added (FlatBuffers defaults new fields to zero-value).
+	IndexedRef string
+	IndexedSHA string
+	IsWorktree bool
 }
 
 // CommunityCount returns the number of aggregate Louvain communities
@@ -230,7 +236,8 @@ func (r *Reader) LoadAlgoStats() AlgoStats {
 }
 
 // LoadGraphMeta returns the (cheap) header fields of the graph: schema
-// version, computed-at timestamp, repo tag. No vectors are touched.
+// version, computed-at timestamp, repo tag, and Phase 0 git metadata (#2088).
+// No vectors are touched; all strings are copied out of the mmap'd bytes.
 func (r *Reader) LoadGraphMeta() GraphMeta {
 	if r == nil || r.root == nil {
 		return GraphMeta{}
@@ -239,6 +246,11 @@ func (r *Reader) LoadGraphMeta() GraphMeta {
 		Version:    int(r.root.Version()),
 		ComputedAt: string(r.root.ComputedAt()),
 		RepoTag:    string(r.root.RepoTag()),
+		// Phase 0 git metadata (#2088). Defaults to "" / false for graphs
+		// written before these fields were added.
+		IndexedRef: string(r.root.IndexedRef()),
+		IndexedSHA: string(r.root.IndexedSha()),
+		IsWorktree: r.root.IsWorktree(),
 	}
 }
 

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -101,6 +101,11 @@ func Marshal(doc *graph.Document) ([]byte, error) {
 	computedAt := b.CreateString(doc.GeneratedAt.UTC().Format("2006-01-02T15:04:05Z"))
 	repoTag := b.CreateString(doc.Repo)
 
+	// Phase 0 git metadata (#2088). Strings must be created before the table
+	// is opened (FlatBuffers ordering rule).
+	indexedRef := b.CreateString(doc.IndexedRef)
+	indexedSHA := b.CreateString(doc.IndexedSHA)
+
 	fb.GraphStart(b)
 	fb.GraphAddVersion(b, int32(FormatVersion))
 	fb.GraphAddComputedAt(b, computedAt)
@@ -116,6 +121,15 @@ func Marshal(doc *graph.Document) ([]byte, error) {
 		fb.GraphAddNumSurpriseEdges(b, int32(st.NumSurpriseEdges))
 		fb.GraphAddAlgoRuntimeMs(b, st.RuntimeMS)
 		fb.GraphAddDenoisedCommunities(b, int32(st.DenoisedCommunities))
+	}
+	// Phase 0 git metadata (#2088). Always add both string offsets (already
+	// created above); the FB runtime writes them as zero-length strings when
+	// the values are empty, which is indistinguishable from "not set" to
+	// older readers that don't know about these slots.
+	fb.GraphAddIndexedRef(b, indexedRef)
+	fb.GraphAddIndexedSha(b, indexedSHA)
+	if doc.IsWorktree {
+		fb.GraphAddIsWorktree(b, true)
 	}
 	root := fb.GraphEnd(b)
 	fb.FinishGraphBuffer(b, root)

--- a/internal/graph/fbwriter/writer_test.go
+++ b/internal/graph/fbwriter/writer_test.go
@@ -165,6 +165,60 @@ func TestRoundtripCommunityAttrs(t *testing.T) {
 	}
 }
 
+// TestRoundtripGitMeta verifies that Phase-0 git metadata (#2088) survives a
+// write→read cycle through graph.fb, and that an old graph written without
+// these fields reads back with the zero-value defaults (empty string / false).
+func TestRoundtripGitMeta(t *testing.T) {
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
+		Repo:        "fixture-gitmeta",
+		Entities:    []graph.Entity{{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"}},
+		// Phase 0 fields.
+		IndexedRef: "feat/my-feature",
+		IndexedSHA: "abc123def456",
+		IsWorktree: true,
+	}
+	doc.Stats.Entities = 1
+	out := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(out, doc); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := graph.LoadGraphFromDir(filepath.Dir(out))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.IndexedRef != "feat/my-feature" {
+		t.Errorf("IndexedRef: got %q want %q", got.IndexedRef, "feat/my-feature")
+	}
+	if got.IndexedSHA != "abc123def456" {
+		t.Errorf("IndexedSHA: got %q want %q", got.IndexedSHA, "abc123def456")
+	}
+	if !got.IsWorktree {
+		t.Error("IsWorktree: got false want true")
+	}
+
+	// Test zero-value defaults: write a doc WITHOUT git meta, verify "" / false.
+	docNoMeta := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-nometa",
+		Entities:    []graph.Entity{{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"}},
+	}
+	docNoMeta.Stats.Entities = 1
+	out2 := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(out2, docNoMeta); err != nil {
+		t.Fatalf("write no-meta: %v", err)
+	}
+	got2, err := graph.LoadGraphFromDir(filepath.Dir(out2))
+	if err != nil {
+		t.Fatalf("load no-meta: %v", err)
+	}
+	if got2.IndexedRef != "" || got2.IndexedSHA != "" || got2.IsWorktree {
+		t.Errorf("zero-value defaults: ref=%q sha=%q wt=%v", got2.IndexedRef, got2.IndexedSHA, got2.IsWorktree)
+	}
+}
+
 // TestRoundtripNoAlgoData verifies a graph written with NO community data
 // (the --skip-pass=graph-algo case) reads back with zero communities, nil
 // AlgorithmStats, and un-annotated entities (#1620 — old-file compatibility).

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -29,6 +29,14 @@ type Document struct {
 	Communities    []CommunityResult `json:"communities,omitempty"`
 	SurpriseEdges  []SurpriseEdge    `json:"surprise_edges,omitempty"`
 	AlgorithmStats *AlgorithmStats   `json:"algorithm_stats,omitempty"`
+
+	// Phase 0 git metadata (#2088). Populated at index time by
+	// internal/gitmeta.Capture. Empty/false for non-git repos or when the
+	// graph was loaded from an older graph.fb written before this field was
+	// added (FlatBuffers defaults to "" / false for missing fields).
+	IndexedRef string `json:"indexed_ref,omitempty"`
+	IndexedSHA string `json:"indexed_sha,omitempty"`
+	IsWorktree bool   `json:"is_worktree,omitempty"`
 }
 
 // Stats summarises a Document.

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -135,6 +135,11 @@ func loadFBDocument(path string) (*Document, error) {
 			Entities:      len(entities),
 			Relationships: len(rels),
 		},
+		// Phase 0 git metadata (#2088). Defaults to "" / false for graphs
+		// written before these fields were added.
+		IndexedRef: meta.IndexedRef,
+		IndexedSHA: meta.IndexedSHA,
+		IsWorktree: meta.IsWorktree,
 	}
 
 	// AlgorithmStats: only attach when the algo pass actually ran. We treat

--- a/internal/graph/schema/graph.fbs
+++ b/internal/graph/schema/graph.fbs
@@ -85,6 +85,18 @@ table Graph {
   num_surprise_edges: int = 0;
   algo_runtime_ms: long = 0;
   denoised_communities: int = 0;
+
+  // Phase 0 git metadata (#2088). Appended after the Pass-4 aggregates so
+  // existing field IDs are unchanged and old graph.fb files read back with
+  // these defaulted to "" / false. All three fields are populated at index
+  // time by internal/gitmeta.Capture.
+  //
+  // indexed_ref   — branch name ("main", "feat/X") or "" for detached HEAD.
+  // indexed_sha   — 12-char abbreviated commit hash, or "" if not a git repo.
+  // is_worktree   — true when the repo is a linked git worktree.
+  indexed_ref: string;
+  indexed_sha: string;
+  is_worktree: bool = false;
 }
 
 root_type Graph;

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -683,6 +683,10 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 				if agentEdges := agentResolvedEdgesForEntity(r.Doc, r.Repo, e.ID, scopeIsOne); len(agentEdges) > 0 {
 					out["agent_resolved_edges"] = agentEdges
 				}
+				// Phase 0 git metadata (#2088).
+				if gm := graphMetaForInspect(r); gm != nil {
+					out["graph_meta"] = gm
+				}
 				return jsonResult(out), nil
 			}
 		}
@@ -730,7 +734,31 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	if agentEdges := agentResolvedEdgesForEntity(m.repo.Doc, m.repo.Repo, m.ent.ID, scopeIsOne); len(agentEdges) > 0 {
 		out["agent_resolved_edges"] = agentEdges
 	}
+	// Phase 0 git metadata (#2088).
+	if gm := graphMetaForInspect(m.repo); gm != nil {
+		out["graph_meta"] = gm
+	}
 	return jsonResult(out), nil
+}
+
+// graphMetaForInspect returns the Phase-0 git metadata (#2088) for a loaded
+// repo as a map suitable for embedding in the archigraph_inspect reply.
+// Returns nil when the document carries no git metadata (pre-#2088 graph or
+// non-git repo), so callers can omit the key entirely.
+func graphMetaForInspect(lr *LoadedRepo) map[string]any {
+	if lr == nil || lr.Doc == nil || lr.Doc.IndexedSHA == "" {
+		return nil
+	}
+	m := map[string]any{
+		"indexed_sha": lr.Doc.IndexedSHA,
+		"is_worktree": lr.Doc.IsWorktree,
+	}
+	if lr.Doc.IndexedRef != "" {
+		m["indexed_ref"] = lr.Doc.IndexedRef
+	} else {
+		m["indexed_ref"] = "detached"
+	}
+	return m
 }
 
 // agentResolvedEdgesForEntity returns the outgoing relationships from entity e


### PR DESCRIPTION
## What we did

Phase 0 of epic #2087 — foundation for multi-branch and worktree awareness.

- **`internal/gitmeta`** — new package: `Capture(repoPath) Info` runs `git symbolic-ref --short HEAD` (ref), `git rev-parse --short=12 HEAD` (SHA), and the git-dir vs git-common-dir pair (worktree detection). All calls use a 2 s `exec.CommandContext` timeout. Non-git directories return zero-value `Info` with no error.

- **FlatBuffers schema** (`graph.fbs`) — appended `indexed_ref: string`, `indexed_sha: string`, `is_worktree: bool` to the `Graph` table (slots 12-14, `StartObject` bumped 12 → 15). Regenerated `internal/graph/fbgraph/Graph.go` via `make fbgen`. Old `graph.fb` files continue to decode correctly with FB default values ("" / false).

- **`graph.Document`** — added `IndexedRef`, `IndexedSHA`, `IsWorktree` (json:"...,omitempty"); carried through both the FB and JSON code paths.

- **fbwriter / fbreader / load.go** — writer emits the new string slots unconditionally (empty string = no metadata); reader extends `GraphMeta` with the three fields; `loadFBDocument` restores them onto `Document`.

- **`cmd/archigraph/index.go`** — calls `gitmeta.Capture(absRepo)` after `idx.Run()`, stamps the three fields on `doc` before serialisation, and logs `archigraph: git HEAD <sha> @ <ref> (worktree=...)`.

- **Status CLI** (`internal/cli/status_stats.go`) — `RepoStatus` carries the git fields; `PrintStatusSummary` appends ` @ main (abc12345)` / ` @ detached (abc12345)` / `[worktree]` suffix per-repo line.

- **Dashboard `/api/v2/groups/{group}`** — `v2SettingsRepo` exposes `indexed_ref`, `indexed_sha`, `is_worktree` JSON fields; a cheap `repoGitMeta()` helper reads them from `graph.fb` header via fbreader (no entity decode).

- **MCP `archigraph_inspect`** — single-entity reply includes `"graph_meta": {"indexed_ref":"main","indexed_sha":"abc12345","is_worktree":false}` when SHA is non-empty.

## What we won

Every graph.fb now self-describes which branch it was built from. No extra I/O at read time — the ref and SHA live in the Graph table header, read in the same mmap pass as `computed_at` and `repo_tag`.

## What it means at scale

Multi-repo groups can surface which repos are on main vs feature branches at a glance. Worktrees are identified to prevent agents from confusing a feature-branch graph with the main checkout.

## What it means for MCP / daemon / UX

- `archigraph_inspect` replies now include `graph_meta` so agents can detect stale or wrong-branch graphs immediately.
- `archigraph status` shows branch + SHA per repo line without any extra subprocess.
- Dashboard settings page gets `indexed_ref/sha/is_worktree` per repo for the Landing card.

## Verification

```
go test ./internal/gitmeta/...              # 5 new tests (main, feat, detached, non-git, worktree)
go test ./internal/graph/fbwriter/...       # TestRoundtripGitMeta + pre-existing 3
go test ./internal/graph/fbreader/...       # pre-existing
go test ./internal/cli/... -run FormatGitRef # new
go build ./...                              # clean
```

Pre-existing failures on `main` (not introduced by this PR):
- `TestModuleCoverage_AllEntitiesTagged` — pre-existing module-tag gap
- `cmd/orphan-probe` build — pre-existing `fmt.Println` vet errors

## Caveats

- `is_worktree` detection relies on `git rev-parse --git-common-dir` which requires Git ≥ 2.5 (2015). Any sufficiently modern Git supports it.
- The `indexed_sha` is 12 chars (abbreviated), matching GitHub's default. Sufficient for display; not guaranteed unique in extremely large repos but appropriate for this use case.

## Bottom line

Closes #2088. Zero-cost metadata extension: 3 new FB fields on the Graph root, populated in a single git subprocess burst at index time, surfaced in status/dashboard/MCP with no ongoing overhead.

Closes #2088