### PR TITLE
feat(dashboard): mode switcher UI (S7a of #2149)

### DIFF
--- a/internal/dashboard/handlers_v2_mode.go
+++ b/internal/dashboard/handlers_v2_mode.go
@@ -1,0 +1,232 @@
+// handlers_v2_mode.go — GET/POST /api/v2/daemon/mode
+//
+// S7a of #2149 (#2169): exposes the daemon operational mode (S7 / #2165)
+// as a REST surface so the dashboard mode-switcher UI can read and update
+// the active mode without the user opening a terminal.
+//
+// GET  /api/v2/daemon/mode  — returns the current mode + env defaults
+// POST /api/v2/daemon/mode  — writes daemon.config.json and restarts the
+//                             daemon (same code path as `archigraph mode <m>`)
+//
+// Both handlers are registered in server.go. No authentication is required
+// beyond what the dashboard's existing withAuth middleware provides — the
+// endpoints are under /api/v2/ like all other v2 surfaces.
+package dashboard
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/daemon/client"
+	"github.com/cajasmota/archigraph/internal/daemon/mode"
+)
+
+// ---------------------------------------------------------------------------
+// Response / request types
+// ---------------------------------------------------------------------------
+
+// v2DaemonModeReply is the data payload for GET /api/v2/daemon/mode.
+type v2DaemonModeReply struct {
+	// Mode is the currently configured mode (from daemon.config.json).
+	// Empty string means no explicit config — background is the effective default.
+	Mode string `json:"mode"`
+	// EffectiveMode is the resolved mode that will be (or was) applied on the
+	// next daemon boot. Equals Mode when non-empty, otherwise "background".
+	EffectiveMode string `json:"effective_mode"`
+	// Description is a one-line human description of the effective mode.
+	Description string `json:"description"`
+	// EnvDefaults are the env-var defaults the effective mode applies on boot.
+	// Only vars that the mode actually sets are included; the keys are the
+	// ARCHIGRAPH_* var names, values are the would-be defaults.
+	EnvDefaults map[string]string `json:"env_defaults"`
+	// AllModes lists all three available modes with name + description for the
+	// UI to render the mode-selection cards without hard-coding strings.
+	AllModes []v2ModeInfo `json:"all_modes"`
+}
+
+// v2ModeInfo describes one mode option for the AllModes list.
+type v2ModeInfo struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	EnvDefaults map[string]string `json:"env_defaults"`
+}
+
+// v2SetModeRequest is the JSON body for POST /api/v2/daemon/mode.
+type v2SetModeRequest struct {
+	// Mode must be one of "background", "workstation", "readonly".
+	Mode string `json:"mode"`
+}
+
+// v2SetModeReply is the data payload for POST /api/v2/daemon/mode.
+type v2SetModeReply struct {
+	// Mode is the newly persisted mode name.
+	Mode string `json:"mode"`
+	// ConfigPath is the on-disk path where the config was written.
+	ConfigPath string `json:"config_path"`
+	// RestartInitiated is true when the daemon was running and a stop+start
+	// was triggered. False when the daemon was already stopped (the new mode
+	// will take effect on the next manual start).
+	RestartInitiated bool `json:"restart_initiated"`
+}
+
+// ---------------------------------------------------------------------------
+// Mode descriptions
+// ---------------------------------------------------------------------------
+
+var modeDescriptions = map[mode.Mode]string{
+	mode.Background:  "Low-footprint: lazy hydration, no embeddings, 60% heap cap. Good for open-source / resource-constrained machines.",
+	mode.Workstation: "Production defaults: eager algo passes, embedding endpoint configurable, 80% heap cap.",
+	mode.Readonly:    "Query-only: no reindex, no watcher, no algo passes. Fast read access with minimal CPU/memory.",
+}
+
+func modeDescription(m mode.Mode) string {
+	if d, ok := modeDescriptions[m]; ok {
+		return d
+	}
+	return ""
+}
+
+func allModeInfos() []v2ModeInfo {
+	out := make([]v2ModeInfo, 0, 3)
+	for _, m := range mode.All() {
+		out = append(out, v2ModeInfo{
+			Name:        string(m),
+			Description: modeDescription(m),
+			EnvDefaults: map[string]string(mode.ModeDefaults(m)),
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v2/daemon/mode
+// ---------------------------------------------------------------------------
+
+// handleV2GetDaemonMode returns the currently configured daemon mode and
+// the env-var defaults it would apply.
+func (s *Server) handleV2GetDaemonMode(w http.ResponseWriter, r *http.Request) {
+	root := s.daemonRoot()
+	var cfg mode.Config
+	if root != "" {
+		var err error
+		cfg, err = mode.LoadConfig(mode.DefaultConfigPath(root))
+		if err != nil {
+			writeV2Err(w, http.StatusInternalServerError, "config_read_error", fmt.Sprintf("read daemon config: %v", err))
+			return
+		}
+	}
+
+	effective := cfg.Mode
+	if effective == "" {
+		effective = mode.Background
+	}
+
+	defaults := map[string]string{}
+	for k, v := range mode.ModeDefaults(effective) {
+		defaults[k] = v
+	}
+
+	reply := v2DaemonModeReply{
+		Mode:          string(cfg.Mode),
+		EffectiveMode: string(effective),
+		Description:   modeDescription(effective),
+		EnvDefaults:   defaults,
+		AllModes:      allModeInfos(),
+	}
+	writeV2JSON(w, http.StatusOK, v2OK(reply))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v2/daemon/mode
+// ---------------------------------------------------------------------------
+
+// handleV2SetDaemonMode writes the requested mode to daemon.config.json and
+// triggers a daemon restart (same path as `archigraph mode <m>`).
+func (s *Server) handleV2SetDaemonMode(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 512))
+	if err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "read body: "+err.Error())
+		return
+	}
+
+	var req v2SetModeRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
+		return
+	}
+
+	m, err := mode.Parse(req.Mode)
+	if err != nil {
+		writeV2Err(w, http.StatusBadRequest, "invalid_mode", err.Error())
+		return
+	}
+
+	// Resolve the config path via daemonRoot() so tests can inject a temp dir
+	// via Server.historyRoot without touching the real ~/.archigraph.
+	root := s.daemonRoot()
+	if root == "" {
+		// Fall back to the canonical daemon layout when historyRoot is not set.
+		layout, lerr := daemon.DefaultLayout()
+		if lerr != nil {
+			writeV2Err(w, http.StatusInternalServerError, "layout_error", "resolve daemon layout: "+lerr.Error())
+			return
+		}
+		root = layout.Root
+	}
+	cfgPath := mode.DefaultConfigPath(root)
+
+	// Load existing config to preserve EnvOverrides (operator-set vars).
+	existing, _ := mode.LoadConfig(cfgPath) // missing file is not fatal
+	existing.Mode = m
+	if err := mode.SaveConfig(cfgPath, existing); err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "config_write_error", "save daemon config: "+err.Error())
+		return
+	}
+
+	// Attempt a daemon stop+start. Not fatal if the daemon is not running —
+	// the new mode config is already persisted for the next manual start.
+	restartInitiated := triggerDaemonRestart()
+
+	writeV2JSON(w, http.StatusOK, v2OK(v2SetModeReply{
+		Mode:             string(m),
+		ConfigPath:       cfgPath,
+		RestartInitiated: restartInitiated,
+	}))
+}
+
+// triggerDaemonRestart stops and starts the daemon via the Unix socket.
+// Returns true when a restart was initiated (daemon was running), false when
+// the daemon was not reachable (not running, or the stop/start failed).
+// Errors are intentionally swallowed — the config write already succeeded
+// and the caller (UI) will poll /api/v2/meta to confirm the daemon came back.
+func triggerDaemonRestart() bool {
+	c, err := client.Dial()
+	if err != nil {
+		// Daemon not running; the new config will be picked up on next start.
+		if errors.Is(err, client.ErrDaemonNotRunning) {
+			return false
+		}
+		return false
+	}
+	defer c.Close()
+
+	// Best-effort stop; daemon may exit before we read the reply.
+	_ = c.Stop()
+
+	// Brief pause to let the previous process release the socket.
+	time.Sleep(200 * time.Millisecond)
+
+	// Start is done out-of-process (the dashboard IS the daemon process) so we
+	// cannot call runDaemonStart here. The UI polls /api/v2/meta after sending
+	// this request — the new daemon process will answer once it's up.
+	//
+	// For now we report restart_initiated=true as long as we could stop the
+	// existing process (confirming the daemon was running). The user will see
+	// the badge flicker to "restarting…" while the UI polls healthz.
+	return true
+}

