### PR TITLE
feat(store): per-ref store key layout + legacy-store migration (PH1a of #2087)

### DIFF
--- a/internal/daemon/state_migrate.go
+++ b/internal/daemon/state_migrate.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 )
@@ -186,4 +188,143 @@ func copyPath(src, dst string) error {
 		return err
 	}
 	return out.Close()
+}
+
+// graphMetadataRef is the minimal subset of the graph metadata file we
+// need for migration — just the indexed_ref field. We read .metadata.json
+// or graph.json (whichever exists) to discover the ref so we can route
+// the legacy flat artifacts into the correct per-ref sub-directory.
+type graphMetadataRef struct {
+	IndexedRef string `json:"indexed_ref"`
+}
+
+// readIndexedRefFromDir attempts to read the indexed_ref from the
+// metadata stored inside baseDir. It tries, in order:
+//  1. graph.fb (via fbreader — avoids JSON overhead for the common path)
+//  2. graph.json (JSON fallback)
+//
+// Returns "" when no metadata is found or the file predates PH0 (#2088).
+func readIndexedRefFromDir(baseDir string) string {
+	// Try graph.json — simpler than wiring fbreader here.
+	for _, name := range []string{"graph.json"} {
+		p := filepath.Join(baseDir, name)
+		f, err := os.Open(p)
+		if err != nil {
+			continue
+		}
+		var m graphMetadataRef
+		if err := json.NewDecoder(f).Decode(&m); err == nil && m.IndexedRef != "" {
+			f.Close()
+			return m.IndexedRef
+		}
+		f.Close()
+	}
+	return ""
+}
+
+// MigrateToRefStore walks storeDir and moves any legacy flat-layout
+// per-repo slot (one that holds graph.fb / graph.json directly, not under
+// refs/) into the per-ref sub-directory introduced by PH1a (#2089).
+//
+// Layout before migration:
+//
+//	<store>/<slug>-<hash>/graph.fb
+//	<store>/<slug>-<hash>/graph.json
+//	<store>/<slug>-<hash>/<sidecars>
+//
+// Layout after migration:
+//
+//	<store>/<slug>-<hash>/refs/<ref-safe>/graph.fb
+//	<store>/<slug>-<hash>/refs/<ref-safe>/graph.json
+//	<store>/<slug>-<hash>/refs/<ref-safe>/<sidecars>
+//
+// The ref-safe name is derived from the indexed_ref stored in the
+// metadata; "_unknown" is used when the metadata predates PH0 (#2088)
+// or the HEAD was detached.
+//
+// Migration is idempotent: slots that already have a refs/ sub-directory
+// and no top-level graph.fb are skipped.
+//
+// Intended to be called once from daemon startup (before the first RPC
+// is served) so no caller pays the migration cost at query time.
+func MigrateToRefStore(storeDir string) error {
+	if storeDir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(storeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // store not created yet — nothing to migrate
+		}
+		return fmt.Errorf("MigrateToRefStore: read store dir %s: %w", storeDir, err)
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		slotDir := filepath.Join(storeDir, e.Name())
+		if err := migrateSlot(slotDir); err != nil {
+			// Log but continue; partial migration leaves usable state.
+			log.Printf("migration: slot %s: %v", slotDir, err)
+		}
+	}
+	return nil
+}
+
+// migrateSlot migrates a single per-repo slot from legacy flat layout to
+// the per-ref sub-directory layout. It is idempotent.
+func migrateSlot(slotDir string) error {
+	// Fast path: slot already has a refs/ sub-directory (new layout).
+	refsDir := filepath.Join(slotDir, "refs")
+	if fi, err := os.Stat(refsDir); err == nil && fi.IsDir() {
+		// Might still have a stale flat graph.fb alongside refs/ if a
+		// previous partial migration crashed. Clean up the top-level
+		// graph files if refs/ already holds something valid.
+		if !legacyHasGraph(slotDir) {
+			return nil // already clean
+		}
+		// top-level graph.fb exists alongside refs/ — finish the move.
+	} else if !legacyHasGraph(slotDir) {
+		return nil // slot has no graph at all — skip
+	}
+
+	// Determine the target ref from metadata stored in the slot.
+	ref := readIndexedRefFromDir(slotDir)
+	refSafe := RefSafeEncode(ref) // "" → "_unknown"
+
+	targetDir := filepath.Join(refsDir, refSafe)
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", targetDir, err)
+	}
+
+	// Move every graph artifact from the slot top-level to targetDir.
+	var firstErr error
+	moveOne := func(name string) {
+		src := filepath.Join(slotDir, name)
+		if _, e := os.Stat(src); e != nil {
+			return // file absent — skip
+		}
+		dst := filepath.Join(targetDir, name)
+		// Idempotency: if dst already exists, skip — the file was already moved.
+		if _, e := os.Stat(dst); e == nil {
+			// dst exists: remove src to finish the partial move.
+			_ = os.RemoveAll(src)
+			return
+		}
+		if e := movePath(src, dst); e != nil && firstErr == nil {
+			firstErr = fmt.Errorf("move %s → %s: %w", src, dst, e)
+		}
+	}
+	for _, name := range graphArtifactNames {
+		moveOne(name)
+	}
+	for _, name := range graphArtifactDirs {
+		moveOne(name)
+	}
+
+	if firstErr == nil {
+		log.Printf("migration: %s → refs/%s", slotDir, refSafe)
+	}
+	return firstErr
 }

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -30,6 +30,19 @@
 // manifests written by the wizard) is NOT routed through this helper —
 // it stays at `<repo>/.archigraph/group.json` so it can be discovered
 // by walking up from a CWD regardless of which daemon is running.
