### PR TITLE
feat(monorepo): unified entity + module tree nav (M3 of #2175)

### DIFF
--- a/internal/cli/monorepo.go
+++ b/internal/cli/monorepo.go
@@ -4,15 +4,27 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cajasmota/archigraph/internal/daemon/client"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/gitmeta"
 	"github.com/cajasmota/archigraph/internal/install/detect"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
+
+// resolveSymlinks resolves any symlinks in path, returning the real absolute
+// path. Falls back to the original path on error.
+func resolveSymlinks(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
+}
 
 func newMonorepoCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -23,6 +35,7 @@ func newMonorepoCmd() *cobra.Command {
 		newMonorepoAddCmd(),
 		newMonorepoRemoveCmd(),
 		newMonorepoListCmd(),
+		newMonorepoMigrateCmd(),
 	)
 	return cmd
 }
@@ -284,4 +297,198 @@ func without(base, drop []string) []string {
 		}
 	}
 	return out
+}
+
+// ---------------------------------------------------------------------------
+// monorepo migrate
+// ---------------------------------------------------------------------------
+
+// MigrateResult describes the outcome of MigratePerSubRepoFleet.
+type MigrateResult struct {
+	// Collapsed is the list of parent repo slugs that were collapsed (had sub-repos merged).
+	Collapsed []string
+	// Already is the list of parent repo slugs that were already collapsed (idempotent).
+	Already []string
+	// Unchanged is the list of repo slugs that were left standalone (no shared git root).
+	Unchanged []string
+}
+
+// MigratePerSubRepoFleet collapses N separate Repo entries that share a
+// common git-toplevel into 1 Repo with N Modules. The parent Repo is the
+// entry whose Path equals the git-toplevel; the others become Module sub-paths
+// relative to the parent. The operation is idempotent: running it twice
+// produces no change after the first run.
+//
+// Only repos inside the given group are considered. Standalone repos (those
+// whose git-toplevel equals their own Path, or those with a unique toplevel)
+// are left untouched.
+func MigratePerSubRepoFleet(group string) (MigrateResult, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return MigrateResult{}, err
+	}
+	var ref *registry.GroupRef
+	for i := range groups {
+		if groups[i].Name == group {
+			ref = &groups[i]
+			break
+		}
+	}
+	if ref == nil {
+		return MigrateResult{}, fmt.Errorf("unknown group: %s", group)
+	}
+	cfg, err := registry.LoadGroupConfig(ref.ConfigPath)
+	if err != nil {
+		return MigrateResult{}, err
+	}
+
+	// Map git-toplevel → list of repos whose path is under that toplevel.
+	type repoIdx struct {
+		idx  int
+		repo *registry.Repo
+	}
+	toplevelMap := map[string][]repoIdx{} // toplevel → repos
+	for i := range cfg.Repos {
+		r := &cfg.Repos[i]
+		meta := gitmeta.Capture(r.Path)
+		top := meta.TopLevel
+		if top == "" {
+			// Not a git repo or git unavailable — treat as standalone.
+			top = r.Path
+		}
+		// Resolve symlinks so macOS /var → /private/var differences don't cause
+		// relative-path mismatches (e.g. in tests using t.TempDir()).
+		top = resolveSymlinks(filepath.Clean(top))
+		toplevelMap[top] = append(toplevelMap[top], repoIdx{idx: i, repo: r})
+	}
+
+	var result MigrateResult
+	// Track which repo indices to keep (by their original index).
+	keepIdx := map[int]bool{}
+	// Track new parent repos to append (already-collapsed ones).
+
+	for top, entries := range toplevelMap {
+		if len(entries) == 1 {
+			// Standalone repo: no collapse needed.
+			keepIdx[entries[0].idx] = true
+			result.Unchanged = append(result.Unchanged, entries[0].repo.Slug)
+			continue
+		}
+
+		// Find the entry whose Path == top (the parent). If none exists,
+		// pick the one with the shortest path as a heuristic parent.
+		parentIdx := -1
+		for _, e := range entries {
+			if resolveSymlinks(filepath.Clean(e.repo.Path)) == top {
+				parentIdx = e.idx
+				break
+			}
+		}
+		if parentIdx == -1 {
+			// Find shortest path as parent.
+			shortest := entries[0]
+			for _, e := range entries[1:] {
+				if len(e.repo.Path) < len(shortest.repo.Path) {
+					shortest = e
+				}
+			}
+			parentIdx = shortest.idx
+		}
+
+		parent := cfg.Repos[parentIdx]
+
+		// Collect module sub-paths from the child entries.
+		var newModules []string
+		for _, e := range entries {
+			if e.idx == parentIdx {
+				continue
+			}
+			// Resolve symlinks on the child path so the relative computation
+			// works correctly on macOS where /tmp → /private/tmp.
+			childPath := resolveSymlinks(filepath.Clean(e.repo.Path))
+			rel, err := filepath.Rel(top, childPath)
+			if err != nil || rel == "." {
+				continue
+			}
+			newModules = append(newModules, rel)
+		}
+		sort.Strings(newModules)
+
+		// Check if parent already has all modules (idempotent).
+		existingSet := map[string]struct{}{}
+		for _, m := range parent.Modules {
+			existingSet[m] = struct{}{}
+		}
+		allPresent := true
+		for _, m := range newModules {
+			if _, ok := existingSet[m]; !ok {
+				allPresent = false
+				break
+			}
+		}
+
+		if allPresent && len(newModules) > 0 {
+			// Already migrated.
+			keepIdx[parentIdx] = true
+			result.Already = append(result.Already, parent.Slug)
+			continue
+		}
+
+		// Add new modules to parent (uniqueAdd is idempotent).
+		cfg.Repos[parentIdx].Modules = uniqueAdd(parent.Modules, newModules)
+		keepIdx[parentIdx] = true
+		result.Collapsed = append(result.Collapsed, parent.Slug)
+	}
+
+	// Rebuild repos list: keep only parent entries (drop collapsed children).
+	newRepos := make([]registry.Repo, 0, len(keepIdx))
+	for i := range cfg.Repos {
+		if keepIdx[i] {
+			newRepos = append(newRepos, cfg.Repos[i])
+		}
+	}
+	cfg.Repos = newRepos
+
+	if err := registry.SaveGroupConfig(ref.ConfigPath, cfg); err != nil {
+		return MigrateResult{}, err
+	}
+	return result, nil
+}
+
+// newMonorepoMigrateCmd returns the `monorepo migrate` subcommand.
+func newMonorepoMigrateCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "migrate <group>",
+		Short: "Collapse per-sub-repo fleet entries into one Repo with Modules",
+		Long: `migrate collapses N separate Repo entries that share a common git-toplevel
+into 1 Repo with N Modules. Idempotent: running it twice produces no change
+after the first run. Standalone repos (unique git root) are left untouched.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			group := args[0]
+			result, err := MigratePerSubRepoFleet(group)
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(result)
+			}
+			w := cmd.OutOrStdout()
+			if len(result.Collapsed) > 0 {
+				fmt.Fprintf(w, "collapsed: %s\n", strings.Join(result.Collapsed, ", "))
+			}
+			if len(result.Already) > 0 {
+				fmt.Fprintf(w, "already migrated: %s\n", strings.Join(result.Already, ", "))
+			}
+			if len(result.Unchanged) > 0 {
+				fmt.Fprintf(w, "unchanged (standalone): %s\n", strings.Join(result.Unchanged, ", "))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON result")
+	return cmd
 }

--- a/internal/cli/monorepo_migrate_test.go
+++ b/internal/cli/monorepo_migrate_test.go
@@ -1,0 +1,291 @@
+package cli
+
+// monorepo_migrate_test.go — tests for MigratePerSubRepoFleet (M3 #2180).
+//
+// Three test cases:
+//  1. simple-collapse: N sub-repos with shared git-toplevel → 1 parent + N modules.
+//  2. idempotent: running migrate twice produces no change after first run.
+//  3. mixed: some repos standalone (unique git root), some collapsable.
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// gitAvailableCLI returns true when git is on PATH.
+func gitAvailableCLI() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+// initGitRepoForMigrate creates a minimal git repo with one commit.
+func initGitRepoForMigrate(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	run("config", "user.email", "test@test.invalid")
+	run("config", "user.name", "Test")
+	placeholder := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(placeholder, []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "init")
+}
+
+// writeTestGroupConfig writes a minimal fleet config + registry in a temp dir
+// and sets ARCHIGRAPH_HOME + XDG_CONFIG_HOME environment overrides so the
+// production registry functions read from the temp dir.
+func writeTestGroupConfig(t *testing.T, tmp, groupName string, repos []registry.Repo) (configPath string) {
+	t.Helper()
+	cfg := &registry.GroupConfig{
+		Name:  groupName,
+		Repos: repos,
+	}
+	configPath = filepath.Join(tmp, groupName+".fleet.json")
+	if err := registry.SaveGroupConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveGroupConfig: %v", err)
+	}
+	// Write registry.json pointing at our fleet config.
+	archigraphHome := filepath.Join(tmp, ".archigraph")
+	if err := os.MkdirAll(archigraphHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ARCHIGRAPH_HOME", archigraphHome)
+	// Also set XDG_CONFIG_HOME so ConfigPathFor writes to tmp.
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	if err := registry.AddGroup(groupName, configPath); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+	return configPath
+}
+
+// TestMigratePerSubRepoFleet_SimpleCollapse verifies that N repos sharing a
+// git-toplevel are collapsed into 1 parent repo with N-1 module sub-paths.
+func TestMigratePerSubRepoFleet_SimpleCollapse(t *testing.T) {
+	if !gitAvailableCLI() {
+		t.Skip("git not on PATH — skipping migrate test")
+	}
+
+	tmp := t.TempDir()
+
+	// Create one git repo that acts as the monorepo root.
+	parentPath := filepath.Join(tmp, "platform")
+	initGitRepoForMigrate(t, parentPath)
+
+	// Create sub-dirs that are "sub-repos" in the old fleet config.
+	paymentsPath := filepath.Join(parentPath, "services", "payments")
+	ordersPath := filepath.Join(parentPath, "services", "orders")
+	if err := os.MkdirAll(paymentsPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(ordersPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repos := []registry.Repo{
+		{Slug: "platform", Path: parentPath},
+		{Slug: "payments-svc", Path: paymentsPath},
+		{Slug: "orders-svc", Path: ordersPath},
+	}
+	writeTestGroupConfig(t, tmp, "fleet-x", repos)
+
+	result, err := MigratePerSubRepoFleet("fleet-x")
+	if err != nil {
+		t.Fatalf("MigratePerSubRepoFleet: %v", err)
+	}
+
+	if len(result.Collapsed) != 1 || result.Collapsed[0] != "platform" {
+		t.Errorf("collapsed: want [platform], got %v", result.Collapsed)
+	}
+
+	// Re-load config and verify shape.
+	groups, err := registry.Groups()
+	if err != nil {
+		t.Fatalf("registry.Groups: %v", err)
+	}
+	var cfgPath string
+	for _, g := range groups {
+		if g.Name == "fleet-x" {
+			cfgPath = g.ConfigPath
+		}
+	}
+	if cfgPath == "" {
+		t.Fatal("group fleet-x not found in registry")
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadGroupConfig: %v", err)
+	}
+
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("repos after migration: want 1, got %d", len(cfg.Repos))
+	}
+	parent := cfg.Repos[0]
+	if parent.Slug != "platform" {
+		t.Errorf("parent slug: want platform, got %q", parent.Slug)
+	}
+	sort.Strings(parent.Modules)
+	want := []string{"services/orders", "services/payments"}
+	if len(parent.Modules) != 2 {
+		t.Fatalf("modules: want 2, got %d: %v", len(parent.Modules), parent.Modules)
+	}
+	for i, m := range parent.Modules {
+		if m != want[i] {
+			t.Errorf("module[%d]: want %q, got %q", i, want[i], m)
+		}
+	}
+}
+
+// TestMigratePerSubRepoFleet_Idempotent verifies that running migrate twice
+// produces no change after the first run.
+func TestMigratePerSubRepoFleet_Idempotent(t *testing.T) {
+	if !gitAvailableCLI() {
+		t.Skip("git not on PATH — skipping migrate idempotent test")
+	}
+
+	tmp := t.TempDir()
+	parentPath := filepath.Join(tmp, "monorepo")
+	initGitRepoForMigrate(t, parentPath)
+
+	subPath := filepath.Join(parentPath, "pkg", "auth")
+	if err := os.MkdirAll(subPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repos := []registry.Repo{
+		{Slug: "monorepo", Path: parentPath},
+		{Slug: "auth-pkg", Path: subPath},
+	}
+	writeTestGroupConfig(t, tmp, "fleet-idem", repos)
+
+	// First run — collapses.
+	res1, err := MigratePerSubRepoFleet("fleet-idem")
+	if err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	if len(res1.Collapsed) != 1 {
+		t.Errorf("first run: want 1 collapsed, got %v", res1.Collapsed)
+	}
+
+	// Second run — idempotent: no new collapses and no changes to fleet config.
+	res2, err := MigratePerSubRepoFleet("fleet-idem")
+	if err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	// After the first run, only 1 repo remains per git root, so the second run
+	// sees it as a standalone and reports it as Unchanged. No additional
+	// collapses should happen.
+	if len(res2.Collapsed) != 0 {
+		t.Errorf("second run: want 0 newly collapsed, got %v", res2.Collapsed)
+	}
+
+	// Fleet config should still have 1 repo with 1 module (unchanged from first run).
+	groups, _ := registry.Groups()
+	var cfgPath string
+	for _, g := range groups {
+		if g.Name == "fleet-idem" {
+			cfgPath = g.ConfigPath
+		}
+	}
+	cfg, _ := registry.LoadGroupConfig(cfgPath)
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("after idempotent run: want 1 repo, got %d", len(cfg.Repos))
+	}
+	if len(cfg.Repos[0].Modules) != 1 {
+		t.Errorf("after idempotent run: want 1 module, got %v", cfg.Repos[0].Modules)
+	}
+}
+
+// TestMigratePerSubRepoFleet_Mixed verifies that standalone repos (unique git
+// root) are left untouched while collapsable repos are merged.
+func TestMigratePerSubRepoFleet_Mixed(t *testing.T) {
+	if !gitAvailableCLI() {
+		t.Skip("git not on PATH — skipping migrate mixed test")
+	}
+
+	tmp := t.TempDir()
+
+	// Monorepo: platform + 2 sub-repos.
+	platformPath := filepath.Join(tmp, "platform")
+	initGitRepoForMigrate(t, platformPath)
+	apiPath := filepath.Join(platformPath, "api")
+	workerPath := filepath.Join(platformPath, "worker")
+	for _, d := range []string{apiPath, workerPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Standalone repo: separate git repo.
+	standaloneA := filepath.Join(tmp, "standalone-a")
+	initGitRepoForMigrate(t, standaloneA)
+	standaloneB := filepath.Join(tmp, "standalone-b")
+	initGitRepoForMigrate(t, standaloneB)
+
+	repos := []registry.Repo{
+		{Slug: "platform", Path: platformPath},
+		{Slug: "api-svc", Path: apiPath},
+		{Slug: "worker-svc", Path: workerPath},
+		{Slug: "standalone-a", Path: standaloneA},
+		{Slug: "standalone-b", Path: standaloneB},
+	}
+	writeTestGroupConfig(t, tmp, "fleet-mixed", repos)
+
+	result, err := MigratePerSubRepoFleet("fleet-mixed")
+	if err != nil {
+		t.Fatalf("MigratePerSubRepoFleet: %v", err)
+	}
+
+	// Exactly 1 parent was collapsed.
+	if len(result.Collapsed) != 1 || result.Collapsed[0] != "platform" {
+		t.Errorf("collapsed: want [platform], got %v", result.Collapsed)
+	}
+	// 2 standalone repos unchanged.
+	if len(result.Unchanged) != 2 {
+		t.Errorf("unchanged: want 2, got %v", result.Unchanged)
+	}
+
+	// Verify final fleet shape: 3 repos (platform + 2 standalones).
+	groups, _ := registry.Groups()
+	var cfgPath string
+	for _, g := range groups {
+		if g.Name == "fleet-mixed" {
+			cfgPath = g.ConfigPath
+		}
+	}
+	cfg, _ := registry.LoadGroupConfig(cfgPath)
+	if len(cfg.Repos) != 3 {
+		slugs := make([]string, len(cfg.Repos))
+		for i, r := range cfg.Repos {
+			slugs[i] = r.Slug
+		}
+		t.Errorf("repos: want 3, got %d: %v", len(cfg.Repos), slugs)
+	}
+
+	// Verify we can JSON-round-trip the result without errors.
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal(result): %v", err)
+	}
+	var rt MigrateResult
+	if err := json.Unmarshal(data, &rt); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+}

--- a/internal/dashboard/handlers_v2_groups_monorepo_test.go
+++ b/internal/dashboard/handlers_v2_groups_monorepo_test.go
@@ -1,0 +1,150 @@
+package dashboard
+
+// handlers_v2_groups_monorepo_test.go — M3 (#2180) monorepo entity tests.
+//
+// Verifies that GET /api/v2/groups returns the correct monorepos map when
+// a group has a repo with declared modules (polyglot-platform style with
+// N sub-paths registered as ONE Repo with N Modules).
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// buildModulePaths returns N synthetic module paths like "services/mod-0", …
+func buildModulePaths(n int) []string {
+	paths := make([]string, n)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("services/mod-%d", i)
+	}
+	return paths
+}
+
+// TestV2Groups_MonorepoShape verifies that a group with a single 36-module
+// repo is returned with:
+//   - repos: ["client-fixture-x"]
+//   - monorepos: {"client-fixture-x": [36 module paths]}
+func TestV2Groups_MonorepoShape(t *testing.T) {
+	const repoSlug = "client-fixture-x"
+	modules := buildModulePaths(36)
+
+	st := newFakeStore()
+	st.groups[repoSlug] = GroupSummary{
+		Name:        "polyglot-fleet",
+		ConfigPath:  "/tmp/polyglot-fleet.json",
+		Repos:       []string{repoSlug},
+		EntityCount: 12000,
+		LastIndexed: time.Now().UTC().Format(time.RFC3339),
+		Monorepos:   map[string][]string{repoSlug: modules},
+	}
+
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups")
+	if err != nil {
+		t.Fatalf("GET /api/v2/groups: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	type wireGroup struct {
+		ID        string              `json:"id"`
+		Repos     []string            `json:"repos"`
+		Monorepos map[string][]string `json:"monorepos"`
+	}
+	var body struct {
+		OK   bool        `json:"ok"`
+		Data []wireGroup `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Error("ok: want true")
+	}
+	if len(body.Data) != 1 {
+		t.Fatalf("want 1 group, got %d", len(body.Data))
+	}
+
+	g := body.Data[0]
+
+	// repos slice must contain exactly the single parent slug.
+	if len(g.Repos) != 1 || g.Repos[0] != repoSlug {
+		t.Errorf("repos: want [%q], got %v", repoSlug, g.Repos)
+	}
+
+	// monorepos must be present and contain the slug key.
+	if g.Monorepos == nil {
+		t.Fatal("monorepos: want non-nil map")
+	}
+	gotModules, ok := g.Monorepos[repoSlug]
+	if !ok {
+		t.Fatalf("monorepos: key %q missing; got keys %v", repoSlug, g.Monorepos)
+	}
+	if len(gotModules) != 36 {
+		t.Errorf("monorepos[%q]: want 36 module paths, got %d", repoSlug, len(gotModules))
+	}
+	// Spot-check first and last module path.
+	if gotModules[0] != "services/mod-0" {
+		t.Errorf("module[0]: want %q, got %q", "services/mod-0", gotModules[0])
+	}
+	if gotModules[35] != "services/mod-35" {
+		t.Errorf("module[35]: want %q, got %q", "services/mod-35", gotModules[35])
+	}
+}
+
+// TestV2Groups_NoModules_MonoreposOmitted verifies that repos without modules
+// do NOT include a monorepos key in the response (omitempty contract).
+func TestV2Groups_NoModules_MonoreposOmitted(t *testing.T) {
+	st := newFakeStore()
+	st.groups["standalone"] = GroupSummary{
+		Name:        "standalone",
+		ConfigPath:  "/tmp/standalone.json",
+		Repos:       []string{"repo-a", "repo-b"},
+		EntityCount: 500,
+		LastIndexed: time.Now().UTC().Format(time.RFC3339),
+		// No Monorepos field
+	}
+
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var body struct {
+		OK   bool `json:"ok"`
+		Data []struct {
+			ID        string              `json:"id"`
+			Monorepos map[string][]string `json:"monorepos"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) == 0 {
+		t.Fatal("want at least 1 group")
+	}
+	if body.Data[0].Monorepos != nil {
+		t.Errorf("monorepos: want nil (omitted) for standalone repo, got %v", body.Data[0].Monorepos)
+	}
+}

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -37,6 +37,11 @@ type GroupSummary struct {
 	LastIndexed string   `json:"last_indexed,omitempty"` // RFC3339, most-recent across repos
 	Frameworks  []string `json:"frameworks,omitempty"`   // top-8 frameworks by frequency, desc
 
+	// Monorepos maps parent-repo slug → list of registered module sub-paths.
+	// Only populated for repos that have at least one Module declared (#2180).
+	// Key is the repo slug; value is the Module slice from the fleet config.
+	Monorepos map[string][]string `json:"monorepos,omitempty"`
+
 	// RepoPaths are the absolute on-disk paths of each repo in the group.
 	// Not serialised to JSON; used internally to compute tier state (S1 #2151).
 	RepoPaths []string `json:"-"`
@@ -129,6 +134,13 @@ func (liveStore) ListGroups() ([]GroupSummary, error) {
 				s.Repos = append(s.Repos, r.Slug)
 				// S1 (#2151): populate RepoPaths for tier-state reporting.
 				s.RepoPaths = append(s.RepoPaths, r.Path)
+				// M3 (#2180): populate Monorepos for repos with declared modules.
+				if len(r.Modules) > 0 {
+					if s.Monorepos == nil {
+						s.Monorepos = make(map[string][]string)
+					}
+					s.Monorepos[r.Slug] = r.Modules
+				}
 			}
 		}
 		// Aggregate entity_count + last_indexed from per-repo graph-stats.json.

--- a/internal/dashboard/v2_groups.go
+++ b/internal/dashboard/v2_groups.go
@@ -47,6 +47,9 @@ type v2Group struct {
 	// Precedence across repos: hot > warm > cold > expired.
 	// "cold" when the group has no graph.fb on disk (S1 #2151).
 	Tier string `json:"tier"`
+	// Monorepos maps parent-repo slug → list of module sub-paths (M3 #2180).
+	// Omitted when no repos have declared modules.
+	Monorepos map[string][]string `json:"monorepos,omitempty"`
 }
 
 const (
@@ -101,6 +104,7 @@ func toV2Group(s GroupSummary, histRoot string, tq TierQuerier) v2Group {
 		IndexedAt:   indexedAt,
 		Health:      health,
 		Tier:        tierStr,
+		Monorepos:   s.Monorepos,
 	}
 }
 

--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -200,6 +200,10 @@ type CWDResolution struct {
 	Group string
 	// RepoSlug is the slug of the repo within the group whose path contains cwd.
 	RepoSlug string
+	// ModuleSlug is the relative sub-path of the module within a monorepo repo
+	// when cwd is inside a declared Module sub-path. Empty when not in a module
+	// (standalone repo or monorepo root). Populated by moduleSlugForCWD (M3 #2180).
+	ModuleSlug string
 	// Ref is the git HEAD ref of the repo (or worktree). Empty string means
 	// detached HEAD or non-git directory.
 	Ref string
@@ -214,6 +218,104 @@ type CWDResolution struct {
 	// Source is "worktree_registry" (PH3 ephemeral child), "cwd_registry",
 	// "worktree" (PH1c sibling match), "cwd", "singleton", "explicit", or "none".
 	Source string
+}
+
+// fleetRepoEntry is the minimal fleet-config repo shape needed for module
+// resolution. It mirrors registry.Repo but avoids an import cycle.
+type fleetRepoEntry struct {
+	Slug    string   `json:"slug"`
+	Path    string   `json:"path"`
+	Modules []string `json:"modules,omitempty"`
+}
+
+// fleetGroupConfig is the minimal fleet-config shape for module resolution.
+type fleetGroupConfig struct {
+	Name  string           `json:"name"`
+	Repos []fleetRepoEntry `json:"repos"`
+}
+
+// loadFleetConfigForGroup reads the per-group fleet config JSON and returns
+// the parsed config. It is used by moduleSlugForCWD to access Module
+// declarations that are not stored in the in-memory mcp.Registry (#2180).
+// Returns nil on any error (config missing, malformed) — callers treat nil as
+// "no module info available".
+func loadFleetConfigForGroup(s *State, groupName string) *fleetGroupConfig {
+	if s == nil || s.registry == nil {
+		return nil
+	}
+	// Walk the raw registry.json to find the config_path for this group.
+	// The mcp.Registry is already a parsed view from registry.json.
+	// We re-read the raw file to get the config_path field which is only
+	// present in the CLI array format.
+	rawData, err := os.ReadFile(s.registry.Path)
+	if err != nil {
+		return nil
+	}
+	var raw struct {
+		Version int `json:"version"`
+		Groups  []struct {
+			Name       string `json:"name"`
+			ConfigPath string `json:"config_path"`
+		} `json:"groups"`
+	}
+	if err := json.Unmarshal(rawData, &raw); err != nil || len(raw.Groups) == 0 {
+		return nil
+	}
+	var configPath string
+	for _, g := range raw.Groups {
+		if g.Name == groupName {
+			configPath = g.ConfigPath
+			break
+		}
+	}
+	if configPath == "" {
+		return nil
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil
+	}
+	var cfg fleetGroupConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+	return &cfg
+}
+
+// moduleSlugForCWD returns the registered Module sub-path that contains abs
+// within the given repoPath. It walks the fleet config for the group, finds the
+// repo, and performs longest-prefix matching among its Module entries. Returns
+// "" when abs is not inside any declared module sub-path, or when the repo has
+// no modules (M3 #2180).
+//
+// Example: repoPath=/repos/platform, Module="payments/svc", abs=/repos/platform/payments/svc/api
+// → returns "payments/svc".
+func moduleSlugForCWD(s *State, groupName, repoSlug, repoPath, abs string) string {
+	cfg := loadFleetConfigForGroup(s, groupName)
+	if cfg == nil {
+		return ""
+	}
+	// Find the specific repo entry.
+	var modules []string
+	for _, r := range cfg.Repos {
+		if r.Slug == repoSlug {
+			modules = r.Modules
+			break
+		}
+	}
+	if len(modules) == 0 {
+		return ""
+	}
+	repoClean := filepath.Clean(repoPath)
+	// Find the longest module sub-path that is an ancestor of abs.
+	best := ""
+	for _, mod := range modules {
+		modAbs := filepath.Join(repoClean, mod)
+		if pathContains(modAbs, abs) && len(mod) > len(best) {
+			best = mod
+		}
+	}
+	return best
 }
 
 // ResolveCWD is the PH1c entry point that maps a cwd to a full
@@ -272,9 +374,13 @@ func ResolveCWD(s *State, cwd string) CWDResolution {
 		// Determine which repo slug contains cwd (longest-prefix match).
 		slug, repoPath := repoSlugForCWD(s, group, abs)
 		meta := gitmeta.Capture(repoPath)
+		// M3 (#2180): if the matched repo has declared modules, determine which
+		// module sub-path cwd is inside.
+		modSlug := moduleSlugForCWD(s, group, slug, repoPath, abs)
 		return CWDResolution{
 			Group:      group,
 			RepoSlug:   slug,
+			ModuleSlug: modSlug,
 			Ref:        meta.Ref,
 			SHA:        meta.SHA,
 			IsWorktree: meta.IsWorktree,

--- a/internal/mcp/routing_module_test.go
+++ b/internal/mcp/routing_module_test.go
@@ -1,0 +1,187 @@
+// routing_module_test.go — M3 (#2180) module-slug resolution tests.
+//
+// Verifies that CWDResolution.ModuleSlug is populated when cwd is inside
+// a declared module sub-path of a registered monorepo repo.
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeRegistryAndFleet writes a minimal registry.json + fleet config in tmp.
+// Returns the registry path and a ready *State.
+// The fleet config has one group with one repo that has nModules modules.
+func writeRegistryAndFleet(t *testing.T, tmp, groupName, repoSlug, repoPath string, moduleSubPaths []string) (*State, string) {
+	t.Helper()
+
+	// Write fleet config.
+	type repoEntry struct {
+		Slug    string   `json:"slug"`
+		Path    string   `json:"path"`
+		Modules []string `json:"modules,omitempty"`
+	}
+	type fleetCfg struct {
+		Name  string      `json:"name"`
+		Repos []repoEntry `json:"repos"`
+	}
+	cfg := fleetCfg{
+		Name:  groupName,
+		Repos: []repoEntry{{Slug: repoSlug, Path: repoPath, Modules: moduleSubPaths}},
+	}
+	fleetData, _ := json.Marshal(cfg)
+	fleetPath := filepath.Join(tmp, groupName+".fleet.json")
+	if err := os.WriteFile(fleetPath, fleetData, 0o644); err != nil {
+		t.Fatalf("write fleet: %v", err)
+	}
+
+	// Write registry.json (CLI array format).
+	type groupRef struct {
+		Name       string `json:"name"`
+		ConfigPath string `json:"config_path"`
+	}
+	type regShape struct {
+		Version int        `json:"version"`
+		Groups  []groupRef `json:"groups"`
+	}
+	reg := regShape{Version: 1, Groups: []groupRef{{Name: groupName, ConfigPath: fleetPath}}}
+	regData, _ := json.Marshal(reg)
+	regPath := filepath.Join(tmp, "registry.json")
+	if err := os.WriteFile(regPath, regData, 0o644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+
+	// Build in-memory Registry (mcp.Registry) that points to the repo path.
+	inMemReg := &Registry{
+		Path: regPath,
+		Groups: map[string]RegistryGroup{
+			groupName: {
+				Repos: map[string]RegistryRepo{
+					repoSlug: {Path: repoPath},
+				},
+			},
+		},
+	}
+	return NewState(inMemReg), regPath
+}
+
+// TestModuleSlugForCWD_InsideModule verifies that moduleSlugForCWD returns
+// the correct module sub-path when cwd is inside a module directory.
+func TestModuleSlugForCWD_InsideModule(t *testing.T) {
+	tmp := t.TempDir()
+
+	repoPath := filepath.Join(tmp, "platform")
+	moduleSubPaths := []string{"services/payments", "services/orders", "services/auth"}
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := writeRegistryAndFleet(t, tmp, "client-fixture-x", "platform", repoPath, moduleSubPaths)
+
+	// CWD inside services/payments/api/handlers
+	cwdInsidePayments := filepath.Join(repoPath, "services", "payments", "api", "handlers")
+	if err := os.MkdirAll(cwdInsidePayments, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := moduleSlugForCWD(st, "client-fixture-x", "platform", repoPath, cwdInsidePayments)
+	if got != "services/payments" {
+		t.Errorf("moduleSlugForCWD: want %q, got %q", "services/payments", got)
+	}
+}
+
+// TestModuleSlugForCWD_AtModuleRoot verifies that being at the exact module
+// root path also resolves correctly.
+func TestModuleSlugForCWD_AtModuleRoot(t *testing.T) {
+	tmp := t.TempDir()
+
+	repoPath := filepath.Join(tmp, "platform")
+	moduleSubPaths := []string{"orders", "payments"}
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := writeRegistryAndFleet(t, tmp, "client-fixture-x", "platform", repoPath, moduleSubPaths)
+
+	// CWD exactly at the orders module root.
+	ordersRoot := filepath.Join(repoPath, "orders")
+	if err := os.MkdirAll(ordersRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := moduleSlugForCWD(st, "client-fixture-x", "platform", repoPath, ordersRoot)
+	if got != "orders" {
+		t.Errorf("moduleSlugForCWD: want %q, got %q", "orders", got)
+	}
+}
+
+// TestModuleSlugForCWD_OutsideModule verifies that being at the repo root
+// (but not inside any module) returns "".
+func TestModuleSlugForCWD_OutsideModule(t *testing.T) {
+	tmp := t.TempDir()
+
+	repoPath := filepath.Join(tmp, "platform")
+	moduleSubPaths := []string{"services/payments", "services/orders"}
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := writeRegistryAndFleet(t, tmp, "client-fixture-x", "platform", repoPath, moduleSubPaths)
+
+	// CWD at the repo root — not inside any module.
+	got := moduleSlugForCWD(st, "client-fixture-x", "platform", repoPath, repoPath)
+	if got != "" {
+		t.Errorf("moduleSlugForCWD at repo root: want %q, got %q", "", got)
+	}
+}
+
+// TestModuleSlugForCWD_NoModules verifies that a repo with no declared
+// modules returns "" without panicking.
+func TestModuleSlugForCWD_NoModules(t *testing.T) {
+	tmp := t.TempDir()
+
+	repoPath := filepath.Join(tmp, "standalone")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write fleet with no modules.
+	st, _ := writeRegistryAndFleet(t, tmp, "client-fixture-y", "standalone", repoPath, nil)
+
+	cwdInside := filepath.Join(repoPath, "src")
+	if err := os.MkdirAll(cwdInside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := moduleSlugForCWD(st, "client-fixture-y", "standalone", repoPath, cwdInside)
+	if got != "" {
+		t.Errorf("moduleSlugForCWD (no modules): want %q, got %q", "", got)
+	}
+}
+
+// TestModuleSlugForCWD_LongestPrefixWins verifies that when two module paths
+// are nested (e.g. "a" and "a/b"), the more specific one wins.
+func TestModuleSlugForCWD_LongestPrefixWins(t *testing.T) {
+	tmp := t.TempDir()
+
+	repoPath := filepath.Join(tmp, "platform")
+	// "shared" is a prefix of "shared/core" — we want the longer match.
+	moduleSubPaths := []string{"shared", "shared/core"}
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := writeRegistryAndFleet(t, tmp, "client-fixture-x", "platform", repoPath, moduleSubPaths)
+
+	cwdInsideCore := filepath.Join(repoPath, "shared", "core", "utils")
+	if err := os.MkdirAll(cwdInsideCore, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := moduleSlugForCWD(st, "client-fixture-x", "platform", repoPath, cwdInsideCore)
+	if got != "shared/core" {
+		t.Errorf("moduleSlugForCWD (longest prefix): want %q, got %q", "shared/core", got)
+	}
+}

--- a/webui-v2/src/components/chrome/monorepo-module-list.tsx
+++ b/webui-v2/src/components/chrome/monorepo-module-list.tsx
@@ -1,0 +1,148 @@
+/* ============================================================
+   chrome/monorepo-module-list.tsx — monorepo module subtree in the
+   nav-rail (M3 / #2180).
+
+   Mirrors the WorktreeList pattern. Shows repos that have declared
+   modules as an expandable chevron tree:
+     ▶ parent-repo   36     ← collapsed row with module count
+     └ payments             ← expanded: N module rows indented
+     └ orders
+     └ …
+
+   Only rendered when the group's /api/v2/groups response includes a
+   non-empty `monorepos` map. Graceful degradation when absent.
+   ============================================================ */
+
+import { useState } from "react";
+import { ChevronRight, Package } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useGroupMonorepos } from "@/hooks/use-group-monorepos";
+
+interface ModuleRowProps {
+  subPath: string;
+}
+
+function ModuleRow({ subPath }: ModuleRowProps) {
+  // Extract the leaf name for display; show full sub-path as tooltip.
+  const parts = subPath.split("/");
+  const leafName = parts[parts.length - 1];
+
+  return (
+    <div
+      className="group/mod relative flex items-center h-8 rounded-md px-2.5 mx-2 gap-2 text-text-3 w-[calc(100%-16px)]"
+      title={subPath}
+      data-testid={`module-row-${subPath}`}
+    >
+      {/* Indent visual */}
+      <span className="w-3 shrink-0 opacity-0 group-hover/rail:opacity-100" aria-hidden>
+        └
+      </span>
+
+      <Package size={13} className="shrink-0 text-text-3" aria-label="module" />
+
+      <span className="flex-1 truncate font-mono text-xs opacity-0 group-hover/rail:opacity-100 transition-opacity whitespace-nowrap">
+        {leafName}
+      </span>
+    </div>
+  );
+}
+
+interface ParentRepoRowProps {
+  slug: string;
+  moduleCount: number;
+  isExpanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}
+
+function ParentRepoRow({ slug, moduleCount, isExpanded, onToggle, children }: ParentRepoRowProps) {
+  return (
+    <div className="flex flex-col gap-0">
+      {/* Parent repo header row */}
+      <button
+        onClick={onToggle}
+        title={`${slug} · ${moduleCount} modules`}
+        className={cn(
+          "group/parent relative flex items-center h-9 rounded-md px-2.5 mx-2 gap-2",
+          "text-text-2 transition-colors duration-[120ms] w-[calc(100%-16px)]",
+          "hover:bg-surface-2",
+        )}
+        data-testid={`monorepo-parent-${slug}`}
+      >
+        {/* Chevron — rotates when expanded */}
+        <ChevronRight
+          size={13}
+          className={cn(
+            "shrink-0 text-text-3 transition-transform duration-150 opacity-0 group-hover/rail:opacity-100",
+            isExpanded && "rotate-90",
+          )}
+        />
+
+        <span className="flex-1 truncate font-mono text-xs opacity-0 group-hover/rail:opacity-100 transition-opacity whitespace-nowrap text-left">
+          {slug}
+        </span>
+
+        {/* Module count badge */}
+        <span className="shrink-0 text-[9px] tabular-nums text-text-4 opacity-0 group-hover/rail:opacity-100 transition-opacity">
+          {moduleCount}
+        </span>
+      </button>
+
+      {/* Expanded module rows */}
+      {isExpanded && children}
+    </div>
+  );
+}
+
+export interface MonorepoModuleListProps {
+  /** Resolved group ID (from URL param). */
+  groupId: string;
+}
+
+/**
+ * Renders the monorepo module subtree in the nav-rail.
+ * Returns null when the group has no monorepo repos (graceful degradation).
+ */
+export function MonorepoModuleList({ groupId }: MonorepoModuleListProps) {
+  const { monorepos, isLoading, isError } = useGroupMonorepos(groupId);
+  // Track expanded state per parent repo slug.
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  if (isLoading || isError || !monorepos) return null;
+
+  const entries = Object.entries(monorepos).filter(([, modules]) => modules.length > 0);
+  if (entries.length === 0) return null;
+
+  function toggleSlug(slug: string) {
+    setExpanded((prev) => ({ ...prev, [slug]: !prev[slug] }));
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-0 mt-1"
+      aria-label="Monorepo modules"
+      data-testid="monorepo-module-list"
+    >
+      <div className="my-1.5 mx-3 border-t border-border" />
+
+      {/* Section header — only visible when rail is expanded */}
+      <p className="px-3 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-4 select-none opacity-0 group-hover/rail:opacity-100 transition-opacity whitespace-nowrap">
+        Modules
+      </p>
+
+      {entries.map(([slug, modules]) => (
+        <ParentRepoRow
+          key={slug}
+          slug={slug}
+          moduleCount={modules.length}
+          isExpanded={!!expanded[slug]}
+          onToggle={() => toggleSlug(slug)}
+        >
+          {modules.map((subPath) => (
+            <ModuleRow key={subPath} subPath={subPath} />
+          ))}
+        </ParentRepoRow>
+      ))}
+    </div>
+  );
+}

--- a/webui-v2/src/components/chrome/nav-rail.tsx
+++ b/webui-v2/src/components/chrome/nav-rail.tsx
@@ -23,6 +23,7 @@ import { useAppStore } from "@/store/use-app-store";
 import { usePendingCount } from "@/hooks/use-pending";
 import { SCREENS, PENDING_SCREEN, SETTINGS_SCREEN } from "./screens";
 import { WorktreeList } from "./worktree-list";
+import { MonorepoModuleList } from "./monorepo-module-list";
 
 function rowClass(active: boolean) {
   return cn(
@@ -85,6 +86,9 @@ export function NavRail() {
 
         {/* PH4: worktree subtree — visible when group has worktree refs */}
         <WorktreeList groupId={groupId} />
+
+        {/* M3: monorepo module tree — visible when group has repos with declared modules */}
+        <MonorepoModuleList groupId={groupId} />
       </nav>
 
       {/* Foot */}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -181,6 +181,12 @@ export interface Group {
   /** ms epoch of the most-recent index across repos; `null` when never indexed. */
   indexedAt: number | null;
   health: GroupHealth;
+  /**
+   * Monorepo module map: parent-repo slug → list of module sub-paths.
+   * Only present when the group has repos with declared modules (M3 #2180).
+   * Absent for groups with no monorepo repos.
+   */
+  monorepos?: Record<string, string[]>;
 }
 
 // ----------------------------------------------------------------

--- a/webui-v2/src/hooks/use-group-monorepos.ts
+++ b/webui-v2/src/hooks/use-group-monorepos.ts
@@ -1,0 +1,44 @@
+/* ============================================================
+   hooks/use-group-monorepos.ts — data hook for M3 monorepo module
+   map (#2180).
+
+   Reads the `monorepos` field from the GET /api/v2/groups response
+   for the current group. The groups list is already fetched by
+   useGroups / Landing; this hook derives the monorepos slice from
+   that cached query so no extra network request is needed.
+
+   Returns:
+     monorepos  — Record<string, string[]> or undefined when absent
+     isLoading  — true while the groups query is in flight
+     isError    — true on network error
+   ============================================================ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { Group } from "@/data/types";
+
+/** Query key for the groups list (matches use-groups.ts). */
+const groupsQueryKey = ["groups"] as const;
+
+/**
+ * Derive the monorepos map for a specific group from the cached /api/v2/groups
+ * response. Re-uses the same query so no additional network call is made when
+ * the Landing screen has already fetched the list.
+ */
+export function useGroupMonorepos(groupId: string) {
+  const query = useQuery({
+    queryKey: groupsQueryKey,
+    queryFn: () => api.listGroups(),
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  const group: Group | undefined = query.data?.find((g) => g.id === groupId);
+  const monorepos = group?.monorepos;
+
+  return {
+    monorepos,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}


### PR DESCRIPTION
## Summary

- **Registry/store**: `GroupSummary` extended with `Monorepos map[string][]string` populated from `Repo.Modules` in `liveStore.ListGroups()`
- **Dashboard API**: `v2Group` gains `monorepos omitempty` field mirroring the registry shape; `toV2Group` wires it through. Test registers a 36-module repo and asserts `repos: ["client-fixture-x"]` AND `monorepos: {"client-fixture-x": [36 paths]}`
- **MCP routing**: `CWDResolution.ModuleSlug` field + `moduleSlugForCWD` helper (longest-prefix match among declared Module sub-paths) + `loadFleetConfigForGroup` reads fleet config from registry path; 5 tests covering inside/at-root/outside/no-modules/longest-prefix cases
- **CLI**: `MigratePerSubRepoFleet(group)` collapses N per-sub-repo Repo entries sharing a git-toplevel into 1 Repo + N Modules (symlink-safe on macOS). `archigraph monorepo migrate <group>` subcommand with `--json` flag. Three tests: simple-collapse, idempotent, mixed standalone+collapsable
- **Frontend**: `Group.monorepos?: Record<string, string[]>` in `types.ts`; `MonorepoModuleList` component (expandable chevron tree, mirrors WorktreeList pattern); `useGroupMonorepos` hook (derives from cached `/api/v2/groups` query, no extra request); `NavRail` wired after `WorktreeList`

## Before / After

**Before**: a fleet with 36 sub-repo entries shows 36 separate sidebar slugs.
**After**: ONE `polyglot-platform` entry + a `▶ polyglot-platform  36` row in the rail; chevron expands to 36 module rows.

## Test plan

- [ ] `go test ./internal/dashboard/ -run "Monorepo"` — 2 tests green
- [ ] `go test ./internal/mcp/ -run "TestModuleSlug"` — 5 tests green
- [ ] `go test ./internal/cli/ -run "TestMigrate"` — 3 tests green
- [ ] `go test ./internal/...` — all green (pre-existing `USES_SCHEMA` failure in `internal/types` is on main, not introduced here)
- [ ] `cd webui-v2 && npm run build` — TypeScript clean, vite build succeeds
- [ ] `archigraph monorepo migrate <group>` on a real polyglot fleet — verify fleet config collapses
- [ ] NavRail module tree renders and expands on click when group has monorepos

Closes #2180
Refs #2175

🤖 Generated with [Claude Code](https://claude.com/claude-code)