### PR TITLE
feat(monorepo): sparse-checkout awareness (M4 of #2175)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -360,6 +360,12 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 		doc.IndexedRef = gi.Ref
 		doc.IndexedSHA = gi.SHA
 		doc.IsWorktree = gi.IsWorktree
+		// M4 sparse-checkout (#2181): stamp the coverage status so dashboard /
+		// MCP readers can surface the "partial" badge without re-probing git.
+		// ProbeRepo is cheap (2-3 git config reads with a 2s timeout each);
+		// calling it here keeps the gitmeta block self-contained.
+		si := gitmeta.ProbeRepo(absRepo)
+		doc.CoverageStatus = si.CoverageStatus()
 		if gi.SHA != "" {
 			fmt.Fprintf(os.Stderr, "archigraph: git HEAD %s @ %s (worktree=%v)\n",
 				gi.SHA, func() string {
@@ -624,8 +630,19 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	}
 	trk := progress.NewTracker(pub, i.groupSlug, repoSlug)
 
+	// M4 sparse-checkout (#2181): probe the repo BEFORE the walk so the
+	// walker can filter out files that are not present locally. The result is
+	// also stored on the Document so the dashboard can show a "partial" badge.
+	sparseInfo := gitmeta.ProbeRepo(absRepo)
+	if sparseInfo.IsSparse {
+		fmt.Fprintf(os.Stderr,
+			"archigraph: sparse-checkout detected (%d pattern(s)) — indexing partial working tree\n",
+			len(sparseInfo.Patterns))
+	}
+
 	walkOpts := &walk.Options{
 		AdditionalSkipDirs: i.additionalSkipDirs,
+		Sparse:             &sparseInfo,
 	}
 	if i.printSkipped {
 		walkOpts.PrintSkipped = os.Stderr

--- a/internal/daemon/walk/sparse_walker_test.go
+++ b/internal/daemon/walk/sparse_walker_test.go
@@ -1,0 +1,147 @@
+package walk_test
+
+// TestWalkRepo_SparseFilter exercises Layer 5 (P4) sparse-checkout filtering.
+// It creates a fixture directory tree simulating a sparse checkout where only
+// "services/payments" is in the sparse pattern set.  The walker must:
+//   - Return files under services/payments/ without error.
+//   - Silently skip files under services/orders/ (not in sparse set).
+//   - Behave identically to a full walk when IsSparse=false.
+//
+// Issue #2181 / M4 of epic #2175.
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/walk"
+	"github.com/cajasmota/archigraph/internal/gitmeta"
+)
+
+// mkTree creates the fixture file tree and returns the root.
+//
+//	root/
+//	  services/
+//	    payments/
+//	      handler.go       ← in sparse set
+//	      service.go       ← in sparse set
+//	    orders/
+//	      handler.go       ← NOT in sparse set
+//	  cmd/main.go          ← NOT in sparse set
+func mkSparseFixtureTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	files := []string{
+		"services/payments/handler.go",
+		"services/payments/service.go",
+		"services/orders/handler.go",
+		"cmd/main.go",
+	}
+	for _, f := range files {
+		abs := filepath.Join(root, filepath.FromSlash(f))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte("package main"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// TestWalkRepo_SparseFilter_ConeMode verifies that cone-mode sparse filtering
+// returns only the files under the sparse pattern prefix and silently skips the
+// rest.
+func TestWalkRepo_SparseFilter_ConeMode(t *testing.T) {
+	root := mkSparseFixtureTree(t)
+
+	si := &gitmeta.SparseInfo{
+		IsSparse: true,
+		ConeMode: true,
+		Patterns: []string{"services/payments"},
+	}
+	opts := &walk.Options{Sparse: si}
+
+	files, _, err := walk.WalkRepo(root, opts)
+	if err != nil {
+		t.Fatalf("WalkRepo: unexpected error: %v", err)
+	}
+
+	sort.Strings(files)
+	want := []string{
+		"services/payments/handler.go",
+		"services/payments/service.go",
+	}
+	if len(files) != len(want) {
+		t.Fatalf("WalkRepo sparse: got %d files %v, want %d %v", len(files), files, len(want), want)
+	}
+	for i, f := range files {
+		if f != want[i] {
+			t.Errorf("files[%d] = %q, want %q", i, f, want[i])
+		}
+	}
+
+	// Verify excluded paths are not present.
+	for _, f := range files {
+		if strings.HasPrefix(f, "services/orders") || strings.HasPrefix(f, "cmd/") {
+			t.Errorf("unexpected file in sparse walk: %q", f)
+		}
+	}
+}
+
+// TestWalkRepo_SparseFilter_NonSparse verifies that when IsSparse=false (or
+// Sparse is nil) the walker returns all source files regardless of what the
+// pattern set contains.
+func TestWalkRepo_SparseFilter_NonSparse(t *testing.T) {
+	root := mkSparseFixtureTree(t)
+
+	// nil Sparse → no filtering.
+	files, _, err := walk.WalkRepo(root, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo(nil opts): unexpected error: %v", err)
+	}
+
+	sort.Strings(files)
+	wantMin := []string{
+		"cmd/main.go",
+		"services/orders/handler.go",
+		"services/payments/handler.go",
+		"services/payments/service.go",
+	}
+	for _, w := range wantMin {
+		found := false
+		for _, f := range files {
+			if f == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in full walk result, got %v", w, files)
+		}
+	}
+}
+
+// TestWalkRepo_SparseFilter_EmptyPatterns verifies that a sparse repo with an
+// empty pattern list returns zero files (nothing is checked out locally).
+func TestWalkRepo_SparseFilter_EmptyPatterns(t *testing.T) {
+	root := mkSparseFixtureTree(t)
+
+	si := &gitmeta.SparseInfo{
+		IsSparse: true,
+		ConeMode: true,
+		Patterns: nil, // no patterns → nothing included
+	}
+	opts := &walk.Options{Sparse: si}
+
+	files, _, err := walk.WalkRepo(root, opts)
+	if err != nil {
+		t.Fatalf("WalkRepo: unexpected error: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected 0 files for sparse repo with empty patterns, got %d: %v", len(files), files)
+	}
+}

--- a/internal/daemon/walk/walker.go
+++ b/internal/daemon/walk/walker.go
@@ -1,10 +1,13 @@
 // Package walk provides the repo file-walker used by the indexer.
-// It combines four skip layers at directory-entry time:
+// It combines five skip layers at directory-entry time:
 //
 //   - Layer 1 (P0): .gitignore semantics (root + nested, lazily loaded)
 //   - Layer 2 (P1): extended hard-coded skip list
 //   - Layer 3 (P2): .archigraphignore overlay
 //   - Layer 4 (P3): .gitattributes linguist-generated=true wildcard
+//   - Layer 5 (P4): git sparse-checkout — files not present in the sparse
+//     pattern set are silently skipped; directories that have no matching
+//     descendants are entered but yield no files (#2181 / M4 of #2175).
 //
 // Directory-level skipping avoids enumerating every file inside build/
 // cache trees — the key performance win for large mobile repos.
@@ -20,6 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/archigraph/internal/gitmeta"
 )
 
 // SkipEntry is one directory that was skipped during a walk.
@@ -39,6 +44,15 @@ type Options struct {
 	// AdditionalSkipDirs extends the hard-coded skip list with per-repo
 	// names from fleet.json's additional_skip_dirs field.
 	AdditionalSkipDirs []string
+
+	// Sparse holds the result of probing the repo for git sparse-checkout
+	// state (Layer 5 / P4). When Sparse.IsSparse is true, files whose
+	// repo-relative path is not covered by the sparse pattern set are
+	// silently skipped — no extraction error is raised. Callers obtain
+	// this by calling gitmeta.ProbeRepo before invoking WalkRepo.
+	//
+	// When nil or zero-value (IsSparse=false), no sparse filtering is applied.
+	Sparse *gitmeta.SparseInfo
 }
 
 // WalkRepo walks root and returns repo-relative file paths (forward-slash,
@@ -163,6 +177,18 @@ func WalkRepo(root string, opts *Options) ([]string, []SkipEntry, error) {
 		if shouldSkipFileByExt(d.Name()) {
 			return nil
 		}
+
+		// Layer 5 (P4): sparse-checkout filter (#2181 / M4 of #2175).
+		// When the repo uses git sparse-checkout, only index files whose
+		// path is included in the sparse pattern set. Missing files are
+		// silently skipped — no error is raised, matching the semantics of
+		// a regular git sparse checkout (absent files are simply not present).
+		if opts.Sparse != nil && opts.Sparse.IsSparse {
+			if !gitmeta.IsPathIncluded(*opts.Sparse, rel) {
+				return nil
+			}
+		}
+
 		files = append(files, rel)
 		return nil
 	})

--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -86,6 +86,11 @@ type v2SettingsRepo struct {
 	IndexedRef string `json:"indexed_ref,omitempty"`
 	IndexedSHA string `json:"indexed_sha,omitempty"`
 	IsWorktree bool   `json:"is_worktree,omitempty"`
+
+	// CoverageStatus — M4 sparse-checkout badge (#2181 / epic #2175).
+	// "" or "full" for a normal checkout; "partial" when git sparse-checkout
+	// was active at index time. Omitted for legacy graphs and full checkouts.
+	CoverageStatus string `json:"coverage_status,omitempty"`
 }
 
 // v2MonorepoInfo matches the SettingsRepo.monorepo shape.
@@ -193,8 +198,9 @@ func loadV2SettingsGroup(groupName, histRoot string) (*v2SettingsGroup, error) {
 			ms := idxAt.UnixMilli()
 			sr.IndexedAt = &ms
 		}
-		// Phase 0 git metadata (#2088). Read cheaply from graph.fb header.
-		sr.IndexedRef, sr.IndexedSHA, sr.IsWorktree = repoGitMeta(stateDir)
+		// Phase 0 git metadata (#2088) + M4 sparse badge (#2181). Read cheaply
+		// from graph.fb header — no entity decode required.
+		sr.IndexedRef, sr.IndexedSHA, sr.IsWorktree, sr.CoverageStatus = repoGitMeta(stateDir)
 		// Monorepo: if the repo has Modules, surface them as a stub MonorepoInfo.
 		if len(r.Modules) > 0 {
 			pkgs := make([]v2MonorepoPkg, 0, len(r.Modules))
@@ -240,18 +246,18 @@ func loadV2SettingsGroup(groupName, histRoot string) (*v2SettingsGroup, error) {
 
 // repoStats reads graph-stats.json for a repo's state dir and returns
 // (files, entities, lastIndexed). Zero values on any read error.
-// repoGitMeta reads the Phase-0 git metadata from graph.fb cheaply using
-// fbreader (no entity/relationship decode). Returns zero values for non-git
-// repos or graphs written before #2088.
-func repoGitMeta(stateDir string) (ref, sha string, isWorktree bool) {
+// repoGitMeta reads the Phase-0 git metadata and M4 coverage status from
+// graph.fb cheaply via fbreader (no entity/relationship decode). Returns zero
+// values for non-git repos or graphs written before these fields were added.
+func repoGitMeta(stateDir string) (ref, sha string, isWorktree bool, coverageStatus string) {
 	fbPath := filepath.Join(stateDir, "graph.fb")
 	r, err := fbreader.Open(fbPath)
 	if err != nil {
-		return "", "", false
+		return "", "", false, ""
 	}
 	defer r.Close()
 	meta := r.LoadGraphMeta()
-	return meta.IndexedRef, meta.IndexedSHA, meta.IsWorktree
+	return meta.IndexedRef, meta.IndexedSHA, meta.IsWorktree, meta.CoverageStatus
 }
 
 func repoStats(stateDir string) (files, entities int, lastIndexed time.Time) {

--- a/internal/gitmeta/sparse.go
+++ b/internal/gitmeta/sparse.go
@@ -1,0 +1,195 @@
+// Package gitmeta — sparse.go detects whether a git repository has
+// sparse-checkout enabled and, if so, which path patterns are active.
+//
+// Sparse-checkout (git sparse-checkout / git sparse-checkout set) limits
+// the working tree to a subset of paths defined in:
+//
+//	<git-dir>/info/sparse-checkout          (cone mode OFF / legacy patterns)
+//	<git-dir>/info/sparse-checkout          (cone mode ON — directory prefixes)
+//
+// The cone-mode flag lives at core.sparseCheckoutCone (bool in git-config).
+//
+// Detection strategy (zero git-process overhead on non-sparse repos):
+//  1. Read the git-dir via `git rev-parse --git-dir` (already available via
+//     RunGit — 2-second timeout, returns "" on failure).
+//  2. Check git-config boolean `core.sparseCheckout`. If false/absent → not sparse.
+//  3. Parse <git-dir>/info/sparse-checkout for the active pattern list.
+//
+// SparseInfo is intentionally lightweight — it is computed once per index
+// run and passed into the walk layer as part of Options. The walker uses
+// IsSparsePresent to decide whether to check each file path against the
+// pattern set.
+//
+// Issue #2181 / epic #2175 — M4 sparse-checkout awareness.
+package gitmeta
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CoverageStatus describes the completeness of an indexed repository.
+// The three-way enum is carried in graph.Document.CoverageStatus and surfaced
+// as a badge in the dashboard.
+//
+// Values:
+//
+//	"full"    — normal full working tree (default / no badge shown).
+//	"partial" — git sparse-checkout is active; only a subset of paths are present.
+//	"sparse"  — alias for "partial" (reserved for future use; currently unused).
+const (
+	CoverageStatusFull    = "full"
+	CoverageStatusPartial = "partial"
+)
+
+// SparseInfo carries the result of probing a repo for sparse-checkout state.
+// The zero value (IsSparse=false, Patterns=nil) represents a normal full checkout.
+type SparseInfo struct {
+	// IsSparse is true when git sparse-checkout is enabled for this repo.
+	IsSparse bool
+
+	// Patterns is the list of raw lines from <git-dir>/info/sparse-checkout.
+	// Blank lines and lines starting with '#' are excluded. May be nil when
+	// IsSparse is false or the pattern file is unreadable.
+	Patterns []string
+
+	// ConeMode is true when core.sparseCheckoutCone is enabled. In cone mode
+	// every pattern is treated as a directory prefix (recursive); in non-cone
+	// mode standard gitignore-style globs apply.
+	ConeMode bool
+}
+
+// ProbeRepo detects whether repoPath has git sparse-checkout enabled.
+// Returns a zero SparseInfo (IsSparse=false) for non-git directories,
+// git errors, or when sparse-checkout is disabled.
+//
+// All git operations use a 2-second timeout via RunGit.
+func ProbeRepo(repoPath string) SparseInfo {
+	// Resolve the git directory (handles worktrees correctly).
+	gitDir := RunGit(repoPath, "rev-parse", "--git-dir")
+	if gitDir == "" {
+		return SparseInfo{}
+	}
+	// git rev-parse --git-dir returns a relative path when inside the repo.
+	// Make it absolute relative to repoPath.
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(repoPath, gitDir)
+	}
+
+	// Check core.sparseCheckout config flag.
+	enabled := RunGit(repoPath, "config", "--local", "--get", "core.sparseCheckout")
+	if enabled != "true" {
+		return SparseInfo{}
+	}
+
+	// Detect cone mode.
+	cone := RunGit(repoPath, "config", "--local", "--get", "core.sparseCheckoutCone")
+	coneMode := cone == "true"
+
+	// Parse the sparse-checkout pattern file.
+	patterns := parseSparsePatternFile(filepath.Join(gitDir, "info", "sparse-checkout"))
+
+	return SparseInfo{
+		IsSparse: true,
+		Patterns: patterns,
+		ConeMode: coneMode,
+	}
+}
+
+// parseSparsePatternFile reads the sparse-checkout pattern file and returns
+// non-empty, non-comment lines. Returns nil when the file is absent or
+// unreadable (a missing file is not an error — it just means no patterns).
+func parseSparsePatternFile(path string) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var patterns []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, line)
+	}
+	return patterns
+}
+
+// IsPathIncluded reports whether relPath (repo-relative forward-slash path)
+// is covered by si's sparse pattern set.
+//
+// When IsSparse is false every path is included (full checkout).
+// When Patterns is empty every path is excluded (nothing checked out).
+//
+// Cone mode: each non-negation pattern is a directory prefix; a file is
+// included when it starts with "<pattern>/" or equals the pattern exactly,
+// OR when the pattern is "/" (repo root match-all).
+//
+// Non-cone mode: standard gitignore-style prefix / glob semantics. For
+// simplicity we use a prefix match: a file is included when one of its
+// ancestor directories or the file itself matches a pattern.
+func IsPathIncluded(si SparseInfo, relPath string) bool {
+	if !si.IsSparse {
+		return true
+	}
+	if len(si.Patterns) == 0 {
+		return false
+	}
+
+	// Normalise: no leading slash, forward slashes only.
+	rel := filepath.ToSlash(relPath)
+	rel = strings.TrimPrefix(rel, "/")
+
+	for _, pat := range si.Patterns {
+		// Negation patterns (!) are not implemented here — cone mode doesn't
+		// use them; non-cone repos with negation patterns are rare. Treat
+		// negation lines as excluders (file is excluded when a negation matches).
+		negation := strings.HasPrefix(pat, "!")
+		p := strings.TrimPrefix(pat, "!")
+		p = strings.TrimPrefix(p, "/")
+		p = strings.TrimSuffix(p, "/")
+
+		var match bool
+		if si.ConeMode {
+			// In cone mode, pat is a directory prefix.
+			if p == "" || p == "*" {
+				match = true // wildcard / root
+			} else {
+				match = rel == p ||
+					strings.HasPrefix(rel, p+"/")
+			}
+		} else {
+			// Non-cone: treat as a path prefix.
+			// A pattern "services/payments" covers "services/payments/file.go".
+			if p == "" || p == "*" || p == "**" {
+				match = true
+			} else {
+				match = rel == p ||
+					strings.HasPrefix(rel, p+"/")
+			}
+		}
+
+		if match {
+			if negation {
+				return false
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// CoverageStatus returns CoverageStatusPartial when the SparseInfo indicates
+// a sparse checkout, otherwise CoverageStatusFull. This is the string stored
+// in graph.Document.CoverageStatus.
+func (si SparseInfo) CoverageStatus() string {
+	if si.IsSparse {
+		return CoverageStatusPartial
+	}
+	return CoverageStatusFull
+}

--- a/internal/gitmeta/sparse_test.go
+++ b/internal/gitmeta/sparse_test.go
@@ -1,0 +1,132 @@
+package gitmeta_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/gitmeta"
+)
+
+// TestProbeRepo_nonSparse verifies that a regular full-checkout repo
+// is not flagged as sparse.
+func TestProbeRepo_nonSparse(t *testing.T) {
+	dir := initBareRepo(t, "main")
+	si := gitmeta.ProbeRepo(dir)
+	if si.IsSparse {
+		t.Errorf("ProbeRepo: expected IsSparse=false for a full checkout")
+	}
+}
+
+// TestProbeRepo_nonGit verifies that a plain directory returns zero SparseInfo.
+func TestProbeRepo_nonGit(t *testing.T) {
+	dir := t.TempDir()
+	si := gitmeta.ProbeRepo(dir)
+	if si.IsSparse {
+		t.Error("ProbeRepo: expected IsSparse=false for a non-git directory")
+	}
+}
+
+// TestProbeRepo_sparseEnabled creates a repo with core.sparseCheckout=true
+// and a sparse-checkout pattern file, then verifies ProbeRepo detects it.
+func TestProbeRepo_sparseEnabled(t *testing.T) {
+	dir := initBareRepo(t, "main")
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Enable sparse-checkout via git config.
+	run("config", "core.sparseCheckout", "true")
+
+	// Write a pattern file.
+	gitDir := filepath.Join(dir, ".git")
+	infoDir := filepath.Join(gitDir, "info")
+	if err := os.MkdirAll(infoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	patternContent := "# comment\nservices/payments\nservices/orders\n"
+	if err := os.WriteFile(filepath.Join(infoDir, "sparse-checkout"), []byte(patternContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	si := gitmeta.ProbeRepo(dir)
+	if !si.IsSparse {
+		t.Fatal("ProbeRepo: expected IsSparse=true when core.sparseCheckout=true")
+	}
+	if len(si.Patterns) != 2 {
+		t.Errorf("ProbeRepo: expected 2 patterns, got %d: %v", len(si.Patterns), si.Patterns)
+	}
+	if si.Patterns[0] != "services/payments" || si.Patterns[1] != "services/orders" {
+		t.Errorf("ProbeRepo: unexpected patterns: %v", si.Patterns)
+	}
+}
+
+// TestIsPathIncluded_nonSparse verifies every path is included for a non-sparse repo.
+func TestIsPathIncluded_nonSparse(t *testing.T) {
+	si := gitmeta.SparseInfo{IsSparse: false}
+	paths := []string{"cmd/main.go", "internal/foo/bar.go", "README.md"}
+	for _, p := range paths {
+		if !gitmeta.IsPathIncluded(si, p) {
+			t.Errorf("IsPathIncluded: expected true for %q on non-sparse repo", p)
+		}
+	}
+}
+
+// TestIsPathIncluded_sparseConeModePatterns tests cone-mode prefix matching.
+func TestIsPathIncluded_sparseConeModePatterns(t *testing.T) {
+	si := gitmeta.SparseInfo{
+		IsSparse: true,
+		ConeMode: true,
+		Patterns: []string{"services/payments", "libs/shared"},
+	}
+
+	included := []string{
+		"services/payments/handler.go",
+		"services/payments/sub/deep.go",
+		"libs/shared/utils.go",
+	}
+	excluded := []string{
+		"services/orders/handler.go",
+		"cmd/main.go",
+		"internal/other.go",
+	}
+
+	for _, p := range included {
+		if !gitmeta.IsPathIncluded(si, p) {
+			t.Errorf("IsPathIncluded: expected true for %q", p)
+		}
+	}
+	for _, p := range excluded {
+		if gitmeta.IsPathIncluded(si, p) {
+			t.Errorf("IsPathIncluded: expected false for %q", p)
+		}
+	}
+}
+
+// TestIsPathIncluded_emptyPatterns verifies all paths excluded when sparse but no patterns.
+func TestIsPathIncluded_emptyPatterns(t *testing.T) {
+	si := gitmeta.SparseInfo{IsSparse: true, Patterns: nil}
+	if gitmeta.IsPathIncluded(si, "cmd/main.go") {
+		t.Error("IsPathIncluded: expected false when sparse with empty patterns")
+	}
+}
+
+// TestCoverageStatus verifies the two states.
+func TestCoverageStatus(t *testing.T) {
+	full := gitmeta.SparseInfo{IsSparse: false}
+	if got := full.CoverageStatus(); got != gitmeta.CoverageStatusFull {
+		t.Errorf("CoverageStatus: got %q, want %q", got, gitmeta.CoverageStatusFull)
+	}
+
+	partial := gitmeta.SparseInfo{IsSparse: true}
+	if got := partial.CoverageStatus(); got != gitmeta.CoverageStatusPartial {
+		t.Errorf("CoverageStatus: got %q, want %q", got, gitmeta.CoverageStatusPartial)
+	}
+}

--- a/internal/graph/fbgraph/Graph.go
+++ b/internal/graph/fbgraph/Graph.go
@@ -238,8 +238,19 @@ func (rcv *Graph) MutateIsWorktree(n bool) bool {
 	return rcv._tab.MutateBoolSlot(32, n)
 }
 
+// CoverageStatus returns the coverage status string ("" / "full" / "partial").
+// Field slot 15 / vtable offset 34 — appended after is_worktree (#2181 / M4).
+// Returns nil (empty) for graphs written before this field was added.
+func (rcv *Graph) CoverageStatus() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(34))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
 func GraphStart(builder *flatbuffers.Builder) {
-	builder.StartObject(15)
+	builder.StartObject(16)
 }
 func GraphAddVersion(builder *flatbuffers.Builder, version int32) {
 	builder.PrependInt32Slot(0, version, 2)
@@ -295,6 +306,13 @@ func GraphAddIndexedSha(builder *flatbuffers.Builder, indexedSha flatbuffers.UOf
 func GraphAddIsWorktree(builder *flatbuffers.Builder, isWorktree bool) {
 	builder.PrependBoolSlot(14, isWorktree, false)
 }
+
+// GraphAddCoverageStatus writes the M4 sparse-checkout coverage_status field
+// (#2181). Slot 15, vtable offset 34. Empty string = omitted by FlatBuffers.
+func GraphAddCoverageStatus(builder *flatbuffers.Builder, coverageStatus flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(15, flatbuffers.UOffsetT(coverageStatus), 0)
+}
+
 func GraphEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }

--- a/internal/graph/fbreader/reader.go
+++ b/internal/graph/fbreader/reader.go
@@ -184,6 +184,11 @@ type GraphMeta struct {
 	IndexedRef string
 	IndexedSHA string
 	IsWorktree bool
+
+	// CoverageStatus — "" / "full" for a normal checkout; "partial" when
+	// git sparse-checkout was active at index time (#2181 / M4 of #2175).
+	// Empty for graphs written before this field was added.
+	CoverageStatus string
 }
 
 // CommunityCount returns the number of aggregate Louvain communities
@@ -251,6 +256,8 @@ func (r *Reader) LoadGraphMeta() GraphMeta {
 		IndexedRef: string(r.root.IndexedRef()),
 		IndexedSHA: string(r.root.IndexedSha()),
 		IsWorktree: r.root.IsWorktree(),
+		// M4 sparse-checkout (#2181). Defaults to "" for legacy graphs.
+		CoverageStatus: string(r.root.CoverageStatus()),
 	}
 }
 

--- a/internal/graph/fbwriter/streaming.go
+++ b/internal/graph/fbwriter/streaming.go
@@ -65,6 +65,9 @@ type GraphMetadata struct {
 	IndexedSHA string
 	// IsWorktree is true when the repo is a linked git worktree.
 	IsWorktree bool
+	// CoverageStatus is "" / "full" for a normal checkout or "partial" when
+	// git sparse-checkout is active (#2181 / M4 of #2175).
+	CoverageStatus string
 	// AlgorithmStats, when non-nil, writes the Pass-4 graph-algorithm
 	// aggregate scalars into the Graph table.
 	AlgorithmStats *graph.AlgorithmStats
@@ -222,6 +225,10 @@ func (sw *StreamingWriter) finalize(meta GraphMetadata) []byte {
 	// which is indistinguishable from "not set" to older readers.
 	indexedRef := b.CreateString(meta.IndexedRef)
 	indexedSHA := b.CreateString(meta.IndexedSHA)
+	// M4 sparse-checkout (#2181): create the coverage_status string offset.
+	// FlatBuffers omits the field when the value is "" (default), so older
+	// readers that don't know this slot see a clean zero.
+	coverageStatus := b.CreateString(meta.CoverageStatus)
 
 	// ── Graph root ─────────────────────────────────────────────────────────
 	fb.GraphStart(b)
@@ -244,6 +251,9 @@ func (sw *StreamingWriter) finalize(meta GraphMetadata) []byte {
 	fb.GraphAddIndexedSha(b, indexedSHA)
 	if meta.IsWorktree {
 		fb.GraphAddIsWorktree(b, true)
+	}
+	if meta.CoverageStatus != "" {
+		fb.GraphAddCoverageStatus(b, coverageStatus)
 	}
 	root := fb.GraphEnd(b)
 	fb.FinishGraphBuffer(b, root)
@@ -295,6 +305,7 @@ func streamingMarshal(doc *graph.Document) ([]byte, error) {
 		IndexedRef:     doc.IndexedRef,
 		IndexedSHA:     doc.IndexedSHA,
 		IsWorktree:     doc.IsWorktree,
+		CoverageStatus: doc.CoverageStatus,
 		AlgorithmStats: doc.AlgorithmStats,
 		Communities:    doc.Communities,
 	}), nil

--- a/internal/graph/fbwriter/writer_test.go
+++ b/internal/graph/fbwriter/writer_test.go
@@ -219,6 +219,54 @@ func TestRoundtripGitMeta(t *testing.T) {
 	}
 }
 
+// TestRoundtripCoverageStatus verifies that the M4 sparse-checkout
+// coverage_status field (#2181) survives a write→read cycle through graph.fb,
+// and that a graph written without it reads back with the zero-value default
+// ("" — treated as "full" by readers).
+func TestRoundtripCoverageStatus(t *testing.T) {
+	// Case 1: partial coverage (sparse checkout).
+	docPartial := &graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		Repo:           "fixture-sparse",
+		Entities:       []graph.Entity{{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "services/payments/a.go"}},
+		CoverageStatus: "partial",
+	}
+	docPartial.Stats.Entities = 1
+	out := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(out, docPartial); err != nil {
+		t.Fatalf("write partial: %v", err)
+	}
+	gotPartial, err := graph.LoadGraphFromDir(filepath.Dir(out))
+	if err != nil {
+		t.Fatalf("load partial: %v", err)
+	}
+	if gotPartial.CoverageStatus != "partial" {
+		t.Errorf("CoverageStatus: got %q want %q", gotPartial.CoverageStatus, "partial")
+	}
+
+	// Case 2: full coverage (field absent — default).
+	docFull := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-full",
+		Entities:    []graph.Entity{{ID: "ent0000000000000a", Name: "bar", Kind: "function", SourceFile: "main.go"}},
+		// CoverageStatus intentionally omitted → should read back as "".
+	}
+	docFull.Stats.Entities = 1
+	out2 := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(out2, docFull); err != nil {
+		t.Fatalf("write full: %v", err)
+	}
+	gotFull, err := graph.LoadGraphFromDir(filepath.Dir(out2))
+	if err != nil {
+		t.Fatalf("load full: %v", err)
+	}
+	if gotFull.CoverageStatus != "" {
+		t.Errorf("CoverageStatus default: got %q want empty string", gotFull.CoverageStatus)
+	}
+}
+
 // TestRoundtripNoAlgoData verifies a graph written with NO community data
 // (the --skip-pass=graph-algo case) reads back with zero communities, nil
 // AlgorithmStats, and un-annotated entities (#1620 — old-file compatibility).

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -37,6 +37,16 @@ type Document struct {
 	IndexedRef string `json:"indexed_ref,omitempty"`
 	IndexedSHA string `json:"indexed_sha,omitempty"`
 	IsWorktree bool   `json:"is_worktree,omitempty"`
+
+	// CoverageStatus indicates whether the indexed working tree is a full
+	// or partial checkout (#2181 / M4 of monorepo epic #2175).
+	//
+	// Values (see internal/gitmeta constants):
+	//   ""        — field absent / legacy graph (treated as "full" by readers).
+	//   "full"    — normal full checkout; all tracked files are present.
+	//   "partial" — git sparse-checkout is active; only a subset of paths
+	//               was indexed. Readers should surface a badge in the UI.
+	CoverageStatus string `json:"coverage_status,omitempty"`
 }
 
 // Stats summarises a Document.

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -140,6 +140,8 @@ func loadFBDocument(path string) (*Document, error) {
 		IndexedRef: meta.IndexedRef,
 		IndexedSHA: meta.IndexedSHA,
 		IsWorktree: meta.IsWorktree,
+		// M4 sparse-checkout (#2181). Defaults to "" for legacy graphs.
+		CoverageStatus: meta.CoverageStatus,
 	}
 
 	// AlgorithmStats: only attach when the algo pass actually ran. We treat

--- a/internal/graph/schema/graph.fbs
+++ b/internal/graph/schema/graph.fbs
@@ -104,6 +104,14 @@ table Graph {
   indexed_ref: string;
   indexed_sha: string;
   is_worktree: bool = false;
+
+  // M4 sparse-checkout awareness (#2181 / epic #2175). Appended after
+  // is_worktree so existing field IDs are unchanged and old graph.fb files
+  // read back with this defaulted to "" (= "full" by convention).
+  //
+  // coverage_status — "" or "full" for a normal checkout; "partial" when
+  //   git sparse-checkout is active and only a subset of paths was indexed.
+  coverage_status: string;
 }
 
 root_type Graph;


### PR DESCRIPTION
## 1. Problem

Meta/Stripe/Google-style users with git sparse-checkout enabled were hitting extraction errors (or indexing files not present on disk) because archigraph walked the full git tree without knowing which paths were locally checked out.

## 2. Solution

Layer 5 (P4) sparse-checkout awareness wired into the walker, plus a `coverage_status` field stamped on every graph.

## 3. Files changed

| File | Change |
|---|---|
| `internal/gitmeta/sparse.go` (new) | `ProbeRepo`, `IsPathIncluded`, `CoverageStatus()`, constants |
| `internal/daemon/walk/walker.go` | Layer 5 P4 filter via `Options.Sparse` |
| `internal/graph/schema/graph.fbs` | `coverage_status: string` slot 15 appended |
| `internal/graph/fbgraph/Graph.go` | Accessor + builder stub for slot 15 |
| `internal/graph/fbwriter/streaming.go` | `GraphMetadata.CoverageStatus`; written when non-empty |
| `internal/graph/fbreader/reader.go` | `GraphMeta.CoverageStatus` decoded |
| `internal/graph/load.go` | `CoverageStatus` propagated into `graph.Document` |
| `internal/graph/graph.go` | `Document.CoverageStatus string` field |
| `cmd/archigraph/index.go` | `ProbeRepo` wired before walk + after Run for doc stamp |
| `internal/dashboard/v2_group_settings.go` | `coverage_status` field on the settings API response |

## 4. Behaviour

- **Full checkout** (no sparse-checkout): zero overhead; `coverage_status` omitted from graph.fb (default "").
- **Sparse checkout active**: walker silently skips absent files; graph stamped with `coverage_status: "partial"`; dashboard settings API returns `"coverage_status": "partial"` for that repo.
- **Old graph.fb** (pre-M4): `CoverageStatus` reads back as "" — treated as full by all readers.

## 5. Tests

- `internal/gitmeta/sparse_test.go` — 7 tests covering ProbeRepo (non-sparse, non-git, sparse-enabled), IsPathIncluded (cone-mode, non-sparse, empty patterns), CoverageStatus enum. All PASS.
- `internal/daemon/walk/sparse_walker_test.go` — 3 tests: cone-mode filter returns only sparse-included files, non-sparse full walk, empty-pattern zero-file result. All PASS.
- `internal/graph/fbwriter/writer_test.go::TestRoundtripCoverageStatus` — "partial" survives write→read; absent field reads back as "". PASS.

## 6. Acceptance

```
ok  github.com/cajasmota/archigraph/internal/gitmeta
ok  github.com/cajasmota/archigraph/internal/daemon/walk
ok  github.com/cajasmota/archigraph/internal/graph
ok  github.com/cajasmota/archigraph/internal/graph/fbreader
ok  github.com/cajasmota/archigraph/internal/graph/fbwriter
ok  github.com/cajasmota/archigraph/internal/dashboard
```

## 7. Dashboard badge

`GET /api/v2/groups/{group}/settings` now includes `"coverage_status": "partial"` for repos indexed under a sparse checkout. Frontend can render a "Partial" badge alongside the repo name.

Closes #2181
Refs #2175

🤖 Generated with [Claude Code](https://claude.com/claude-code)