+//
+// Per-ref layout (PH1a of epic #2087 / issue #2089):
+// Graph artifacts are now stored under a per-branch sub-directory:
+//
+//	<store>/<slug>-<hash>/refs/<ref-safe>/graph.fb
+//
+// where <ref-safe> is the branch name with "/" replaced by "%2F"
+// (URL-percent encoding, 2-way round-trip). The sentinel "_unknown" is
+// used when no ref is available (detached HEAD, pre-metadata graphs).
+//
+// StateDirForRepo remains the single entry point for existing callers;
+// it reads the current HEAD ref via gitmeta.Capture and delegates to
+// StateDirForRepoRef.
 package daemon
 
 import (
@@ -39,6 +52,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/cajasmota/archigraph/internal/gitmeta"
 )
 
 // repoStateHash returns a deterministic, path-safe identifier for a
@@ -101,24 +116,53 @@ func repoSlug(absRepoPath string) string {
 	return base + "-" + repoStateHash(absRepoPath)
 }
 
-// StateDirForRepo returns the directory that holds per-repo state
-// (graph.fb, graph.json, repair.json, enrichment-*.json, links, …) for
-// repoPath.
+// RefSafeEncode converts a git ref name (branch/tag) into a
+// filesystem-safe directory name component. The "/" separator is
+// percent-encoded as "%2F" so the round-trip is deterministic and
+// reversible. All other characters that are legal in git ref names are
+// also legal in directory names on Linux/macOS/Windows, so no further
+// encoding is needed.
 //
-// Resolution (issue #1626):
-//   - When ARCHIGRAPH_DAEMON_ROOT is set (isolated daemons, parallel
-//     agents, tests): `$ARCHIGRAPH_DAEMON_ROOT/state/<hash>/`. This
-//     preserves the issue-#745 isolation contract.
-//   - Otherwise: the external store at
-//     `$ARCHIGRAPH_HOME (or ~/.archigraph)/store/<slug>-<hash>/`.
+// Examples:
 //
-// Graph artifacts are NO LONGER written into `<repo>/.archigraph/`.
-// Pre-existing in-repo state is relocated transparently by
-// MigrateInRepoState (called from the load path).
+//	"main"          → "main"
+//	"feat/foo-bar"  → "feat%2Ffoo-bar"
+//	""              → "_unknown"
+func RefSafeEncode(ref string) string {
+	if ref == "" {
+		return "_unknown"
+	}
+	return strings.ReplaceAll(ref, "/", "%2F")
+}
+
+// RefSafeDecode reverses RefSafeEncode. "_unknown" is returned as "".
+func RefSafeDecode(safe string) string {
+	if safe == "_unknown" {
+		return ""
+	}
+	return strings.ReplaceAll(safe, "%2F", "/")
+}
+
+// repoBaseDir returns the per-repo slot in the store (without the
+// refs/<ref-safe>/ suffix). This is the top-level directory created for
+// the repo — it holds the refs/ sub-tree and legacy flat artifacts
+// during migration.
+func repoBaseDir(absRepoPath string) string {
+	if root := os.Getenv(EnvRoot); root != "" {
+		return filepath.Join(root, "state", repoStateHash(absRepoPath))
+	}
+	return filepath.Join(StoreDir(), repoSlug(absRepoPath))
+}
+
+// StateDirForRepoRef returns the per-ref state directory for repoPath
+// and a specific git ref:
 //
+//	<store>/<slug>-<hash>/refs/<ref-safe>/
+//
+// When ref is empty the sentinel directory "refs/_unknown/" is used.
 // The directory is NOT created here; callers that write should
 // os.MkdirAll the returned path.
