### PR TITLE
fix(skill): generate-docs enforces MCP-first; refuses grep fallback (#2177)

### DIFF
--- a/skills/generate-docs/SKILL.md
+++ b/skills/generate-docs/SKILL.md
@@ -1,5 +1,61 @@
 # generate-docs
 
+---
+
+## CRITICAL TOOL DISCIPLINE (enforced on every pass — read before ANY action)
+========================
+
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+- `archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+- `archigraph_clusters`, `archigraph_traces`, `archigraph_whoami`,
+- (full list in the "archigraph MCP tool surface" section below)
+
+You are STRICTLY FORBIDDEN from using:
+- `find` / `ls` / `wc` / `grep` on the codebase **for entity discovery**
+- Reading source files directly to enumerate APIs or list what exists
+- Inferring structure from `package.json` / `pyproject.toml` / `go.mod` etc. without first confirming via MCP
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for:
+- Reading specific source line ranges that `archigraph_get_source` returns
+- Running `archigraph docgen --llm-mode=apply` at the end of Pass 20
+- Writing output files under `~/.archigraph/docs/<group>/...`
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+> **Note on grep:** grep and `rg` are permitted inside individual writer subagents for raw
+> pattern enumeration (every `if err != nil`, exact symbol spellings, finding concrete source
+> lines). They are NOT permitted as substitutes for graph navigation -- use MCP first to narrow
+> the search space, then grep only to verify edge-property questions that MCP models at the
+> entity level rather than the text level.
+
+### Pre-flight assertion (FIRST action in every pass)
+
+Call `archigraph_whoami` before doing anything else in each pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+### Tool whitelist
+
+- `mcp__archigraph__*` (all archigraph MCP tools) -- primary navigation
+- `Read` -- source_window reads (specific line ranges from `archigraph_get_source` output) and output file reads/writes
+- `Write` / `Edit` -- output doc files under `~/.archigraph/docs/<group>/...` only
+- `Bash` -- ONLY for `archigraph docgen --llm-mode=apply` invocations and writing output files
+
+Explicitly EXCLUDED for entity discovery:
+- `Grep` for structural/inventory queries (these enable the grep-fallback anti-pattern)
+- `Glob` for enumerating what exists in the codebase
+
+### Pass telemetry (print at end of every pass)
+
+```
+[pass-N] archigraph MCP calls: X | Bash invocations: Y
+```
+
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."
+
+---
+
 Generate documentation for a registered archigraph group in two independent
 **tiers**:
 

--- a/skills/generate-docs/prompts/00-domain-qa.md
+++ b/skills/generate-docs/prompts/00-domain-qa.md
@@ -1,5 +1,31 @@
 # Pass 0 — Domain Q&A
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 You are a documentation architect. Before you index anything or query archigraph, you need to understand the domain.
 
 Run this pass **only on the first invocation of `generate-docs` for a given group**. Subsequent runs skip Pass 0 unless the user explicitly asks to rebuild domain context.
@@ -81,3 +107,11 @@ Write the answers into `domain.md` with this skeleton:
 ```
 
 When finished, hand control back to the orchestrator with the path to `domain.md`.
+
+---
+
+**[pass-00 telemetry]** Print at end of this pass:
+```
+[pass-00] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/01-inventory.md
+++ b/skills/generate-docs/prompts/01-inventory.md
@@ -1,5 +1,31 @@
 # Pass 1 — Inventory
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Discover what is actually in each repo by querying archigraph. Do not read source files directly. The graph is the source of truth for what entities exist; the writer passes will read source via `archigraph_get_source` when they need verbatim snippets.
 
 ## Inputs
@@ -82,3 +108,11 @@ Write `~/.archigraph/groups/<group>/inventory.json`:
 ```
 
 When the file is written, hand control back to the orchestrator with its path. Do not move on to Pass 2 yourself.
+
+---
+
+**[pass-01 telemetry]** Print at end of this pass:
+```
+[pass-01] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/01a-residual-repair-sweep.md
+++ b/skills/generate-docs/prompts/01a-residual-repair-sweep.md
@@ -1,5 +1,31 @@
 # Pass 1a — Residual repair sweep (pre-Q&A)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Runs **after Pass 1 (inventory)** and **before any deeper writer passes**. Closes the gap between the static-analysis recall ceiling (~85% on cross-repo b→a) and full coverage by annotating runtime-resolved edges that the resolver structurally cannot bind.
 
 This pass is the doc skill's integration with the ADR-0015 residual-repair mechanism. The MCP tool `archigraph_repairs` is the only surface used; do **not** read or write `repair.json` directly. See `docs/specs/repair-trust-model.md` for the allowlist of resolutions and verification rules.
@@ -181,3 +207,11 @@ Before recording a `PatternCandidate` in Pass 4 / aggregating in Pass 10, the ag
 - Never invent a `target_entity_id` that doesn't appear in `inventory.json`. Trust-model rule `R2` rejects unknown targets; the rejection becomes a user question.
 - Never submit `reasoning` shorter than ~10 characters. Trust-model rule `R7` flags it; we treat <10 as effectively rejected and demote to user question.
 - Auto-resolution must be reproducible — the same `repair-templates.json` + same `inventory.json` + same residuals must produce the same submits (no time-based or random decisions). This preserves ADR-0015's determinism guarantee.
+
+---
+
+**[pass-01a telemetry]** Print at end of this pass:
+```
+[pass-01a] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/01b-repair-aware-qa.md
+++ b/skills/generate-docs/prompts/01b-repair-aware-qa.md
@@ -1,5 +1,31 @@
 # Pass 1b — Repair-aware Q&A
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Surfaces the residuals Pass 1a could not auto-resolve (see Pass 1a § "Classify each residual" for the narrowed auto-resolve scope). The user answers in plain language; the agent translates each answer into an `archigraph_repairs(action=submit)` call.
 
 This pass handles all three resolution kinds — `bind_to_entity`, `reclassify_as_external`, `reclassify_as_dynamic` — because the user's answer provides the disambiguation that Pass 1a lacked. When the user provides a binding target for `bind_to_entity`, use `archigraph_find` to confirm the entity exists before submitting; do not fabricate ids.
@@ -123,3 +149,11 @@ Continue to Pass 2 regardless of skip/reject counts; the doc-gen pipeline is rob
 - Never invent `target_entity_id` values the user did not provide. If the user gestures at a target without an exact id, search with `archigraph_find` and present the candidates back to the user; only submit once they pick one.
 - The pass is **interactive** — never silently fall through unanswered questions. If the user requests "skip the rest," record the remaining questions back into `repair-questions.json` for the next run.
 - Don't re-ask answered residuals. The history file is authoritative.
+
+---
+
+**[pass-01b telemetry]** Print at end of this pass:
+```
+[pass-01b] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/02-plan.md
+++ b/skills/generate-docs/prompts/02-plan.md
@@ -1,5 +1,31 @@
 # Pass 2 — Plan
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Convert the raw community list from Pass 1 into a documentation plan. The plan is the contract that Passes 3-6 execute against.
 
 ## Inputs
@@ -113,3 +139,11 @@ Wait for confirmation before handing back to the orchestrator. The orchestrator 
 
 - If a module has `depends_on`, Pass 4 schedules it after its dependencies. Use this when one module's flow page must reference another module's API page.
 - Modules whose `token_budget` exceeds 8000 must be split before the plan is finalized; the plan file is rejected by the orchestrator otherwise.
+
+---
+
+**[pass-02 telemetry]** Print at end of this pass:
+```
+[pass-02] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/03-overview.md
+++ b/skills/generate-docs/prompts/03-overview.md
@@ -1,5 +1,31 @@
 # Pass 3 — Repo Overview
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Write `~/.archigraph/docs/<group>/<repo-slug>/overview.md` for every repo in the group. The overview is the entry point a new engineer reads first; it is also the page Pass 7 quotes when synthesizing the group-level page.
 
 > **Pass 3a hook active.** Before writing any paragraph that describes an entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. Auto-repair residuals where unambiguous; otherwise emit the documented "Runtime-resolved edge" callout from that prompt. Do not silently drop unresolved outbound edges.
@@ -84,3 +110,11 @@ archigraph_save_finding(
 This creates a memory entry the future grooming agents can find by query.
 
 When all repos are done, hand control back to the orchestrator.
+
+---
+
+**[pass-03 telemetry]** Print at end of this pass:
+```
+[pass-03] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/03a-generation-time-repair.md
+++ b/skills/generate-docs/prompts/03a-generation-time-repair.md
@@ -1,5 +1,31 @@
 # Pass 3a — Generation-time repair (in-prose hook)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 A **hook**, not a standalone pass. Every writer subagent in Passes 3, 4, 5, 6, and 12 runs this check immediately before emitting prose that describes an entity. The hook is the primary site for `bind_to_entity` resolutions — Pass 1a deliberately defers those here because the writer has full local subgraph context via `archigraph_expand`. It also catches residuals discovered late (after Pass 1a) that the earlier sweep missed.
 
 ## When the hook fires
@@ -93,3 +119,11 @@ When a pattern's recipe references an entity with unresolved outbound edges, the
 - Writes go through `archigraph_repairs(action=submit)` only. No direct file writes.
 - The hook is idempotent: running it twice on the same entity produces zero new submits because the second pass sees `total == 0` for that `from_entity.id`.
 - Source attribution: every submit from this pass uses `source="generate-docs/pass-3a"` so the audit trail distinguishes sweep-time from generation-time repairs.
+
+---
+
+**[pass-03a telemetry]** Print at end of this pass:
+```
+[pass-03a] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/04-cluster.md
+++ b/skills/generate-docs/prompts/04-cluster.md
@@ -1,5 +1,31 @@
 # Pass 4 — Per-module deep-dive
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 For every entry under `plan.passes.4_cluster.modules`, produce a self-contained module page (or set of pages). This pass runs writer subagents **in parallel** — one subagent per module — bounded by a configured concurrency limit.
 
 > **Pass 3a hook active.** Before writing any paragraph that describes an entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. Auto-repair residuals where unambiguous; otherwise emit the documented "Runtime-resolved edge" callout from that prompt. Do not silently drop unresolved outbound edges.
@@ -143,3 +169,11 @@ archigraph_save_finding(
 ```
 
 Hand control back to the orchestrator. The orchestrator joins all writer subagents and starts Pass 5 only when every module has produced verified output.
+
+---
+
+**[pass-04 telemetry]** Print at end of this pass:
+```
+[pass-04] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/05-reference.md
+++ b/skills/generate-docs/prompts/05-reference.md
@@ -1,5 +1,31 @@
 # Pass 5 — Reference
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Reference docs are the dry, exhaustive, alphabetized pages. They live under `~/.archigraph/docs/<group>/<repo-slug>/reference/` and are produced one section at a time, sequentially, by a single writer subagent per repo.
 
 > **Pass 3a hook active.** Before writing any paragraph that describes an entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. Auto-repair residuals where unambiguous; otherwise emit the documented "Runtime-resolved edge" callout from that prompt. Do not silently drop unresolved outbound edges.
@@ -129,3 +155,11 @@ archigraph_save_finding(
 ```
 
 When all repos in the group have completed reference docs, hand back to the orchestrator.
+
+---
+
+**[pass-05 telemetry]** Print at end of this pass:
+```
+[pass-05] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/06-cross-cutting.md
+++ b/skills/generate-docs/prompts/06-cross-cutting.md
@@ -1,5 +1,31 @@
 # Pass 6 — Cross-cutting concerns
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Some topics span every module: authentication, authorization, logging, error handling, observability, feature flags, rate limiting. They deserve their own pages so readers don't have to reconstruct them from per-module docs.
 
 > **Pass 3a hook active.** Before writing any paragraph that describes an entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. Auto-repair residuals where unambiguous; otherwise emit the documented "Runtime-resolved edge" callout from that prompt. Do not silently drop unresolved outbound edges.
@@ -129,3 +155,11 @@ Use `source: "generate-docs/pass-6"` in every candidate.
 Run `snippets/verification-checklist.md` for each file produced.
 
 When every topic is done across every repo, hand back to the orchestrator.
+
+---
+
+**[pass-06 telemetry]** Print at end of this pass:
+```
+[pass-06] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/07-group-synthesis.md
+++ b/skills/generate-docs/prompts/07-group-synthesis.md
@@ -1,5 +1,31 @@
 # Pass 7 — Group synthesis
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Tie the per-repo outputs into one group-level page. This page is what an executive, a new hire, or an external consumer reads first.
 
 ## Inputs
@@ -66,3 +92,11 @@ archigraph_save_finding(
 ```
 
 Hand back to the orchestrator.
+
+---
+
+**[pass-07 telemetry]** Print at end of this pass:
+```
+[pass-07] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/08-cross-link.md
+++ b/skills/generate-docs/prompts/08-cross-link.md
@@ -1,5 +1,31 @@
 # Pass 8 — Cross-link validation
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Two responsibilities:
 
 1. Validate that every relative link inside the generated docs resolves.
@@ -112,3 +138,11 @@ Write `~/.archigraph/groups/<group>/docs/cross-links.md` with sections:
 ```
 
 Hand back to the orchestrator. The orchestrator now decides whether to run Pass 10 (pattern convergence), which runs only if Pass 4 emitted pattern candidates.
+
+---
+
+**[pass-08 telemetry]** Print at end of this pass:
+```
+[pass-08] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/10-pattern-convergence.md
+++ b/skills/generate-docs/prompts/10-pattern-convergence.md
@@ -1,5 +1,31 @@
 # Pass 10 — Pattern convergence + promotion (Phase 4 of ADR-0018)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 You are the `/generate-docs` coordinator running after Passes 4–7 produced the prose docs. Your job here is to aggregate per-subagent pattern observations and promote those that converged into approved patterns.
 
 This pass produces no markdown. Its outputs are mutations on the pattern store via the `archigraph_patterns` MCP tool.
@@ -62,3 +88,11 @@ Non-convergent candidates stay in the store with `is_candidate=true`. They may c
 - DO NOT promote a candidate that has < `convergence_threshold` proposers, even if its similarity score is high.
 - DO NOT silently merge candidates across categories; promote within a category only.
 - DO NOT delete candidates here — the gc subcommand owns lifecycle pruning.
+
+---
+
+**[pass-10 telemetry]** Print at end of this pass:
+```
+[pass-10] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/11-pattern-cross-link.md
+++ b/skills/generate-docs/prompts/11-pattern-cross-link.md
@@ -1,5 +1,31 @@
 # Pass 11 — Pattern cross-link (Phase 5 of ADR-0018)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 For every pattern approved in Pass 10 (or refined in this run), populate its `documentation_url` field so the graph holds a forward pointer to the markdown emitted in Pass 12.
 
 ## Procedure
@@ -35,3 +61,11 @@ For each approved pattern `p`:
 - DO NOT write `documentation_url` for `is_candidate=true` patterns. Their docs are not generated.
 - DO NOT delete an existing `documentation_url` when re-running — refinement only overwrites it with the new computed URL.
 - DO NOT chase `SUPERSEDES` edges here. Superseded patterns keep their old documentation_url until the user runs `archigraph patterns delete` or v1.1's history surface lights up.
+
+---
+
+**[pass-11 telemetry]** Print at end of this pass:
+```
+[pass-11] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/12-pattern-prose.md
+++ b/skills/generate-docs/prompts/12-pattern-prose.md
@@ -1,5 +1,31 @@
 # Pass 12 — Pattern prose generation (Phase 6 of ADR-0018)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Emit one markdown file per approved pattern under `docs/patterns/<category>/<pattern-id>.md`. Re-runs of `/generate-docs` overwrite these files from the current pattern store, so refinements and new applies propagate automatically.
 
 > **Pass 3a hook active.** Before writing the section that names an exemplar entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. This prevents pattern exemplars from referencing dangling targets and implements the "patterns → repair" cross-link from #732.
@@ -139,3 +165,11 @@ Use `source: "generate-docs/pass-12"` in all candidates. Append to
 - DO NOT omit the `Status`, `Category`, `Confidence` front-matter block. Downstream tooling parses it.
 - DO NOT inline private anti-patterns under any circumstance. Tests in `internal/agentpatterns/docs_test.go` enforce this.
 - DO NOT skip Pass 11 — without `documentation_url`, the graph cannot link prose to pattern docs.
+
+---
+
+**[pass-12 telemetry]** Print at end of this pass:
+```
+[pass-12] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/13-enrichment.md
+++ b/skills/generate-docs/prompts/13-enrichment.md
@@ -1,5 +1,31 @@
 # Pass 13 — LLM Enrichment
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Produce structured YAML frontmatter enrichments for every `http_endpoint`,
 `process_flow`, and `message_topic` entity in the group. The dashboard Paths,
 Flows, and Topology surfaces consume this data to surface summaries, group
@@ -288,3 +314,11 @@ archigraph_save_finding(
 
 Hand control back to the orchestrator. The orchestrator marks Pass 13 complete
 in docgen-state.json and queues Pass 14 (frontmatter validation).
+
+---
+
+**[pass-13 telemetry]** Print at end of this pass:
+```
+[pass-13] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/14-frontmatter-validation.md
+++ b/skills/generate-docs/prompts/14-frontmatter-validation.md
@@ -1,5 +1,31 @@
 # Pass 14 — Frontmatter Validation
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Validate every enriched doc file written by Pass 13. Catch schema drift between
 the skill output and the backend parser's expectations before the user sees a
 blank panel in the dashboard.
@@ -140,3 +166,11 @@ Report to the orchestrator:
 
 Pass 14 does **not** modify doc files. It only reports. The fix is always a
 Pass 13 re-run for the affected entity.
+
+---
+
+**[pass-14 telemetry]** Print at end of this pass:
+```
+[pass-14] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/15-business-domain.md
+++ b/skills/generate-docs/prompts/15-business-domain.md
@@ -1,5 +1,31 @@
 # Pass 15 — Business domain model + glossary (BUSINESS tier)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 The first business pass. Produce the product's business vocabulary: the nouns a
 PM uses (Inspection, Deficiency, Jurisdiction, Customer, Order), each defined in
 plain language. Later business passes (capabilities, journeys, rules) link into
@@ -120,3 +146,11 @@ archigraph_save_finding(
 
 Hand back to the orchestrator. Pass 16 (capabilities) and Pass 17 (journeys)
 both link into this glossary, so they run after it.
+
+---
+
+**[pass-15 telemetry]** Print at end of this pass:
+```
+[pass-15] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/16-business-capabilities.md
+++ b/skills/generate-docs/prompts/16-business-capabilities.md
@@ -1,5 +1,31 @@
 # Pass 16 — Product capabilities (BUSINESS tier)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Produce one page per product capability: what the system does and why, in
 business language. Capabilities are derived from the system's externally-visible
 behaviour — HTTP endpoints, process flows, message topics, scheduled jobs —
@@ -116,3 +142,11 @@ archigraph_save_finding(
 
 Hand back. Pass 19 (business overview) will index every capability page you
 wrote, so report the list of capability slugs to the orchestrator.
+
+---
+
+**[pass-16 telemetry]** Print at end of this pass:
+```
+[pass-16] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/17-business-journeys.md
+++ b/skills/generate-docs/prompts/17-business-journeys.md
@@ -1,5 +1,31 @@
 # Pass 17 — User journeys as business narrative (BUSINESS tier)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Produce end-to-end user journeys written as PLAIN-LANGUAGE narratives — a user
 accomplishing a goal across the whole product. This pass exists specifically to
 fix the audit finding that the old `user-journeys.md` was a 60-step mermaid
@@ -115,3 +141,11 @@ archigraph_save_finding(
 ```
 
 Hand back; report the list of journey slugs for Pass 19's index.
+
+---
+
+**[pass-17 telemetry]** Print at end of this pass:
+```
+[pass-17] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/18-business-rules.md
+++ b/skills/generate-docs/prompts/18-business-rules.md
@@ -1,5 +1,31 @@
 # Pass 18 — Business rules / requirements (BUSINESS tier)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Reverse-engineer the product's business rules — constraints, requirements,
 policies — from the implementation, and state them as PRODUCT REQUIREMENTS. This
 is the layer a team lead extracts engineering requirements from; here we
@@ -115,3 +141,11 @@ archigraph_save_finding(
 ```
 
 Hand back to the orchestrator.
+
+---
+
+**[pass-18 telemetry]** Print at end of this pass:
+```
+[pass-18] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/19-business-overview.md
+++ b/skills/generate-docs/prompts/19-business-overview.md
@@ -1,5 +1,31 @@
 # Pass 19 — Business overview / landing page (BUSINESS tier)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 The last business pass. Produce the single landing page a PM opens first: what
 the product does, who uses it, and an index into the capabilities, journeys,
 domain glossary, and rules written by Passes 15–18. It runs last because it
@@ -68,3 +94,11 @@ archigraph_save_finding(
 Hand back to the orchestrator. The business tier is complete:
 `business/overview.md`, `business/capabilities/*`, `business/domain-glossary.md`,
 `business/journeys/*`, `business/rules/index.md`.
+
+---
+
+**[pass-19 telemetry]** Print at end of this pass:
+```
+[pass-19] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."

--- a/skills/generate-docs/prompts/20-llm-orchestrate.md
+++ b/skills/generate-docs/prompts/20-llm-orchestrate.md
@@ -1,5 +1,31 @@
 # Pass 20 — LLM-Mode Orchestrate (Ticket F)
 
+---
+
+## CRITICAL TOOL DISCIPLINE
+========================
+For ANY question about "what entities/files exist in this codebase", "who calls X",
+"what does Y import", "what's in module Z", you MUST use archigraph MCP tools:
+`archigraph_inspect`, `archigraph_find`, `archigraph_expand`, `archigraph_stats`,
+`archigraph_clusters`, `archigraph_whoami`, (full list in SKILL.md).
+
+You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
+entity discovery, or reading source files directly to enumerate APIs.
+
+The MCP daemon has the resolved graph; trust it. Use Bash ONLY for reading specific
+source line ranges that `archigraph_get_source` returns, or writing output files.
+
+If the MCP returns empty or seems wrong, file a side ticket and ABORT --
+do NOT silently substitute grep results for graph queries.
+
+### Pre-flight assertion -- FIRST action in this pass
+
+Call `archigraph_whoami` before doing anything else in this pass. If it errors:
+ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
+
+---
+
+
 Read every `*-bundle.json` file in a docgen output directory, call the LLM
 section-by-section, assemble an `LLMRunResult`, write a matching
 `*-result.json`, and invoke `archigraph docgen --tier=1 --llm-mode=apply` to
@@ -232,3 +258,11 @@ keep the score clean.
 
 `link_refs` in each section result are used by `ApplyResult` for cross-page
 link validation. Populate them accurately.
+
+---
+
+**[pass-20 telemetry]** Print at end of this pass:
+```
+[pass-20] archigraph MCP calls: X | Bash invocations: Y
+```
+If Y > 5 and X < 10: print warning "Likely fallback pattern detected -- investigate skill prompt."


### PR DESCRIPTION
## Summary

- Injects `CRITICAL TOOL DISCIPLINE` block at the top of every pass prompt (`00-domain-qa` through `20-llm-orchestrate`, 23 files) and into `SKILL.md`'s preamble, making MCP-first the literal first thing any agent reads in any pass.
- Adds `archigraph_whoami` pre-flight assertion as the mandatory first action in every pass — aborts with a clear user-facing message if MCP is not configured for the current directory.
- Excludes `Grep` and `Glob` for entity discovery (tool whitelist in SKILL.md clarifies these enable the grep-fallback anti-pattern; raw grep is still permitted inside writer subagents for line-level verification after MCP navigation).
- Appends a `[pass-N] archigraph MCP calls: X | Bash invocations: Y` telemetry line at the end of every pass prompt; warns when `Y > 5` and `X < 10` to surface fallback patterns at runtime.

## Which prompts received the injection

All 23 prompts in `skills/generate-docs/prompts/` (passes 0 through 20, including sub-passes 1a, 1b, 3a). No prompt was excluded — every pass can be a fallback entry point so every pass needs the guard.

## Test plan

- [ ] `grep -L "CRITICAL TOOL DISCIPLINE" skills/generate-docs/prompts/*.md` returns empty (all prompts have it).
- [ ] `grep -L "archigraph_whoami" skills/generate-docs/prompts/*.md` returns empty (all prompts have pre-flight).
- [ ] `grep -L "telemetry" skills/generate-docs/prompts/*.md` returns empty (all prompts have telemetry footer).
- [ ] Manual dry-run: invoke `/generate-docs` and confirm the discipline block appears before any entity-discovery action in the session.

Closes #2177

🤖 Generated with [Claude Code](https://claude.com/claude-code)