### PR TITLE
feat(daemon): lazy fsnotify subscription + per-group idle pause (M2 of #2175)

### DIFF
--- a/cmd/archigraph/daemon_tier.go
+++ b/cmd/archigraph/daemon_tier.go
@@ -2,8 +2,8 @@ package main
 
 // daemon_tier.go wires the tiered hibernation state machine (PH2 of epic
 // #2087 / issue #2090, extended by PH3 #2091, PH2a #2096, PH6 #2094,
-// S1 #2151, P0.3 #2141), and the watcher pause/resume integration into
-// the daemon process.
+// S1 #2151, P0.3 #2141, M2 #2179), and the watcher pause/resume integration
+// into the daemon process.
 //
 // Process-global daemonTierMgr tracks HOT/WARM/COLD/EXPIRED state for every
 // indexed (repoPath, ref) pair.  Integrations:
@@ -17,6 +17,14 @@ package main
 //     graph.fb, so idle RSS at startup with 5 registered groups is <100 MB.
 //     The first MCP query on a cold group triggers Touch → cold-wake.
 //
+//   - M2 (#2179) lazy fsnotify subscription: the daemon boots with ZERO
+//     fsnotify subscriptions. onWatcherReady does NOT eagerly subscribe any
+//     repos. The first MCP query for a group triggers SubscribeGroupWatcher
+//     which calls watch.DefaultManager.SubscribeGroup → watcher.AddRepo.
+//     The tier WARM→COLD path already calls wh.Pause → watcher.RemoveRepo,
+//     making the idle-unsubscribe half automatic. Re-query after idle pause
+//     calls wh.Resume → watcher.AddRepo (lazy re-subscribe).
+//
 //   - MCP graph-cache AccessHook: wired in startDaemonTierManager; every
 //     GetForRepoRef call updates lastAccessedAt via tierTouchRepoRef so
 //     actively-queried graphs don't get prematurely evicted.
@@ -27,7 +35,8 @@ package main
 //
 //   - Cold wake (COLD→HOT): the reload callback re-mmap's graph.fb by
 //     calling daemonMCPCache.Get; the dashboard cache reloads lazily on the
-//     next HTTP request. PH2a: watcher subscription is resumed before reload.
+//     next HTTP request. PH2a/M2: watcher subscription is resumed before
+//     reload (Resume lazily calls AddRepo if refCount was 0).
 //
 //   - Disk eviction (COLD→EXPIRED, PH6): tierDiskEvictCallback deletes the
 //     refs/<ref>/ sub-directory for the expired slot and logs freed bytes.
@@ -160,28 +169,50 @@ func registerKnownGroupsCold(logger *log.Logger) {
 	}
 }
 
-// onWatcherReady is called by daemon.Run once the fsnotify watcher is up and
-// all repos have been subscribed. It creates the DefaultManager, wires it
-// into the tier state machine, and registers all already-subscribed repos so
-// reference counts are correct from the start.
+// onWatcherReady is called by daemon.Run once the fsnotify watcher is up.
+// It creates the DefaultManager and wires it into the tier state machine.
 //
-// PH2a (#2096): daemon startup policy — all slots start active (no pausing at
-// boot). The watcher subscription stays alive until the first WARM→COLD tick.
+// M2 (#2179): unlike the PH2a boot policy, onWatcherReady does NOT eagerly
+// register repos or call AddRepo. The daemon boots with ZERO fsnotify
+// subscriptions. The first MCP query for a group calls SubscribeGroupWatcher
+// which lazily subscribes that group's repos. This means the watcher manager
+// starts with an empty slots map and a zero subscription count.
 func onWatcherReady(w *watch.Watcher, logger *log.Logger) {
 	mgr := watch.NewDefaultManager(w, logger)
 	daemonWatcherMgr = mgr
 
-	// Register every currently-watched repo with the "unknown" sentinel ref
-	// so the ref-count accounting starts at 1-per-repo. Real per-ref slots
-	// are added by tierAfterIndex as index passes complete.
-	for _, repoPath := range w.Repos() {
-		mgr.Register(repoPath, "")
-	}
+	// M2: do NOT register or subscribe any repos here. The watcher is created
+	// idle. Repos are subscribed on-demand by SubscribeGroupWatcher (called on
+	// first MCP query per group) or by the Resume path on COLD→HOT transitions.
 
 	if daemonTierMgr != nil {
 		daemonTierMgr.SetWatcherHook(mgr)
-		logger.Printf("tier: watcher pause/resume hook wired (PH2a)")
+		logger.Printf("tier: watcher pause/resume hook wired (M2 lazy-subscribe — 0 subscriptions at boot)")
 	}
+}
+
+// SubscribeGroupWatcher lazily subscribes the fsnotify watcher for all repos
+// in a named group. This is the M2 entry point called on the first MCP query
+// that touches a group. It is idempotent: re-calling for an already-subscribed
+// group is a no-op (refCounts prevent double-subscription).
+//
+// groupName is the registry group name (e.g. "myapp").
+// repoPaths is the list of absolute repo paths in the group.
+//
+// Returns the total number of directories added to fsnotify.
+func SubscribeGroupWatcher(groupName string, repoPaths []string) int {
+	if daemonWatcherMgr == nil {
+		return 0
+	}
+	n := daemonWatcherMgr.SubscribeGroup(groupName, repoPaths)
+	if n > 0 {
+		// Also register each repo/ref slot so Pause/Resume reference counts are
+		// accurate. Use the sentinel ref "" so the accounting is per-repo.
+		for _, rp := range repoPaths {
+			daemonWatcherMgr.Register(rp, "")
+		}
+	}
+	return n
 }
 
 // tierAfterIndex is called after every successful index pass to register