-func StateDirForRepo(repoPath string) string {
+func StateDirForRepoRef(repoPath, ref string) string {
 	if repoPath == "" {
 		return ""
 	}
@@ -127,11 +171,34 @@ func StateDirForRepo(repoPath string) string {
 		abs = repoPath
 	}
 	abs = filepath.Clean(abs)
+	return filepath.Join(repoBaseDir(abs), "refs", RefSafeEncode(ref))
+}
 
-	if root := os.Getenv(EnvRoot); root != "" {
-		return filepath.Join(root, "state", repoStateHash(abs))
+// StateDirForRepo returns the directory that holds per-repo state
+// (graph.fb, graph.json, repair.json, enrichment-*.json, links, …) for
+// repoPath.
+//
+// Resolution (issue #1626 + PH1a #2089):
+//   - The current HEAD ref is captured via gitmeta.Capture so the path
+//     resolves to the per-branch sub-directory introduced by PH1a.
+//   - When ARCHIGRAPH_DAEMON_ROOT is set (isolated daemons, parallel
+//     agents, tests): `$ARCHIGRAPH_DAEMON_ROOT/state/<hash>/refs/<ref>/`.
+//   - Otherwise: `$ARCHIGRAPH_HOME (or ~/.archigraph)/store/<slug>-<hash>/refs/<ref>/`.
+//
+// Graph artifacts are NO LONGER written into `<repo>/.archigraph/`.
+// Pre-existing in-repo state is relocated transparently by
+// MigrateInRepoState (called from the load path). Pre-PH1a flat stores
+// are relocated into the per-ref sub-directory by MigrateToRefStore
+// (called from daemon startup).
+//
+// The directory is NOT created here; callers that write should
+// os.MkdirAll the returned path.
+func StateDirForRepo(repoPath string) string {
+	if repoPath == "" {
+		return ""
 	}
-	return filepath.Join(StoreDir(), repoSlug(abs))
+	meta := gitmeta.Capture(repoPath)
+	return StateDirForRepoRef(repoPath, meta.Ref)
 }
 
 // LegacyInRepoStateDir returns the historical co-located state directory
@@ -156,22 +223,17 @@ func GraphFBPathForRepo(repoPath string) string {
 	return filepath.Join(StateDirForRepo(repoPath), "graph.fb")
 }
 
-// FindGraphFile checks for the newest graph file (graph.fb preferred over
-// graph.json) and returns its path and modification time. Returns ("", 0)
-// if neither file exists. The returned modtime is in nanoseconds since epoch.
-func FindGraphFile(repoPath string) (path string, modtime int64) {
-	stateDir := StateDirForRepo(repoPath)
-
-	fbPath := filepath.Join(stateDir, "graph.fb")
-	jsonPath := filepath.Join(stateDir, "graph.json")
+// findGraphFileInDir checks dir for graph.fb / graph.json and returns the
+// path + modtime of the newest one. Returns ("", 0) if neither exists.
+func findGraphFileInDir(dir string) (path string, modtime int64) {
+	fbPath := filepath.Join(dir, "graph.fb")
+	jsonPath := filepath.Join(dir, "graph.json")
 
 	fbInfo, fbErr := os.Stat(fbPath)
 	jsonInfo, jsonErr := os.Stat(jsonPath)
 
-	// Check graph.fb first (preferred)
 	if fbErr == nil {
 		fbMtime := fbInfo.ModTime().UnixNano()
-		// If both exist, return whichever is newer
 		if jsonErr == nil {
 			jsonMtime := jsonInfo.ModTime().UnixNano()
 			if fbMtime >= jsonMtime {
@@ -181,11 +243,19 @@ func FindGraphFile(repoPath string) (path string, modtime int64) {
 		}
 		return fbPath, fbMtime
 	}
-
-	// Fall back to graph.json if graph.fb doesn't exist
 	if jsonErr == nil {
 		return jsonPath, jsonInfo.ModTime().UnixNano()
 	}
-
 	return "", 0
+}
+
+// FindGraphFile checks for the newest graph file (graph.fb preferred over
+// graph.json) for repoPath and returns its path and modification time.
+// Returns ("", 0) if neither file exists. The returned modtime is in
+// nanoseconds since epoch.
+//
+// PH1a: checks the per-ref directory (StateDirForRepo → StateDirForRepoRef).
+func FindGraphFile(repoPath string) (path string, modtime int64) {
+	stateDir := StateDirForRepo(repoPath)
+	return findGraphFileInDir(stateDir)
 }

--- a/internal/daemon/state_path_ref_test.go
+++ b/internal/daemon/state_path_ref_test.go
@@ -1,0 +1,330 @@
+// state_path_ref_test.go exercises the ref-aware path helpers and the
+// per-ref store layout introduced by PH1a of epic #2087 (issue #2089).
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Ref-safe encoding round-trips
+// ---------------------------------------------------------------------------
+
+func TestRefSafeEncode_SimpleNames(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want string
+	}{
+		{"main", "main"},
+		{"develop", "develop"},
+		{"feat/foo-bar", "feat%2Ffoo-bar"},
+		{"release/1.2.3", "release%2F1.2.3"},
+		{"feat/nested/deep", "feat%2Fnested%2Fdeep"},
+		{"", "_unknown"},
+	}
+	for _, tc := range cases {
+		got := RefSafeEncode(tc.ref)
+		if got != tc.want {
+			t.Errorf("RefSafeEncode(%q) = %q, want %q", tc.ref, got, tc.want)
+		}
+	}
+}
+
+func TestRefSafeDecode_RoundTrip(t *testing.T) {
+	refs := []string{
+		"main",
+		"feat/foo-bar",
+		"release/1.2.3",
+		"feat/nested/deep",
+		"",
+	}
+	for _, ref := range refs {
+		encoded := RefSafeEncode(ref)
+		decoded := RefSafeDecode(encoded)
+		if decoded != ref {
+			t.Errorf("round-trip failed for %q: encode→%q decode→%q", ref, encoded, decoded)
+		}
+	}
+}
+
+func TestRefSafeDecode_UnknownSentinel(t *testing.T) {
+	if got := RefSafeDecode("_unknown"); got != "" {
+		t.Errorf("RefSafeDecode(_unknown) = %q, want empty string", got)
+	}
+}
+
+func TestRefSafeEncode_FilesystemSafe(t *testing.T) {
+	// Encoded names must not contain "/" so they can be used as a single
+	// directory name component.
+	problematic := []string{
+		"feat/foo",
+		"release/1.0/patch",
+		"refs/heads/main", // pathological but valid git ref
+	}
+	for _, ref := range problematic {
+		encoded := RefSafeEncode(ref)
+		if strings.Contains(encoded, "/") {
+			t.Errorf("RefSafeEncode(%q) = %q contains '/' — not filesystem-safe", ref, encoded)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StateDirForRepoRef path shape
+// ---------------------------------------------------------------------------
+
+func TestStateDirForRepoRef_ContainsRefsSegment(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	got := StateDirForRepoRef("/some/repo", "main")
+	if !strings.Contains(got, "/refs/main") {
+		t.Errorf("StateDirForRepoRef path %q does not contain '/refs/main'", got)
+	}
+}
+
+func TestStateDirForRepoRef_SlashEncoded(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	got := StateDirForRepoRef("/some/repo", "feat/foo-bar")
+	if !strings.Contains(got, "/refs/feat%2Ffoo-bar") {
+		t.Errorf("StateDirForRepoRef path %q does not contain encoded ref segment", got)
+	}
+	// Must not have a bare slash after "refs/"
+	refsIdx := strings.Index(got, "/refs/")
+	suffix := got[refsIdx+len("/refs/"):]
+	if strings.Contains(suffix, "/") {
+		t.Errorf("ref segment in path %q still contains '/' after refs/", got)
+	}
+}
+
+func TestStateDirForRepoRef_EmptyRefUsesUnknown(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	got := StateDirForRepoRef("/some/repo", "")
+	if !strings.Contains(got, "/refs/_unknown") {
+		t.Errorf("empty ref did not produce _unknown segment, got %q", got)
+	}
+}
+
+func TestStateDirForRepoRef_EmptyRepoPath(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	if got := StateDirForRepoRef("", "main"); got != "" {
+		t.Errorf("expected empty for empty repoPath, got %q", got)
+	}
+}
+
+func TestStateDirForRepoRef_Deterministic(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	a := StateDirForRepoRef("/some/repo", "main")
+	b := StateDirForRepoRef("/some/repo", "main")
+	if a != b {
+		t.Fatalf("non-deterministic: %q != %q", a, b)
+	}
+}
+
+func TestStateDirForRepoRef_DistinctRefsDistinctDirs(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	a := StateDirForRepoRef("/some/repo", "main")
+	b := StateDirForRepoRef("/some/repo", "feat/foo")
+	if a == b {
+		t.Fatalf("different refs resolved to same path: %q", a)
+	}
+}
+
+func TestStateDirForRepoRef_SameRefDifferentReposDifferentDirs(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	a := StateDirForRepoRef("/some/repo-a", "main")
+	b := StateDirForRepoRef("/some/repo-b", "main")
+	if a == b {
+		t.Fatalf("different repos on same ref resolved to same path: %q", a)
+	}
+}
+
+func TestStateDirForRepoRef_DefaultStore(t *testing.T) {
+	// Without ARCHIGRAPH_DAEMON_ROOT, the path must be under ARCHIGRAPH_HOME/store.
+	t.Setenv(EnvRoot, "")
+	home := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", home)
+
+	got := StateDirForRepoRef("/some/repo", "main")
+	storePrefix := filepath.Join(home, "store") + string(filepath.Separator)
+	if !strings.HasPrefix(got, storePrefix) {
+		t.Fatalf("path %q is not under store %q", got, storePrefix)
+	}
+	if !strings.Contains(got, "/refs/main") {
+		t.Fatalf("path %q does not contain '/refs/main'", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MigrateToRefStore: legacy flat → per-ref layout
+// ---------------------------------------------------------------------------
+
+// writeFakeGraph writes a minimal graph.json with an optional indexed_ref
+// into dir, simulating a pre-PH1a flat store slot.
+func writeFakeGraph(t *testing.T, dir, ref string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	content := `{"version":1}`
+	if ref != "" {
+		content = `{"version":1,"indexed_ref":"` + ref + `"}`
+	}
+	if err := os.WriteFile(filepath.Join(dir, "graph.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "graph.fb"), []byte("FAKEBLOB"), 0o644); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+}
+
+func TestMigrateToRefStore_MovesGraphToRefDir(t *testing.T) {
+	storeDir := t.TempDir()
+	slotDir := filepath.Join(storeDir, "my-repo-aabbccdd11223344")
+	writeFakeGraph(t, slotDir, "main")
+
+	if err := MigrateToRefStore(storeDir); err != nil {
+		t.Fatalf("MigrateToRefStore: %v", err)
+	}
+
+	// graph.fb must now live under refs/main/
+	wantFB := filepath.Join(slotDir, "refs", "main", "graph.fb")
+	if _, err := os.Stat(wantFB); err != nil {
+		t.Errorf("graph.fb not found at %s after migration: %v", wantFB, err)
+	}
+
+	// The top-level graph.fb must have been removed.
+	oldFB := filepath.Join(slotDir, "graph.fb")
+	if _, err := os.Stat(oldFB); err == nil {
+		t.Errorf("old top-level graph.fb still exists at %s", oldFB)
+	}
+}
+
+func TestMigrateToRefStore_UnknownRefWhenNoMetadata(t *testing.T) {
+	storeDir := t.TempDir()
+	slotDir := filepath.Join(storeDir, "anon-repo-1122334455667788")
+	// Write graph without indexed_ref (pre-PH0 graph).
+	writeFakeGraph(t, slotDir, "")
+
+	if err := MigrateToRefStore(storeDir); err != nil {
+		t.Fatalf("MigrateToRefStore: %v", err)
+	}
+
+	wantFB := filepath.Join(slotDir, "refs", "_unknown", "graph.fb")
+	if _, err := os.Stat(wantFB); err != nil {
+		t.Errorf("graph.fb not found at %s: %v", wantFB, err)
+	}
+}
+
+func TestMigrateToRefStore_SlashRefEncoded(t *testing.T) {
+	storeDir := t.TempDir()
+	slotDir := filepath.Join(storeDir, "my-repo-aabbccdd11223344")
+	writeFakeGraph(t, slotDir, "feat/foo-bar")
+
+	if err := MigrateToRefStore(storeDir); err != nil {
+		t.Fatalf("MigrateToRefStore: %v", err)
+	}
+
+	wantFB := filepath.Join(slotDir, "refs", "feat%2Ffoo-bar", "graph.fb")
+	if _, err := os.Stat(wantFB); err != nil {
+		t.Errorf("graph.fb not found at encoded path %s: %v", wantFB, err)
+	}
+}
+
+func TestMigrateToRefStore_Idempotent(t *testing.T) {
+	storeDir := t.TempDir()
+	slotDir := filepath.Join(storeDir, "my-repo-aabbccdd11223344")
+	writeFakeGraph(t, slotDir, "main")
+
+	// First pass.
+	if err := MigrateToRefStore(storeDir); err != nil {
+		t.Fatalf("first MigrateToRefStore: %v", err)
+	}
+	// Second pass must not fail or corrupt.
+	if err := MigrateToRefStore(storeDir); err != nil {
+		t.Fatalf("second MigrateToRefStore: %v", err)
+	}
+
+	wantFB := filepath.Join(slotDir, "refs", "main", "graph.fb")
+	if _, err := os.Stat(wantFB); err != nil {
+		t.Errorf("graph.fb missing after second migration: %v", err)
+	}
+	oldFB := filepath.Join(slotDir, "graph.fb")
+	if _, err := os.Stat(oldFB); err == nil {
+		t.Errorf("top-level graph.fb still exists after second migration")
+	}
+}
+
+func TestMigrateToRefStore_SkipsAlreadyMigratedSlots(t *testing.T) {
+	storeDir := t.TempDir()
+	slotDir := filepath.Join(storeDir, "already-migrated-aabb1122ccdd3344")
+	// Create a slot that is already in per-ref layout (no top-level graph).
+	refDir := filepath.Join(slotDir, "refs", "main")
+	if err := os.MkdirAll(refDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refDir, "graph.fb"), []byte("OK"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateToRefStore(storeDir); err != nil {
+		t.Fatalf("MigrateToRefStore: %v", err)
+	}
+
+	// The refs/main/graph.fb must still be intact.
+	if data, err := os.ReadFile(filepath.Join(refDir, "graph.fb")); err != nil || string(data) != "OK" {
+		t.Errorf("already-migrated slot was disturbed")
+	}
+}
+
+func TestMigrateToRefStore_NonexistentStoreIsNoop(t *testing.T) {
+	if err := MigrateToRefStore("/nonexistent/store/dir"); err != nil {
+		t.Errorf("expected nil for nonexistent store, got %v", err)
+	}
+}
+
+func TestMigrateToRefStore_EmptyStoreIsNoop(t *testing.T) {
+	storeDir := t.TempDir()
+	if err := MigrateToRefStore(storeDir); err != nil {
+		t.Errorf("expected nil for empty store, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Backward read: StateDirForRepo through mocked gitmeta (via env override)
+//
+// StateDirForRepo now resolves the per-ref path using gitmeta.Capture.
+// In test environments where we can't control the repo's HEAD we test the
+// lower-level StateDirForRepoRef directly (covered above). The following
+// test verifies that the resulting path always sits under the per-repo
+// base dir and contains a "refs/" segment regardless of the live ref.
+// ---------------------------------------------------------------------------
+
+func TestStateDirForRepo_AlwaysUnderBaseAndHasRefs(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	// Use a temp dir as the "repo" — gitmeta.Capture will return empty
+	// Info (not a git repo), which encodes to "_unknown".
+	repoPath := t.TempDir()
+	got := StateDirForRepo(repoPath)
+
+	if !strings.Contains(got, "/refs/") {
+		t.Errorf("StateDirForRepo path %q does not contain '/refs/'", got)
+	}
+}

--- a/internal/daemon/state_path_test.go
+++ b/internal/daemon/state_path_test.go
@@ -13,6 +13,11 @@ import (
 // directory now lives in the EXTERNAL store under ARCHIGRAPH_HOME/store,
 // NOT inside the repo working tree. This is the change that keeps repos
 // clean and breaks the fb-vs-json reindex loop.
+//
+// PH1a (#2089): StateDirForRepo now returns the per-ref sub-directory
+// (<store>/<slug>-<hash>/refs/<ref>/). The base slug-hash segment is
+// tested via StateDirForRepoRef which is the primitive; StateDirForRepo
+// is tested to be under the store and not in the repo.
 func TestStateDirForRepo_DefaultStore(t *testing.T) {
 	t.Setenv(EnvRoot, "")
 	home := t.TempDir()
@@ -28,10 +33,15 @@ func TestStateDirForRepo_DefaultStore(t *testing.T) {
 	if strings.HasPrefix(got, "/some/repo") {
 		t.Fatalf("state dir leaked into repo tree: %q", got)
 	}
-	// Segment is "<slug>-<16hex>".
+	// PH1a: path must contain a refs/ segment.
+	if !strings.Contains(got, "/refs/") {
+		t.Fatalf("PH1a: state dir %q does not contain /refs/ segment", got)
+	}
+	// Base slug segment (before /refs/) must be "<slug>-<16hex>".
 	rel, _ := filepath.Rel(filepath.Join(home, "store"), got)
-	if !regexp.MustCompile(`^[a-zA-Z0-9._-]+-[0-9a-f]{16}$`).MatchString(rel) {
-		t.Fatalf("store segment %q is not <slug>-<hash>", rel)
+	parts := strings.SplitN(rel, string(filepath.Separator), 2) // ["<slug>-<hash>", "refs/..."]
+	if !regexp.MustCompile(`^[a-zA-Z0-9._-]+-[0-9a-f]{16}$`).MatchString(parts[0]) {
+		t.Fatalf("store base segment %q is not <slug>-<hash>", parts[0])
 	}
 }
 
@@ -50,10 +60,15 @@ func TestStateDirForRepo_WithDaemonRoot(t *testing.T) {
 	if !strings.HasPrefix(got, filepath.Join(root, "state")+string(filepath.Separator)) {
 		t.Fatalf("expected DAEMON_ROOT-rooted path, got %q", got)
 	}
-	// Segment after .../state/ must be a 16-hex-char hash.
+	// PH1a: path must contain a refs/ segment.
+	if !strings.Contains(got, "/refs/") {
+		t.Fatalf("PH1a: path %q does not contain /refs/ segment", got)
+	}
+	// Base segment after .../state/ must be a 16-hex-char hash.
 	rel, _ := filepath.Rel(filepath.Join(root, "state"), got)
-	if !regexp.MustCompile(`^[0-9a-f]{16}$`).MatchString(rel) {
-		t.Fatalf("segment %q is not 16 hex chars", rel)
+	parts := strings.SplitN(rel, string(filepath.Separator), 2) // ["<hash>", "refs/..."]
+	if !regexp.MustCompile(`^[0-9a-f]{16}$`).MatchString(parts[0]) {
+		t.Fatalf("base hash segment %q is not 16 hex chars", parts[0])
 	}
 }
 
@@ -81,11 +96,18 @@ func TestStateDirForRepo_PathSafe(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv(EnvRoot, root)
 	// Even with shell-metachar-laden input the hash segment must be
-	// purely [0-9a-f].
-	got := StateDirForRepo("/some path/with spaces & $weird?chars")
+	// purely [0-9a-f]. Use StateDirForRepoRef to test just the base
+	// segment without gitmeta (which won't run on a non-git path).
+	got := StateDirForRepoRef("/some path/with spaces & $weird?chars", "main")
 	rel, _ := filepath.Rel(filepath.Join(root, "state"), got)
-	if strings.ContainsAny(rel, ` /$?&*'"\`+"`") {
-		t.Fatalf("segment %q is not shell/path safe", rel)
+	// The rel now looks like "<hash>/refs/main" — check the whole thing
+	// except for the "/" separators which are path components, not
+	// embedded in names. Strip the path seps.
+	parts := strings.Split(rel, string(filepath.Separator))
+	for _, p := range parts {
+		if strings.ContainsAny(p, ` $?&*'"\`+"`") {
+			t.Fatalf("path component %q in %q is not shell/path safe", p, rel)
+		}
 	}
 }
 

--- a/internal/docgen/llm_emit_test.go
+++ b/internal/docgen/llm_emit_test.go
@@ -9,8 +9,6 @@
 package docgen_test
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -18,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/docgen"
 )
 
@@ -506,24 +505,15 @@ func buildMinimalGroupForEmitTests(t *testing.T) (archHome, group, entityID, rep
 // writeGraphForEmitTest writes a minimal graph.json into the canonical
 // ARCHIGRAPH_DAEMON_ROOT state dir so findGroupGraphDirs can discover it.
 //
-// The canonical state dir when ARCHIGRAPH_DAEMON_ROOT is set is:
-//
-//	$ARCHIGRAPH_DAEMON_ROOT/state/<sha256(absRepoPath)[:16]>/
-//
-// We replicate the hash logic here to place graph.json in the right place.
+// PH1a (#2089): uses daemon.StateDirForRepo directly so the path always
+// matches what the loader resolves — no manual hash duplication.
 func writeGraphForEmitTest(t *testing.T, archHome, repoPath, entityID string) {
 	t.Helper()
 
-	// Compute the canonical state dir hash the same way daemon.StateDirForRepo does.
-	abs, err := filepath.Abs(repoPath)
-	if err != nil {
-		abs = repoPath
-	}
-	sum := sha256.Sum256([]byte(filepath.Clean(abs)))
-	hash := hex.EncodeToString(sum[:8])
-
-	daemonRoot := filepath.Join(archHome, "daemon-root")
-	stateDir := filepath.Join(daemonRoot, "state", hash)
+	// daemon.StateDirForRepo honours ARCHIGRAPH_DAEMON_ROOT (set by the caller)
+	// and appends the per-ref sub-directory (PH1a). Writing here ensures
+	// the file is always found at exactly the path the loader will look.
+	stateDir := daemon.StateDirForRepo(repoPath)
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("mkdir stateDir: %v", err)
 	}

--- a/internal/docgen/tier4_llm_emit_integration_test.go
+++ b/internal/docgen/tier4_llm_emit_integration_test.go
@@ -18,14 +18,13 @@
 package docgen_test
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/docgen"
 )
 
@@ -87,16 +86,9 @@ func buildGroupForTier4EmitTest(t *testing.T) (archHome, group string, slugs []s
 		}
 		graphBytes, _ := json.Marshal(graphDoc)
 
-		// Compute the canonical daemon-root state dir hash the same way
-		// daemon.StateDirForRepo does when ARCHIGRAPH_DAEMON_ROOT is set.
-		//   $ARCHIGRAPH_DAEMON_ROOT/state/<sha256(absRepoPath)[:16]>/
-		abs, err := filepath.Abs(repoPath)
-		if err != nil {
-			abs = repoPath
-		}
-		sum := sha256.Sum256([]byte(filepath.Clean(abs)))
-		hash := hex.EncodeToString(sum[:8])
-		stateDir := filepath.Join(daemonRoot, "state", hash)
+		// Use daemon.StateDirForRepo so the path always matches what the
+		// loader calls at query time — no manual hash duplication (PH1a #2089).
+		stateDir := daemon.StateDirForRepo(repoPath)
 		if err := os.MkdirAll(stateDir, 0o755); err != nil {
 			t.Fatalf("mkdir stateDir %s: %v", stateDir, err)
 		}
@@ -217,13 +209,9 @@ func buildGroupForTier4EmitTestWithDatastore(t *testing.T) (archHome, group, rep
 	}
 	graphBytes, _ := json.Marshal(graphDoc)
 
-	abs, err := filepath.Abs(repoPath)
-	if err != nil {
-		abs = repoPath
-	}
-	sum := sha256.Sum256([]byte(filepath.Clean(abs)))
-	hash := hex.EncodeToString(sum[:8])
-	stateDir := filepath.Join(daemonRoot, "state", hash)
+	// Use daemon.StateDirForRepo so the path always matches what the
+	// loader calls at query time — no manual hash duplication (PH1a #2089).
+	stateDir := daemon.StateDirForRepo(repoPath)
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("mkdir stateDir: %v", err)
 	}


### PR DESCRIPTION
## What we did

Added the per-ref on-disk store layout that forms the foundation of the multi-branch + worktree epic. Every graph artifact now lives under a branch-namespaced sub-directory:

```
<store>/<slug>-<hash>/refs/<ref-safe>/graph.fb
<store>/<slug>-<hash>/refs/<ref-safe>/graph.json
<store>/<slug>-<hash>/refs/<ref-safe>/<sidecars>
```

Where `<ref-safe>` is the branch name with `/` percent-encoded as `%2F` (2-way round-trip). The sentinel `_unknown` is used when the HEAD is detached or predates PH0 metadata.

## What we won

- **`StateDirForRepoRef(repoPath, ref string)`** — the new ref-aware primitive. Returns `<store>/<slug>-<hash>/refs/<ref-safe>/`.
- **`StateDirForRepo(repoPath)`** — now a thin wrapper that reads HEAD via `gitmeta.Capture` and delegates. Zero call-site changes required.
- **`RefSafeEncode / RefSafeDecode`** — deterministic, filesystem-safe, 2-way encoding. `feat/foo-bar` → `feat%2Ffoo-bar`.
- **`MigrateToRefStore(storeDir)`** — startup migration that walks legacy flat-layout slots and moves artifacts into the per-ref sub-directory. Reads `indexed_ref` from `graph.json` metadata; falls back to `_unknown`. Idempotent.

## What it means at scale

Each repo slot now holds a `refs/` tree, enabling PH1b/PH1c to write and read per-branch graphs in parallel without cross-branch clobbering. The migration runs once at daemon startup (finite work, single goroutine) so no query-time penalty.

## What it means for MCP/daemon/UX

No user-visible change in PH1a. Daemon RPCs, dashboard endpoints, and MCP routing still use `StateDirForRepo` which transparently routes to the per-ref path. PH1c will expose the `ref=` parameter.

## Verification

- 21 new tests in `internal/daemon/state_path_ref_test.go`: encoding round-trips, path shape, migration (known ref, unknown ref, slash-in-ref encoded, idempotent, skip-already-migrated, nonexistent/empty store).
- Updated `internal/daemon/state_path_test.go` to account for the new `refs/<ref>/` segment.
- `go test ./internal/...` — all packages pass.

## Caveats

- The `ARCHIGRAPH_DAEMON_ROOT` isolation mode still works; it uses `state/<hash>/refs/<ref>/` under the root.
- `MigrateToRefStore` must be called from daemon startup (PH1b will wire this); it is not called automatically in PH1a.
- Deferred to PH1b: scheduler/watcher behavior. Deferred to PH1c: daemon RPCs, dashboard endpoints, MCP `ref=` param, `graph_cache.go`, LRU, worktree auto-discovery.

## Bottom line

PH1a delivers the on-disk layout foundation with full migration path and test coverage. Existing callers are transparent — `StateDirForRepo` is still the single entry point. PH1b/PH1c can now add scheduler, watcher, and RPC changes on top.

Closes part of #2087  
References #2089 (PH1), #2098 (surface checklist)