### PR TITLE
fix(daemon): canonicalize path before hashing — prevent case-collision store duplicates (#2086)

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -169,6 +169,7 @@ func Run(ctx context.Context, cfg Config) error {
 		} else {
 			logger.Printf("startup: MigrateToRefStore complete store=%s", storeDir)
 		}
+
 	}
 
 	releasePID, err := AcquirePIDFile(cfg.Layout.PIDPath)
@@ -281,6 +282,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 			// #1456: subscribe repos OFF the critical boot path.
 			if cfg.ReposToWatch != nil {
+				capturedStore := StoreDir()
 				go func() {
 					t0 := time.Now()
 					repos := cfg.ReposToWatch()
@@ -294,6 +296,19 @@ func Run(ctx context.Context, cfg Config) error {
 					}
 					logger.Printf("watcher: subscription complete repos=%d took=%s",
 						len(repos), time.Since(t0).Truncate(time.Millisecond))
+
+					// #2086: now that we have the full repo list, check for
+					// case-collision store dirs produced before canonicalizePath
+					// was introduced. Run here (inside the watcher goroutine)
+					// so ReposToWatch is called exactly once.
+					if capturedStore != "" {
+						if dups := WarnCaseCollisions(capturedStore, repos); len(dups) > 0 {
+							for _, pair := range dups {
+								logger.Printf("store: detected case-collision dup: stale=%s canonical=%s — remove stale dir to avoid confusion (archigraph cleanup --case-merge)",
+									pair[0], pair[1])
+							}
+						}
+					}
 				}()
 			}
 			if cfg.OnWatcherReady != nil {

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -52,16 +52,121 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
+	"unicode/utf8"
 
 	"github.com/cajasmota/archigraph/internal/gitmeta"
 )
 
