### PR TITLE
feat(daemon): aggressive watcher filter + git-diff ref validation (S4 of #2149)

### DIFF
--- a/internal/daemon/watch/githead_poller.go
+++ b/internal/daemon/watch/githead_poller.go
@@ -3,9 +3,16 @@
 // Option B implementation: keep .git/ in SkipDirs (no fsnotify noise from
 // git object/pack writes) and poll .git/HEAD content for each registered
 // repo on a configurable interval (default 2 s). When the poller detects a
-// branch switch (HEAD ref OR commit SHA changes) it emits a synthetic event
-// via the BranchSwitchSink callback so the scheduler can trigger a new index
-// pass targeted at the new ref.
+// branch switch (HEAD ref OR commit SHA changes) it runs a lightweight
+// "git diff --name-only OLD NEW" and emits a BranchSwitchEvent only when
+// at least one indexed-source file changed (S4 of #2149, fixes #2154).
+//
+// Reindex policy (set in BranchSwitchEvent.ReindexHint):
+//
+//	NoSourceChanges  → skip reindex entirely
+//	SmallDiff        → incremental if S3 available, else full
+//	LargeDiff        → full reindex
+//	Unknown          → full reindex (diff failed or SHAs unavailable)
 //
 // Design notes
 //   - Polling is deliberately coarse (2 s) — sub-second precision is not
@@ -26,11 +33,36 @@ package watch
 import (
 	"log"
 	"os"
+	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/gitmeta"
 )
+
+// ReindexHint classifies how much source changed between two commits,
+// guiding the scheduler's reindex strategy.
+type ReindexHint int
+
+const (
+	// ReindexUnknown means the diff could not be computed (missing SHAs,
+	// git error). The scheduler should do a full reindex to be safe.
+	ReindexUnknown ReindexHint = iota
+	// ReindexNone means git diff showed zero source-file changes. The
+	// scheduler should skip reindexing entirely.
+	ReindexNone
+	// ReindexSmall means ≤20 indexed-source files changed. The scheduler
+	// may use incremental reindex if S3 is available.
+	ReindexSmall
+	// ReindexFull means >20 indexed-source files changed. The scheduler
+	// should do a full reindex.
+	ReindexFull
+)
+
+// smallDiffThreshold is the maximum number of changed source files before
+// we recommend a full reindex instead of an incremental one.
+const smallDiffThreshold = 20
 
 // HeadSnapshot is the last-seen HEAD state for one repo.
 type HeadSnapshot struct {
@@ -38,13 +70,19 @@ type HeadSnapshot struct {
 	SHA string // abbreviated commit SHA (12 chars)
 }
 
-// BranchSwitchEvent is emitted by the poller when it detects a HEAD change.
+// BranchSwitchEvent is emitted by the poller when it detects a HEAD change
+// that involves at least one indexed-source file change (or when the diff
+// cannot be computed). Events where only non-source files changed are
+// suppressed (ReindexHint == ReindexNone is never emitted to the sink;
+// those are logged and discarded instead).
 type BranchSwitchEvent struct {
-	RepoPath string
-	OldRef   string
-	OldSHA   string
-	NewRef   string
-	NewSHA   string
+	RepoPath     string
+	OldRef       string
+	OldSHA       string
+	NewRef       string
+	NewSHA       string
+	ReindexHint  ReindexHint // scheduling guidance for the caller
+	ChangedFiles []string    // source files changed (capped at smallDiffThreshold+1)
 }
 
 // BranchSwitchSink is the callback invoked for each detected branch switch.
@@ -144,6 +182,60 @@ func (p *GitHeadPoller) loop() {
 	}
 }
 
+// classifyRefChange runs "git diff --name-only OLD NEW" in repoPath and
+// filters the result to indexed-source paths using ShouldSkipPath. It returns
+// a ReindexHint and the list of changed source files (capped at
+// smallDiffThreshold+1 to bound memory).
+//
+// If either SHA is empty or the git command fails, ReindexUnknown is returned.
+func classifyRefChange(repoPath, oldSHA, newSHA string, logger *log.Logger) (ReindexHint, []string) {
+	if oldSHA == "" || newSHA == "" {
+		return ReindexUnknown, nil
+	}
+	// Same SHA (pure ref change, e.g. "git checkout -b newbranch"): the
+	// working tree has not changed but the ref name has. Emit as Unknown so
+	// the scheduler re-indexes under the new ref name.
+	if oldSHA == newSHA {
+		return ReindexUnknown, nil
+	}
+
+	// git diff --name-only <old>..<new>
+	cmd := exec.Command("git", "diff", "--name-only", oldSHA+".."+newSHA)
+	cmd.Dir = repoPath
+	out, err := cmd.Output()
+	if err != nil {
+		logger.Printf("classifyRefChange: git diff failed in %s: %v", repoPath, err)
+		return ReindexUnknown, nil
+	}
+
+	// Filter to indexed-source paths.
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	var sourcePaths []string
+	for _, rel := range lines {
+		rel = strings.TrimSpace(rel)
+		if rel == "" {
+			continue
+		}
+		// Build an absolute-style path for ShouldSkipPath (it checks basenames
+		// against SkipDirs and extensions against SkipExts).
+		abs := repoPath + "/" + rel
+		if !ShouldSkipPath(abs) {
+			sourcePaths = append(sourcePaths, rel)
+			if len(sourcePaths) > smallDiffThreshold {
+				break // cap — we only need to know "large"
+			}
+		}
+	}
+
+	if len(sourcePaths) == 0 {
+		return ReindexNone, nil
+	}
+	if len(sourcePaths) <= smallDiffThreshold {
+		return ReindexSmall, sourcePaths
+	}
+	return ReindexFull, sourcePaths
+}
+
 // poll captures the current HEAD for every registered repo and calls the
 // sink for any that changed.
 func (p *GitHeadPoller) poll() {
@@ -179,8 +271,22 @@ func (p *GitHeadPoller) poll() {
 				NewRef:   current.Ref,
 				NewSHA:   current.SHA,
 			}
-			p.logger.Printf("branch-switch detected: %s %s@%s -> %s@%s",
-				repoPath, ev.OldRef, ev.OldSHA, ev.NewRef, ev.NewSHA)
+
+			// S4 git-diff validation: compute source-change set before
+			// forwarding to the sink so we can suppress no-op reindexes.
+			hint, changedFiles := classifyRefChange(repoPath, prev.SHA, current.SHA, p.logger)
+			ev.ReindexHint = hint
+			ev.ChangedFiles = changedFiles
+
+			if hint == ReindexNone {
+				// No indexed-source files changed — suppress reindex entirely.
+				p.logger.Printf("ref-change: %s %s..%s no-source-changes — skipping reindex",
+					repoPath, prev.SHA, current.SHA)
+				continue
+			}
+
+			p.logger.Printf("branch-switch detected: %s %s@%s -> %s@%s hint=%d changed_files=%d",
+				repoPath, ev.OldRef, ev.OldSHA, ev.NewRef, ev.NewSHA, hint, len(changedFiles))
 			p.sink(ev)
 		}
 	}

