### PR TITLE
feat(daemon): operational modes — background / workstation / readonly (S7 of #2149)

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/agents"
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/daemon/mode"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/daemon/watch"
 	"github.com/cajasmota/archigraph/internal/dashboard"
@@ -138,6 +139,10 @@ func resolveEnvRebuildConcurrency() int {
 // the cap — the cap applies to repos within a single group rebuild.
 var rebuildConcurrency = defaultRebuildConcurrency()
 
+// activeDaemonMode is set by runDaemon after loading the mode config.
+// It is read-only after that point (written once before the RPC server starts).
+var activeDaemonMode string
+
 // rebuildIndexFunc is the per-repo index entrypoint used by daemonRebuildFunc.
 // It defaults to the package-level Index function but can be replaced in tests
 // to validate parallelism semantics without running a real extractor pass.
@@ -177,6 +182,9 @@ func runDaemon(argv []string) error {
 	// disabled for "daemon" so we own the argv. Unknown flags exit
 	// with a clear error rather than being silently ignored.
 	fs := flag.NewFlagSet("daemon", flag.ContinueOnError)
+	var daemonModeFlag string
+	fs.StringVar(&daemonModeFlag, "mode", "",
+		"operational mode: background, workstation, readonly (default: read from daemon.config.json)")
 	var maxRSSBudget int64
 	envBudget := defaultRSSBudgetMB()
 	if v := os.Getenv("ARCHIGRAPH_MAX_RSS_BUDGET_MB"); v != "" {
@@ -201,6 +209,28 @@ func runDaemon(argv []string) error {
 	if err != nil {
 		return fmt.Errorf("resolve daemon layout: %w", err)
 	}
+
+	// S7 (#2157): load mode from daemon.config.json then apply env defaults.
+	// Precedence: --mode flag > daemon.config.json > Background default.
+	// Env vars always win over mode defaults (ApplyDefaults only sets unset vars).
+	{
+		cfgPath := mode.DefaultConfigPath(layout.Root)
+		modeCfg, _ := mode.LoadConfig(cfgPath) // missing file → zero value; not fatal
+		activeMode := modeCfg.Mode
+		if daemonModeFlag != "" {
+			if parsed, perr := mode.Parse(daemonModeFlag); perr == nil {
+				activeMode = parsed
+			}
+		}
+		if activeMode == "" {
+			activeMode = mode.Background // open-source default
+		}
+		mode.ApplyDefaults(activeMode)
+		gcLog.Printf("daemon mode: %s", activeMode)
+		// Store the active mode in a package-level var so the Status RPC can surface it.
+		activeDaemonMode = string(activeMode)
+	}
+
 	if err := daemon.EnsureLayout(layout); err != nil {
 		return fmt.Errorf("ensure layout: %w", err)
 	}
@@ -261,6 +291,10 @@ func runDaemon(argv []string) error {
 		MaxRSSBudgetMB:      maxRSSBudget,
 		RSSHistoryPath:      filepath.Join(filepath.Dir(layout.PIDPath), "repo-rss-history.json"),
 		MaxConcurrentGroups: maxConcurrentGroups,
+
+		// S7 (#2157): propagate the resolved operational mode so the Status
+		// RPC can surface it for `archigraph status`.
+		DaemonMode: activeDaemonMode,
 
 		// Pattern confidence time-decay: runs every 6 hours.
 		// PatternGroupDirs returns the patterns storage directory for each

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,0 +1,97 @@
+# Daemon Operational Modes (S7 of #2149)
+
+The archigraph daemon supports three operational modes that control memory usage,
+background activity, and feature activation. The mode is persisted in
+`~/.archigraph/daemon.config.json` and read on every boot.
+
+## Modes
+
+### background (default)
+
+Low-footprint preset designed for open-source / first-time installs and
+resource-constrained machines.
+
+| Env var | Default |
+|---------|---------|
+| `ARCHIGRAPH_EAGER_ALGO` | `false` — algo passes run on-demand only |
+| `ARCHIGRAPH_EMBEDDING_URL` | `` (empty) — MiniLM embeddings disabled |
+| `ARCHIGRAPH_HEAP_MAX_PCT` | `60` — heap capped at 60% of available memory |
+
+### workstation
+
+Restores the historical production defaults: eager algo passes, no heap cap
+override, embedding endpoint is freely configurable.
+
+| Env var | Default |
+|---------|---------|
+| `ARCHIGRAPH_EAGER_ALGO` | `true` |
+| `ARCHIGRAPH_HEAP_MAX_PCT` | `80` |
+
+### readonly
+
+Serves graph queries against the existing `graph.fb` only. No reindex, no
+watcher subscriptions, no algo passes. Use this when you want fast read-only
+access without any background CPU or memory pressure.
+
+| Env var | Default |
+|---------|---------|
+| `ARCHIGRAPH_DISABLE_WATCHER` | `true` |
+| `ARCHIGRAPH_DISABLE_REBUILD` | `true` |
+| `ARCHIGRAPH_DISABLE_ALGO` | `true` |
+
+## Precedence
+
+Env vars set in the process environment **always** take precedence over the mode
+defaults. This lets operators fine-tune a single variable without switching modes:
+
+```
+ARCHIGRAPH_EAGER_ALGO=true archigraph daemon --mode=background
+```
+
+In the example above the daemon runs in background mode except that eager algo is
+enabled.
+
+## CLI reference
+
+```
+# Pick mode at install time (default: background)
+archigraph install --mode=workstation
+
+# Override mode at daemon start
+archigraph daemon --mode=readonly
+
+# Switch mode persistently (saves config + restarts daemon)
+archigraph mode background
+archigraph mode workstation
+archigraph mode readonly
+
+# Show current mode
+archigraph status
+```
+
+`archigraph status` reports the active mode in the daemon header line:
+
+```
+Daemon: running  pid=12345  uptime=2h3m  rss=180.4MB  in_flight=0
+  version: 1.x.y
+  socket:  /Users/you/.archigraph/sockets/daemon.sock
+  mode:    background
+  dashboard: http://127.0.0.1:47274/
+```
+
+## Config file
+
+`~/.archigraph/daemon.config.json` persists the active mode plus any
+operator-supplied env overrides written by `archigraph mode`:
+
+```json
+{
+  "mode": "background",
+  "env_overrides": {
+    "ARCHIGRAPH_HEAP_MAX_PCT": "50"
+  }
+}
+```
+
+The file is written atomically (write to `.tmp` then rename) and is
+backwards-compatible: daemons predating S7 simply ignore it.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/daemon/mode"
 	"github.com/cajasmota/archigraph/internal/daemon/service"
 	"github.com/cajasmota/archigraph/internal/install/mcpreg"
 	"github.com/cajasmota/archigraph/internal/install/skilllink"
@@ -68,6 +69,7 @@ func newInstallCmd() *cobra.Command {
 	var claudeConfigDirs []string
 	var skillsSourceDir string
 	var skipSkillLink bool
+	var installMode string
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -88,6 +90,9 @@ status and exits successfully (idempotent).
 
 Use --foreground to skip service registration and run the daemon directly
 in this terminal — useful for debugging launchd/systemd issues.
+
+Use --mode to select the operational preset (background, workstation, readonly).
+The default is background. See 'archigraph mode --help' for details.
 
 Install also symlinks the 6 archigraph skills into every detected Claude Code
 config directory's skills/ subdirectory. Use --skip-skill-link to disable this,
@@ -113,6 +118,25 @@ or --skills-source-dir to override the skills discovery location.`,
 			layout, err := daemon.DefaultLayout()
 			if err != nil {
 				return fmt.Errorf("resolve daemon layout: %w", err)
+			}
+
+			// Persist the selected mode so the daemon reads it on every boot.
+			// Default is background (low-footprint for open-source installs).
+			selectedMode := mode.Background
+			if installMode != "" {
+				parsed, merr := mode.Parse(installMode)
+				if merr != nil {
+					return merr
+				}
+				selectedMode = parsed
+			}
+			cfgPath := mode.DefaultConfigPath(layout.Root)
+			existing, _ := mode.LoadConfig(cfgPath) // best-effort; ignore missing-file error
+			existing.Mode = selectedMode
+			if serr := mode.SaveConfig(cfgPath, existing); serr != nil {
+				fmt.Fprintf(out, "  ⚠ save daemon config: %v\n", serr)
+			} else {
+				fmt.Fprintf(out, "  mode:    %s\n", selectedMode)
 			}
 
 			opts := service.Options{
@@ -164,5 +188,7 @@ or --skills-source-dir to override the skills discovery location.`,
 		"override the skills directory location (default: auto-detect from binary location or dev paths)")
 	cmd.Flags().BoolVar(&skipSkillLink, "skip-skill-link", false,
 		"skip symlinking skills into Claude Code's skills/ directories")
+	cmd.Flags().StringVar(&installMode, "mode", "",
+		"operational mode: background (default), workstation, or readonly")
 	return cmd
 }

--- a/internal/cli/mode.go
+++ b/internal/cli/mode.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/daemon/client"
+	"github.com/cajasmota/archigraph/internal/daemon/mode"
+)
+
+// newModeCmd returns the `archigraph mode <m>` subcommand.
+//
+// It writes the chosen mode to ~/.archigraph/daemon.config.json and then
+// kicks (stop + start) the daemon so the new defaults take effect
+// immediately. No-op when the daemon is not running.
+func newModeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mode <background|workstation|readonly>",
+		Short: "Switch the daemon operational mode and restart",
+		Long: `Switch the daemon operational mode and restart.
+
+Modes:
+  background   Low-footprint preset for open-source / resource-constrained
+               environments. Disables eager algo passes and MiniLM embeddings;
+               caps the heap at 60% of available memory.
+
+  workstation  Restores production defaults: eager algo passes, no heap cap
+               override, embedding endpoint configurable via env var.
+
+  readonly     Serves queries against the existing graph only. No reindex, no
+               watcher, no algo passes. Useful when you want fast read-only
+               access without background CPU/memory work.
+
+The chosen mode is persisted in ~/.archigraph/daemon.config.json and read
+by the daemon on every boot. Env vars (e.g. ARCHIGRAPH_EAGER_ALGO) always
+take precedence over the mode defaults.`,
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"background", "workstation", "readonly"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+
+			m, err := mode.Parse(args[0])
+			if err != nil {
+				return err
+			}
+
+			// Resolve the config path via the daemon layout so it respects
+			// ARCHIGRAPH_DAEMON_ROOT overrides used in tests.
+			layout, err := daemon.DefaultLayout()
+			if err != nil {
+				return fmt.Errorf("resolve daemon layout: %w", err)
+			}
+			cfgPath := mode.DefaultConfigPath(layout.Root)
+
+			// Load existing config (if any) so we preserve EnvOverrides.
+			existing, err := mode.LoadConfig(cfgPath)
+			if err != nil {
+				// Non-fatal: start fresh.
+				existing = mode.Config{}
+			}
+			existing.Mode = m
+			if err := mode.SaveConfig(cfgPath, existing); err != nil {
+				return fmt.Errorf("save daemon config: %w", err)
+			}
+			fmt.Fprintf(out, "mode set to %q — config written to %s\n", m, cfgPath)
+
+			// Kick the daemon: stop then start. Both errors are soft — if the
+			// daemon is already stopped we can still start it; if start fails
+			// we report it but don't fail the command (the config is saved).
+			fmt.Fprintln(out, "restarting daemon…")
+			if err := runModeRestart(out); err != nil {
+				fmt.Fprintf(out, "  ⚠ restart: %v\n", err)
+				fmt.Fprintf(out, "  Run 'archigraph start' to launch the daemon in %s mode.\n", m)
+			} else {
+				fmt.Fprintf(out, "daemon restarted in %s mode\n", m)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// runModeRestart stops a running daemon (if any) then brings it back up.
+// It mirrors the restart logic in watcher_ctl.go but is kept separate so
+// the mode command can suppress the "daemon not running" stop error.
+func runModeRestart(out io.Writer) error {
+	// Stop: ignore ErrDaemonNotRunning — the mode config is already saved
+	// so the next start will pick it up regardless.
+	if c, err := client.Dial(); err == nil {
+		defer c.Close()
+		_ = c.Stop() // best-effort; the daemon may exit before we read the reply
+	} else if !errors.Is(err, client.ErrDaemonNotRunning) {
+		fmt.Fprintf(out, "  stop: %v\n", err)
+	}
+	// Brief pause to let the previous daemon release the socket.
+	time.Sleep(200 * time.Millisecond)
+	return runDaemonStart(out)
+}

--- a/internal/cli/mode_test.go
+++ b/internal/cli/mode_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/mode"
+)
+
+// TestNewModeCmd_unknownMode verifies that an unrecognised mode name returns
+// a descriptive error and does not write anything to disk.
+func TestNewModeCmd_unknownMode(t *testing.T) {
+	cmd := newModeCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	err := cmd.RunE(cmd, []string{"turbo"})
+	if err == nil {
+		t.Fatal("expected error for unknown mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown mode") {
+		t.Errorf("error %q does not mention 'unknown mode'", err.Error())
+	}
+}
+
+// TestSaveModeConfig_roundtrip verifies that SaveConfig + LoadConfig preserve
+// both the Mode and EnvOverrides fields.
+func TestSaveModeConfig_roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon.config.json")
+
+	cfg := mode.Config{
+		Mode:         mode.Workstation,
+		EnvOverrides: map[string]string{"ARCHIGRAPH_HEAP_MAX_PCT": "70"},
+	}
+	if err := mode.SaveConfig(path, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+	got, err := mode.LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got.Mode != mode.Workstation {
+		t.Errorf("mode = %q, want workstation", got.Mode)
+	}
+	if got.EnvOverrides["ARCHIGRAPH_HEAP_MAX_PCT"] != "70" {
+		t.Errorf("env override = %q, want 70", got.EnvOverrides["ARCHIGRAPH_HEAP_MAX_PCT"])
+	}
+}
+
+// TestModeDefaults_readonlyDisablesAll verifies that readonly mode sets all
+// three DISABLE_ vars.
+func TestModeDefaults_readonlyDisablesAll(t *testing.T) {
+	d := mode.ModeDefaults(mode.Readonly)
+	for _, k := range []string{
+		"ARCHIGRAPH_DISABLE_WATCHER",
+		"ARCHIGRAPH_DISABLE_REBUILD",
+		"ARCHIGRAPH_DISABLE_ALGO",
+	} {
+		if d[k] != "true" {
+			t.Errorf("readonly default %s = %q, want true", k, d[k])
+		}
+	}
+}
+
+// TestModeDefaults_backgroundLowFootprint verifies background mode defaults.
+func TestModeDefaults_backgroundLowFootprint(t *testing.T) {
+	d := mode.ModeDefaults(mode.Background)
+	if d["ARCHIGRAPH_EAGER_ALGO"] != "false" {
+		t.Errorf("background ARCHIGRAPH_EAGER_ALGO = %q, want false", d["ARCHIGRAPH_EAGER_ALGO"])
+	}
+	if d["ARCHIGRAPH_HEAP_MAX_PCT"] != "60" {
+		t.Errorf("background ARCHIGRAPH_HEAP_MAX_PCT = %q, want 60", d["ARCHIGRAPH_HEAP_MAX_PCT"])
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,6 +45,7 @@ func newRoot() *cobra.Command {
 		newRebuildCmd(),
 		newResetCmd(),
 		newUninstallCmd(),
+		newModeCmd(),
 		newStartCmd(),
 		newStopCmd(),
 		newRestartCmd(),
@@ -122,6 +123,10 @@ Operate:
 Repair:
   rebuild [group] [slug]          Force AST rebuild (no cache, daemon RPC)
   reset [group] [slug]            Wipe .archigraph/ and rebuild via daemon
+
+Daemon modes (S7):
+  mode <background|workstation|readonly>
+                                  Switch operational mode + restart daemon
 
 Lifecycle:
   remove <group> <slug>           Remove a single repo from a group

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -60,6 +60,9 @@ func runStatus(w io.Writer, filter string) error {
 					st.PID, uptime, humanBytes(st.RSSBytes), st.InFlight)
 				fmt.Fprintf(w, "  version: %s\n", st.Version)
 				fmt.Fprintf(w, "  socket:  %s\n", st.SocketPath)
+				if st.DaemonMode != "" {
+					fmt.Fprintf(w, "  mode:    %s\n", st.DaemonMode)
+				}
 				if st.DashboardPort > 0 {
 					fmt.Fprintf(w, "  dashboard: http://127.0.0.1:%d/\n", st.DashboardPort)
 				}

--- a/internal/daemon/mode/mode.go
+++ b/internal/daemon/mode/mode.go
@@ -1,0 +1,148 @@
+// Package mode defines the three operational modes of the archigraph daemon
+// (S7 of #2149). Each mode is a preset of env-var defaults that controls
+// memory usage, background activity, and feature activation.
+//
+// Env vars are resolved with the following precedence (highest wins):
+//
+//  1. Process env (explicitly set by the operator)
+//  2. Mode defaults applied by ApplyDefaults
+//  3. Compiled-in Go defaults
+//
+// The active mode name is persisted in ~/.archigraph/daemon.config.json
+// so `archigraph status` can surface it without querying the live process.
+package mode
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Mode is one of the three operational presets.
+type Mode string
+
+const (
+	// Background is the default for first-time / open-source installs.
+	// It minimises memory and CPU footprint: lazy hydration, no
+	// MiniLM embeddings, on-demand algo passes, 60% heap budget.
+	Background Mode = "background"
+
+	// Workstation restores the historical defaults: eager algo passes,
+	// MiniLM embeddings allowed, no heap cap override.
+	Workstation Mode = "workstation"
+
+	// Readonly serves graph queries against the existing graph.fb only.
+	// No reindexing, no watcher, no algo passes run.
+	Readonly Mode = "readonly"
+)
+
+// All returns the full set of valid mode names in display order.
+func All() []Mode { return []Mode{Background, Workstation, Readonly} }
+
+// Parse returns the Mode for s, or an error if s is unrecognised.
+func Parse(s string) (Mode, error) {
+	switch Mode(s) {
+	case Background, Workstation, Readonly:
+		return Mode(s), nil
+	default:
+		return "", fmt.Errorf("unknown mode %q: must be one of background, workstation, readonly", s)
+	}
+}
+
+// Defaults holds the env-var defaults for a mode.
+// An empty-string value means "set the var to the empty string" (disables
+// the feature). A nil map entry is never written.
+type Defaults map[string]string
+
+// ModeDefaults returns the env-var defaults for m.
+func ModeDefaults(m Mode) Defaults {
+	switch m {
+	case Background:
+		return Defaults{
+			"ARCHIGRAPH_EAGER_ALGO":    "false",
+			"ARCHIGRAPH_EMBEDDING_URL": "",
+			"ARCHIGRAPH_HEAP_MAX_PCT":  "60",
+		}
+	case Workstation:
+		// Restore current production defaults; don't force-set EMBEDDING_URL
+		// so the operator can configure their own endpoint freely.
+		return Defaults{
+			"ARCHIGRAPH_EAGER_ALGO":   "true",
+			"ARCHIGRAPH_HEAP_MAX_PCT": "80",
+		}
+	case Readonly:
+		return Defaults{
+			"ARCHIGRAPH_DISABLE_WATCHER": "true",
+			"ARCHIGRAPH_DISABLE_REBUILD": "true",
+			"ARCHIGRAPH_DISABLE_ALGO":    "true",
+		}
+	default:
+		return Defaults{}
+	}
+}
+
+// ApplyDefaults sets each env-var from ModeDefaults(m) only when the
+// variable is not already present in the process environment.
+// This respects the "env vars still override mode" contract from the spec.
+func ApplyDefaults(m Mode) {
+	for k, v := range ModeDefaults(m) {
+		if _, ok := os.LookupEnv(k); !ok {
+			os.Setenv(k, v) //nolint:errcheck // os.Setenv only fails on empty key
+		}
+	}
+}
+
+// Config is the on-disk schema for ~/.archigraph/daemon.config.json.
+// It persists the active mode plus any operator-supplied env overrides
+// (written by `archigraph mode <m>`).
+type Config struct {
+	// Mode is the active operational mode.
+	Mode Mode `json:"mode"`
+
+	// EnvOverrides, if non-nil, are written into the service unit alongside
+	// the mode defaults. Operator-supplied; not set by the mode presets.
+	EnvOverrides map[string]string `json:"env_overrides,omitempty"`
+}
+
+// DefaultConfigPath returns the canonical path for daemon.config.json,
+// rooted under root (typically ~/.archigraph).
+func DefaultConfigPath(root string) string {
+	return filepath.Join(root, "daemon.config.json")
+}
+
+// LoadConfig reads and parses daemon.config.json from path.
+// Returns (Config{}, nil) when the file does not exist (first run).
+func LoadConfig(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return Config{}, nil
+	}
+	if err != nil {
+		return Config{}, fmt.Errorf("read daemon config %s: %w", path, err)
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Config{}, fmt.Errorf("parse daemon config %s: %w", path, err)
+	}
+	return c, nil
+}
+
+// SaveConfig writes cfg to path atomically (write-to-tmp + rename).
+func SaveConfig(path string, cfg Config) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal daemon config: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write daemon config tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename daemon config: %w", err)
+	}
+	return nil
+}

--- a/internal/daemon/mode/mode_test.go
+++ b/internal/daemon/mode/mode_test.go
@@ -1,0 +1,128 @@
+package mode_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/mode"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    mode.Mode
+		wantErr bool
+	}{
+		{"background", mode.Background, false},
+		{"workstation", mode.Workstation, false},
+		{"readonly", mode.Readonly, false},
+		{"BACKGROUND", "", true},
+		{"", "", true},
+		{"unknown", "", true},
+	}
+	for _, tc := range tests {
+		got, err := mode.Parse(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("Parse(%q): expected error, got nil", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Parse(%q): unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("Parse(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestModeDefaultsBackground(t *testing.T) {
+	d := mode.ModeDefaults(mode.Background)
+	if d["ARCHIGRAPH_EAGER_ALGO"] != "false" {
+		t.Errorf("background: ARCHIGRAPH_EAGER_ALGO = %q, want false", d["ARCHIGRAPH_EAGER_ALGO"])
+	}
+	if d["ARCHIGRAPH_HEAP_MAX_PCT"] != "60" {
+		t.Errorf("background: ARCHIGRAPH_HEAP_MAX_PCT = %q, want 60", d["ARCHIGRAPH_HEAP_MAX_PCT"])
+	}
+	if _, ok := d["ARCHIGRAPH_EMBEDDING_URL"]; !ok {
+		t.Error("background: ARCHIGRAPH_EMBEDDING_URL key should be present (empty string)")
+	}
+}
+
+func TestModeDefaultsWorkstation(t *testing.T) {
+	d := mode.ModeDefaults(mode.Workstation)
+	if d["ARCHIGRAPH_EAGER_ALGO"] != "true" {
+		t.Errorf("workstation: ARCHIGRAPH_EAGER_ALGO = %q, want true", d["ARCHIGRAPH_EAGER_ALGO"])
+	}
+	if d["ARCHIGRAPH_HEAP_MAX_PCT"] != "80" {
+		t.Errorf("workstation: ARCHIGRAPH_HEAP_MAX_PCT = %q, want 80", d["ARCHIGRAPH_HEAP_MAX_PCT"])
+	}
+}
+
+func TestModeDefaultsReadonly(t *testing.T) {
+	d := mode.ModeDefaults(mode.Readonly)
+	for _, k := range []string{"ARCHIGRAPH_DISABLE_WATCHER", "ARCHIGRAPH_DISABLE_REBUILD", "ARCHIGRAPH_DISABLE_ALGO"} {
+		if d[k] != "true" {
+			t.Errorf("readonly: %s = %q, want true", k, d[k])
+		}
+	}
+}
+
+func TestApplyDefaults_setsUnset(t *testing.T) {
+	// Unset the key, apply background, verify it is set.
+	os.Unsetenv("ARCHIGRAPH_EAGER_ALGO")
+	t.Cleanup(func() { os.Unsetenv("ARCHIGRAPH_EAGER_ALGO") })
+
+	mode.ApplyDefaults(mode.Background)
+	if v := os.Getenv("ARCHIGRAPH_EAGER_ALGO"); v != "false" {
+		t.Errorf("ARCHIGRAPH_EAGER_ALGO = %q after ApplyDefaults, want false", v)
+	}
+}
+
+func TestApplyDefaults_doesNotOverrideExisting(t *testing.T) {
+	os.Setenv("ARCHIGRAPH_EAGER_ALGO", "true")
+	t.Cleanup(func() { os.Unsetenv("ARCHIGRAPH_EAGER_ALGO") })
+
+	mode.ApplyDefaults(mode.Background)
+	if v := os.Getenv("ARCHIGRAPH_EAGER_ALGO"); v != "true" {
+		t.Errorf("ARCHIGRAPH_EAGER_ALGO = %q after ApplyDefaults, want true (existing override preserved)", v)
+	}
+}
+
+func TestSaveLoadConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon.config.json")
+
+	cfg := mode.Config{
+		Mode:         mode.Background,
+		EnvOverrides: map[string]string{"ARCHIGRAPH_HEAP_MAX_PCT": "50"},
+	}
+	if err := mode.SaveConfig(path, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	got, err := mode.LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got.Mode != mode.Background {
+		t.Errorf("loaded mode = %q, want background", got.Mode)
+	}
+	if got.EnvOverrides["ARCHIGRAPH_HEAP_MAX_PCT"] != "50" {
+		t.Errorf("loaded override = %q, want 50", got.EnvOverrides["ARCHIGRAPH_HEAP_MAX_PCT"])
+	}
+}
+
+func TestLoadConfig_missingFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := mode.LoadConfig(filepath.Join(dir, "does-not-exist.json"))
+	if err != nil {
+		t.Fatalf("LoadConfig missing file: %v", err)
+	}
+	if cfg.Mode != "" {
+		t.Errorf("expected empty mode for missing file, got %q", cfg.Mode)
+	}
+}

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -96,6 +96,11 @@ type StatusReply struct {
 	// has been suspended because the slot is COLD.
 	WatcherActiveSlots int `json:"watcher_active_slots,omitempty"`
 	WatcherPausedSlots int `json:"watcher_paused_slots,omitempty"`
+
+	// S7 (#2157): operational mode the daemon booted with.
+	// One of "background", "workstation", "readonly". Empty for daemons
+	// predating S7 (backwards-compatible; older clients ignore the field).
+	DaemonMode string `json:"daemon_mode,omitempty"`
 }
 
 // InFlightJobState mirrors sched.InFlightJob on the wire.

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -117,6 +117,12 @@ type Config struct {
 	// Configurable via --max-concurrent-groups on the daemon subcommand
 	// or ARCHIGRAPH_MAX_CONCURRENT_GROUPS env var. Added in #1276.
 	MaxConcurrentGroups int
+
+	// DaemonMode is the operational mode the daemon was booted in (S7 #2157).
+	// One of "background", "workstation", "readonly". Empty string means
+	// the caller did not specify a mode (treated as background).
+	// Surfaced in Status RPC so `archigraph status` can display it.
+	DaemonMode string
 }
 
 // Run starts the daemon. It blocks until either:
@@ -192,6 +198,8 @@ func Run(ctx context.Context, cfg Config) error {
 	if cfg.DashboardPort > 0 {
 		svc.dashboardPort = cfg.DashboardPort
 	}
+	// S7 (#2157): wire the operational mode so Status can surface it.
+	svc.daemonMode = cfg.DaemonMode
 	// PH2a (#2096): wire watcher pause/resume slot counts into Status RPC.
 	if cfg.WatcherMgrStats != nil {
 		svc.watcherMgrStats = cfg.WatcherMgrStats

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -170,6 +170,10 @@ type Service struct {
 	// bound to. Set by server.go after the dashboard goroutine starts.
 	// Zero means dashboard is not running. Read by Status RPC (#938).
 	dashboardPort int
+
+	// daemonMode is the operational mode the daemon booted in (S7 #2157).
+	// Surfaced by the Status RPC for `archigraph status`.
+	daemonMode string
 }
 
 // newService wires the injected entrypoints onto a fresh Service. The
@@ -227,6 +231,9 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 	// Report the dashboard port so `archigraph dashboard` can construct
 	// the URL without a separate config read (#938).
 	reply.DashboardPort = s.dashboardPort
+
+	// S7 (#2157): surface the active operational mode.
+	reply.DaemonMode = s.daemonMode
 
 	if s.watcher != nil {
 		repos, dirs, events, dropped := s.watcher.Stats()


### PR DESCRIPTION
## What

Implements S7 of #2149: three operational modes for the archigraph daemon that let users select a resource / feature tradeoff at install time or at runtime.

## Why

The open-source default (workstation mode) runs eager algo passes and allows MiniLM embeddings — too heavy for many first-time installs. Background mode gives a safe low-footprint default; readonly mode enables use-cases where indexing is unwanted.

## Changes

**New package** `internal/daemon/mode`:
- `Mode` enum (`background` / `workstation` / `readonly`)
- `ModeDefaults(m)` → env-var preset map
- `ApplyDefaults(m)` → sets unset env vars; explicit env always wins
- `Config` / `LoadConfig` / `SaveConfig` → `~/.archigraph/daemon.config.json`

**New CLI** `archigraph mode <m>`:
- Persists chosen mode to `daemon.config.json`
- Stops + starts the daemon so new defaults take effect immediately

**`archigraph install --mode=<m>`**:
- Defaults to `background` (low-footprint open-source default)
- Saves mode to `daemon.config.json` before the OS service is registered

**`archigraph daemon --mode=<m>`**:
- Reads `daemon.config.json` on boot (flag overrides file)
- Calls `mode.ApplyDefaults` before any flag parsing that reads the same env vars

**`archigraph status`**:
- Shows `mode: background` (or workstation/readonly) in the daemon header

**`proto.StatusReply`**:
- New `daemon_mode` field (omitempty; old clients ignore it)

## Tests

- 8 unit tests in `internal/daemon/mode/mode_test.go`
- 4 CLI-level tests in `internal/cli/mode_test.go`
- All pass; `go build ./...` clean

## Env-var defaults

| Mode | Var | Default |
|------|-----|---------|
| background | `ARCHIGRAPH_EAGER_ALGO` | `false` |
| background | `ARCHIGRAPH_EMBEDDING_URL` | `` (empty) |
| background | `ARCHIGRAPH_HEAP_MAX_PCT` | `60` |
| workstation | `ARCHIGRAPH_EAGER_ALGO` | `true` |
| workstation | `ARCHIGRAPH_HEAP_MAX_PCT` | `80` |
| readonly | `ARCHIGRAPH_DISABLE_WATCHER` | `true` |
| readonly | `ARCHIGRAPH_DISABLE_REBUILD` | `true` |
| readonly | `ARCHIGRAPH_DISABLE_ALGO` | `true` |

Explicit env vars always override mode defaults.

Closes #2157
Refs #2149