+// canonicalCache caches (inputPath → canonicalPath) resolutions so that
+// every daemon startup pays the os.ReadDir cost at most once per unique
+// input path. Paths do not change casing during a daemon's lifetime.
+var canonicalCache sync.Map // map[string]string
+
+// canonicalizePath returns the path with the actual on-disk casing of
+// each component. On case-insensitive filesystems (APFS, NTFS) two
+// inputs that differ only in casing refer to the same directory but
+// sha256(path) would produce different hashes. canonicalizePath walks
+// each segment top-down via os.ReadDir and substitutes the real entry
+// name so that "UpVate" and "upvate" both canonicalize to whichever
+// casing the filesystem holds (e.g. "UpVate").
+//
+// If a segment is not found on disk (path may be virtual or not yet
+// created) the input casing is preserved for that segment and all
+// subsequent ones.
+//
+// The result is cached in a sync.Map keyed by the input path. This is
+// safe because path casing never changes while the daemon runs.
+func canonicalizePath(absPath string) string {
+	if absPath == "" {
+		return absPath
+	}
+	// Fast path: already cached.
+	if v, ok := canonicalCache.Load(absPath); ok {
+		return v.(string)
+	}
+
+	// Split into volume (e.g. "C:" on Windows, "" on Unix) + segments.
+	vol := filepath.VolumeName(absPath)
+	rest := absPath[len(vol):]
+
+	// Trim leading separator so Split doesn't produce empty leading element.
+	rest = strings.TrimLeft(rest, string(filepath.Separator))
+	segments := strings.Split(rest, string(filepath.Separator))
+
+	canonical := vol + string(filepath.Separator)
+	for _, seg := range segments {
+		if seg == "" {
+			continue
+		}
+		// Try to find the real on-disk name for this segment.
+		entries, err := os.ReadDir(canonical)
+		if err != nil {
+			// Directory doesn't exist or isn't readable; preserve input
+			// casing for this segment and all remaining segments.
+			canonical = filepath.Join(canonical, seg)
+			continue
+		}
+		found := false
+		for _, e := range entries {
+			if equalFold(e.Name(), seg) {
+				canonical = filepath.Join(canonical, e.Name())
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Segment not present; preserve input casing.
+			canonical = filepath.Join(canonical, seg)
+		}
+	}
+
+	canonicalCache.Store(absPath, canonical)
+	return canonical
+}
+
+// equalFold reports whether a and b are equal under Unicode case-folding.
+// filepath.Match on case-insensitive OSes uses the same folding; we
+// replicate it here to avoid depending on the OS for the comparison.
+func equalFold(a, b string) bool {
+	if len(a) != len(b) {
+		// Fast reject: UTF-8 lengths differ — can't be equal under fold
+		// unless multi-byte fold produces same length, which is not the
+		// case for the ASCII range we care about.  For non-ASCII we fall
+		// through to the rune loop.
+	}
+	for len(a) > 0 && len(b) > 0 {
+		ra, sza := utf8.DecodeRuneInString(a)
+		rb, szb := utf8.DecodeRuneInString(b)
+		if ra != rb {
+			// Try simple ASCII fold first (most common case).
+			if ra >= 'A' && ra <= 'Z' {
+				ra += 'a' - 'A'
+			}
+			if rb >= 'A' && rb <= 'Z' {
+				rb += 'a' - 'A'
+			}
+			if ra != rb {
+				return false
+			}
+		}
+		a = a[sza:]
+		b = b[szb:]
+	}
+	return len(a) == 0 && len(b) == 0
+}
+
 // repoStateHash returns a deterministic, path-safe identifier for a
-// repo path. Callers MUST pass an absolute, lexically-clean path
-// (filepath.Abs + filepath.Clean) so that the same repo always maps
-// to the same hash regardless of how the caller addressed it.
+// repo path. The path is canonicalized via canonicalizePath before
+// hashing so that case variants on case-insensitive filesystems (APFS,
+// NTFS) always produce the same hash — fixing the case-collision store
+// duplicate bug (#2086).
+//
+// Callers MUST pass an absolute, lexically-clean path
+// (filepath.Abs + filepath.Clean).
 func repoStateHash(absRepoPath string) string {
-	sum := sha256.Sum256([]byte(absRepoPath))
+	canonical := canonicalizePath(absRepoPath)
+	sum := sha256.Sum256([]byte(canonical))
 	return hex.EncodeToString(sum[:8]) // 16 hex chars
 }
 
@@ -258,4 +363,87 @@ func findGraphFileInDir(dir string) (path string, modtime int64) {
 func FindGraphFile(repoPath string) (path string, modtime int64) {
 	stateDir := StateDirForRepo(repoPath)
 	return findGraphFileInDir(stateDir)
+}
+
+// WarnCaseCollisions scans the store directory for store slots whose
+// directory name (slug-hash) does not match the hash derived from the
+// canonical fleet repo path. This detects legacy store dirs created
+// before canonicalizePath was introduced (#2086), where a
+// case-variant of the path produced a different hash and a duplicate
+// store slot.
+//
+// repoPaths is the list of repo paths registered in the fleet. For
+// each repo the function computes the current (canonical) slug-hash
+// and compares it to every existing store entry that shares the same
+// base name (repo basename). Mismatches are returned as a list of
+// (stale-dir, canonical-dir) pairs so the caller can log a warning.
+//
+// The function does NOT auto-merge or delete the stale dirs — that
+// is reserved for `archigraph cleanup --case-merge`. Manual cleanup:
+// rm -rf the stale dir and let the daemon reindex.
+//
+// Returns nil when storeDir is empty, doesn't exist, or no collisions
+// are found.
+func WarnCaseCollisions(storeDir string, repoPaths []string) [][2]string {
+	if storeDir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(storeDir)
+	if err != nil {
+		return nil
+	}
+
+	// Build a set of current canonical slugs for fast lookup.
+	canonical := make(map[string]string, len(repoPaths)) // slug → repoPath
+	for _, rp := range repoPaths {
+		if rp == "" {
+			continue
+		}
+		abs, err := filepath.Abs(rp)
+		if err != nil {
+			abs = rp
+		}
+		abs = filepath.Clean(abs)
+		slug := repoSlug(abs)
+		canonical[slug] = abs
+	}
+
+	// For each repo, also find store entries with the same base name but
+	// a different hash (i.e. a hash computed from a case-variant path).
+	// We do this by checking every on-disk entry against the list of known
+	// repos, matching by the base-name prefix.
+	var collisions [][2]string
+	for _, rp := range repoPaths {
+		if rp == "" {
+			continue
+		}
+		abs, err := filepath.Abs(rp)
+		if err != nil {
+			abs = rp
+		}
+		abs = filepath.Clean(abs)
+
+		expectedSlug := repoSlug(abs)
+		base := unsafeSlugChars.ReplaceAllString(filepath.Base(abs), "-")
+		base = strings.Trim(base, "-._")
+		if base == "" {
+			base = "repo"
+		}
+		if len(base) > 48 {
+			base = base[:48]
+		}
+		prefix := base + "-"
+
+		for _, e := range entries {
+			name := e.Name()
+			// Only compare store slots that share the same base-name prefix
+			// but have a different hash suffix.
+			if strings.HasPrefix(name, prefix) && name != expectedSlug {
+				staleDir := filepath.Join(storeDir, name)
+				canonicalDir := filepath.Join(storeDir, expectedSlug)
+				collisions = append(collisions, [2]string{staleDir, canonicalDir})
+			}
+		}
+	}
+	return collisions
 }

--- a/internal/daemon/state_path_canonical_test.go
+++ b/internal/daemon/state_path_canonical_test.go
@@ -1,0 +1,248 @@
+package daemon
+
+// Tests for canonicalizePath + the case-collision fix (#2086).
+//
+// These tests verify that:
+//   - Two inputs that differ only in casing hash to the SAME value when
+//     the on-disk directory exists (case-insensitive FS behaviour).
+//   - The logic still works correctly on case-sensitive paths (canonical
+//     == input when the exact-cased entry is on disk).
+//   - The cache is hit on repeated calls (no additional fs walk).
+//   - A completely missing path preserves the input casing and still
+//     produces a valid (non-panicking, non-empty) hash.
+//   - WarnCaseCollisions detects stale store dirs correctly.
+//
+// All temp directories are created under os.TempDir() — no real project
+// paths are referenced so the tests are safe on any machine.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// clearCanonicalCache evicts all entries from the package-level sync.Map
+// so tests start with a clean slate and don't interfere with each other.
+func clearCanonicalCache() {
+	canonicalCache.Range(func(k, v any) bool {
+		canonicalCache.Delete(k)
+		return true
+	})
+}
+
+// TestCanonicalizePathSameCasing verifies that the canonical path equals
+// the exact on-disk path when casing matches.
+func TestCanonicalizePathSameCasing(t *testing.T) {
+	clearCanonicalCache()
+	dir := t.TempDir() // already the on-disk casing
+	got := canonicalizePath(dir)
+	// canonicalizePath should return the same path (or an equivalent
+	// absolute path) since the casing is already correct.
+	// Use os.SameFile to handle symlinks / trailing sep differences.
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("canonicalized path %q does not exist: %v", got, err)
+	}
+	wantInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("original path %q does not exist: %v", dir, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Errorf("canonicalizePath(%q) = %q, not the same inode", dir, got)
+	}
+}
+
+// TestRepoStateHashCaseVariants is the core regression test for #2086.
+// It creates an actual directory with CamelCase on disk, then hashes
+// the correct-cased path and a lower-cased variant. On a
+// case-insensitive filesystem (APFS on macOS) both must produce the
+// same hash because they refer to the same directory.
+//
+// On a truly case-sensitive filesystem (Linux ext4, some tmpfs) this
+// test is skipped automatically when the two probed paths are
+// physically different inodes.
+func TestRepoStateHashCaseVariants(t *testing.T) {
+	clearCanonicalCache()
+
+	// Create a temp parent and a CamelCase child.
+	parent := t.TempDir()
+	camel := filepath.Join(parent, "CamelCaseDir")
+	if err := os.Mkdir(camel, 0755); err != nil {
+		t.Fatalf("mkdir CamelCaseDir: %v", err)
+	}
+	lower := filepath.Join(parent, "camelcasedir")
+
+	// Probe whether the FS is case-insensitive.
+	_, err := os.Stat(lower)
+	if err != nil {
+		// Lower path doesn't resolve — case-sensitive FS. Skip the
+		// collision assertion but still verify the hash doesn't panic.
+		t.Logf("case-sensitive filesystem detected: skipping collision assertion, verifying no-panic only")
+		h := repoStateHash(camel)
+		if h == "" {
+			t.Fatal("repoStateHash returned empty string")
+		}
+		return
+	}
+
+	// Case-insensitive: both paths must canonicalize to the same on-disk
+	// name and therefore produce the same hash.
+	clearCanonicalCache()
+	hCamel := repoStateHash(camel)
+	clearCanonicalCache()
+	hLower := repoStateHash(lower)
+
+	if hCamel != hLower {
+		t.Errorf("case-insensitive FS: hash mismatch — camel=%s lower=%s want equal", hCamel, hLower)
+	}
+}
+
+// TestRepoStateHashMissingPath verifies that a completely non-existent
+// path does not panic and produces a non-empty, valid hash string.
+func TestRepoStateHashMissingPath(t *testing.T) {
+	clearCanonicalCache()
+	h := repoStateHash("/tmp/nonexistent-archigraph-test-2086/sub/dir")
+	if h == "" {
+		t.Fatal("repoStateHash returned empty string for missing path")
+	}
+	if len(h) != 16 {
+		t.Errorf("expected 16-hex-char hash, got %q (len %d)", h, len(h))
+	}
+	for _, c := range h {
+		if !strings.ContainsRune("0123456789abcdef", c) {
+			t.Errorf("hash %q contains non-hex char %q", h, c)
+		}
+	}
+}
+
+// TestCanonicalizePathCacheHit verifies that after the first call the
+// cache is populated and a subsequent call returns the same value
+// without errors.
+func TestCanonicalizePathCacheHit(t *testing.T) {
+	clearCanonicalCache()
+	dir := t.TempDir()
+
+	first := canonicalizePath(dir)
+	second := canonicalizePath(dir)
+
+	if first != second {
+		t.Errorf("cache hit returned different value: first=%q second=%q", first, second)
+	}
+	// Verify the cache has an entry.
+	_, loaded := canonicalCache.Load(dir)
+	if !loaded {
+		t.Error("expected cache entry after call, found none")
+	}
+}
+
+// TestCanonicalizePathEmpty verifies the empty-string fast-return.
+func TestCanonicalizePathEmpty(t *testing.T) {
+	got := canonicalizePath("")
+	if got != "" {
+		t.Errorf("canonicalizePath(\"\") = %q, want \"\"", got)
+	}
+}
+
+// TestWarnCaseCollisions_DetectsStaleDir verifies that WarnCaseCollisions
+// reports a stale store dir whose hash was computed from a case-variant
+// of the fleet path.
+func TestWarnCaseCollisions_DetectsStaleDir(t *testing.T) {
+	clearCanonicalCache()
+	storeDir := t.TempDir()
+
+	// Simulate: the fleet registers /tmp/.../CamelDir (on-disk casing).
+	parent := t.TempDir()
+	camelDir := filepath.Join(parent, "CamelDir")
+	if err := os.Mkdir(camelDir, 0755); err != nil {
+		t.Fatalf("mkdir CamelDir: %v", err)
+	}
+
+	// Compute what the canonical slug would be.
+	canonicalSlug := repoSlug(canonicalizePath(camelDir))
+
+	// Simulate a stale store entry with the WRONG-casing hash.
+	// We do this by computing the hash of the lower-cased variant directly.
+	lowerVariant := filepath.Join(parent, "cameldir") // wrong casing
+	// We can't call repoSlug on lowerVariant as canonicalizePath will fix
+	// it on case-insensitive FS. Construct the stale slug manually by
+	// hashing the lower-cased path string directly.
+	import_safe_hash := func(p string) string {
+		// Inline sha256 + hex to avoid importing crypto in the test body.
+		// We already import crypto via the package under test; just call
+		// repoStateHash but bypass the cache by using the raw path.
+		// We need a stale slug, so we produce one with a different hash.
+		// Strategy: create a slug from a path that we know differs.
+		return repoSlug(p + "-collision-suffix") // force a different hash
+	}
+	_ = import_safe_hash
+	_ = lowerVariant
+
+	// Simpler: just create a store dir whose name shares the base prefix
+	// but has a different hash suffix (anything != canonicalSlug).
+	base := strings.SplitN(canonicalSlug, "-", -1)
+	basePart := strings.Join(base[:len(base)-1], "-") // everything before last "-<hash>"
+	staleSlug := basePart + "-0000000000000000"        // obviously wrong hash
+	staleDir := filepath.Join(storeDir, staleSlug)
+	if err := os.Mkdir(staleDir, 0755); err != nil {
+		t.Fatalf("mkdir staleDir: %v", err)
+	}
+
+	// Also create the canonical dir so both exist.
+	canonicalDir := filepath.Join(storeDir, canonicalSlug)
+	if err := os.Mkdir(canonicalDir, 0755); err != nil {
+		t.Fatalf("mkdir canonicalDir: %v", err)
+	}
+
+	dups := WarnCaseCollisions(storeDir, []string{camelDir})
+	if len(dups) == 0 {
+		t.Fatalf("expected WarnCaseCollisions to detect stale dir %q, got none", staleSlug)
+	}
+	found := false
+	for _, pair := range dups {
+		if pair[0] == staleDir {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected stale dir %q in collision list, got: %v", staleDir, dups)
+	}
+}
+
+// TestWarnCaseCollisions_NoDuplicates verifies that WarnCaseCollisions
+// returns nil when there are no stale store dirs.
+func TestWarnCaseCollisions_NoDuplicates(t *testing.T) {
+	clearCanonicalCache()
+	storeDir := t.TempDir()
+
+	parent := t.TempDir()
+	camelDir := filepath.Join(parent, "CamelDir")
+	if err := os.Mkdir(camelDir, 0755); err != nil {
+		t.Fatalf("mkdir CamelDir: %v", err)
+	}
+
+	// Create only the canonical store dir.
+	canonicalSlug := repoSlug(camelDir)
+	canonicalDir := filepath.Join(storeDir, canonicalSlug)
+	if err := os.Mkdir(canonicalDir, 0755); err != nil {
+		t.Fatalf("mkdir canonicalDir: %v", err)
+	}
+
+	dups := WarnCaseCollisions(storeDir, []string{camelDir})
+	if len(dups) != 0 {
+		t.Errorf("expected no collisions, got: %v", dups)
+	}
+}
+
+// TestWarnCaseCollisions_EmptyStore verifies no panic on empty / missing store.
+func TestWarnCaseCollisions_EmptyStore(t *testing.T) {
+	dups := WarnCaseCollisions("", []string{"/some/repo"})
+	if dups != nil {
+		t.Errorf("expected nil for empty storeDir, got %v", dups)
+	}
+	dups = WarnCaseCollisions("/tmp/nonexistent-store-archigraph-2086", []string{"/some/repo"})
+	if dups != nil {
+		t.Errorf("expected nil for nonexistent storeDir, got %v", dups)
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `repoStateHash` hashed the path string directly; on APFS (case-insensitive) `/Users/foo/UpVate` and `/Users/foo/upvate` refer to the same directory but produce different sha256 hashes → duplicate store slots.
- **Fix**: `canonicalizePath` walks each path segment via `os.ReadDir`, resolves the real on-disk casing, and caches the result in a `sync.Map`. `repoStateHash` now hashes the canonical path, so casing variants always land in the same store slot.
- **Observability**: On daemon startup (inside the existing watcher goroutine, off the boot critical path) `WarnCaseCollisions` scans the store for stale wrong-casing slots and logs `store: detected case-collision dup: stale=<dir> canonical=<dir>` so users can clean up with `rm -rf` or `archigraph cleanup --case-merge`.

## Changes

| File | Change |
|------|--------|
| `internal/daemon/state_path.go` | `canonicalizePath`, `equalFold`, updated `repoStateHash`, new `WarnCaseCollisions` |
| `internal/daemon/server.go` | Wire `WarnCaseCollisions` inside existing watcher goroutine (single `ReposToWatch()` call) |
| `internal/daemon/state_path_canonical_test.go` | 8 new tests covering case-fold, missing path, cache hit, collision detection |

## Test plan

- [x] `go test ./internal/daemon/...` — all 13 packages green
- [x] `TestRepoStateHashCaseVariants` — on macOS APFS: creates `/tmp/.../CamelCaseDir`, hashes both `CamelCaseDir` and `camelcasedir`, asserts same hash; auto-skips on case-sensitive FS
- [x] `TestWarnCaseCollisions_DetectsStaleDir` — synthetic stale slug detected
- [x] `TestBoot_WatcherSubscriptionDoesNotBlockBind` — passes (collision check runs inside existing goroutine, not a second `ReposToWatch()` call)
- [x] All pre-existing `state_path` and `state_migrate` tests pass without modification

## Backward compatibility

Existing stores created with wrong-casing hashes continue to work: the daemon resolves the canonical hash, finds an empty slot, and reindexes into the correct slot. Stale dirs are warned about but not auto-deleted.

Closes #2086

🤖 Generated with [Claude Code](https://claude.com/claude-code)