--- a/internal/daemon/watch/gitignore.go
+++ b/internal/daemon/watch/gitignore.go
@@ -1,0 +1,150 @@
+// Package watch — gitignore.go
+//
+// Thin bridge between the watcher's skip logic and the walk package's
+// fully-featured gitignore parser. At AddRepo time we load the repo's
+// root .gitignore once and expose a fast ShouldSkipDirGitignore helper
+// that the subscribeRepo walk can consult.
+//
+// Design notes
+//   - We reuse walk.ParseIgnoreFile so the watcher honours exactly the
+//     same gitignore semantics as the indexer (no duplicate parser).
+//   - Per-repo override: <repo>/.archigraph/watch.json with optional
+//     include/exclude lists (see RepoWatchConfig).
+//   - The cache is keyed by repo absolute path and is safe for concurrent
+//     reads after the initial population in AddRepo.
+package watch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/cajasmota/archigraph/internal/daemon/walk"
+)
+
+// RepoWatchConfig is the optional per-repo override stored at
+// <repo>/.archigraph/watch.json. All fields are optional; the zero
+// value means "no overrides".
+type RepoWatchConfig struct {
+	// ExcludeDirs lists additional directory basenames (beyond the global
+	// SkipDirs) that should never be watched for this repo.
+	ExcludeDirs []string `json:"exclude_dirs,omitempty"`
+	// IncludeOnlyDirs, when non-empty, restricts subscription to exactly
+	// these top-level directory names. Any top-level dir NOT in this list
+	// is skipped outright. Has no effect on deeper levels (only top-level).
+	IncludeOnlyDirs []string `json:"include_only_dirs,omitempty"`
+}
+
+// repoIgnoreState bundles the parsed .gitignore (may be nil/empty) and the
+// optional per-repo watch config for a single repo.
+type repoIgnoreState struct {
+	gitignore   *walk.IgnoreFile // root .gitignore; never nil (may be no-op)
+	watchCfg    RepoWatchConfig
+	extraSkip   map[string]struct{} // fast set from watchCfg.ExcludeDirs
+	includeOnly map[string]struct{} // fast set from watchCfg.IncludeOnlyDirs
+}
+
+// gitignoreCache is the process-wide cache of per-repo gitignore state.
+// Populated by loadRepoIgnoreState; read-only after that.
+type gitignoreCache struct {
+	mu    sync.RWMutex
+	repos map[string]*repoIgnoreState // key: absolute repo path
+}
+
+var repoIgnoreCache = &gitignoreCache{
+	repos: make(map[string]*repoIgnoreState),
+}
+
+// loadRepoIgnoreState parses <repo>/.gitignore and <repo>/.archigraph/watch.json
+// (both optional), caches the result, and returns the state. If repoPath was
+// already cached the cached value is returned directly.
+func loadRepoIgnoreState(repoPath string) *repoIgnoreState {
+	repoIgnoreCache.mu.RLock()
+	if s, ok := repoIgnoreCache.repos[repoPath]; ok {
+		repoIgnoreCache.mu.RUnlock()
+		return s
+	}
+	repoIgnoreCache.mu.RUnlock()
+
+	// Parse .gitignore (non-fatal if absent).
+	giPath := filepath.Join(repoPath, ".gitignore")
+	ig, _ := walk.ParseIgnoreFile(repoPath, giPath, ".gitignore")
+	if ig == nil {
+		ig = &walk.IgnoreFile{}
+	}
+
+	// Parse per-repo watch.json override (non-fatal if absent).
+	var cfg RepoWatchConfig
+	cfgPath := filepath.Join(repoPath, ".archigraph", "watch.json")
+	if data, err := os.ReadFile(cfgPath); err == nil {
+		_ = json.Unmarshal(data, &cfg)
+	}
+
+	extraSkip := make(map[string]struct{}, len(cfg.ExcludeDirs))
+	for _, d := range cfg.ExcludeDirs {
+		extraSkip[d] = struct{}{}
+	}
+	includeOnly := make(map[string]struct{}, len(cfg.IncludeOnlyDirs))
+	for _, d := range cfg.IncludeOnlyDirs {
+		includeOnly[d] = struct{}{}
+	}
+
+	s := &repoIgnoreState{
+		gitignore:   ig,
+		watchCfg:    cfg,
+		extraSkip:   extraSkip,
+		includeOnly: includeOnly,
+	}
+
+	repoIgnoreCache.mu.Lock()
+	repoIgnoreCache.repos[repoPath] = s
+	repoIgnoreCache.mu.Unlock()
+	return s
+}
+
+// evictRepoIgnoreState removes a repo from the cache. Called by RemoveRepo
+// so that a subsequent re-add picks up any .gitignore changes.
+func evictRepoIgnoreState(repoPath string) {
+	repoIgnoreCache.mu.Lock()
+	delete(repoIgnoreCache.repos, repoPath)
+	repoIgnoreCache.mu.Unlock()
+}
+
+// ShouldSkipDirGitignore reports whether absDir should be excluded from the
+// fsnotify subscription based on the repo's .gitignore and per-repo watch.json.
+//
+// repoPath must be the absolute repo root. absDir must be inside repoPath.
+// relPath is absDir relative to repoPath (forward-slash, no leading slash).
+//
+// Returns (skip=true, reason) when the directory should be excluded.
+func ShouldSkipDirGitignore(repoPath, absDir, relPath string) (bool, string) {
+	s := loadRepoIgnoreState(repoPath)
+
+	// Per-repo explicit exclude overrides.
+	base := filepath.Base(absDir)
+	if _, ok := s.extraSkip[base]; ok {
+		return true, "watch.json:exclude_dirs"
+	}
+
+	// Per-repo include-only: if the top-level dir is not in the allow-list,
+	// skip it. We detect "top-level" as a relPath with no slash separators.
+	if len(s.includeOnly) > 0 {
+		// Only apply at depth-1 directories directly under the repo root.
+		// Deeper levels are not filtered here — they rely on the hard-skip list
+		// and gitignore rules.
+		if filepath.Dir(relPath) == "." {
+			if _, ok := s.includeOnly[base]; !ok {
+				return true, "watch.json:include_only_dirs"
+			}
+		}
+	}
+
+	// .gitignore match.
+	if skip, line := s.gitignore.MatchDir(relPath); skip {
+		return true, ".gitignore line " + strconv.Itoa(line)
+	}
+
+	return false, ""
+}

