### PR TITLE
fix(daemon): auto-tune rebuildConcurrency cap (#2127)

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -76,17 +76,65 @@ func systemTotalMemoryMB() int64 {
 	return process.TotalMemoryMB()
 }
 
-// defaultMaxConcurrentGroups is the production default for parallel group
-// indexing during a Rebuild RPC (#1276). With 2 concurrent group slots a
-// 4-group cold-start completes in approximately half the serial time.
-const defaultMaxConcurrentGroups = 2
+// computeRebuildConcurrency applies the auto-tune formula to an explicit
+// memory size (in MB). This is the pure, testable core of defaultRebuildConcurrency.
+// Formula: min(8, sysMB/4096), floored at 2.
+//
+//   - sysMB ≤ 0 → 2 (sysinfo unavailable)
+//   - < 8 GB    → 2 (floor)
+//   -  8 GB     → 2
+//   - 16 GB     → 4
+//   - 32 GB     → 8
+//   - ≥ 32 GB   → 8 (ceiling; above this, file-I/O contention outweighs the gain)
+func computeRebuildConcurrency(sysMB int64) int {
+	if sysMB <= 0 {
+		return 2
+	}
+	n := int(sysMB / 4096)
+	if n < 2 {
+		n = 2
+	}
+	if n > 8 {
+		n = 8
+	}
+	return n
+}
+
+// defaultRebuildConcurrency auto-tunes the parallel rebuild cap based on
+// available system memory (#2127). Delegates to computeRebuildConcurrency
+// with the live system total so the logic is independently testable.
+//
+// The env var ARCHIGRAPH_REBUILD_CONCURRENCY and the --max-concurrent-groups
+// flag both override the result.
+func defaultRebuildConcurrency() int {
+	return computeRebuildConcurrency(systemTotalMemoryMB())
+}
+
+// resolveEnvRebuildConcurrency reads ARCHIGRAPH_REBUILD_CONCURRENCY (then
+// ARCHIGRAPH_MAX_CONCURRENT_GROUPS as a legacy fallback) and returns the
+// effective concurrency value, falling back to the auto-tuned default when
+// the env var is absent or invalid. This mirrors the parsing logic in
+// runDaemon and is exposed for unit testing.
+func resolveEnvRebuildConcurrency() int {
+	if v := os.Getenv("ARCHIGRAPH_REBUILD_CONCURRENCY"); v != "" {
+		if parsed, perr := strconv.Atoi(v); perr == nil && parsed >= 1 {
+			return parsed
+		}
+	}
+	if v := os.Getenv("ARCHIGRAPH_MAX_CONCURRENT_GROUPS"); v != "" {
+		if parsed, perr := strconv.Atoi(v); perr == nil && parsed >= 1 {
+			return parsed
+		}
+	}
+	return defaultRebuildConcurrency()
+}
 
 // rebuildConcurrency is the package-level concurrency cap used by
 // daemonRebuildFunc. It is set once by runDaemon before the RPC server
 // starts accepting connections. Concurrent calls to daemonRebuildFunc
 // each get their own semaphore, so different group rebuilds do not share
 // the cap — the cap applies to repos within a single group rebuild.
-var rebuildConcurrency = defaultMaxConcurrentGroups
+var rebuildConcurrency = defaultRebuildConcurrency()
 
 // rebuildIndexFunc is the per-repo index entrypoint used by daemonRebuildFunc.
 // It defaults to the package-level Index function but can be replaced in tests
@@ -125,14 +173,10 @@ func runDaemon(argv []string) error {
 		"max predicted RSS (MB) for concurrent index jobs; 0 disables admission control")
 
 	var maxConcurrentGroups int
-	envConcGroups := defaultMaxConcurrentGroups
-	if v := os.Getenv("ARCHIGRAPH_MAX_CONCURRENT_GROUPS"); v != "" {
-		if parsed, perr := strconv.Atoi(v); perr == nil && parsed >= 1 {
-			envConcGroups = parsed
-		}
-	}
+	// Priority: ARCHIGRAPH_REBUILD_CONCURRENCY > ARCHIGRAPH_MAX_CONCURRENT_GROUPS > auto-tune.
+	envConcGroups := resolveEnvRebuildConcurrency()
 	fs.IntVar(&maxConcurrentGroups, "max-concurrent-groups", envConcGroups,
-		"max groups indexed in parallel during rebuild (default 2; 1 = serial)")
+		"max repos indexed in parallel during rebuild (auto-tuned from memory; floor=2 cap=8)")
 
 	if err := fs.Parse(argv); err != nil {
 		return err

--- a/cmd/archigraph/daemon_concurrency_test.go
+++ b/cmd/archigraph/daemon_concurrency_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestDefaultRebuildConcurrency verifies the auto-tune formula:
+// min(8, totalMemoryMB/4096), floored at 2.
+func TestDefaultRebuildConcurrency(t *testing.T) {
+	cases := []struct {
+		sysMB int64
+		want  int
+		label string
+	}{
+		{sysMB: 0, want: 2, label: "sysinfo unavailable → fallback floor"},
+		{sysMB: 2048, want: 2, label: "4GB: 2048/4096=0 → floor=2"},
+		{sysMB: 4096, want: 2, label: "4GB (exact): 4096/4096=1 → floor=2"},
+		{sysMB: 8192, want: 2, label: "8GB: 8192/4096=2 → 2"},
+		{sysMB: 16384, want: 4, label: "16GB: 16384/4096=4 → 4"},
+		{sysMB: 32768, want: 8, label: "32GB: 32768/4096=8 → 8"},
+		{sysMB: 131072, want: 8, label: "128GB: 131072/4096=32 → ceiling=8"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			got := computeRebuildConcurrency(tc.sysMB)
+			if got != tc.want {
+				t.Errorf("computeRebuildConcurrency(%d) = %d, want %d", tc.sysMB, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRebuildConcurrencyEnvOverride verifies that ARCHIGRAPH_REBUILD_CONCURRENCY
+// overrides the auto-tuned default when runDaemon parses its flags.
+// We test the env-parse path directly by inspecting the resolved default.
+func TestRebuildConcurrencyEnvOverride(t *testing.T) {
+	orig := os.Getenv("ARCHIGRAPH_REBUILD_CONCURRENCY")
+	defer os.Setenv("ARCHIGRAPH_REBUILD_CONCURRENCY", orig)
+
+	// Set override to 6.
+	t.Setenv("ARCHIGRAPH_REBUILD_CONCURRENCY", "6")
+
+	// resolveEnvRebuildConcurrency replicates the env-parse logic from runDaemon.
+	got := resolveEnvRebuildConcurrency()
+	if got != 6 {
+		t.Errorf("ARCHIGRAPH_REBUILD_CONCURRENCY=6: got %d, want 6", got)
+	}
+}
+
+// TestRebuildConcurrencyEnvInvalid verifies that an invalid env value falls
+// back to the auto-tuned default rather than crashing.
+func TestRebuildConcurrencyEnvInvalid(t *testing.T) {
+	orig := os.Getenv("ARCHIGRAPH_REBUILD_CONCURRENCY")
+	defer os.Setenv("ARCHIGRAPH_REBUILD_CONCURRENCY", orig)
+
+	t.Setenv("ARCHIGRAPH_REBUILD_CONCURRENCY", "not-a-number")
+
+	got := resolveEnvRebuildConcurrency()
+	// Should be the auto-tuned value (≥2), not 0 or an error.
+	if got < 2 {
+		t.Errorf("invalid env: got %d, want ≥2 (auto-tuned floor)", got)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -85,6 +85,10 @@ func runStatus(w io.Writer, filter string) error {
 				fmt.Fprintf(w, "  admission: queued=%d admitted=%d predicted=%dMB / budget=%dMB (headroom=%dMB)\n",
 					len(st.BlockedJobs), len(st.InFlightJobs),
 					st.AdmissionUsedMB, st.RSSBudgetMB, admHeadroom)
+				if st.RebuildConcurrencyCap > 0 {
+					fmt.Fprintf(w, "  rebuild: in_flight=%d / cap=%d\n",
+						st.RebuildInFlight, st.RebuildConcurrencyCap)
+				}
 				if len(st.InFlightJobs) > 0 {
 					for _, j := range st.InFlightJobs {
 						fmt.Fprintf(w, "    admitted: %s (predicted=%dMB)\n", j.Path, j.PredictedMB)

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -81,8 +81,13 @@ type StatusReply struct {
 	//
 	// RebuildInFlight mirrors InFlight but scoped to Rebuild RPCs only (not
 	// Index or QualityAudit calls). Populated server-side for diagnostic clarity.
-	RebuildGroupsActive int `json:"rebuild_groups_active,omitempty"`
-	RebuildInFlight     int `json:"rebuild_in_flight,omitempty"`
+	//
+	// RebuildConcurrencyCap is the current parallel-repo cap for Rebuild RPCs
+	// (#2127). Auto-tuned from system memory (floor=2, cap=8); overrideable
+	// via ARCHIGRAPH_REBUILD_CONCURRENCY or --max-concurrent-groups.
+	RebuildGroupsActive    int `json:"rebuild_groups_active,omitempty"`
+	RebuildInFlight        int `json:"rebuild_in_flight,omitempty"`
+	RebuildConcurrencyCap  int `json:"rebuild_concurrency_cap,omitempty"`
 }
 
 // InFlightJobState mirrors sched.InFlightJob on the wire.

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -206,6 +206,7 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 	reply.InFlight = int(atomic.LoadInt64(&s.inFlight))
 	reply.RebuildInFlight = int(atomic.LoadInt64(&s.rebuildInFlight))
 	reply.RebuildGroupsActive = int(atomic.LoadInt64(&s.groupsActiveCount))
+	reply.RebuildConcurrencyCap = s.maxConcurrentGroups
 	reply.StartedAt = s.startedAt.UTC().Format(time.RFC3339)
 	reply.SocketPath = s.socketPath
 	// Report the binary path so clients can detect stale daemons (#855).


### PR DESCRIPTION
## What

Raise the `rebuildConcurrency` cap from a hard-coded 2 to an auto-tuned value based on system memory, with a `ARCHIGRAPH_REBUILD_CONCURRENCY` env override.

Closes #2127

## Why

Today's `const defaultMaxConcurrentGroups = 2` was set for 8 GB machines in 2024. Parallel-agent workflows (3–5–7 concurrent agents) each trigger a Rebuild RPC, but only 2 repos can index simultaneously — the rest block. On a 16 GB+ machine there is headroom for 4–8 parallel rebuilds before file-I/O contention becomes the bottleneck.

## Formula

`min(8, totalMemoryMB / 4096)`, floored at 2:

| RAM    | cap |
|--------|-----|
| ≤ 8 GB |   2 |
|  16 GB |   4 |
|  32 GB |   8 |
| ≥ 32 GB|   8 (ceiling) |

This machine (16 GB) gets **cap = 4**.

## Changes

### 1. `cmd/archigraph/daemon.go`
- Replace `const defaultMaxConcurrentGroups = 2` with `computeRebuildConcurrency(sysMB int64) int` (pure, testable) and `defaultRebuildConcurrency()` (reads live sysinfo)
- Add `resolveEnvRebuildConcurrency()` that honours `ARCHIGRAPH_REBUILD_CONCURRENCY` (new, primary) then `ARCHIGRAPH_MAX_CONCURRENT_GROUPS` (legacy fallback) then auto-tune
- Simplify `runDaemon` flag default to call `resolveEnvRebuildConcurrency()`

### 2. `internal/daemon/proto/proto.go`
- Add `RebuildConcurrencyCap int` to `StatusReply` (`json:"rebuild_concurrency_cap,omitempty"`)

### 3. `internal/daemon/service.go`
- Populate `reply.RebuildConcurrencyCap = s.maxConcurrentGroups` in `Status` handler

### 4. `internal/cli/status.go`
- After the `admission:` line, emit:
  ```
  rebuild: in_flight=M / cap=K
  ```
  when `RebuildConcurrencyCap > 0`

### 5. `cmd/archigraph/daemon_concurrency_test.go` (new)
- `TestDefaultRebuildConcurrency`: 7 sub-cases covering formula breakpoints (0, 4GB, 8GB, 16GB, 32GB, 128GB)
- `TestRebuildConcurrencyEnvOverride`: `ARCHIGRAPH_REBUILD_CONCURRENCY=6` → cap=6
- `TestRebuildConcurrencyEnvInvalid`: bad env value falls back to auto-tune floor (≥2)

## Out of scope
- Per-group cap (noted in #2127 as future work)
- Rebuild prioritization