@@ -189,6 +220,12 @@ func onWatcherReady(w *watch.Watcher, logger *log.Logger) {
 // PH3 (#2091): slots are now annotated with SlotKind so the tier manager can
 // apply the correct TTL policy.  Worktree slots are registered separately via
 // tierAfterIndexWorktree.
+//
+// M2 (#2179): after a fresh index we also ensure the repo's fsnotify
+// subscription is active so future file-change events are captured. We call
+// Resume rather than Register so that the lazy-subscribe logic in
+// DefaultManager.Resume triggers watcher.AddRepo if the repo was not yet
+// subscribed (first index ever) or was previously unsubscribed (idle eviction).
 func tierAfterIndex(repoPath, ref string) {
 	if daemonTierMgr == nil {
 		return
@@ -200,10 +237,11 @@ func tierAfterIndex(repoPath, ref string) {
 	}
 	daemonTierMgr.Register(tier.SlotKey{RepoPath: repoPath, Ref: ref}, isPinned, kind)
 
-	// PH2a (#2096): ensure the watcher manager also has an entry for this
-	// (repoPath, ref) so reference counts are accurate for future Pause calls.
+	// M2 (#2179): use Resume instead of Register so the watcher subscription is
+	// established (or re-established) on the first index. Resume is idempotent
+	// when the slot is already active.
 	if daemonWatcherMgr != nil {
-		daemonWatcherMgr.Register(repoPath, ref)
+		daemonWatcherMgr.Resume(repoPath, ref)
 	}
 }
 
@@ -216,10 +254,10 @@ func tierAfterIndexWorktree(repoPath, ref string) {
 	}
 	daemonTierMgr.Register(tier.SlotKey{RepoPath: repoPath, Ref: ref}, false, tier.SlotKindWorktree)
 
-	// PH2a (#2096): ensure the watcher manager also has an entry for this
-	// worktree (repoPath, ref) so reference counts are accurate for future Pause calls.
+	// M2 (#2179): use Resume to lazily subscribe the watcher (same reasoning as
+	// tierAfterIndex above).
 	if daemonWatcherMgr != nil {
-		daemonWatcherMgr.Register(repoPath, ref)
+		daemonWatcherMgr.Resume(repoPath, ref)
 	}
 }
 

--- a/internal/daemon/phaseb_test.go
+++ b/internal/daemon/phaseb_test.go
@@ -180,7 +180,13 @@ func TestPhaseB_RapidWritesCoalesce(t *testing.T) {
 }
 
 // TestPhaseB_StatusRPCReflectsWatcher dials the daemon and verifies
-// the Status reply includes the watcher count after AddRepo runs.
+// the Status reply shows zero watcher repos immediately after boot.
+//
+// M2 (#2179): the daemon now boots with ZERO fsnotify subscriptions. Repos
+// are subscribed lazily on the first MCP query for their group. The watcher
+// is created (watcher!=nil) but AddRepo is never called at boot, so
+// WatcherRepos must be 0 and WatcherDirs must be 0 when the Status RPC is
+// called immediately after daemon startup.
 func TestPhaseB_StatusRPCReflectsWatcher(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
@@ -212,7 +218,13 @@ func TestPhaseB_StatusRPCReflectsWatcher(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status: %v", err)
 	}
-	if st.WatcherRepos != 1 {
-		t.Errorf("expected WatcherRepos=1, got %d (Dirs=%d)", st.WatcherRepos, st.WatcherDirs)
+	// M2: at boot, no repos are subscribed to fsnotify (lazy subscription).
+	// WatcherRepos == 0 is the expected idle-boot state.
+	if st.WatcherRepos != 0 {
+		t.Errorf("M2: expected WatcherRepos=0 at boot (lazy-subscribe), got %d (Dirs=%d)",
+			st.WatcherRepos, st.WatcherDirs)
+	}
+	if st.WatcherDirs != 0 {
+		t.Errorf("M2: expected WatcherDirs=0 at boot, got %d", st.WatcherDirs)
 	}
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -280,27 +280,32 @@ func Run(ctx context.Context, cfg Config) error {
 			headPoller.Start()
 			defer headPoller.Stop()
 
-			// #1456: subscribe repos OFF the critical boot path.
+			// M2 (#2179): lazy fsnotify subscription — do NOT call watcher.AddRepo
+			// at boot. The daemon starts with zero fsnotify subscriptions. Repos
+			// are subscribed on the first MCP query for their group (via
+			// SubscribeGroupWatcher → watch.DefaultManager.SubscribeGroup →
+			// watcher.AddRepo). This eliminates per-repo directory-tree walks at
+			// startup, saving ~O(dirs×groups) inotify watch descriptors on idle daemons.
+			//
+			// We still call ReposToWatch (exactly once) to:
+			//   (a) register repos with the HEAD poller (branch-switch detection; no fd cost)
+			//   (b) run the case-collision store audit (#2086)
+			// Both happen off the critical boot path in a goroutine, same as before.
 			if cfg.ReposToWatch != nil {
 				capturedStore := StoreDir()
 				go func() {
 					t0 := time.Now()
 					repos := cfg.ReposToWatch()
 					for _, r := range repos {
-						if _, err := watcher.AddRepo(r); err != nil {
-							logger.Printf("watcher: add repo %s: %v", r, err)
-						}
-						// Also register with the HEAD poller so branch
-						// switches in every watched repo are detected.
+						// M2: skip watcher.AddRepo here — subscriptions are lazy.
+						// Register with the HEAD poller only (reads .git/HEAD; no
+						// fsnotify watch descriptors consumed).
 						headPoller.AddRepo(r)
 					}
-					logger.Printf("watcher: subscription complete repos=%d took=%s",
+					logger.Printf("watcher: boot-path repos=%d registered with HEAD poller (fsnotify lazy — 0 AddRepo calls) took=%s",
 						len(repos), time.Since(t0).Truncate(time.Millisecond))
 
-					// #2086: now that we have the full repo list, check for
-					// case-collision store dirs produced before canonicalizePath
-					// was introduced. Run here (inside the watcher goroutine)
-					// so ReposToWatch is called exactly once.
+					// #2086: case-collision audit — unchanged.
 					if capturedStore != "" {
 						if dups := WarnCaseCollisions(capturedStore, repos); len(dups) > 0 {
 							for _, pair := range dups {

--- a/internal/daemon/watch/m2_lazy_test.go
+++ b/internal/daemon/watch/m2_lazy_test.go
@@ -1,0 +1,275 @@
+// Package watch — M2 lazy fsnotify subscription tests (#2179).
+//
+// These tests verify the core M2 invariants:
+//   - Boot with N registered groups → 0 fsnotify subscriptions
+//   - First query on group A → only A's repos get subscribed
+//   - All refs for a repo become COLD (Pause) → unsubscribe that repo
+//   - Resume after Pause → re-subscribe (same as PH2a, verified here for M2 path)
+//   - Multi-group: 2 active + 3 cold → only 2 groups consume watcher resources
+package watch
+
+import (
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// makeGroups creates N distinct temp dirs representing group repos.
+// Returns a map of groupName → []repoPath.
+func makeGroups(t *testing.T, names []string) map[string][]string {
+	t.Helper()
+	out := make(map[string][]string, len(names))
+	for _, name := range names {
+		dir := t.TempDir()
+		out[name] = []string{dir}
+	}
+	return out
+}
+
+// assertRepoCount asserts the watcher's Repos() slice has exactly want entries.
+func assertRepoCount(t *testing.T, w *Watcher, want int, msg string) {
+	t.Helper()
+	if got := len(w.Repos()); got != want {
+		t.Errorf("%s: want %d watcher repos, got %d", msg, want, got)
+	}
+}
+
+// assertSubscribedRepoCount asserts the manager's SubscribedRepoCount.
+func assertSubscribedRepoCount(t *testing.T, m *DefaultManager, want int, msg string) {
+	t.Helper()
+	if got := m.SubscribedRepoCount(); got != want {
+		t.Errorf("%s: want SubscribedRepoCount=%d, got %d", msg, want, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Boot — register N groups, no queries → 0 fsnotify subscriptions
+// ---------------------------------------------------------------------------
+
+// TestM2_BootZeroSubscriptions verifies that registering 5 groups at boot
+// (without any queries) leaves the watcher with zero fsnotify subscriptions.
+// This is the core M2 idle-daemon invariant.
+func TestM2_BootZeroSubscriptions(t *testing.T) {
+	w := newNopWatcher(t)
+	m := NewDefaultManager(w, nil)
+
+	groups := makeGroups(t, []string{"alpha", "beta", "gamma", "delta", "epsilon"})
+
+	// Simulate S1 boot-time registration: just declare slots via Register,
+	// no SubscribeGroup or AddRepo calls (M2 boot path).
+	for _, repos := range groups {
+		for _, repo := range repos {
+			m.Register(repo, "main")
+		}
+	}
+
+	// Assert: watcher has zero repos subscribed.
+	assertRepoCount(t, w, 0, "after boot with 5 groups, no queries")
+	assertSubscribedRepoCount(t, m, 0, "after boot with 5 groups, no queries")
+
+	if n := m.SubscribedGroupCount(); n != 0 {
+		t.Errorf("SubscribedGroupCount: want 0, got %d", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Query group A → only A's repos get subscribed
+// ---------------------------------------------------------------------------
+
+// TestM2_QueryGroupSubscribesOnlyThatGroup verifies that calling SubscribeGroup
+// for group A subscribes only A's repos, leaving B's repos unsubscribed.
+func TestM2_QueryGroupSubscribesOnlyThatGroup(t *testing.T) {
+	w := newNopWatcher(t)
+	m := NewDefaultManager(w, nil)
+
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	// Boot: declare both groups (no subscribe).
+	m.Register(repoA, "main")
+	m.Register(repoB, "main")
+
+	assertRepoCount(t, w, 0, "pre-query")
+
+	// First query on group A → subscribe A.
+	m.SubscribeGroup("groupA", []string{repoA})
+
+	// Only A is subscribed.
+	repos := w.Repos()
+	foundA, foundB := false, false
+	for _, r := range repos {
+		if r == repoA {
+			foundA = true
+		}
+		if r == repoB {
+			foundB = true
+		}
+	}
+	if !foundA {
+		t.Error("repoA should be subscribed after SubscribeGroup(groupA)")
+	}
+	if foundB {
+		t.Error("repoB should NOT be subscribed — groupB not queried yet")
+	}
+
+	if n := m.SubscribedGroupCount(); n != 1 {
+		t.Errorf("SubscribedGroupCount: want 1, got %d", n)
+	}
+	if n := m.SubscribedRepoCount(); n != 1 {
+		t.Errorf("SubscribedRepoCount: want 1, got %d", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Idle (Pause all refs) → unsubscribe
+// ---------------------------------------------------------------------------
+
+// TestM2_IdlePauseUnsubscribes verifies that pausing all refs for a repo
+// (simulating the WARM→COLD tier transition) removes the fsnotify subscription.
+// This is the "idle TTL → unsubscribe" half of M2.
+func TestM2_IdlePauseUnsubscribes(t *testing.T) {
+	w := newNopWatcher(t)
+	m := NewDefaultManager(w, nil)
+
+	repo := t.TempDir()
+
+	// Subscribe the repo via SubscribeGroup (first query).
+	m.SubscribeGroup("groupA", []string{repo})
+	if len(w.Repos()) != 1 {
+		t.Fatalf("prereq: want 1 subscribed repo after SubscribeGroup, got %d", len(w.Repos()))
+	}
+
+	// Simulate tier WARM→COLD: Pause the sentinel ref.
+	// (In production, Pause is called with the indexed ref. Using "" here
+	// since SubscribeGroup registers with the sentinel.)
+	m.Pause(repo, "")
+
+	// Watcher should now have 0 repos.
+	assertRepoCount(t, w, 0, "after idle Pause")
+	assertSubscribedRepoCount(t, m, 0, "after idle Pause")
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Re-query after idle → re-subscribe
+// ---------------------------------------------------------------------------
+
+// TestM2_ReQueryResubscribes verifies that after an idle unsubscription,
+// a new query (Resume call from cold-wake) re-subscribes the repo.
+func TestM2_ReQueryResubscribes(t *testing.T) {
+	w := newNopWatcher(t)
+	m := NewDefaultManager(w, nil)
+
+	repo := t.TempDir()
+
+	// First subscription.
+	m.SubscribeGroup("groupA", []string{repo})
+	if len(w.Repos()) != 1 {
+		t.Fatalf("prereq: want 1 repo after first subscribe")
+	}
+
+	// Idle eviction.
+	m.Pause(repo, "")
+	if len(w.Repos()) != 0 {
+		t.Fatalf("prereq: want 0 repos after pause")
+	}
+
+	// Re-query: tier cold-wake calls Resume.
+	elapsed := m.Resume(repo, "")
+	if elapsed > 2*time.Second {
+		t.Errorf("Resume took too long: %s", elapsed)
+	}
+
+	// Re-subscribed.
+	assertRepoCount(t, w, 1, "after Resume (re-query)")
+	assertSubscribedRepoCount(t, m, 1, "after Resume (re-query)")
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Multi-tier — 2 active groups + 3 cold → only 2 groups use watchers
+// ---------------------------------------------------------------------------
+
+// TestM2_MultiTierActiveVsCold verifies that with 5 groups, subscribing 2 and
+// leaving 3 cold results in only 2 groups consuming fsnotify resources.
+func TestM2_MultiTierActiveVsCold(t *testing.T) {
+	w := newNopWatcher(t)
+	m := NewDefaultManager(w, nil)
+
+	// Create 5 groups, each with 1 repo.
+	groupNames := []string{"g1", "g2", "g3", "g4", "g5"}
+	groups := makeGroups(t, groupNames)
+
+	// Boot: declare all 5 groups (no subscribe).
+	for _, repos := range groups {
+		for _, repo := range repos {
+			m.Register(repo, "main")
+		}
+	}
+	assertRepoCount(t, w, 0, "pre-query: 5 cold groups")
+
+	// Subscribe 2 of the 5 groups (MCP queries arrive for g1 and g2 only).
+	m.SubscribeGroup("g1", groups["g1"])
+	m.SubscribeGroup("g2", groups["g2"])
+
+	// Exactly 2 repos subscribed.
+	assertRepoCount(t, w, 2, "after subscribing 2 groups")
+	if n := m.SubscribedGroupCount(); n != 2 {
+		t.Errorf("SubscribedGroupCount: want 2 (g1+g2 active), got %d", n)
+	}
+	if n := m.SubscribedRepoCount(); n != 2 {
+		t.Errorf("SubscribedRepoCount: want 2, got %d", n)
+	}
+
+	// Verify that g3/g4/g5 repos are NOT in the watcher.
+	watchedSet := make(map[string]bool)
+	for _, r := range w.Repos() {
+		watchedSet[r] = true
+	}
+	for _, coldGroup := range []string{"g3", "g4", "g5"} {
+		for _, repo := range groups[coldGroup] {
+			if watchedSet[repo] {
+				t.Errorf("cold group %s repo %s should NOT be in watcher", coldGroup, repo)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: SubscribeGroup idempotent — double-call doesn't double-subscribe
+// ---------------------------------------------------------------------------
+
+// TestM2_SubscribeGroupIdempotent verifies that calling SubscribeGroup twice
+// for the same group does not double-subscribe the repos.
+func TestM2_SubscribeGroupIdempotent(t *testing.T) {
+	w := newNopWatcher(t)
+	m := NewDefaultManager(w, nil)
+
+	repo := t.TempDir()
+
+	m.SubscribeGroup("groupA", []string{repo})
+	m.SubscribeGroup("groupA", []string{repo}) // second call — should be a no-op
+
+	assertRepoCount(t, w, 1, "after double SubscribeGroup")
+	assertSubscribedRepoCount(t, m, 1, "after double SubscribeGroup")
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Register declares slot but does not subscribe
+// ---------------------------------------------------------------------------
+
+// TestM2_RegisterDoesNotSubscribe verifies that Register (called at boot)
+// does not trigger any fsnotify subscription.
+func TestM2_RegisterDoesNotSubscribe(t *testing.T) {
+	w := newNopWatcher(t)
+	m := NewDefaultManager(w, nil)
+
+	// Register many slots — as if registerKnownGroupsCold ran.
+	for i := 0; i < 20; i++ {
+		m.Register(t.TempDir(), "main")
+	}
+
+	assertRepoCount(t, w, 0, "Register must not subscribe fsnotify")
+	assertSubscribedRepoCount(t, m, 0, "Register must not subscribe fsnotify")
+}

--- a/internal/daemon/watch/manager.go
+++ b/internal/daemon/watch/manager.go
@@ -2,6 +2,7 @@
 // (repoPath, ref) when a tier slot transitions HOT/WARM → COLD or vice-versa.
 //
 // PH2a of epic #2087 (#2096).
+// M2 of epic #2175 (#2179): lazy subscription + per-group idle pause.
 //
 // Design: the daemon uses a single shared fsnotify Watcher that subscribes
 // entire repo trees. "Pausing" a slot means removing that repo's directory
@@ -16,6 +17,18 @@
 // for the repo is not paused. The subscription is removed only when all refs
 // for a repo are paused, and restored when the first ref for that repo is
 // resumed.
+//
+// M2 lazy subscription: the daemon boots with ZERO fsnotify subscriptions.
+// SubscribeGroup wires a group's repos on the first MCP query that touches
+// that group. Resume also lazily subscribes a repo whose refCount was 0 (i.e.
+// it was never subscribed, not merely paused). When all refs for a repo
+// become COLD (via Pause), the fsnotify subscription is removed. On the next
+// query, Resume re-subscribes — making the full cycle:
+//
+//	boot (no subscriptions)
+//	→ first query → SubscribeGroup / Resume → AddRepo
+//	→ idle TTL → Pause (WARM→COLD) → RemoveRepo
+//	→ re-query → Resume → AddRepo
 package watch
 
 import (
@@ -33,7 +46,8 @@ type Manager interface {
 	// that repo tree is removed.
 	Pause(repoPath, ref string)
 	// Resume marks (repoPath, ref) as active. When the repo was fully
-	// unsubscribed (all refs paused), the fsnotify subscription is re-added.
+	// unsubscribed (all refs paused or never subscribed), the fsnotify
+	// subscription is added via AddRepo.
 	// Returns the time taken for the resume operation.
 	Resume(repoPath, ref string) time.Duration
 	// IsPaused reports whether (repoPath, ref) is currently paused.
@@ -55,11 +69,16 @@ type DefaultManager struct {
 	watcher *Watcher
 	logger  *log.Logger
 
-	mu     sync.Mutex
+	mu sync.Mutex
 	// slots maps "repoPath\x00ref" → slotState
-	slots  map[string]*slotState
-	// refCounts maps repoPath → number of active (non-paused) refs
+	slots map[string]*slotState
+	// refCounts maps repoPath → number of active (non-paused) refs.
+	// A refCount of 0 means the repo is either paused or never subscribed.
+	// The watcher tracks actual subscriptions via its own repos map.
 	refCounts map[string]int
+	// groups maps groupName → []repoPath (M2: for SubscribeGroup tracking).
+	// Populated by SubscribeGroup; used to report SubscribedGroupCount.
+	groups map[string][]string
 }
 
 // NewDefaultManager creates a DefaultManager backed by w.
@@ -73,6 +92,7 @@ func NewDefaultManager(w *Watcher, logger *log.Logger) *DefaultManager {
 		logger:    logger,
 		slots:     make(map[string]*slotState),
 		refCounts: make(map[string]int),
+		groups:    make(map[string][]string),
 	}
 }
 
@@ -80,10 +100,13 @@ func slotKey(repoPath, ref string) string {
 	return repoPath + "\x00" + ref
 }
 
-// Register declares that (repoPath, ref) is actively watched. This is
-// called by the server at startup for every repo it subscribes. It
-// initialises the ref-count bookkeeping without touching the fsnotify
-// subscription (AddRepo was already called by the boot path).
+// Register declares that (repoPath, ref) is tracked by the manager but does
+// NOT eagerly subscribe the fsnotify watcher. M2: boot-time calls should only
+// declare known slots; actual fsnotify subscription happens lazily via
+// SubscribeGroup or the first Resume call when the ref transitions COLD→HOT.
+//
+// Register is idempotent: re-registering a known slot is a no-op. If the slot
+// was previously paused, Register does NOT un-pause it — use Resume for that.
 func (m *DefaultManager) Register(repoPath, ref string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -91,8 +114,100 @@ func (m *DefaultManager) Register(repoPath, ref string) {
 	if _, exists := m.slots[k]; exists {
 		return // idempotent
 	}
-	m.slots[k] = &slotState{paused: false}
-	m.refCounts[repoPath]++
+	// Mark the slot as paused=false (active) in the slot table, but do NOT
+	// increment refCounts or call AddRepo. refCounts stays 0 until the first
+	// Resume or SubscribeGroup call — that is the M2 lazy-subscribe signal.
+	//
+	// Note: this differs from the pre-M2 behavior where Register incremented
+	// refCounts (assuming AddRepo had already been called by the boot path).
+	// Now Register is purely declarative; fsnotify subscription is deferred.
+	m.slots[k] = &slotState{paused: true} // treat as paused until subscribed
+}
+
+// SubscribeGroup lazily subscribes all repos in a named group. This is the
+// M2 group-level subscription entry point: call it on the first MCP query that
+// touches groupName. Repos that are already subscribed (refCount > 0) are
+// skipped to preserve idempotency.
+//
+// SubscribeGroup records the group→repoPaths mapping so SubscribedGroupCount
+// can report how many groups have live fsnotify subscriptions.
+//
+// Returns the number of repos newly subscribed (dirs added to fsnotify).
+func (m *DefaultManager) SubscribeGroup(groupName string, repoPaths []string) int {
+	if len(repoPaths) == 0 {
+		return 0
+	}
+
+	// Snapshot which repos need subscribing (those with refCount == 0).
+	m.mu.Lock()
+	m.groups[groupName] = repoPaths
+	var toSubscribe []string
+	for _, rp := range repoPaths {
+		if m.refCounts[rp] == 0 {
+			toSubscribe = append(toSubscribe, rp)
+		}
+	}
+	// Pre-increment so concurrent SubscribeGroup calls for the same repo don't
+	// double-add. We will decrement if AddRepo fails.
+	for _, rp := range toSubscribe {
+		m.refCounts[rp]++
+		// Ensure the sentinel slot exists so Pause/Resume bookkeeping is correct.
+		sentinelKey := slotKey(rp, "")
+		if _, ok := m.slots[sentinelKey]; !ok {
+			m.slots[sentinelKey] = &slotState{paused: false}
+		} else {
+			m.slots[sentinelKey].paused = false
+		}
+	}
+	m.mu.Unlock()
+
+	added := 0
+	for _, rp := range toSubscribe {
+		n, err := m.watcher.AddRepo(rp)
+		if err != nil {
+			m.logger.Printf("watcher-mgr: SubscribeGroup %s repo=%s AddRepo err=%v", groupName, rp, err)
+			// Decrement on failure so the next call retries.
+			m.mu.Lock()
+			m.refCounts[rp]--
+			m.slots[slotKey(rp, "")].paused = true
+			m.mu.Unlock()
+			continue
+		}
+		m.logger.Printf("watcher-mgr: SubscribeGroup %s repo=%s dirs=%d (lazy subscribe)", groupName, rp, n)
+		added += n
+	}
+	return added
+}
+
+// SubscribedGroupCount returns the number of distinct groups that currently
+// have at least one repo with an active fsnotify subscription (refCount > 0).
+func (m *DefaultManager) SubscribedGroupCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, repos := range m.groups {
+		for _, rp := range repos {
+			if m.refCounts[rp] > 0 {
+				count++
+				break // one active repo is enough to count this group
+			}
+		}
+	}
+	return count
+}
+
+// SubscribedRepoCount returns the number of distinct repos with at least one
+// active (non-paused) ref, i.e. refCount > 0. Used for observability.
+func (m *DefaultManager) SubscribedRepoCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, rc := range m.refCounts {
+		if rc > 0 {
+			count++
+		}
+	}
+	return count
 }
 
 // Pause marks (repoPath, ref) paused. If this is the last active ref for
@@ -128,8 +243,15 @@ func (m *DefaultManager) Pause(repoPath, ref string) {
 	}
 }
 
-// Resume marks (repoPath, ref) active. If the repo was fully unsubscribed,
-// the fsnotify subscription is re-added via AddRepo.
+// Resume marks (repoPath, ref) active. If the repo was fully unsubscribed
+// (refCount == 0, either because all refs were paused or because it was never
+// subscribed at boot), the fsnotify subscription is added via AddRepo.
+//
+// M2: this is also the lazy-subscribe path for the first cold-wake of a slot
+// that was registered at boot via RegisterCold (S1) but never subscribed to
+// fsnotify. The refCount check handles both the re-subscribe and first-subscribe
+// cases identically.
+//
 // Returns the time taken for the resume.
 func (m *DefaultManager) Resume(repoPath, ref string) time.Duration {
 	start := time.Now()
@@ -137,7 +259,7 @@ func (m *DefaultManager) Resume(repoPath, ref string) time.Duration {
 	k := slotKey(repoPath, ref)
 	st, known := m.slots[k]
 	if !known {
-		st = &slotState{}
+		st = &slotState{paused: true}
 		m.slots[k] = st
 	}
 	if !st.paused {
@@ -150,7 +272,7 @@ func (m *DefaultManager) Resume(repoPath, ref string) time.Duration {
 	m.mu.Unlock()
 
 	if wasZero {
-		// Re-subscribe.
+		// Subscribe (or re-subscribe after idle unsubscription).
 		n, err := m.watcher.AddRepo(repoPath)
 		elapsed := time.Since(start)
 		if err != nil {

--- a/internal/daemon/watch/manager_test.go
+++ b/internal/daemon/watch/manager_test.go
@@ -23,30 +23,44 @@ func newNopWatcher(t *testing.T) *Watcher {
 
 // TestManagerPauseResume verifies the basic Pause/Resume lifecycle.
 // Uses a real tmp directory so AddRepo can walk real paths.
+//
+// M2 semantics: Register declares a slot as paused (not subscribed). A
+// subsequent Resume or SubscribeGroup call activates the fsnotify subscription.
 func TestManagerPauseResume(t *testing.T) {
 	w := newNopWatcher(t)
 	m := NewDefaultManager(w, nil)
 
 	dir := t.TempDir()
 
-	// Register and verify active.
+	// M2: Register declares the slot as paused (not subscribed at boot).
 	m.Register(dir, "main")
+	if !m.IsPaused(dir, "main") {
+		t.Fatal("M2: want paused after Register (no eager subscribe at boot)")
+	}
+	if m.ActiveCount() != 0 {
+		t.Fatalf("M2: want ActiveCount=0 after Register, got %d", m.ActiveCount())
+	}
+	if m.PausedCount() != 1 {
+		t.Fatalf("M2: want PausedCount=1 after Register, got %d", m.PausedCount())
+	}
+
+	// Activate via Resume (simulates first MCP query / cold-wake).
+	// Resume lazily calls AddRepo since refCount was 0.
+	elapsed := m.Resume(dir, "main")
 	if m.IsPaused(dir, "main") {
-		t.Fatal("want not paused after Register")
+		t.Fatal("want not paused after Resume")
 	}
 	if m.ActiveCount() != 1 {
-		t.Fatalf("want ActiveCount=1, got %d", m.ActiveCount())
+		t.Fatalf("want ActiveCount=1 after Resume, got %d", m.ActiveCount())
 	}
 	if m.PausedCount() != 0 {
-		t.Fatalf("want PausedCount=0, got %d", m.PausedCount())
+		t.Fatalf("want PausedCount=0 after Resume, got %d", m.PausedCount())
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("resume took unexpectedly long: %s", elapsed)
 	}
 
-	// First add the repo so Pause will remove a real subscription.
-	if _, err := w.AddRepo(dir); err != nil {
-		t.Fatalf("AddRepo: %v", err)
-	}
-
-	// Pause.
+	// Pause — removes fsnotify subscription (idle eviction).
 	m.Pause(dir, "main")
 	if !m.IsPaused(dir, "main") {
 		t.Fatal("want paused after Pause")
@@ -64,16 +78,10 @@ func TestManagerPauseResume(t *testing.T) {
 		t.Fatal("double-pause must be idempotent")
 	}
 
-	// Resume.
-	elapsed := m.Resume(dir, "main")
-	if m.IsPaused(dir, "main") {
-		t.Fatal("want not paused after Resume")
-	}
+	// Resume again — re-subscribes.
+	m.Resume(dir, "main")
 	if m.ActiveCount() != 1 {
-		t.Fatalf("want ActiveCount=1 after resume, got %d", m.ActiveCount())
-	}
-	if elapsed > 2*time.Second {
-		t.Errorf("resume took unexpectedly long: %s", elapsed)
+		t.Fatalf("want ActiveCount=1 after second Resume, got %d", m.ActiveCount())
 	}
 
 	// Resume again — idempotent.
@@ -85,23 +93,27 @@ func TestManagerPauseResume(t *testing.T) {
 
 // TestManagerMultiRefRefcount verifies that the fsnotify subscription stays
 // alive while at least one ref is active.
+//
+// M2 semantics: Register declares slots as paused. Resume activates them and
+// creates the fsnotify subscription. RefCount tracks active refs; the
+// subscription is removed only when all refs are paused.
 func TestManagerMultiRefRefcount(t *testing.T) {
 	w := newNopWatcher(t)
 	m := NewDefaultManager(w, nil)
 
 	dir := t.TempDir()
-	if _, err := w.AddRepo(dir); err != nil {
-		t.Fatalf("AddRepo: %v", err)
-	}
 
-	// Register two refs.
+	// M2: Register two refs (declares slots, no subscribe).
 	m.Register(dir, "main")
 	m.Register(dir, "feat/x")
 
-	// Pause one — repo should still be subscribed.
+	// Activate both refs via Resume (simulates first query / cold-wake).
+	// The first Resume triggers AddRepo; the second finds refCount > 0 and skips.
+	m.Resume(dir, "main")
+	m.Resume(dir, "feat/x")
+
+	// Pause one — repo should still be subscribed (feat/x still active).
 	m.Pause(dir, "main")
-	// The repo is still active because feat/x is active.
-	// We can verify indirectly: watcher should still list the repo.
 	repos := w.Repos()
 	found := false
 	for _, r := range repos {


### PR DESCRIPTION
## 1. Problem

Before this PR the daemon called `watcher.AddRepo()` for every registered repo at boot. With 5 idle groups this consumed ~800+ inotify watch descriptors and measurable background CPU — even when zero MCP queries had arrived. The daemon's watcher was fully subscribed regardless of whether any group was ever queried.

## 2. Solution

M2 implements lazy fsnotify subscription: the daemon boots with **0 subscriptions**. Repos are subscribed on-demand — either on the first MCP query for a group (`SubscribeGroup`) or on the first cold-wake `Resume` call from the tier manager.

## 3. Changes

### `internal/daemon/watch/manager.go`
- **`Register()`**: now declares a slot as *paused* (deferred subscribe). No `refCount` increment, no `AddRepo` call — boot is completely fd-free.
- **`Resume()`**: unified lazy-subscribe path. When `refCount == 0` (never subscribed OR after idle unsubscription) it calls `AddRepo`. Idempotent when already active. This handles both first-subscribe and re-subscribe cases identically.
- **`SubscribeGroup(groupName, repoPaths)`**: group-level entry point for the first MCP query on a group. Tracks group→repos mapping for `SubscribedGroupCount`. Skips repos whose `refCount > 0`.
- **`SubscribedGroupCount()` / `SubscribedRepoCount()`**: observability metrics.

### `internal/daemon/server.go`
- Boot goroutine no longer calls `watcher.AddRepo()`. Repos are registered with the HEAD poller only (reads `.git/HEAD`; no fd cost). **fsnotify subscription count at boot: 0.**

### `cmd/archigraph/daemon_tier.go`
- `onWatcherReady()` drops the eager Register-all loop. Manager starts idle.
- `SubscribeGroupWatcher()` is the new on-demand group subscribe entry point.
- `tierAfterIndex` / `tierAfterIndexWorktree` call `Resume()` instead of `Register()` so a fresh index lazily subscribes the repo's watcher.

## 4. Tests

7 new M2 tests in `internal/daemon/watch/m2_lazy_test.go`:
- `TestM2_BootZeroSubscriptions`: 5 groups registered, no queries → 0 fsnotify subscriptions
- `TestM2_QueryGroupSubscribesOnlyThatGroup`: query group A → only A's repos subscribed
- `TestM2_IdlePauseUnsubscribes`: Pause all refs → fsnotify subscription removed
- `TestM2_ReQueryResubscribes`: Resume after idle Pause → re-subscribes
- `TestM2_MultiTierActiveVsCold`: 2 active + 3 cold → only 2 groups consume watcher resources
- `TestM2_SubscribeGroupIdempotent`: double SubscribeGroup is a no-op
- `TestM2_RegisterDoesNotSubscribe`: Register never touches fsnotify

Updated existing tests:
- `watch/manager_test.go`: updated `TestManagerPauseResume` and `TestManagerMultiRefRefcount` to M2 semantics
- `internal/daemon/phaseb_test.go`: `TestPhaseB_StatusRPCReflectsWatcher` now asserts `WatcherRepos=0` at boot

## 5. Measurement

Idle daemon with 5 registered groups, 0 queries:
- `WatcherRepos=0`, `WatcherDirs=0` ✓ (verified by `TestPhaseB_StatusRPCReflectsWatcher`)
- All 7 M2 tests pass
- All pre-existing daemon/watch and internal/daemon tests pass

## 6. Backward Compatibility

The idle-unsubscribe half (WARM→COLD → `Pause` → `RemoveRepo`) was already implemented in PH2a (#2096). M2 adds only the lazy-subscribe half. The `tier.WatcherHook` interface is unchanged.

## 7. Links

Closes #2179
Refs #2175
Pairs with #2151 S1

🤖 Generated with [Claude Code](https://claude.com/claude-code)