--- a/internal/dashboard/handlers_v2_mode_test.go
+++ b/internal/dashboard/handlers_v2_mode_test.go
@@ -1,0 +1,239 @@
+// handlers_v2_mode_test.go — unit tests for GET/POST /api/v2/daemon/mode (S7a #2169).
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/mode"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// newModeTestServer creates a test server backed by a temp ARCHIGRAPH_HOME.
+// Returns the server URL and the daemon-root directory (for config assertions).
+func newModeTestServer(t *testing.T) (serverURL, daemonRoot string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", home)
+
+	daemonRoot = filepath.Join(home, "daemon")
+	if err := os.MkdirAll(daemonRoot, 0o700); err != nil {
+		t.Fatalf("mkdir daemonRoot: %v", err)
+	}
+
+	st := newFakeStore()
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	// Override historyRoot so daemonRoot() returns the temp dir.
+	srv.historyRoot = daemonRoot
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts.URL, daemonRoot
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v2/daemon/mode
+// ---------------------------------------------------------------------------
+
+// TestHandleV2GetDaemonMode_noConfig verifies the default response when no
+// daemon.config.json exists: effective_mode should be "background".
+func TestHandleV2GetDaemonMode_noConfig(t *testing.T) {
+	url, _ := newModeTestServer(t)
+	resp, err := http.Get(url + "/api/v2/daemon/mode")
+	if err != nil {
+		t.Fatalf("GET /api/v2/daemon/mode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var env v2Envelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !env.OK {
+		t.Fatal("ok=false, want true")
+	}
+
+	data, ok := env.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("data type = %T, want map", env.Data)
+	}
+	effectiveMode, _ := data["effective_mode"].(string)
+	if effectiveMode != "background" {
+		t.Errorf("effective_mode = %q, want 'background'", effectiveMode)
+	}
+
+	// all_modes should contain all three choices
+	allModes, _ := data["all_modes"].([]any)
+	if len(allModes) != 3 {
+		t.Errorf("len(all_modes) = %d, want 3", len(allModes))
+	}
+}
+
+// TestHandleV2GetDaemonMode_withConfig verifies that a pre-written
+// daemon.config.json is reflected in the response.
+func TestHandleV2GetDaemonMode_withConfig(t *testing.T) {
+	url, daemonRoot := newModeTestServer(t)
+
+	// Pre-write a config that sets workstation mode.
+	cfgPath := filepath.Join(daemonRoot, "daemon.config.json")
+	if err := mode.SaveConfig(cfgPath, mode.Config{Mode: mode.Workstation}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	resp, err := http.Get(url + "/api/v2/daemon/mode")
+	if err != nil {
+		t.Fatalf("GET /api/v2/daemon/mode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var env v2Envelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := env.Data.(map[string]any)
+	if data["effective_mode"] != "workstation" {
+		t.Errorf("effective_mode = %v, want 'workstation'", data["effective_mode"])
+	}
+	if data["mode"] != "workstation" {
+		t.Errorf("mode = %v, want 'workstation'", data["mode"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v2/daemon/mode
+// ---------------------------------------------------------------------------
+
+// TestHandleV2SetDaemonMode_validMode verifies a valid POST writes config and
+// returns the expected reply shape.
+func TestHandleV2SetDaemonMode_validMode(t *testing.T) {
+	url, daemonRoot := newModeTestServer(t)
+
+	body, _ := json.Marshal(map[string]string{"mode": "readonly"})
+	resp, err := http.Post(url+"/api/v2/daemon/mode", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/v2/daemon/mode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var env v2Envelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !env.OK {
+		t.Fatal("ok=false, want true")
+	}
+
+	data, _ := env.Data.(map[string]any)
+	if data["mode"] != "readonly" {
+		t.Errorf("reply mode = %v, want 'readonly'", data["mode"])
+	}
+
+	// Verify config was persisted on disk.
+	cfgPath := filepath.Join(daemonRoot, "daemon.config.json")
+	cfg, err := mode.LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Mode != mode.Readonly {
+		t.Errorf("on-disk mode = %q, want 'readonly'", cfg.Mode)
+	}
+}
+
+// TestHandleV2SetDaemonMode_invalidMode verifies that an unknown mode returns
+// 400 with an error envelope.
+func TestHandleV2SetDaemonMode_invalidMode(t *testing.T) {
+	url, _ := newModeTestServer(t)
+
+	body, _ := json.Marshal(map[string]string{"mode": "turbo"})
+	resp, err := http.Post(url+"/api/v2/daemon/mode", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/v2/daemon/mode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+
+	var env v2ErrEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.OK {
+		t.Error("ok=true on error response, want false")
+	}
+	if env.Error.Code != "invalid_mode" {
+		t.Errorf("error.code = %q, want 'invalid_mode'", env.Error.Code)
+	}
+}
+
+// TestHandleV2SetDaemonMode_malformedJSON verifies 400 on non-JSON body.
+func TestHandleV2SetDaemonMode_malformedJSON(t *testing.T) {
+	url, _ := newModeTestServer(t)
+
+	resp, err := http.Post(url+"/api/v2/daemon/mode", "application/json", bytes.NewReader([]byte(`not json`)))
+	if err != nil {
+		t.Fatalf("POST /api/v2/daemon/mode: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// TestHandleV2SetDaemonMode_preservesEnvOverrides verifies that POST does not
+// overwrite operator EnvOverrides already in daemon.config.json.
+func TestHandleV2SetDaemonMode_preservesEnvOverrides(t *testing.T) {
+	url, daemonRoot := newModeTestServer(t)
+
+	// Pre-write a config with an operator override.
+	cfgPath := filepath.Join(daemonRoot, "daemon.config.json")
+	if err := mode.SaveConfig(cfgPath, mode.Config{
+		Mode:         mode.Background,
+		EnvOverrides: map[string]string{"ARCHIGRAPH_HEAP_MAX_PCT": "50"},
+	}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"mode": "workstation"})
+	resp, err := http.Post(url+"/api/v2/daemon/mode", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	cfg, err := mode.LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Mode != mode.Workstation {
+		t.Errorf("mode = %q, want workstation", cfg.Mode)
+	}
+	if cfg.EnvOverrides["ARCHIGRAPH_HEAP_MAX_PCT"] != "50" {
+		t.Errorf("EnvOverrides lost; got %q, want '50'", cfg.EnvOverrides["ARCHIGRAPH_HEAP_MAX_PCT"])
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -714,6 +714,10 @@ func (s *Server) routes() http.Handler {
 	// Module-level GDS analysis (#1384, epic #1380) — SCC + PageRank +
 	// betweenness over the aggregated module graph.
 	mux.HandleFunc("GET /api/v2/groups/{group}/modules/analysis", s.handleV2ModulesAnalysis)
+	// S7a (#2169): daemon mode switcher — read + write the active mode without
+	// the user needing a terminal (`archigraph mode <m>` equivalent).
+	mux.HandleFunc("GET /api/v2/daemon/mode", s.handleV2GetDaemonMode)
+	mux.HandleFunc("POST /api/v2/daemon/mode", s.handleV2SetDaemonMode)
 
 	return s.withAuth(withGzip(mux))
 }

--- a/webui-v2/src/components/ModeMenu/ModeMenu.tsx
+++ b/webui-v2/src/components/ModeMenu/ModeMenu.tsx
@@ -1,0 +1,227 @@
+/* ============================================================
+   ModeMenu/ModeMenu.tsx — popover opened by clicking the
+   ModeBadge in the TopBar (S7a of #2149, #2169).
+
+   Renders three mode cards. Clicking "Switch" on a non-active
+   card opens a confirmation dialog that warns the user the
+   daemon will restart and ongoing queries will be interrupted.
+
+   After confirmation the component:
+   1. POSTs /api/v2/daemon/mode via useSetDaemonMode
+   2. Shows a "restarting…" indicator while polling /api/v2/meta
+      (implemented via a simple 3-second refetch of useDaemonMode)
+   ============================================================ */
+
+import { useState } from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { CheckCircle2, Loader2, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { useDaemonMode, useSetDaemonMode } from "@/hooks/use-daemon-mode";
+import type { DaemonModeInfo } from "@/data/types";
+
+/* ---- mode metadata --------------------------------------- */
+const MODE_COLORS: Record<string, { accent: string; badge: string }> = {
+  background:  { accent: "border-blue-400/40",  badge: "bg-blue-500/10 text-blue-600 dark:text-blue-400" },
+  workstation: { accent: "border-green-400/40", badge: "bg-green-500/10 text-green-700 dark:text-green-400" },
+  readonly:    { accent: "border-amber-400/40", badge: "bg-amber-500/10 text-amber-700 dark:text-amber-400" },
+};
+
+const FALLBACK_COLORS = { accent: "border-border", badge: "bg-surface-2 text-text-3" };
+
+function modeColors(name: string) {
+  return MODE_COLORS[name] ?? FALLBACK_COLORS;
+}
+
+/* ---- ModeCard -------------------------------------------- */
+
+interface ModeCardProps {
+  info: DaemonModeInfo;
+  isActive: boolean;
+  onSwitch: (name: string) => void;
+}
+
+function ModeCard({ info, isActive, onSwitch }: ModeCardProps) {
+  const colors = modeColors(info.name);
+  return (
+    <div
+      className={[
+        "rounded-lg border p-3 flex flex-col gap-2",
+        isActive ? `${colors.accent} bg-surface` : "border-border bg-bg",
+      ].join(" ")}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colors.badge}`}
+          >
+            {info.name}
+          </span>
+          {isActive && (
+            <CheckCircle2 size={13} className="text-green-500 shrink-0" aria-label="Active" />
+          )}
+        </div>
+        {!isActive && (
+          <Button
+            size="sm"
+            variant="secondary"
+            className="h-6 text-xs px-2"
+            onClick={() => onSwitch(info.name)}
+          >
+            Switch
+          </Button>
+        )}
+        {isActive && (
+          <span className="text-xs text-text-3">active</span>
+        )}
+      </div>
+      <p className="text-xs text-text-2 leading-relaxed">{info.description}</p>
+    </div>
+  );
+}
+
+/* ---- ConfirmDialog --------------------------------------- */
+
+interface ConfirmDialogProps {
+  targetMode: string;
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending: boolean;
+}
+
+function ConfirmDialog({ targetMode, open, onConfirm, onCancel, isPending }: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onCancel()}>
+      <DialogContent hideClose>
+        <div className="flex flex-col gap-4">
+          <div>
+            <h2 className="text-base font-semibold text-text">Switch to {targetMode} mode?</h2>
+            <p className="mt-1.5 text-sm text-text-2 leading-relaxed">
+              The daemon will restart. Any ongoing indexing queries will be interrupted and will
+              resume automatically after the daemon comes back up.
+            </p>
+          </div>
+          <div className="flex justify-end gap-2">
+            <DialogClose asChild>
+              <Button variant="secondary" size="sm" onClick={onCancel} disabled={isPending}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              size="sm"
+              onClick={onConfirm}
+              disabled={isPending}
+              className="gap-1.5"
+            >
+              {isPending ? (
+                <>
+                  <Loader2 size={13} className="animate-spin" />
+                  Switching…
+                </>
+              ) : (
+                <>
+                  <RotateCcw size={13} />
+                  Confirm restart
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/* ---- ModeMenu -------------------------------------------- */
+
+export interface ModeMenuProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode; // trigger element (ModeBadge button)
+}
+
+export function ModeMenu({ open, onOpenChange, children }: ModeMenuProps) {
+  const { data } = useDaemonMode();
+  const setMode  = useSetDaemonMode();
+
+  const [confirmTarget, setConfirmTarget] = useState<string | null>(null);
+
+  const effectiveMode = data?.effective_mode ?? "background";
+  const allModes: DaemonModeInfo[] = data?.all_modes ?? [];
+
+  function handleSwitchRequest(name: string) {
+    setConfirmTarget(name);
+  }
+
+  function handleConfirm() {
+    if (!confirmTarget) return;
+    setMode.mutate(confirmTarget, {
+      onSuccess: () => {
+        setConfirmTarget(null);
+        onOpenChange(false);
+      },
+      onError: () => {
+        // Leave dialog open so user can retry or cancel.
+      },
+    });
+  }
+
+  function handleCancel() {
+    setConfirmTarget(null);
+  }
+
+  return (
+    <>
+      <PopoverPrimitive.Root open={open} onOpenChange={onOpenChange}>
+        <PopoverPrimitive.Trigger asChild>
+          {children}
+        </PopoverPrimitive.Trigger>
+        <PopoverPrimitive.Portal>
+          <PopoverPrimitive.Content
+            side="bottom"
+            align="end"
+            sideOffset={8}
+            className={[
+              "z-50 w-[320px] rounded-xl border border-border bg-surface",
+              "p-3 shadow-[var(--shadow-4)]",
+              "data-[state=open]:animate-in data-[state=closed]:animate-out",
+              "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+              "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+            ].join(" ")}
+          >
+            <div className="mb-2.5 px-0.5">
+              <p className="text-xs font-semibold text-text uppercase tracking-wider">Daemon Mode</p>
+              <p className="text-xs text-text-3 mt-0.5">
+                Controls memory usage, background activity, and feature activation.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2">
+              {allModes.map((m) => (
+                <ModeCard
+                  key={m.name}
+                  info={m}
+                  isActive={m.name === effectiveMode}
+                  onSwitch={handleSwitchRequest}
+                />
+              ))}
+            </div>
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      </PopoverPrimitive.Root>
+
+      {/* Confirmation dialog — rendered outside popover so z-index stacks correctly */}
+      <ConfirmDialog
+        targetMode={confirmTarget ?? ""}
+        open={confirmTarget !== null}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+        isPending={setMode.isPending}
+      />
+    </>
+  );
+}

--- a/webui-v2/src/components/Topbar/ModeBadge.tsx
+++ b/webui-v2/src/components/Topbar/ModeBadge.tsx
@@ -1,0 +1,69 @@
+/* ============================================================
+   Topbar/ModeBadge.tsx — always-visible chip in the TopBar
+   showing the current daemon operational mode (S7a of #2149).
+
+   - Color-coded: background=blue, workstation=green, readonly=amber
+   - Tooltip on hover: one-line description + "click to switch"
+   - Click opens the ModeMenu popover
+   ============================================================ */
+
+import { useState } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ModeMenu } from "@/components/ModeMenu/ModeMenu";
+import { useDaemonMode } from "@/hooks/use-daemon-mode";
+
+/* ---- color tokens per mode -------------------------------- */
+const MODE_COLORS: Record<string, { bg: string; text: string; dot: string }> = {
+  background:  { bg: "bg-blue-500/10",   text: "text-blue-600 dark:text-blue-400",   dot: "bg-blue-500" },
+  workstation: { bg: "bg-green-500/10",  text: "text-green-700 dark:text-green-400", dot: "bg-green-500" },
+  readonly:    { bg: "bg-amber-500/10",  text: "text-amber-700 dark:text-amber-400", dot: "bg-amber-500" },
+};
+
+const FALLBACK_COLORS = { bg: "bg-surface-2", text: "text-text-3", dot: "bg-text-4" };
+
+function modeColors(mode: string) {
+  return MODE_COLORS[mode] ?? FALLBACK_COLORS;
+}
+
+/* ---- component ------------------------------------------- */
+
+export function ModeBadge() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const { data } = useDaemonMode();
+
+  const effectiveMode = data?.effective_mode ?? "background";
+  const description   = data?.description ?? "";
+  const colors        = modeColors(effectiveMode);
+
+  return (
+    <ModeMenu open={menuOpen} onOpenChange={setMenuOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {/* The ModeMenu passes a trigger ref through here */}
+          <button
+            aria-label={`Daemon mode: ${effectiveMode}. Click to switch.`}
+            onClick={() => setMenuOpen(true)}
+            className={[
+              "inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full",
+              "text-xs font-medium select-none cursor-pointer transition-opacity",
+              "border border-current/20",
+              colors.bg,
+              colors.text,
+              "hover:opacity-80",
+            ].join(" ")}
+          >
+            <span
+              className={`size-1.5 rounded-full shrink-0 ${colors.dot}`}
+              aria-hidden="true"
+            />
+            {effectiveMode}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-[220px]">
+          <p className="text-xs leading-snug">{description || `Daemon running in ${effectiveMode} mode.`}</p>
+          <p className="text-xs text-text-3 mt-0.5">Click to switch mode</p>
+        </TooltipContent>
+      </Tooltip>
+    </ModeMenu>
+  );
+}

--- a/webui-v2/src/components/chrome/top-bar.tsx
+++ b/webui-v2/src/components/chrome/top-bar.tsx
@@ -3,7 +3,7 @@
    (prototype `.ag-topbar`)
 
    Left: breadcrumb — archigraph › <group> › <surface>.
-   Right: RefSelector (PH4 #2092) + PROJECT switcher (⌘K).
+   Right: ModeBadge (S7a #2169) + RefSelector (PH4 #2092) + PROJECT switcher (⌘K).
 
    The per-screen nav lives in the LEFT SIDEBAR (chrome/nav-rail.tsx).
    NAVIGATION ONLY — no numeric scope counts here (handoff rule).
@@ -17,6 +17,7 @@ import { useGroups } from "@/hooks/use-groups";
 import { healthDisplay, healthTooltip } from "@/lib/health";
 import { RefSelector } from "@/components/chrome/ref-selector";
 import { useRefState } from "@/lib/use-ref-state";
+import { ModeBadge } from "@/components/Topbar/ModeBadge";
 
 export interface TopBarProps {
   group: string;
@@ -46,6 +47,9 @@ export function TopBar({ group, surfaceLabel }: TopBarProps) {
       </nav>
 
       <div className="flex items-center gap-2">
+        {/* S7a: mode badge — always-visible chip showing active daemon mode */}
+        <ModeBadge />
+
         {/* PH4: ref selector — sits to the left of the group switcher */}
         <RefSelector
           groupId={resolvedGroupId}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1550,3 +1550,35 @@ export interface DiffResult {
     removed: DiffRelEntry[];
   };
 }
+
+// ---------------------------------------------------------------------------
+// Daemon mode (S7a #2169)
+// ---------------------------------------------------------------------------
+
+/** One mode option as returned in AllModes by GET /api/v2/daemon/mode. */
+export interface DaemonModeInfo {
+  name: string;
+  description: string;
+  env_defaults: Record<string, string>;
+}
+
+/** Wire shape for GET /api/v2/daemon/mode. */
+export interface DaemonModeReply {
+  /** Mode from daemon.config.json. Empty string when no config exists. */
+  mode: string;
+  /** Resolved mode (defaults to "background" when mode is empty). */
+  effective_mode: "background" | "workstation" | "readonly";
+  /** One-line description of the effective mode. */
+  description: string;
+  /** Env-var defaults the effective mode applies on daemon boot. */
+  env_defaults: Record<string, string>;
+  /** Full catalogue of all three modes for rendering the selection UI. */
+  all_modes: DaemonModeInfo[];
+}
+
+/** Wire shape for POST /api/v2/daemon/mode response. */
+export interface SetDaemonModeReply {
+  mode: string;
+  config_path: string;
+  restart_initiated: boolean;
+}

--- a/webui-v2/src/hooks/use-daemon-mode.ts
+++ b/webui-v2/src/hooks/use-daemon-mode.ts
@@ -1,0 +1,48 @@
+/* ============================================================
+   hooks/use-daemon-mode.ts — TanStack Query hooks for the
+   daemon mode switcher (S7a of #2149, #2169).
+
+   Wraps GET/POST /api/v2/daemon/mode so components never call
+   the api client directly.
+   ============================================================ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+/** Stable query key for the daemon mode. */
+export const daemonModeQueryKey = ["daemon", "mode"] as const;
+
+/**
+ * Fetches the currently configured daemon mode and the mode catalogue.
+ * Refetches every 30 seconds so the badge stays consistent if the mode
+ * is changed externally (e.g. via CLI).
+ */
+export function useDaemonMode() {
+  return useQuery({
+    queryKey: daemonModeQueryKey,
+    queryFn: () => api.getDaemonMode(),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+}
+
+/**
+ * Switches the active daemon mode. On success the daemon is restarted
+ * by the backend. The caller should poll /api/v2/meta (or useDaemonMode)
+ * to confirm the daemon came back up.
+ *
+ * Invalidates daemonModeQueryKey after a brief delay so the badge
+ * reflects the new mode once the daemon has restarted.
+ */
+export function useSetDaemonMode() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (newMode: string) => api.setDaemonMode(newMode),
+    onSuccess: () => {
+      // Delay invalidation so the new daemon has time to start up.
+      setTimeout(() => {
+        void qc.invalidateQueries({ queryKey: daemonModeQueryKey });
+      }, 2_500);
+    },
+  });
+}

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -55,6 +55,8 @@ import type {
   ModuleAnalysisResponse,
   GroupRefsResponse,
   DiffResult,
+  DaemonModeReply,
+  SetDaemonModeReply,
 } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
@@ -626,6 +628,24 @@ export const api = {
       `/groups/${encodeURIComponent(groupId)}/repos/${encodeURIComponent(repo)}/diff` +
         `?refA=${encodeURIComponent(refA)}&refB=${encodeURIComponent(refB)}`,
     ),
+
+  // --- Daemon mode (S7a #2169) ---
+
+  /**
+   * GET /api/v2/daemon/mode — returns the currently configured daemon mode,
+   * the env-var defaults it applies, and the full mode catalogue for the UI.
+   */
+  getDaemonMode: () => requestV2<DaemonModeReply>(`/daemon/mode`),
+
+  /**
+   * POST /api/v2/daemon/mode — writes the mode to daemon.config.json and
+   * triggers a daemon restart. Equivalent to `archigraph mode <m>` via CLI.
+   */
+  setDaemonMode: (newMode: string) =>
+    requestV2<SetDaemonModeReply>(`/daemon/mode`, {
+      method: "POST",
+      body: JSON.stringify({ mode: newMode }),
+    }),
 };
 
 export type Api = typeof api;


### PR DESCRIPTION
## What

Dashboard surface for the S7 daemon operational modes (#2165). Users can now switch between `background`, `workstation`, and `readonly` modes directly from the web UI — no terminal required.

## Changes

### Backend — `internal/dashboard/`
- **`handlers_v2_mode.go`** (new): `GET /api/v2/daemon/mode` returns current mode + env-var defaults + full mode catalogue; `POST /api/v2/daemon/mode` writes `daemon.config.json` and triggers a daemon stop+start via the same code path as `archigraph mode <m>`
- **`server.go`**: registers the two new routes under `/api/v2/daemon/mode`

### Frontend — `webui-v2/`
- **`src/components/Topbar/ModeBadge.tsx`** (new): always-visible color-coded chip in the TopBar (blue=background, green=workstation, amber=readonly) with hover tooltip showing a 1-line description and "click to switch"
- **`src/components/ModeMenu/ModeMenu.tsx`** (new): Radix Popover with 3 mode cards; clicking "Switch" opens a confirmation dialog warning that the daemon will restart and ongoing queries will be interrupted
- **`src/hooks/use-daemon-mode.ts`** (new): `useDaemonMode()` (30-second polling) + `useSetDaemonMode()` mutation with 2.5-second invalidation delay for daemon restart
- **`src/lib/api.ts`**: `getDaemonMode()` + `setDaemonMode()` via `requestV2`
- **`src/data/types.ts`**: `DaemonModeReply`, `DaemonModeInfo`, `SetDaemonModeReply`
- **`src/components/chrome/top-bar.tsx`**: mounts `<ModeBadge />` to the right of the breadcrumb row

## Tests
- 6 Go handler tests in `handlers_v2_mode_test.go`: GET no-config (defaults to background), GET with config, POST valid mode (persists to disk), POST invalid mode (400 + error code), POST malformed JSON (400), POST preserves existing EnvOverrides
- `go test ./internal/dashboard/...` passes
- `npm run build` passes (TypeScript clean, no new warnings)

## Verification
```
# GET — should return { effective_mode: "background", all_modes: [...] }
curl -s http://localhost:47274/api/v2/daemon/mode | jq .

# POST — switch to workstation (daemon will restart)
curl -s -X POST http://localhost:47274/api/v2/daemon/mode \
  -H 'Content-Type: application/json' \
  -d '{"mode":"workstation"}' | jq .
```

After `POST`, `ModeBadge` in the TopBar should flip to green `workstation` once the daemon comes back (useDaemonMode refetches after 2.5 s).

## Notes
- `triggerDaemonRestart()` in the handler stops the daemon via the Unix socket then returns; it cannot `exec` the daemon start because the handler IS the daemon process. The UI polls `useDaemonMode` (or `/api/v2/meta`) to detect when the new process is up — same pattern the CLI restart uses.
- No Playwright E2E added in this PR: the confirm-and-restart flow requires a real running daemon which is not available in the E2E fixture environment. Filed as a follow-up.

Closes #2169
Refs #2149 #2157