### PR TITLE
fix(flows): fill viewport + per-step repo color + vertical legend (#2115 #2116)

### DIFF
--- a/webui-v2/e2e/flows-fills-viewport.spec.ts
+++ b/webui-v2/e2e/flows-fills-viewport.spec.ts
@@ -1,0 +1,148 @@
+// webui-v2/e2e/flows-fills-viewport.spec.ts
+//
+// Regression guard for #2115 — Flows diagram empty whitespace below.
+//
+// Asserts that after selecting a flow the DAG canvas SVG/canvas area
+// covers > 65% of the viewport height below the topbar.  Past fixes
+// kept regressing because the FlowDag viewport had a hard pixel-height
+// cap (flex-none + height: 400px) instead of participating in the flex
+// layout.  This test catches that regression.
+import { test, expect, type Page } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ─── Shared mock flow ────────────────────────────────────────────────────────
+
+const FILL_FLOW = {
+  process_id: "proc-fill-2115",
+  label: "AuthController.login → SessionRepository.create",
+  repo: "client-fixture-a",
+  entry_id: "f0",
+  entry_name: "AuthController.login",
+  entry_kind: "http_handler",
+  terminal_id: "f4",
+  step_count: 5,
+  cross_stack: false,
+  is_cross_repo: false,
+  chain_labels: ["login", "validateCreds", "createToken", "auditLog", "create"],
+  is_dag: false,
+  steps: [
+    { entity_id: "f0", name: "AuthController.login",            step_index: 0, source_file: "src/auth.ts",    start_line: 10, repo: "client-fixture-a", edge_kind: null,    step_kind: "http_fetch" },
+    { entity_id: "f1", name: "AuthService.validateCredentials", step_index: 1, source_file: "src/auth.ts",    start_line: 42, repo: "client-fixture-a", edge_kind: "CALLS", step_kind: "validation" },
+    { entity_id: "f2", name: "TokenService.createToken",        step_index: 2, source_file: "src/token.ts",   start_line: 18, repo: "client-fixture-a", edge_kind: "CALLS", step_kind: "transform" },
+    { entity_id: "f3", name: "AuditService.log",                step_index: 3, source_file: "src/audit.ts",   start_line: 55, repo: "client-fixture-a", edge_kind: "CALLS", step_kind: "db_write" },
+    { entity_id: "f4", name: "SessionRepository.create",        step_index: 4, source_file: "src/session.ts", start_line: 29, repo: "client-fixture-a", edge_kind: "CALLS", step_kind: "db_write" },
+  ],
+};
+
+async function mockFlowsPage(page: Page) {
+  const pid = FILL_FLOW.process_id;
+
+  await page.route("**/api/v2/meta**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ version: "dev", daemon_running: true, groups: ["demo"] }) }));
+  await page.route("**/api/v2/groups", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify([{ id: "demo", name: "Demo", repos: ["client-fixture-a"], entityCount: 10, fidelity: 0.95, indexedAt: Date.now(), health: "healthy" }]) }));
+  await page.route("**/api/v2/groups/demo**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ id: "demo", name: "Demo", entities: 10, fidelity: 0.95, indexedAt: Date.now(), health: "healthy", features: { watchers: false, gitHooks: false }, docsPath: "", repos: [] }) }));
+  await page.route("**/api/flows/demo?**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ processes: [FILL_FLOW], count: 1, entry_kind_groups: [{ kind: "http_handler", count: 1 }] }) }));
+  await page.route("**/api/flows/demo", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ processes: [FILL_FLOW], count: 1, entry_kind_groups: [{ kind: "http_handler", count: 1 }] }) }));
+  await page.route(`**/api/flows/demo/${encodeURIComponent(pid)}**`, (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ process: FILL_FLOW, chain_entities: FILL_FLOW.steps, source_snippets: {} }) }));
+  await page.route(`**/api/flows/demo/${pid}**`, (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ process: FILL_FLOW, chain_entities: FILL_FLOW.steps, source_snippets: {} }) }));
+  await page.route("**/api/flows/demo/dead-ends**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ dead_ends: [], count: 0 }) }));
+  await page.route("**/api/flows/demo/truncated**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ processes: [], count: 0, entry_kind_groups: [] }) }));
+  await page.route("**/api/system**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ status: "running", version: "dev", commit_sha: "abc", built_at: "2026-01-01", stale_build: false, pid: 1, rss_mb: 64 }) }));
+  await page.route("**/api/groups/demo**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ id: "demo", name: "Demo", repos: ["client-fixture-a"], entityCount: 10, fidelity: 0.95, indexedAt: Date.now(), health: "healthy" }) }));
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test.describe("#2115 — Flows diagram fills viewport", () => {
+  test("DAG canvas covers > 65% of viewport height after flow selection", async ({ page }) => {
+    await mockFlowsPage(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/g/demo/flows");
+
+    // Wait for the list to load
+    await page.waitForTimeout(800);
+
+    // Click the flow row
+    const flowRow = page.locator("button").filter({ hasText: /AuthController|login/ }).first();
+    await expect(flowRow).toBeVisible({ timeout: 5000 });
+    await flowRow.click();
+
+    // Wait for detail panel to render
+    await page.waitForTimeout(800);
+
+    // Screenshot before assertion
+    await page.screenshot({
+      path: path.join(__dirname, "../../2115-dag-fill-viewport.png"),
+      fullPage: false,
+    });
+
+    // Find the DAG viewport element — it has the canvas grid background and
+    // contains the SVG overlay. We identify it by the data-testid on the
+    // parent DetailPanel body area, or by querying the SVG inside the canvas.
+    //
+    // The fix puts FlowDag viewport as flex-1 min-h-0. After the fix, the
+    // element should occupy substantially more than 65% of the visible viewport
+    // below the topbar (which is ~42px for the tab strip + ~120px header =
+    // roughly 160-180px chrome). At 900px viewport height, 65% = 585px;
+    // below the chrome means the DAG area height should be > (900 - 180) * 0.65
+    // = 468px minimum.
+    //
+    // We measure via getBoundingClientRect of the SVG inside the FlowDag.
+    const dagSvg = page.locator("svg").first();
+    await expect(dagSvg).toBeVisible({ timeout: 5000 });
+
+    const viewportHeight = 900;
+    // Account for topbar chrome: tab strip (42px) + detail header (~150px).
+    const chromeHeight = 200;
+    const availableHeight = viewportHeight - chromeHeight;
+    const threshold = availableHeight * 0.65;
+
+    // Get the bounding box of the DAG canvas wrapper (the div with the
+    // radial-gradient background). We find it by looking for the container
+    // that wraps the SVG and has overflow:hidden and the grab cursor.
+    //
+    // Alternative: use evaluate to measure how much vertical space the DAG
+    // element occupies.
+    const dagHeight = await page.evaluate((): number => {
+      // Walk all divs to find the one with the canvas grid background.
+      const all = Array.from(document.querySelectorAll("div"));
+      for (const el of all) {
+        const style = window.getComputedStyle(el);
+        if (
+          style.backgroundImage?.includes("radial-gradient") &&
+          style.overflow === "hidden" &&
+          style.cursor?.includes("grab")
+        ) {
+          return el.getBoundingClientRect().height;
+        }
+      }
+      return 0;
+    });
+
+    // Expect the DAG to fill at least 65% of the available space below chrome.
+    expect(dagHeight).toBeGreaterThan(threshold);
+  });
+});

--- a/webui-v2/e2e/flows-repo-colors.spec.ts
+++ b/webui-v2/e2e/flows-repo-colors.spec.ts
@@ -1,0 +1,251 @@
+// webui-v2/e2e/flows-repo-colors.spec.ts
+//
+// Playwright E2E tests for #2116 — per-step repo color + vertical legend.
+//
+// Three assertions:
+//   1. Cross-repo flow → step cards in different repos have distinct
+//      left-edge accent-stripe colors (borderLeftColor differs).
+//   2. Legend lists repos in a vertical column (flex-col, not flex-row).
+//   3. No kind chips in the legend (no "HTTP Fetch", "DB Query", etc. text).
+//
+// All API responses are mocked so this runs standalone without a daemon.
+import { test, expect, type Page } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ─── Cross-repo mock flow ────────────────────────────────────────────────────
+// Two repos so we get distinct accent stripes.
+
+const CROSS_REPO_FLOW = {
+  process_id: "proc-xrepo-2116",
+  label: "ApiGateway.handleRequest → DataService.persist",
+  repo: "client-fixture-b",
+  entry_id: "x0",
+  entry_name: "ApiGateway.handleRequest",
+  entry_kind: "http_handler",
+  terminal_id: "x3",
+  step_count: 4,
+  cross_stack: true,
+  is_cross_repo: true,
+  chain_labels: ["handleRequest", "parseBody", "fetchUser", "persist"],
+  is_dag: false,
+  steps: [
+    {
+      entity_id: "x0",
+      name: "ApiGateway.handleRequest",
+      step_index: 0,
+      source_file: "src/gateway.ts",
+      start_line: 10,
+      repo: "client-fixture-b",
+      edge_kind: null,
+      step_kind: "http_fetch",
+    },
+    {
+      entity_id: "x1",
+      name: "RequestParser.parseBody",
+      step_index: 1,
+      source_file: "src/parser.ts",
+      start_line: 22,
+      repo: "client-fixture-b",
+      edge_kind: "CALLS",
+      step_kind: "transform",
+    },
+    {
+      entity_id: "x2",
+      name: "UserService.fetchUser",
+      step_index: 2,
+      source_file: "src/user.ts",
+      start_line: 31,
+      // Different repo — accent stripe should differ from client-fixture-b
+      repo: "client-fixture-c",
+      edge_kind: "CALLS",
+      step_kind: "db_query",
+    },
+    {
+      entity_id: "x3",
+      name: "DataService.persist",
+      step_index: 3,
+      source_file: "src/data.ts",
+      start_line: 67,
+      repo: "client-fixture-c",
+      edge_kind: "CALLS",
+      step_kind: "db_write",
+    },
+  ],
+};
+
+async function mockXrepoPage(page: Page) {
+  const pid = CROSS_REPO_FLOW.process_id;
+  const flowsBody = JSON.stringify({
+    processes: [CROSS_REPO_FLOW],
+    count: 1,
+    entry_kind_groups: [{ kind: "http_handler", count: 1 }],
+  });
+  const detailBody = JSON.stringify({
+    process: CROSS_REPO_FLOW,
+    chain_entities: CROSS_REPO_FLOW.steps,
+    source_snippets: {},
+  });
+
+  await page.route("**/api/v2/meta**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ version: "dev", daemon_running: true, groups: ["demo"] }) }));
+  await page.route("**/api/v2/groups", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify([{ id: "demo", name: "Demo", repos: ["client-fixture-b", "client-fixture-c"], entityCount: 20, fidelity: 0.95, indexedAt: Date.now(), health: "healthy" }]) }));
+  await page.route("**/api/v2/groups/demo**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ id: "demo", name: "Demo", entities: 20, fidelity: 0.95, indexedAt: Date.now(), health: "healthy", features: { watchers: false, gitHooks: false }, docsPath: "", repos: [] }) }));
+  await page.route("**/api/flows/demo?**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: flowsBody }));
+  await page.route("**/api/flows/demo", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: flowsBody }));
+  await page.route(`**/api/flows/demo/${encodeURIComponent(pid)}**`, (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: detailBody }));
+  await page.route(`**/api/flows/demo/${pid}**`, (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: detailBody }));
+  await page.route("**/api/flows/demo/dead-ends**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ dead_ends: [], count: 0 }) }));
+  await page.route("**/api/flows/demo/truncated**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ processes: [], count: 0, entry_kind_groups: [] }) }));
+  await page.route("**/api/system**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ status: "running", version: "dev", commit_sha: "abc", built_at: "2026-01-01", stale_build: false, pid: 1, rss_mb: 64 }) }));
+  await page.route("**/api/groups/demo**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ id: "demo", name: "Demo", repos: ["client-fixture-b", "client-fixture-c"], entityCount: 20, fidelity: 0.95, indexedAt: Date.now(), health: "healthy" }) }));
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test.describe("#2116 — per-step repo color + vertical legend", () => {
+  test("cross-repo steps have distinct left-edge accent stripe colors", async ({ page }) => {
+    await mockXrepoPage(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/g/demo/flows");
+
+    await page.waitForTimeout(800);
+
+    const flowRow = page
+      .locator("button")
+      .filter({ hasText: /ApiGateway|handleRequest/ })
+      .first();
+    await expect(flowRow).toBeVisible({ timeout: 5000 });
+    await flowRow.click();
+    await page.waitForTimeout(1000);
+
+    await page.screenshot({
+      path: path.join(__dirname, "../../2116-01-repo-stripe-colors.png"),
+      fullPage: false,
+    });
+
+    // Collect borderLeftColor values for step nodes across the two repos.
+    // Step nodes carry data-repo and data-step-node attributes.
+    const stripeColors = await page.evaluate((): { repo: string; color: string }[] => {
+      const nodes = Array.from(document.querySelectorAll("button[data-step-node]"));
+      return nodes.map((el) => {
+        const style = window.getComputedStyle(el as HTMLElement);
+        return {
+          repo: (el as HTMLElement).dataset.repo ?? "",
+          color: style.borderLeftColor,
+        };
+      });
+    });
+
+    // Must have nodes from both repos
+    const repoB = stripeColors.filter((n) => n.repo === "client-fixture-b");
+    const repoC = stripeColors.filter((n) => n.repo === "client-fixture-c");
+
+    expect(repoB.length).toBeGreaterThan(0);
+    expect(repoC.length).toBeGreaterThan(0);
+
+    // The stripe colors for the two repos must differ.
+    const colorB = repoB[0].color;
+    const colorC = repoC[0].color;
+    expect(colorB).not.toBe(colorC);
+  });
+
+  test("vertical legend lists repos in a column, not in a horizontal row", async ({ page }) => {
+    await mockXrepoPage(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/g/demo/flows");
+
+    await page.waitForTimeout(800);
+
+    const flowRow = page
+      .locator("button")
+      .filter({ hasText: /ApiGateway|handleRequest/ })
+      .first();
+    await expect(flowRow).toBeVisible({ timeout: 5000 });
+    await flowRow.click();
+    await page.waitForTimeout(1000);
+
+    await page.screenshot({
+      path: path.join(__dirname, "../../2116-02-vertical-legend.png"),
+      fullPage: false,
+    });
+
+    // Legend element
+    const legend = page.locator("[data-testid='flow-legend']");
+    await expect(legend).toBeVisible({ timeout: 5000 });
+
+    // Both repo slugs should appear as legend entries.
+    const legendText = await legend.innerText();
+    expect(legendText).toContain("client-fixture-b");
+    expect(legendText).toContain("client-fixture-c");
+
+    // The legend must be a vertical column — flex-col. Measure bounding rects
+    // of the repo legend items: they should be stacked (different Y, same X).
+    const repoBItem = legend.locator("[data-repo-legend='client-fixture-b']");
+    const repoCItem = legend.locator("[data-repo-legend='client-fixture-c']");
+    await expect(repoBItem).toBeVisible({ timeout: 3000 });
+    await expect(repoCItem).toBeVisible({ timeout: 3000 });
+
+    const bBox = await repoBItem.boundingBox();
+    const cBox = await repoCItem.boundingBox();
+    expect(bBox).not.toBeNull();
+    expect(cBox).not.toBeNull();
+
+    // Vertical: C row should be BELOW B row (higher Y).
+    expect(cBox!.y).toBeGreaterThan(bBox!.y);
+    // And they should have approximately the same X (within 10px).
+    expect(Math.abs(cBox!.x - bBox!.x)).toBeLessThan(10);
+  });
+
+  test("no kind chips (HTTP Fetch, DB Query, etc.) appear in legend", async ({ page }) => {
+    await mockXrepoPage(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/g/demo/flows");
+
+    await page.waitForTimeout(800);
+
+    const flowRow = page
+      .locator("button")
+      .filter({ hasText: /ApiGateway|handleRequest/ })
+      .first();
+    await expect(flowRow).toBeVisible({ timeout: 5000 });
+    await flowRow.click();
+    await page.waitForTimeout(1000);
+
+    await page.screenshot({
+      path: path.join(__dirname, "../../2116-03-no-kind-chips.png"),
+      fullPage: false,
+    });
+
+    const legend = page.locator("[data-testid='flow-legend']");
+    await expect(legend).toBeVisible({ timeout: 5000 });
+    const legendText = await legend.innerText();
+
+    // Kind chip labels that the old legend showed — must NOT be present.
+    const kindLabels = ["HTTP Fetch", "DB Query", "DB Write", "Publish", "Function", "Render"];
+    for (const label of kindLabels) {
+      expect(legendText).not.toContain(label);
+    }
+
+    // Cross-repo dashed line indicator should still be present.
+    expect(legendText).toContain("cross-repo");
+  });
+});

--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -35,7 +35,7 @@ import type {
   ChainStep,
 } from "@/data/types";
 import { cn } from "@/lib/utils";
-import { RepoChip as SharedRepoChip } from "@/lib/repo-color";
+import { RepoChip as SharedRepoChip, getRepoColorForGroup } from "@/lib/repo-color";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   createFlowAnim, useFlowAnim,
@@ -975,6 +975,7 @@ function FlowDag({
   anim,
   reducedMotion = false,
   onBridgeMap,
+  groupId = "",
 }: {
   flow: Process;
   detailSteps?: ProcessStep[];
@@ -984,6 +985,8 @@ function FlowDag({
   anim?: FlowAnimSnapshot;
   reducedMotion?: boolean;
   onBridgeMap?: (bridges: boolean[]) => void;
+  /** Group id for stable repo-color slot assignment (#2116). */
+  groupId?: string;
 }) {
   const steps = detailSteps ?? flow.steps ?? [];
 
@@ -1330,15 +1333,16 @@ function FlowDag({
     <div
       ref={viewportRef}
       className={cn(
-        "relative overflow-hidden border-b border-border flex-none select-none",
+        // #2115: flex-1 + min-h-0 lets this viewport fill its flex parent
+        // instead of being constrained to a fixed pixel height. minHeight
+        // guards keep the canvas usable even at small window sizes.
+        "relative overflow-hidden border-b border-border flex-1 min-h-0 select-none",
         dragging ? "cursor-grabbing" : "cursor-grab",
       )}
       style={{
         background:
           "radial-gradient(circle at 1px 1px, var(--canvas-grid) 1px, transparent 1px) 0 0 / 18px 18px, var(--canvas-bg)",
         minHeight: mode === LAYOUT_MEDIUM ? 220 : 320,
-        height: mode === LAYOUT_LONG ? 520 : 400,
-        maxHeight: mode === LAYOUT_LONG ? 680 : 560,
       }}
       onWheel={onWheel}
       onPointerDown={onPointerDown}
@@ -1731,11 +1735,22 @@ function FlowDag({
           const isFanOutNode = fanOutMap.has(i);
           const isInTrail =
             anim != null && i < anim.playhead;
+
+          // #2116: left-edge accent stripe color = repo color (not step-kind color).
+          // This makes repo-transitions visible at a glance across the DAG.
+          const repoColors = getRepoColorForGroup(groupId, s.repo ?? "");
+          // Extract the hex/hsl foreground for use as the stripe color.
+          // getRepoColorForGroup returns CSS var strings for the first 8 repos
+          // (pastel-N-ink) and HSL literals for overflow repos. We use the
+          // foreground token so the stripe is vibrant in both themes.
+          const repoStripeColor = repoColors.foreground;
+
           return (
             <button
               key={s.entity_id}
               type="button"
               data-step-node
+              data-repo={s.repo}
               onClick={() => onPickStep(i)}
               className={cn(
                 "absolute flex flex-col gap-1 rounded-md border cursor-pointer text-left",
@@ -1757,8 +1772,9 @@ function FlowDag({
                   isEntry || isTerminal
                     ? `color-mix(in srgb, ${meta.color} 8%, var(--surface))`
                     : "var(--surface)",
+                // #2116: repo color on left edge stripe, not step-kind color.
                 borderLeftWidth: 4,
-                borderLeftColor: meta.color,
+                borderLeftColor: repoStripeColor,
                 boxShadow: selectedStepIdx === i
                   ? "0 0 0 2px var(--accent-ring), var(--shadow-2)"
                   : "var(--shadow-1)",
@@ -1872,31 +1888,50 @@ function FlowDag({
         </span>
       </div>
 
-      {/* Legend */}
-      <div className="absolute left-3 bottom-3 flex flex-wrap gap-2 rounded-sm border border-border bg-[var(--overlay)] px-2 py-1.5 max-w-xs backdrop-blur-sm z-10">
-        {(
-          [
-            "http_fetch",
-            "db_query",
-            "db_write",
-            "message_publish",
-            "function_call",
-            "component_render",
-          ] as StepKind[]
-        ).map((k) => {
-          const m = getStepMeta(k);
+      {/* Legend — #2116: vertical repo list (no kind chips — cards already show
+          kind via icon+label). Cross-repo dashed-line indicator is kept.
+          Branch-arm entry kept for DAG flows (#2027). */}
+      <div
+        className="absolute left-3 bottom-3 flex flex-col gap-1.5 rounded-sm border border-border bg-[var(--overlay)] px-2.5 py-2 backdrop-blur-sm z-10"
+        data-testid="flow-legend"
+      >
+        {/* Repos header */}
+        {steps.length > 0 && (() => {
+          // Collect unique repos in order of first appearance.
+          const seen: string[] = [];
+          for (const s of steps) {
+            if (s.repo && !seen.includes(s.repo)) seen.push(s.repo);
+          }
+          if (seen.length === 0) return null;
           return (
-            <span key={k} className="inline-flex items-center gap-1 text-[9px] text-text-3">
-              <span
-                className="w-[7px] h-[7px] rounded-[2px] flex-none"
-                style={{ background: m.color }}
-              />
-              {m.label}
-            </span>
+            <>
+              <span className="text-[8px] font-semibold uppercase tracking-wider text-text-4 select-none">
+                Repos
+              </span>
+              {seen.map((slug) => {
+                const colors = getRepoColorForGroup(groupId, slug);
+                return (
+                  <span
+                    key={slug}
+                    className="inline-flex items-center gap-1.5 text-[9px] text-text-3"
+                    data-repo-legend={slug}
+                  >
+                    <span
+                      className="w-[8px] h-[8px] rounded-full flex-none"
+                      style={{ background: colors.foreground }}
+                    />
+                    <span className="font-mono leading-none">{slug}</span>
+                  </span>
+                );
+              })}
+            </>
           );
-        })}
-        <span className="inline-flex items-center gap-1 text-[9px] text-text-3">
-          <svg width="14" height="10">
+        })()}
+        {/* Separator */}
+        <span className="border-t border-border-soft" />
+        {/* Cross-repo dashed edge */}
+        <span className="inline-flex items-center gap-1.5 text-[9px] text-text-3">
+          <svg width="14" height="10" className="flex-none">
             <line
               x1="0"
               y1="5"
@@ -1911,8 +1946,8 @@ function FlowDag({
         </span>
         {/* Branch-arm legend entry — only shown for DAG flows (#2027) */}
         {flow.is_dag && (
-          <span className="inline-flex items-center gap-1 text-[9px] text-text-3">
-            <svg width="14" height="10">
+          <span className="inline-flex items-center gap-1.5 text-[9px] text-text-3">
+            <svg width="14" height="10" className="flex-none">
               <line
                 x1="0"
                 y1="5"
@@ -2400,6 +2435,7 @@ function FlowDagWithAnim({
   controller: FlowAnimController | null;
   reducedMotion?: boolean;
   onBridgeMap?: (bridges: boolean[]) => void;
+  groupId?: string;
 }) {
   if (!controller) {
     return <FlowDag {...rest} />;
@@ -2419,6 +2455,7 @@ function FlowDagWithAnimInner({
   controller: FlowAnimController;
   reducedMotion?: boolean;
   onBridgeMap?: (bridges: boolean[]) => void;
+  groupId?: string;
 }) {
   const snap = useFlowAnim(controller);
   return <FlowDag {...rest} anim={snap} />;
@@ -3043,32 +3080,34 @@ function DetailPanel({
         </div>
       </header>
 
-      {/* Body — scrollable */}
-      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col">
+      {/* Body — #2115 fix: split into two sections so the DAG fills available
+          height. The DAG area is flex-1 min-h-0 (flex child that grows to fill
+          the panel). The sections below it scroll independently. */}
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
         {/* DAG skeleton */}
         {detailQ.isLoading && !fullFlow.steps?.length && (
-          <div className="flex items-center justify-center min-h-[280px] text-text-4 text-sm animate-pulse">
+          <div className="flex items-center justify-center min-h-[280px] text-text-4 text-sm animate-pulse flex-none">
             Loading flow chain…
           </div>
         )}
 
-        {/* DAG canvas — when a step is selected, switch to 60/40 side-by-side.
-            The DAG takes 60% and the StepInspector takes 40%. The side-effects
-            panel remains floating (anchored bottom-left inside the DAG area)
-            and is only shown when no step is selected. */}
+        {/* DAG canvas — #2115: flex-1 flex flex-col min-h-0 so the canvas fills
+            the remaining panel height and FlowDag's own flex-1 takes effect.
+            When a step is selected: 60/40 side-by-side split (same as before). */}
         {(fullFlow.steps?.length ?? 0) > 0 && (
           <div
             className={cn(
-              "flex-none",
-              selectedStep ? "flex" : "relative",
+              // #2115 key fix: was "flex-none" — now flex-1 so the DAG grows.
+              "flex-1 min-h-0 flex flex-col",
+              selectedStep ? "flex-row" : "",
             )}
-            style={selectedStep ? { minHeight: 400 } : undefined}
+            style={selectedStep ? { flexDirection: "row" } : undefined}
           >
             {/* DAG — 60% when step is open, full-width otherwise */}
             <div
               className={cn(
-                "relative",
-                selectedStep ? "flex-none" : "w-full",
+                "relative flex flex-col flex-1 min-h-0",
+                selectedStep ? "flex-none" : "",
               )}
               style={selectedStep ? { width: "60%" } : undefined}
             >
@@ -3088,6 +3127,7 @@ function DetailPanel({
                 onBridgeMap={(map) => {
                   bridgeRef.current = map;
                 }}
+                groupId={groupId}
               />
               {/* Scrubber — directly under the DAG, only when steps exist. */}
               {controller && (fullFlow.steps?.length ?? 0) >= 2 && (
@@ -3121,8 +3161,10 @@ function DetailPanel({
           </div>
         )}
 
-        {/* Sections */}
-        <DetailSections flow={fullFlow} />
+        {/* Sections — scroll independently below the DAG */}
+        <div className="flex-none overflow-y-auto">
+          <DetailSections flow={fullFlow} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **#2115 (recurring)** — DAG canvas no longer leaves empty whitespace below: `FlowDag` viewport changed from `flex-none + height: 400/520px` to `flex-1 min-h-0`, and the detail body layout restructured so the canvas participates in flex growth and fills available panel height.
- **#2116** — Step cards show a 4px left-edge accent stripe colored by repo (not step-kind), making repo transitions visible at a glance across the DAG.
- **#2116** — Legend redesigned: vertical repo list with colored circles replaces the horizontal kind chips. Kind chips removed (step cards already show kind via icon + label). Cross-repo dashed-line indicator kept. Branch arm entry kept for DAG flows.

Closes #2115, #2116

## Root cause — #2115 (the recurring whitespace bug)

The `FlowDag` viewport div had **`flex-none` + hard `height: 400px` (520px for long mode) + `maxHeight: 560px`**. The `DetailPanel` body was `flex-1 min-h-0 overflow-y-auto flex flex-col` with the DAG wrapper tagged `flex-none`, so the canvas never grew beyond its pixel cap and the remaining 60–70% of the panel was blank. On a 900px display the DAG occupied the top ~45%, with dead space below.

The fix drops the hard height/maxHeight entirely and switches the viewport to `flex-1 min-h-0`. The parent DAG wrapper becomes `flex-1 flex flex-col min-h-0`, and the `DetailPanel` body is split: the DAG area grows to fill available space, and the detail sections below scroll independently via their own `flex-none overflow-y-auto` wrapper.

The existing `ResizeObserver`-based `fitToView` already fires on container resize, so the DAG auto-scales to the newly available canvas without additional wiring.

## Changes

- `webui-v2/src/routes/flows.tsx` — three focused changes: viewport class, legend rewrite, step node stripe color
- `webui-v2/e2e/flows-fills-viewport.spec.ts` — regression guard: asserts DAG bbox > 65% of available viewport height after flow selection
- `webui-v2/e2e/flows-repo-colors.spec.ts` — asserts distinct stripe colors per repo, vertical legend layout, no kind chips

## Test plan

- [ ] Load flows view → select a flow → DAG should fill ~full panel height, not 30-40%
- [ ] Cross-repo flow → step cards from repo A and repo B show visually distinct left-edge stripe colors
- [ ] Legend is a vertical column (Repos header → one repo per row → separator → cross-repo dashed line)
- [ ] Legend contains NO "HTTP Fetch", "DB Query", "DB Write", "Publish", "Function", "Render" chips
- [ ] `npm run build` passes (no TS errors)
- [ ] Playwright tests: `flows-fills-viewport.spec.ts` and `flows-repo-colors.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)