### PR TITLE
fix(extractors): same self-recursion guard bug pattern across Scala/C#/Groovy/Solidity (refs #2114)

### DIFF
--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -412,12 +412,17 @@ func extractCallRelationships(
 		if target == "" {
 			continue
 		}
-		// Self-recursion check on bare leaf.
-		leaf := target
-		if dot := strings.LastIndexByte(target, '.'); dot >= 0 {
-			leaf = target[dot+1:]
-		}
-		if leaf == callerName {
+		// Self-recursion check: skip bare-name targets that match the
+		// caller's own leaf name (e.g. `Process()` calling itself without
+		// a receiver). Dotted targets (e.g. "OrderService.Process") are
+		// cross-type calls and MUST NOT be filtered even when the leaf
+		// matches the caller's name — "OrderController.Process" calling
+		// "OrderService.Process" is a legitimate outbound call, not
+		// recursion (#2114). The previous check applied the leaf match
+		// to all dotted targets, which incorrectly dropped every CALLS
+		// edge where the callee method shared its name with the enclosing
+		// method.
+		if strings.IndexByte(target, '.') < 0 && target == callerName {
 			continue
 		}
 		if seen[target] {

--- a/internal/extractors/csharp/issue2114_self_recursion_dotted_target_test.go
+++ b/internal/extractors/csharp/issue2114_self_recursion_dotted_target_test.go
@@ -1,0 +1,77 @@
+package csharp_test
+
+// Issue #2114 — same self-recursion guard bug class as the Java fix.
+// The guard was:
+//
+//	leaf := target
+//	if dot := strings.LastIndexByte(target, '.'); dot >= 0 { leaf = target[dot+1:] }
+//	if leaf == callerName { continue }   // BUG: fires on cross-type dotted calls
+//
+// When client-fixture-A.OrderController.Process() called
+// _orderService.Process(req), the resolved target "OrderService.Process" had
+// its leaf "Process" matched against the caller's bare "Process" → edge
+// silently dropped as "self-recursion".
+//
+// Fix: restrict the self-recursion skip to bare-name (undotted) targets only
+// (strings.IndexByte(target, '.') < 0 && target == callerName).
+
+import (
+	"testing"
+)
+
+// TestCSharp_CallsFieldReceiverDottedTarget_SameLeaf (#2114): a controller
+// method named "Process" that delegates to a field receiver
+// "_orderService.Process(req)" MUST emit a CALLS edge to "OrderService.Process".
+// Before the fix, the leaf "Process" matched callerName "Process" and the edge
+// was silently dropped.
+func TestCSharp_CallsFieldReceiverDottedTarget_SameLeaf(t *testing.T) {
+	src := `
+public class OrderController
+{
+    private readonly OrderService _orderService;
+
+    public OrderController(OrderService orderService)
+    {
+        _orderService = orderService;
+    }
+
+    public string Process(string req)
+    {
+        return _orderService.Process(req);
+    }
+}
+`
+	ents := runCSharp(t, src)
+	ctrl := csFind(ents, "OrderController.Process", "SCOPE.Operation")
+	if ctrl == nil {
+		t.Fatal("expected entity 'OrderController.Process' (SCOPE.Operation)")
+	}
+	for _, r := range ctrl.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "OrderService.Process" {
+			return // pass
+		}
+	}
+	t.Errorf("OrderController.Process has no CALLS edge to OrderService.Process; got: %+v",
+		ctrl.Relationships)
+}
+
+// TestCSharp_SelfRecursionStillDropped (#2114): true self-recursion (a bare
+// method calling itself without a receiver) MUST still be suppressed.
+func TestCSharp_SelfRecursionStillDropped(t *testing.T) {
+	src := `
+public class Looper
+{
+    public void Loop() { Loop(); }
+}
+`
+	ents := runCSharp(t, src)
+	looper := csFind(ents, "Looper.Loop", "SCOPE.Operation")
+	if looper == nil {
+		t.Fatal("expected entity 'Looper.Loop' (SCOPE.Operation)")
+	}
+	for _, r := range looper.Relationships {
+		if r.Kind == "CALLS" && (r.ToID == "Loop" || r.ToID == "Looper.Loop") {
+			t.Errorf("self-recursion should not produce a CALLS edge: %+v", r)
+		}
+	}
+}

--- a/internal/extractors/groovy/groovy.go
+++ b/internal/extractors/groovy/groovy.go
@@ -655,12 +655,17 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 		if groovyKeywordStop[target] {
 			continue
 		}
-		// Self-recursion check on the bare leaf name.
-		leaf := target
-		if dot := strings.LastIndexByte(target, '.'); dot >= 0 {
-			leaf = target[dot+1:]
-		}
-		if leaf == callerName {
+		// Self-recursion check: skip bare-name targets that match the
+		// caller's own leaf name (e.g. `process()` calling itself without
+		// a receiver). Dotted targets (e.g. "OrderService.process") are
+		// cross-type calls and MUST NOT be filtered even when the leaf
+		// matches the caller's name — "OrderController.process" calling
+		// "OrderService.process" is a legitimate outbound call, not
+		// recursion (#2114). The previous check applied the leaf match
+		// to all dotted targets, which incorrectly dropped every CALLS
+		// edge where the callee method shared its name with the enclosing
+		// method.
+		if strings.IndexByte(target, '.') < 0 && target == callerName {
 			continue
 		}
 		if seen[target] {

--- a/internal/extractors/groovy/issue2114_self_recursion_dotted_target_test.go
+++ b/internal/extractors/groovy/issue2114_self_recursion_dotted_target_test.go
@@ -1,0 +1,71 @@
+package groovy_test
+
+// Issue #2114 — same self-recursion guard bug class as the Java fix.
+// The guard was:
+//
+//	leaf := target
+//	if dot := strings.LastIndexByte(target, '.'); dot >= 0 { leaf = target[dot+1:] }
+//	if leaf == callerName { continue }   // BUG: fires on cross-type dotted calls
+//
+// When client-fixture-A.OrderController.process() called
+// orderService.process(req), the resolved target "OrderService.process" had
+// its leaf "process" matched against the caller's bare "process" → edge
+// silently dropped as "self-recursion".
+//
+// Fix: restrict the self-recursion skip to bare-name (undotted) targets only
+// (strings.IndexByte(target, '.') < 0 && target == callerName).
+
+import (
+	"testing"
+)
+
+// TestGroovy_CallsFieldReceiverDottedTarget_SameLeaf (#2114): a controller
+// method named "process" that delegates to a PascalCase static/companion call
+// "OrderService.process(req)" MUST emit a CALLS edge to "OrderService.process".
+//
+// Groovy's groovyCallTarget only emits dotted targets for PascalCase receivers
+// (e.g. "Service.run()" → "Service.run"). For camelCase receivers it emits
+// only the bare leaf. The bug fires when the PascalCase receiver's method name
+// matches the caller's bare name: leaf("OrderService.process") == "process"
+// == callerName "process" → edge incorrectly dropped as self-recursion.
+func TestGroovy_CallsFieldReceiverDottedTarget_SameLeaf(t *testing.T) {
+	src := `class OrderController {
+    def process(String req) {
+        OrderService.process(req)
+    }
+}
+`
+	ents := runGroovy(t, src)
+	ctrl := gFind(ents, "process", "SCOPE.Operation")
+	if ctrl == nil {
+		t.Fatal("expected entity 'process' (SCOPE.Operation)")
+	}
+	for _, r := range ctrl.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "OrderService.process" {
+			return // pass
+		}
+	}
+	t.Errorf("process has no CALLS edge to OrderService.process; got: %+v",
+		ctrl.Relationships)
+}
+
+// TestGroovy_SelfRecursionStillDropped (#2114): true self-recursion (a bare
+// method calling itself without a receiver) MUST still be suppressed.
+func TestGroovy_SelfRecursionStillDropped(t *testing.T) {
+	src := `class Looper {
+    def loop() {
+        loop()
+    }
+}
+`
+	ents := runGroovy(t, src)
+	looper := gFind(ents, "loop", "SCOPE.Operation")
+	if looper == nil {
+		t.Fatal("expected entity 'loop' (SCOPE.Operation)")
+	}
+	for _, r := range looper.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "loop" {
+			t.Errorf("self-recursion should not produce a CALLS edge: %+v", r)
+		}
+	}
+}

--- a/internal/extractors/scala/issue2114_self_recursion_dotted_target_test.go
+++ b/internal/extractors/scala/issue2114_self_recursion_dotted_target_test.go
@@ -1,0 +1,70 @@
+package scala_test
+
+// Issue #2114 — same self-recursion guard bug class as the Java fix.
+// The guard was:
+//
+//	leaf := target
+//	if dot := strings.LastIndexByte(target, '.'); dot >= 0 { leaf = target[dot+1:] }
+//	if leaf == callerName { continue }   // BUG: fires on cross-type dotted calls
+//
+// When client-fixture-A.OrderController.process() called
+// client-fixture-B.orderService.process(req), the resolved target
+// "OrderService.process" had its leaf "process" matched against the
+// caller's bare "process" → edge silently dropped as "self-recursion".
+//
+// Fix: restrict the self-recursion skip to bare-name (undotted) targets only
+// (strings.IndexByte(target, '.') < 0 && target == callerName).
+
+import (
+	"testing"
+)
+
+// TestScala_CallsFieldReceiverDottedTarget_SameLeaf (#2114): a controller
+// method named "process" that delegates to a field receiver
+// "orderService.process(req)" MUST emit a CALLS edge to "OrderService.process".
+// Before the fix, the leaf "process" matched callerName "process" and the edge
+// was silently dropped.
+//
+// The Scala extractor names operations by their bare method identifier (no
+// class prefix), so scalaFind uses "process" not "OrderController.process".
+func TestScala_CallsFieldReceiverDottedTarget_SameLeaf(t *testing.T) {
+	src := `class OrderController(orderService: OrderService) {
+  def process(req: String): String = {
+    orderService.process(req)
+  }
+}
+`
+	ents := runScala(t, src)
+	ctrl := scalaFind(ents, "process", "SCOPE.Operation")
+	if ctrl == nil {
+		t.Fatal("expected entity 'process' (SCOPE.Operation)")
+	}
+	for _, r := range ctrl.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "OrderService.process" {
+			return // pass
+		}
+	}
+	t.Errorf("process has no CALLS edge to OrderService.process; got: %+v",
+		ctrl.Relationships)
+}
+
+// TestScala_SelfRecursionStillDropped (#2114): true self-recursion (a bare
+// method calling itself without a receiver) MUST still be suppressed.
+func TestScala_SelfRecursionStillDropped(t *testing.T) {
+	src := `class Looper {
+  def loop(): Unit = {
+    loop()
+  }
+}
+`
+	ents := runScala(t, src)
+	looper := scalaFind(ents, "loop", "SCOPE.Operation")
+	if looper == nil {
+		t.Fatal("expected entity 'loop' (SCOPE.Operation)")
+	}
+	for _, r := range looper.Relationships {
+		if r.Kind == "CALLS" && (r.ToID == "loop" || r.ToID == "Looper.loop") {
+			t.Errorf("self-recursion should not produce a CALLS edge: %+v", r)
+		}
+	}
+}

--- a/internal/extractors/scala/scala.go
+++ b/internal/extractors/scala/scala.go
@@ -404,12 +404,17 @@ func extractCallRelationships(
 		if scalaKeywordStop[target] {
 			continue
 		}
-		// Self-recursion check on the bare leaf name.
-		leaf := target
-		if dot := strings.LastIndexByte(target, '.'); dot >= 0 {
-			leaf = target[dot+1:]
-		}
-		if leaf == callerName {
+		// Self-recursion check: skip bare-name targets that match the
+		// caller's own leaf name (e.g. `process()` calling itself without
+		// a receiver). Dotted targets (e.g. "OrderService.process") are
+		// cross-type calls and MUST NOT be filtered even when the leaf
+		// matches the caller's name — "OrderController.process" calling
+		// "OrderService.process" is a legitimate outbound call, not
+		// recursion (#2114). The previous check applied the leaf match
+		// to all dotted targets, which incorrectly dropped every CALLS
+		// edge where the callee method shared its name with the enclosing
+		// method.
+		if strings.IndexByte(target, '.') < 0 && target == callerName {
 			continue
 		}
 		if seen[target] {

--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -396,13 +396,21 @@ func collectCallsFromBody(body, callerName string) []types.RelationshipRecord {
 		if solidityKeywords[leaf] {
 			return
 		}
-		// Avoid self-recursion on simple name match.
-		callerLeaf := callerName
-		if dot := strings.LastIndexByte(callerName, '.'); dot >= 0 {
-			callerLeaf = callerName[dot+1:]
-		}
-		if leaf == callerLeaf {
-			return
+		// Self-recursion check: skip bare-name targets that match the
+		// caller's own leaf name (e.g. `transfer()` calling itself without
+		// a receiver). Dotted targets (e.g. "token.transfer") are
+		// cross-contract calls and MUST NOT be filtered even when the
+		// leaf matches the caller's leaf name — "ERC20Vault.transfer"
+		// calling "token.transfer" is a legitimate outbound call, not
+		// recursion (#2114). Restrict the check to undotted targets only.
+		if strings.IndexByte(target, '.') < 0 {
+			callerLeaf := callerName
+			if dot := strings.LastIndexByte(callerName, '.'); dot >= 0 {
+				callerLeaf = callerName[dot+1:]
+			}
+			if leaf == callerLeaf {
+				return
+			}
 		}
 		seen[target] = true
 		out = append(out, types.RelationshipRecord{

--- a/internal/extractors/solidity/issue2114_self_recursion_dotted_target_test.go
+++ b/internal/extractors/solidity/issue2114_self_recursion_dotted_target_test.go
@@ -1,0 +1,71 @@
+package solidity_test
+
+// Issue #2114 — same self-recursion guard bug class as the Java fix.
+// The Solidity guard was:
+//
+//	callerLeaf := callerName
+//	if dot := strings.LastIndexByte(callerName, '.'); dot >= 0 {
+//	    callerLeaf = callerName[dot+1:]
+//	}
+//	if leaf == callerLeaf { return }   // BUG: fires on cross-contract dotted calls
+//
+// When client-fixture-A.ERC20Vault.transfer() called
+// token.transfer(to, amount), the resolved target "token.transfer" had its
+// leaf "transfer" matched against callerLeaf("ERC20Vault.transfer") == "transfer"
+// → edge silently dropped as "self-recursion".
+//
+// Fix: restrict the self-recursion skip to bare-name (undotted) targets only.
+// A dotted target like "token.transfer" is a cross-contract call and must
+// never be filtered by a bare-leaf match against the caller's own leaf name.
+
+import (
+	"testing"
+)
+
+// TestSolidity_CallsFieldReceiverDottedTarget_SameLeaf (#2114): a contract
+// function named "transfer" that delegates to a field receiver
+// "token.transfer(to, amount)" MUST emit a CALLS edge to "token.transfer".
+// Before the fix, leaf("token.transfer") == "transfer" matched
+// callerLeaf("ERC20Vault.transfer") == "transfer" and the edge was dropped.
+func TestSolidity_CallsFieldReceiverDottedTarget_SameLeaf(t *testing.T) {
+	src := `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ERC20Vault {
+    function transfer(address to, uint256 amount) external {
+        token.transfer(to, amount);
+    }
+}
+`
+	ents := runSolidity(t, src, "ERC20Vault.sol")
+	if !solHasRel(ents, "ERC20Vault.transfer", "SCOPE.Operation", "CALLS", "token.transfer") {
+		t.Errorf("ERC20Vault.transfer has no CALLS edge to token.transfer; want cross-contract call preserved")
+	}
+}
+
+// TestSolidity_SelfRecursionStillDropped (#2114): true self-recursion (a bare
+// function call to itself without a receiver) MUST still be suppressed.
+func TestSolidity_SelfRecursionStillDropped(t *testing.T) {
+	src := `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Looper {
+    function loop() external {
+        loop();
+    }
+}
+`
+	ents := runSolidity(t, src, "Looper.sol")
+	for _, ent := range ents {
+		if ent.Name == "Looper.loop" {
+			for _, r := range ent.Relationships {
+				if r.Kind == "CALLS" && r.ToID == "loop" {
+					t.Errorf("self-recursion should not produce a CALLS edge: %+v", r)
+				}
+			}
+			return
+		}
+	}
+	// If we didn't find the entity that's also a test failure
+	t.Fatal("expected entity 'Looper.loop' (SCOPE.Operation)")
+}


### PR DESCRIPTION
## Summary

Sweep of the bug class fixed in Java by #2114. Found and fixed the identical over-eager self-recursion guard in **4 additional extractors**: Scala, C#, Groovy, and Solidity.

**Root cause (all four):** the guard extracted the leaf from every target — including dotted cross-type targets like `"OrderService.process"` — and compared it to the caller's bare name. When `OrderController.process` called `OrderService.process`, `leaf("OrderService.process") == "process" == callerName` → edge silently dropped as "self-recursion".

**Fix (all four):** restrict the self-recursion skip to bare-name (undotted) targets only, mirroring the Java fix in #2114:
```go
// Before (broken):
leaf := target
if dot := strings.LastIndexByte(target, '.'); dot >= 0 { leaf = target[dot+1:] }
if leaf == callerName { continue }

// After (correct):
if strings.IndexByte(target, '.') < 0 && target == callerName { continue }
```

## Findings Table

| Extractor | File:line | Bug present? | Fix | Test added |
|---|---|---|---|---|
| Scala | `internal/extractors/scala/scala.go:407-413` | Yes | Undotted-only guard | `TestScala_CallsFieldReceiverDottedTarget_SameLeaf` |
| C# | `internal/extractors/csharp/csharp.go:415-421` | Yes | Undotted-only guard | `TestCSharp_CallsFieldReceiverDottedTarget_SameLeaf` |
| Groovy | `internal/extractors/groovy/groovy.go:658-664` | Yes (fires on PascalCase receivers) | Undotted-only guard | `TestGroovy_CallsFieldReceiverDottedTarget_SameLeaf` |
| Solidity | `internal/extractors/solidity/extractor.go:399-406` | Yes (leaf-of-caller vs leaf-of-target) | Undotted-only guard | `TestSolidity_CallsFieldReceiverDottedTarget_SameLeaf` |

## Extractors confirmed clean (no fix needed)

Python, Go, JavaScript/TypeScript, Ruby, Rust, Kotlin, Dart, Nim, Elixir, Erlang, Elm, OCaml, Pony, Zig, Lisp, F#, ReasonML, ReScript, SML, Haskell, Swift, C++, PHP, Lua, Shell, Fish, Clojure, Razor — each uses either a correct FQN comparison or a target resolver that only ever returns bare names.

## Test plan

- [x] Each regression test `FAILED` on the pre-fix code and `PASSES` after
- [x] Companion `*StillDropped` test confirms true self-recursion (bare call to self) is still suppressed
- [x] Full test suites for all 4 extractors pass (`go test ./internal/extractors/scala/... ./internal/extractors/csharp/... ./internal/extractors/groovy/... ./internal/extractors/solidity/...`)
- [x] `go build ./...` clean

## Bonus / side observations (no fix in this PR)

- **Groovy's PascalCase-only dotted target resolution** means the bug only fires for static/companion-object style calls (`OrderService.process()`), not field-receiver calls (`orderService.process()`). This is a separate expressiveness limitation worth tracking (not a correctness regression).
- **Solidity's `collectCallsFromBody` is regex-based** (not tree-sitter). The regex approach means it can match patterns in strings/comments — existing `stripCommentsAndStrings` mitigates this but edge cases exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #2114