### PR TITLE
fix(orphan-probe): drop redundant \n from fmt.Println (go vet)

### DIFF
--- a/cmd/orphan-probe/main.go
+++ b/cmd/orphan-probe/main.go
@@ -453,7 +453,7 @@ func printTextReport(report ProbeReport) {
 
 		// Per-repo table.
 		if len(gr.Repos) > 0 {
-			fmt.Println("### Per-repo breakdown\n")
+			fmt.Println("### Per-repo breakdown")
 			fmt.Printf("| Repo | Entities | Orphans | Rate | Bar |\n")
 			fmt.Printf("|------|----------|---------|------|-----|\n")
 			for _, r := range gr.Repos {
@@ -469,7 +469,7 @@ func printTextReport(report ProbeReport) {
 
 		// Top clusters.
 		if len(gr.Clusters) > 0 {
-			fmt.Println("### Top orphan clusters\n")
+			fmt.Println("### Top orphan clusters")
 			fmt.Printf("| # | Kind | SourceFile pattern | Count | Rep IDs |\n")
 			fmt.Printf("|---|------|--------------------|-------|---------|\n")
 			for i, c := range gr.Clusters {
@@ -482,14 +482,14 @@ func printTextReport(report ProbeReport) {
 			}
 			fmt.Println()
 		} else {
-			fmt.Println("_No orphan clusters found._\n")
+			fmt.Println("_No orphan clusters found._")
 		}
 	}
 
 	// Cross-group patterns.
-	fmt.Println("## Cross-group patterns\n")
+	fmt.Println("## Cross-group patterns")
 	if len(report.CrossGroupPatterns) == 0 {
-		fmt.Println("_No patterns appear in more than one group._\n")
+		fmt.Println("_No patterns appear in more than one group._")
 	} else {
 		fmt.Printf("| Kind | SourceFile pattern | Groups | Total count |\n")
 		fmt.Printf("|------|--------------------|--------|-------------|\n")


### PR DESCRIPTION
## What
`go vet` errors in `cmd/orphan-probe/main.go` lines 456, 472, 485, 490, 492 — all `fmt.Println("text\\n")` style. Vet treats trailing \\n in Println args as redundant.

## Why this matters now
Blocks CI on **all in-flight PRs** (#2082 pytest parametrize, #2095 admission control, #2102 PH0 gitmeta) — each of those failed for the same reason on first CI run.

## Fix
`sed -E 's/fmt\\.Println\\("([^"]*)\\\\n"\\)/fmt.Println("\\1")/g'` on the single file. 10 lines, 5 affected callsites.

## Verification
`go vet ./cmd/orphan-probe/...` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)