--- a/internal/daemon/watch/s4_test.go
+++ b/internal/daemon/watch/s4_test.go
@@ -1,0 +1,378 @@
+// Package watch — S4 tests (#2154): aggressive watcher filter + git-diff
+// ref-change validation.
+package watch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// makeGitRepo creates a real git repo with an initial commit and returns
+// its absolute path. Re-uses initGitRepo from githead_poller_test.go (same
+// package) but avoids importing it — just re-declare the helper name here.
+func makeGitRepoS4(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	run("config", "user.email", "s4@client-fixture-a.test")
+	run("config", "user.name", "S4Test")
+	f := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(f, []byte("# s4 test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "init")
+	return dir
+}
+
+// gitAdd stages + commits a file in dir.
+func gitCommitFileS4(t *testing.T, dir, name, content string) {
+	t.Helper()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "add "+name)
+}
+
+// currentSHA returns the abbreviated commit SHA at HEAD.
+func currentSHA(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "--short=12", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse: %v", err)
+	}
+	s := string(out)
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// A. Strict pre-subscription filter tests
+// ---------------------------------------------------------------------------
+
+// TestSkipDirsExtended verifies the newly-added hard-excludes from S4.
+func TestSkipDirsExtended(t *testing.T) {
+	cases := map[string]bool{
+		".cache":   true,
+		".vite":    true,
+		".esbuild": true,
+		// pre-existing
+		".archigraph":   true,
+		"node_modules":  true,
+		"__pycache__":   true,
+		".pytest_cache": true,
+		".gradle":       true,
+		".idea":         true,
+		".vscode":       true,
+		// should NOT be skipped
+		"src":      false,
+		"internal": false,
+		"cmd":      false,
+		"lib":      false,
+		"app":      false,
+	}
+	for dir, wantSkip := range cases {
+		if got := ShouldSkipDir(dir); got != wantSkip {
+			t.Errorf("ShouldSkipDir(%q) = %v, want %v", dir, got, wantSkip)
+		}
+	}
+}
+
+// TestGitignoreRespected verifies that ShouldSkipDirGitignore respects
+// a root .gitignore file.
+func TestGitignoreRespected(t *testing.T) {
+	dir := t.TempDir()
+	// Write a .gitignore that excludes "private/" but not "src/".
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("private/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Evict cache in case this dir was used before.
+	evictRepoIgnoreState(dir)
+
+	skip, reason := ShouldSkipDirGitignore(dir, filepath.Join(dir, "private"), "private")
+	if !skip {
+		t.Errorf("expected 'private' to be skipped by .gitignore, got skip=false (reason=%q)", reason)
+	}
+
+	skip2, _ := ShouldSkipDirGitignore(dir, filepath.Join(dir, "src"), "src")
+	if skip2 {
+		t.Errorf("expected 'src' NOT to be skipped")
+	}
+}
+
+// TestPerRepoWatchJSON verifies exclude_dirs and include_only_dirs.
+func TestPerRepoWatchJSON(t *testing.T) {
+	dir := t.TempDir()
+	archDir := filepath.Join(dir, ".archigraph")
+	if err := os.MkdirAll(archDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := RepoWatchConfig{
+		ExcludeDirs:     []string{"fixtures"},
+		IncludeOnlyDirs: []string{"src", "internal"},
+	}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(archDir, "watch.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	evictRepoIgnoreState(dir)
+
+	// 'fixtures' should be excluded.
+	skip, reason := ShouldSkipDirGitignore(dir, filepath.Join(dir, "fixtures"), "fixtures")
+	if !skip {
+		t.Errorf("expected fixtures to be excluded by watch.json, reason=%q", reason)
+	}
+
+	// 'docs' is not in include_only_dirs → should be excluded.
+	skip2, reason2 := ShouldSkipDirGitignore(dir, filepath.Join(dir, "docs"), "docs")
+	if !skip2 {
+		t.Errorf("expected docs to be excluded by include_only_dirs, reason=%q", reason2)
+	}
+
+	// 'src' is in include_only_dirs → should NOT be excluded.
+	skip3, _ := ShouldSkipDirGitignore(dir, filepath.Join(dir, "src"), "src")
+	if skip3 {
+		t.Errorf("expected src to pass include_only_dirs filter")
+	}
+}
+
+// TestWatcherSkipsGitignored verifies end-to-end that a directory excluded
+// by .gitignore does not receive fsnotify subscriptions and events from it
+// do not fire the sink.
+func TestWatcherSkipsGitignored(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+
+	// Write .gitignore that excludes "generated/".
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("generated/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	generatedDir := filepath.Join(repo, "generated")
+	srcDir := filepath.Join(repo, "src")
+	for _, d := range []string{generatedDir, srcDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Evict so loadRepoIgnoreState picks up the new .gitignore.
+	evictRepoIgnoreState(repo)
+
+	var calls atomic.Int32
+	w, err := newTestWatcher(100*time.Millisecond, func(string, bool) {
+		calls.Add(1)
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// Write into the gitignored dir — should NOT fire the sink.
+	if err := os.WriteFile(filepath.Join(generatedDir, "foo.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if n := calls.Load(); n != 0 {
+		t.Errorf("expected 0 sink calls for gitignored dir write, got %d", n)
+	}
+
+	// Write into src — should fire.
+	if err := os.WriteFile(filepath.Join(srcDir, "bar.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected 1 sink call for src write, got %d", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B. Git-driven ref-change validation tests
+// ---------------------------------------------------------------------------
+
+// TestClassifyRefChange_NoSourceChanges verifies that a commit touching only
+// non-source files (e.g. .log) returns ReindexNone.
+func TestClassifyRefChange_NoSourceChanges(t *testing.T) {
+	dir := makeGitRepoS4(t)
+	oldSHA := currentSHA(t, dir)
+
+	// Commit only a .log file (hits SkipExts → not a source file).
+	gitCommitFileS4(t, dir, "build.log", "build output\n")
+	newSHA := currentSHA(t, dir)
+
+	hint, files := classifyRefChange(dir, oldSHA, newSHA, nil)
+	if hint != ReindexNone {
+		t.Errorf("expected ReindexNone, got %d; files=%v", hint, files)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected 0 changed source files, got %v", files)
+	}
+}
+
+// TestClassifyRefChange_SmallDiff verifies that a commit touching a small
+// number of source files returns ReindexSmall.
+func TestClassifyRefChange_SmallDiff(t *testing.T) {
+	dir := makeGitRepoS4(t)
+	oldSHA := currentSHA(t, dir)
+
+	// Commit 3 .go files — well under smallDiffThreshold.
+	for _, name := range []string{"a.go", "b.go", "c.go"} {
+		gitCommitFileS4(t, dir, name, "package main\n")
+	}
+	// Combine into a single measurable diff: just two SHAs apart.
+	oldSHA2 := oldSHA
+	newSHA := currentSHA(t, dir)
+
+	hint, files := classifyRefChange(dir, oldSHA2, newSHA, nil)
+	if hint != ReindexSmall {
+		t.Errorf("expected ReindexSmall, got %d; files=%v", hint, files)
+	}
+	if len(files) == 0 {
+		t.Error("expected at least 1 changed source file")
+	}
+}
+
+// TestClassifyRefChange_LargeDiff verifies that >20 source files returns
+// ReindexFull.
+func TestClassifyRefChange_LargeDiff(t *testing.T) {
+	dir := makeGitRepoS4(t)
+	oldSHA := currentSHA(t, dir)
+
+	// Commit 25 .go files in one shot.
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	for i := 0; i < 25; i++ {
+		name := filepath.Join(dir, fmt.Sprintf("file%d.go", i))
+		_ = os.WriteFile(name, []byte("package main\n"), 0o644)
+	}
+	run("add", ".")
+	run("commit", "-m", "large diff")
+	newSHA := currentSHA(t, dir)
+
+	hint, _ := classifyRefChange(dir, oldSHA, newSHA, nil)
+	if hint != ReindexFull {
+		t.Errorf("expected ReindexFull for >%d files, got %d", smallDiffThreshold, hint)
+	}
+}
+
+// TestClassifyRefChange_Unknown verifies that empty SHAs return ReindexUnknown.
+func TestClassifyRefChange_Unknown(t *testing.T) {
+	dir := makeGitRepoS4(t)
+	hint, _ := classifyRefChange(dir, "", "abc123", nil)
+	if hint != ReindexUnknown {
+		t.Errorf("expected ReindexUnknown for empty oldSHA, got %d", hint)
+	}
+}
+
+// TestPoller_SkipsNoSourceReindex verifies that when a commit touches only
+// non-source files the poller emits zero BranchSwitchEvents to the sink.
+func TestPoller_SkipsNoSourceReindex(t *testing.T) {
+	dir := makeGitRepoS4(t)
+
+	var count atomic.Int32
+	p := NewGitHeadPoller(50*time.Millisecond, func(_ BranchSwitchEvent) {
+		count.Add(1)
+	}, nil)
+	p.AddRepo(dir)
+	p.Start()
+	defer p.Stop()
+
+	// Commit only a .log file → no source changes → poller should suppress.
+	gitCommitFileS4(t, dir, "ci.log", "logs\n")
+
+	// Wait for multiple poll cycles.
+	time.Sleep(400 * time.Millisecond)
+
+	if n := count.Load(); n != 0 {
+		t.Errorf("expected 0 sink calls for non-source commit, got %d", n)
+	}
+}
+
+// TestPoller_EmitsForSourceReindex verifies that a commit touching a .go
+// file does trigger a BranchSwitchEvent with the correct hint.
+func TestPoller_EmitsForSourceReindex(t *testing.T) {
+	dir := makeGitRepoS4(t)
+
+	var events []BranchSwitchEvent
+	var evMu sync.Mutex
+	p := NewGitHeadPoller(50*time.Millisecond, func(ev BranchSwitchEvent) {
+		evMu.Lock()
+		events = append(events, ev)
+		evMu.Unlock()
+	}, nil)
+	p.AddRepo(dir)
+	p.Start()
+	defer p.Stop()
+
+	gitCommitFileS4(t, dir, "main.go", "package main\n")
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		evMu.Lock()
+		n := len(events)
+		evMu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	evMu.Lock()
+	got := make([]BranchSwitchEvent, len(events))
+	copy(got, events)
+	evMu.Unlock()
+
+	if len(got) == 0 {
+		t.Fatal("expected at least 1 BranchSwitchEvent for source commit")
+	}
+	ev := got[0]
+	if ev.ReindexHint == ReindexNone {
+		t.Errorf("ReindexHint should not be ReindexNone for source-file commit")
+	}
+	if len(ev.ChangedFiles) == 0 {
+		t.Error("ChangedFiles should be non-empty")
+	}
+}

--- a/internal/daemon/watch/skip.go
+++ b/internal/daemon/watch/skip.go
@@ -75,6 +75,10 @@ var SkipDirs = map[string]struct{}{
 	".vscode": {},
 	// Generated code (MANIFEST §25, D24)
 	"_generated": {},
+	// Build / cache (S4 #2154: aggressive filter)
+	".cache":    {},
+	".vite":     {},
+	".esbuild":  {},
 }
 
 // SkipExts is the suffix list for files we never re-index for. Lock

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -218,6 +218,11 @@ func (w *Watcher) AddRepo(repoPath string) (int, error) {
 // subscribeRepo walks the repo tree and adds every non-skipped dir to
 // the fsnotify instance. Separated from AddRepo so the restart path
 // can call it without the idempotency guard.
+//
+// Three-layer skip check (S4 #2154):
+//  1. Hard-coded SkipDirs / walk.IsHardcodedSkip (ShouldSkipDir)
+//  2. Per-instance ExcludeDirs (extraSkip)
+//  3. .gitignore + .archigraph/watch.json (ShouldSkipDirGitignore)
 func (w *Watcher) subscribeRepo(abs string) (int, error) {
 	added := 0
 	walkErr := filepath.WalkDir(abs, func(p string, d os.DirEntry, err error) error {
@@ -227,9 +232,21 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 		if !d.IsDir() {
 			return nil
 		}
-		base := filepath.Base(p)
-		if p != abs && w.shouldSkipDir(base) {
-			return filepath.SkipDir
+		if p != abs {
+			base := filepath.Base(p)
+			// Layer 1 + 2: hard-coded + per-instance excludes.
+			if w.shouldSkipDir(base) {
+				return filepath.SkipDir
+			}
+			// Layer 3: .gitignore + per-repo watch.json.
+			relPath, relErr := filepath.Rel(abs, p)
+			if relErr == nil {
+				relPath = filepath.ToSlash(relPath)
+				if skip, reason := ShouldSkipDirGitignore(abs, p, relPath); skip {
+					w.logger.Printf("watcher: skip %s (%s)", p, reason)
+					return filepath.SkipDir
+				}
+			}
 		}
 		if err := w.fs.Add(p); err != nil {
 			w.logger.Printf("watcher: add %s: %v", p, err)
@@ -265,6 +282,8 @@ func (w *Watcher) RemoveRepo(repoPath string) {
 			delete(w.dirToRepo, d)
 		}
 	}
+	// Evict gitignore cache so a re-add picks up any .gitignore changes.
+	evictRepoIgnoreState(abs)
 }
 
 // Repos returns a snapshot of the currently watched repos.


### PR DESCRIPTION
## 1. Problem

The daemon's fsnotify watcher subscribed to every directory in every registered repo and triggered a full reindex on every HEAD SHA change — including commits that only touched lock files, logs, or CI config. With 43+ repos this produced 50-200 spurious fsnotify events/minute at idle.

## 2. What changed

### A. Strict pre-subscription filter (`internal/daemon/watch/`)
- **`skip.go`**: Added `.cache`, `.vite`, `.esbuild` to `SkipDirs`.
- **`gitignore.go`** (new): `loadRepoIgnoreState` parses `<repo>/.gitignore` once at `AddRepo` time (reuses `walk.ParseIgnoreFile`). Also reads `<repo>/.archigraph/watch.json` for per-repo `include_only_dirs` / `exclude_dirs` overrides. Cache is evicted on `RemoveRepo`.
- **`watcher.go`** `subscribeRepo`: extended to a three-layer skip check: hard-coded SkipDirs → instance `ExcludeDirs` → `.gitignore` + `watch.json`. Skipped directories are logged at subscribe time.

### B. Git-driven ref-change validation (`githead_poller.go`)
New `classifyRefChange(repoPath, oldSHA, newSHA)`:
1. Runs `git diff --name-only OLD..NEW`
2. Filters result through `ShouldSkipPath` (same filter as the watcher)
3. Returns `ReindexHint` enum: `None` / `Small` (≤20 files) / `Full` (>20) / `Unknown`

`poll()` suppresses the `BranchSwitchEvent` entirely when hint is `None`; logs `"ref-change: <repo> OLD..NEW no-source-changes"`. Same-SHA ref changes (e.g. `git checkout -b newbranch`) return `Unknown` and are forwarded so the scheduler re-indexes under the new ref name.

`BranchSwitchEvent` gains `ReindexHint` + `ChangedFiles` fields for scheduler use.

### C. Per-file debounce
The existing 5 s per-repo settle window is unchanged and already covers the per-file 100 ms coalescing requirement.

## 3. Tests (`s4_test.go` — 10 new tests, all pass)
| Test | Covers |
|---|---|
| `TestSkipDirsExtended` | `.cache/.vite/.esbuild` hard-excludes |
| `TestGitignoreRespected` | root `.gitignore` exclusion |
| `TestPerRepoWatchJSON` | `exclude_dirs` + `include_only_dirs` |
| `TestWatcherSkipsGitignored` | end-to-end: no sink fire for gitignored dir |
| `TestClassifyRefChange_NoSourceChanges` | `.log`-only commit → `ReindexNone` |
| `TestClassifyRefChange_SmallDiff` | 3 `.go` files → `ReindexSmall` |
| `TestClassifyRefChange_LargeDiff` | 25 `.go` files → `ReindexFull` |
| `TestClassifyRefChange_Unknown` | empty SHA → `ReindexUnknown` |
| `TestPoller_SkipsNoSourceReindex` | `.log` commit → 0 sink calls |
| `TestPoller_EmitsForSourceReindex` | `.go` commit → 1 event with correct hint |

## 4. Backward compatibility
- `BranchSwitchEvent` is extended (additive fields, zero-value `ReindexUnknown` is safe).
- `BranchSwitchSink` signature unchanged.
- All 22 pre-existing watch package tests continue to pass.

## 5. Not in scope
- Scheduler-side incremental reindex (uses `ReindexSmall` hint) — separate ticket.
- S3-backed incremental path — depends on S3 feature.

## 6. Deployment
No config changes required. Per-repo `watch.json` is opt-in. The `.gitignore` load happens at `AddRepo` time; daemon restart or `RemoveRepo`/`AddRepo` cycle picks up `.gitignore` changes.

## 7. References
Closes #2154
Refs #2149