### PR TITLE
fix(skill): enforce STORAGE DISCIPLINE — never write to repo working tree (#2190)

### DIFF
--- a/internal/cli/docgen.go
+++ b/internal/cli/docgen.go
@@ -70,10 +70,13 @@
 package cli
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -245,6 +248,10 @@ Available sections (--section, used by --tier=0 only):
 		"override the section-level LLM cache directory (default: ~/.archigraph/docs/<group>/.llm-cache/); applies to all tiers")
 	cmd.Flags().BoolVar(&noCache, "no-cache", false,
 		"disable section-level LLM cache reads and writes for this run; applies to all tiers")
+
+	// Sub-commands: storage discipline helpers (#2190).
+	cmd.AddCommand(newDocgenMigrateInRepoCmd())
+	cmd.AddCommand(newDocgenAuditCmd())
 
 	return cmd
 }
@@ -660,3 +667,314 @@ func resolveGroupConfig(group string) (map[string]interface{}, error) {
 	}
 	return out, nil
 }
+
+// ---------------------------------------------------------------------------
+// Storage-discipline helpers (#2190)
+// ---------------------------------------------------------------------------
+
+// docgenHeuristics are file names that indicate a directory is archigraph
+// docgen output (as opposed to hand-written docs). The heuristic is
+// conservative: all three markers come from the generate-docs skill pipeline.
+var docgenHeuristics = []string{
+	".plan.md",
+	".inventory.json",
+	".metadata.json",
+}
+
+// isDocgenOutput reports whether dir looks like archigraph docgen output by
+// checking for any of the heuristic marker files.
+func isDocgenOutput(dir string) bool {
+	for _, name := range docgenHeuristics {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// findInRepoDocgenDirs walks every repo in cfg and returns the list of
+// docs/ (or doc/) directories that appear to be docgen output.
+// It does NOT walk into ~/.archigraph/ to avoid false positives.
+func findInRepoDocgenDirs(cfg *registry.GroupConfig) []string {
+	var found []string
+	for _, r := range cfg.Repos {
+		if r.Path == "" {
+			continue
+		}
+		for _, candidate := range []string{"docs", "doc"} {
+			dir := filepath.Join(r.Path, candidate)
+			info, err := os.Stat(dir)
+			if err != nil || !info.IsDir() {
+				continue
+			}
+			if isDocgenOutput(dir) {
+				found = append(found, dir)
+			}
+		}
+	}
+	return found
+}
+
+// newDocgenMigrateInRepoCmd returns the `archigraph docgen migrate-in-repo`
+// subcommand (#2190).
+func newDocgenMigrateInRepoCmd() *cobra.Command {
+	var group string
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "migrate-in-repo [--group <name>] [--yes]",
+		Short: "Move in-repo docgen output into the archigraph-managed store",
+		Long: `Walks every repo registered in the group and looks for docs/ (or doc/)
+directories that appear to be archigraph docgen output (heuristic: presence of
+.plan.md, .inventory.json, or .metadata.json inside the directory).
+
+For each match the user is asked to confirm before the directory is moved to:
+  ~/.archigraph/docs/<group>/<repo-slug>/
+
+The operation is idempotent: if the target already exists the command skips
+that repo with a warning rather than overwriting existing store content.
+
+Use --yes to skip confirmation prompts (non-interactive / CI).
+
+After migration, the source directory inside the repo working tree is removed.
+Run ` + "`archigraph docgen audit`" + ` first to inspect what would be moved without
+making any changes.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			resolvedGroup, err := resolveGroup(group)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := loadGroupConfigFromRegistry(resolvedGroup)
+			if err != nil {
+				return err
+			}
+
+			dirs := findInRepoDocgenDirs(cfg)
+			if len(dirs) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No in-repo docgen output found. Nothing to migrate.")
+				return nil
+			}
+
+			homeDir, err := registry.HomeDir()
+			if err != nil {
+				return fmt.Errorf("resolve archigraph home: %w", err)
+			}
+
+			w := cmd.OutOrStdout()
+			scanner := bufio.NewScanner(cmd.InOrStdin())
+			migrated, skipped := 0, 0
+
+			for _, srcDir := range dirs {
+				// Determine target path: ~/.archigraph/docs/<group>/<repo-slug>/
+				// We derive the repo slug by matching srcDir prefix against cfg.Repos.
+				repoSlug := ""
+				for _, r := range cfg.Repos {
+					if r.Path != "" && strings.HasPrefix(srcDir, r.Path) {
+						repoSlug = r.Slug
+						break
+					}
+				}
+				if repoSlug == "" {
+					repoSlug = filepath.Base(filepath.Dir(srcDir))
+				}
+
+				targetDir := filepath.Join(homeDir, "docs", resolvedGroup, repoSlug)
+
+				fmt.Fprintf(w, "\nFound in-repo docgen output:\n  src:  %s\n  dst:  %s\n", srcDir, targetDir)
+
+				if !yes {
+					fmt.Fprintf(w, "Move? [y/N]: ")
+					if !scanner.Scan() {
+						fmt.Fprintln(w, "  skipped (no input)")
+						skipped++
+						continue
+					}
+					if strings.ToLower(strings.TrimSpace(scanner.Text())) != "y" {
+						fmt.Fprintln(w, "  skipped.")
+						skipped++
+						continue
+					}
+				}
+
+				// Idempotency guard: skip if target already exists.
+				if _, err := os.Stat(targetDir); err == nil {
+					fmt.Fprintf(w, "  [warn] target already exists, skipping to avoid overwrite: %s\n", targetDir)
+					skipped++
+					continue
+				}
+
+				// Ensure parent directory.
+				if err := os.MkdirAll(filepath.Dir(targetDir), 0o755); err != nil {
+					return fmt.Errorf("create parent for %s: %w", targetDir, err)
+				}
+
+				// Move srcDir → targetDir.
+				if err := os.Rename(srcDir, targetDir); err != nil {
+					return fmt.Errorf("move %s → %s: %w", srcDir, targetDir, err)
+				}
+
+				fmt.Fprintf(w, "  [ ok ] moved to %s\n", targetDir)
+				migrated++
+			}
+
+			fmt.Fprintf(w, "\nmigrate-in-repo complete: %d moved, %d skipped.\n", migrated, skipped)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&group, "group", "", "group name (defaults to sole registered group)")
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip confirmation prompts and move all matches automatically")
+	return cmd
+}
+
+// newDocgenAuditCmd returns the `archigraph docgen audit` subcommand (#2190).
+// It reports in-repo docgen output without moving anything.
+func newDocgenAuditCmd() *cobra.Command {
+	var group string
+
+	cmd := &cobra.Command{
+		Use:   "audit [--group <name>]",
+		Short: "Detect in-repo docgen output (read-only; does not move anything)",
+		Long: `Walks every repo registered in the group and reports docs/ (or doc/)
+directories that appear to contain archigraph docgen output (heuristic: presence
+of .plan.md, .inventory.json, or .metadata.json).
+
+Nothing is moved or deleted. Use this before ` + "`archigraph docgen migrate-in-repo`" + `
+to inspect what would be migrated.
+
+Exit codes:
+  0  No in-repo docgen output detected.
+  1  One or more in-repo docgen directories found (actionable: run migrate-in-repo).
+  2  Internal error (registry unreadable, etc.).`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			resolvedGroup, err := resolveGroup(group)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := loadGroupConfigFromRegistry(resolvedGroup)
+			if err != nil {
+				return err
+			}
+
+			dirs := findInRepoDocgenDirs(cfg)
+			w := cmd.OutOrStdout()
+
+			if len(dirs) == 0 {
+				fmt.Fprintln(w, "[ ok ] No in-repo docgen output detected for group:", resolvedGroup)
+				return nil
+			}
+
+			fmt.Fprintf(w, "[warn] In-repo docgen output detected (group: %s):\n", resolvedGroup)
+			for _, d := range dirs {
+				// Report which heuristic markers were found.
+				var markers []string
+				for _, name := range docgenHeuristics {
+					if _, err := os.Stat(filepath.Join(d, name)); err == nil {
+						markers = append(markers, name)
+					}
+				}
+				fmt.Fprintf(w, "  %s  (markers: %s)\n", d, strings.Join(markers, ", "))
+			}
+			fmt.Fprintln(w, "\nRun `archigraph docgen migrate-in-repo` to move these to the archigraph store.")
+
+			// Return a sentinel error so the shell exit code is 1.
+			return &docgenAuditError{count: len(dirs)}
+		},
+	}
+
+	cmd.Flags().StringVar(&group, "group", "", "group name (defaults to sole registered group)")
+	return cmd
+}
+
+// loadGroupConfigFromRegistry looks up the group's config path from the
+// registry (which respects ARCHIGRAPH_HOME) and loads it. This is the
+// correct way to load group config when the caller only has a group name —
+// it avoids hardcoding the XDG config path.
+func loadGroupConfigFromRegistry(groupName string) (*registry.GroupConfig, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil, fmt.Errorf("read registry: %w", err)
+	}
+	for _, g := range groups {
+		if g.Name == groupName {
+			cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+			if err != nil {
+				return nil, fmt.Errorf("load group config for %q: %w", groupName, err)
+			}
+			return cfg, nil
+		}
+	}
+	return nil, fmt.Errorf("group %q not found in registry; run `archigraph wizard` to register it", groupName)
+}
+
+// docgenAuditError is a sentinel returned by the audit command when in-repo
+// docgen output is found. It causes a non-zero exit code without printing an
+// extra error message (cobra prints Error() for non-nil errors).
+type docgenAuditError struct{ count int }
+
+func (e *docgenAuditError) Error() string {
+	return fmt.Sprintf("%d in-repo docgen director(ies) detected; run `archigraph docgen migrate-in-repo` to fix", e.count)
+}
+
+// auditDocgenForGroup is the shared logic used by both `archigraph docgen
+// audit` and the `--audit-docs` flag on `archigraph doctor`. It returns the
+// list of offending directories (nil == clean). The w parameter is unused
+// in this function but kept for interface consistency with callers that also
+// write supplementary output — see runDoctorAuditDocs.
+func auditDocgenForGroup(w interface{ Write([]byte) (int, error) }, groupName string) ([]string, error) {
+	cfg, err := loadGroupConfigFromRegistry(groupName)
+	if err != nil {
+		return nil, err
+	}
+	dirs := findInRepoDocgenDirs(cfg)
+	return dirs, nil
+}
+
+// DocsDirFor is a package-level helper that returns ~/.archigraph/docs/<group>/
+// using the canonical HomeDir logic from the registry package. Exported so
+// the doctor command and tests can reference the expected path.
+func DocsDirFor(group string) (string, error) {
+	h, err := registry.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(h, "docs", group), nil
+}
+
+// looksLikeGitWorkdir reports true when dir (or any ancestor up to depth 3)
+// contains a .git entry — a cheap guard used by the audit to avoid flagging
+// the archigraph store itself if it happens to live inside a git repo.
+func looksLikeGitWorkdir(dir string) bool {
+	p := dir
+	for range [3]struct{}{} {
+		if _, err := os.Stat(filepath.Join(p, ".git")); err == nil {
+			return true
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			break
+		}
+		p = parent
+	}
+	return false
+}
+
+// walkSubdirs calls fn for every immediate subdirectory of dir. It does not
+// recurse further — the heuristic only needs the top-level docs/ directory.
+func walkSubdirs(dir string, fn func(string)) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			fn(filepath.Join(dir, e.Name()))
+		}
+	}
+}
+
+// Ensure fs and filepath are used (they are used by the migration helpers).
+var _ = fs.ErrNotExist
+var _ = filepath.Join

--- a/internal/cli/docgen_storage_test.go
+++ b/internal/cli/docgen_storage_test.go
@@ -1,0 +1,372 @@
+package cli
+
+// Tests for the storage-discipline helpers introduced by #2190:
+//   - `archigraph docgen migrate-in-repo`
+//   - `archigraph docgen audit`
+//
+// Fixtures use synthetic ("client-fixture-X") directory names — no real
+// client or product names appear in any test path.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// makeFixtureGroup creates a synthetic group config under tmpDir that
+// registers two repos: client-fixture-a and client-fixture-b.
+// Each repo gets a .git directory so isDocgenOutput won't confuse them
+// with store directories.
+func makeFixtureGroup(t *testing.T, tmpDir string) (cfgPath string, repoA, repoB string) {
+	t.Helper()
+
+	repoA = filepath.Join(tmpDir, "client-fixture-a")
+	repoB = filepath.Join(tmpDir, "client-fixture-b")
+	for _, r := range []string{repoA, repoB} {
+		if err := os.MkdirAll(filepath.Join(r, ".git"), 0o755); err != nil {
+			t.Fatalf("create repo dir: %v", err)
+		}
+	}
+
+	cfg := registry.GroupConfig{
+		Name: "fixture-group",
+		Repos: []registry.Repo{
+			{Slug: "client-fixture-a", Path: repoA},
+			{Slug: "client-fixture-b", Path: repoB},
+		},
+	}
+	cfgPath = filepath.Join(tmpDir, "fixture-group.fleet.json")
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatalf("write group config: %v", err)
+	}
+	return cfgPath, repoA, repoB
+}
+
+// plantDocgenMarker writes one of the heuristic marker files into dir/docs/
+// so that isDocgenOutput returns true for that directory.
+func plantDocgenMarker(t *testing.T, repoDir, markerFile string) string {
+	t.Helper()
+	docsDir := filepath.Join(repoDir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("create docs dir: %v", err)
+	}
+	markerPath := filepath.Join(docsDir, markerFile)
+	if err := os.WriteFile(markerPath, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	return docsDir
+}
+
+// ---------------------------------------------------------------------------
+// isDocgenOutput unit tests
+// ---------------------------------------------------------------------------
+
+func TestIsDocgenOutput_NoMarkers(t *testing.T) {
+	dir := t.TempDir()
+	if isDocgenOutput(dir) {
+		t.Error("empty dir should not be detected as docgen output")
+	}
+}
+
+func TestIsDocgenOutput_PlanMd(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".plan.md"), []byte("# plan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !isDocgenOutput(dir) {
+		t.Error("dir with .plan.md should be detected as docgen output")
+	}
+}
+
+func TestIsDocgenOutput_InventoryJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".inventory.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !isDocgenOutput(dir) {
+		t.Error("dir with .inventory.json should be detected as docgen output")
+	}
+}
+
+func TestIsDocgenOutput_MetadataJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".metadata.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !isDocgenOutput(dir) {
+		t.Error("dir with .metadata.json should be detected as docgen output")
+	}
+}
+
+func TestIsDocgenOutput_UnrelatedDocsDir(t *testing.T) {
+	// A docs/ with only README.md should NOT be flagged.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# docs"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isDocgenOutput(dir) {
+		t.Error("docs/ with only README.md should not be flagged as docgen output")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// findInRepoDocgenDirs unit tests
+// ---------------------------------------------------------------------------
+
+func TestFindInRepoDocgenDirs_NonePresent(t *testing.T) {
+	tmpDir := t.TempDir()
+	_, repoA, repoB := makeFixtureGroup(t, tmpDir)
+	// repos exist but have no docs/ at all
+	_ = repoA
+	_ = repoB
+
+	cfgPath := filepath.Join(tmpDir, "fixture-group.fleet.json")
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	dirs := findInRepoDocgenDirs(cfg)
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs, got %d: %v", len(dirs), dirs)
+	}
+}
+
+func TestFindInRepoDocgenDirs_OnePresent(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath, repoA, _ := makeFixtureGroup(t, tmpDir)
+	plantDocgenMarker(t, repoA, ".plan.md")
+
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	dirs := findInRepoDocgenDirs(cfg)
+	if len(dirs) != 1 {
+		t.Fatalf("expected 1 dir, got %d: %v", len(dirs), dirs)
+	}
+	if !strings.HasSuffix(dirs[0], filepath.Join("client-fixture-a", "docs")) {
+		t.Errorf("unexpected dir: %s", dirs[0])
+	}
+}
+
+func TestFindInRepoDocgenDirs_BothPresent(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath, repoA, repoB := makeFixtureGroup(t, tmpDir)
+	plantDocgenMarker(t, repoA, ".inventory.json")
+	plantDocgenMarker(t, repoB, ".metadata.json")
+
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	dirs := findInRepoDocgenDirs(cfg)
+	if len(dirs) != 2 {
+		t.Fatalf("expected 2 dirs, got %d: %v", len(dirs), dirs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// migrate-in-repo: move happens when confirmed
+// ---------------------------------------------------------------------------
+
+func TestMigrateInRepo_MovesDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath, repoA, _ := makeFixtureGroup(t, tmpDir)
+
+	// Plant docgen output inside repoA.
+	srcDocs := plantDocgenMarker(t, repoA, ".plan.md")
+	// Also write a real doc file so we can verify content moved.
+	if err := os.WriteFile(filepath.Join(srcDocs, "overview.md"), []byte("# overview"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Override ARCHIGRAPH_HOME to a temp dir so we don't touch real user state.
+	storeRoot := filepath.Join(tmpDir, "store")
+	t.Setenv("ARCHIGRAPH_HOME", storeRoot)
+
+	// Build the cobra command tree.
+	root := newRoot()
+	_ = cfgPath
+
+	// We need to invoke migrate-in-repo --group fixture-group --yes
+	// But the group config is at a non-standard path. Seed the registry.
+	seedRegistry(t, tmpDir, cfgPath)
+
+	root.SetArgs([]string{"docgen", "migrate-in-repo", "--group", "fixture-group", "--yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("migrate-in-repo failed: %v", err)
+	}
+
+	// Source should be gone.
+	if _, err := os.Stat(srcDocs); !os.IsNotExist(err) {
+		t.Errorf("source docs dir should have been removed, stat err: %v", err)
+	}
+
+	// Target should exist with the overview file.
+	targetDocs := filepath.Join(storeRoot, "docs", "fixture-group", "client-fixture-a")
+	if _, err := os.Stat(filepath.Join(targetDocs, "overview.md")); err != nil {
+		t.Errorf("overview.md should exist in target: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// migrate-in-repo: idempotent (target already exists → skip)
+// ---------------------------------------------------------------------------
+
+func TestMigrateInRepo_IdempotentSkipsExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath, repoA, _ := makeFixtureGroup(t, tmpDir)
+	srcDocs := plantDocgenMarker(t, repoA, ".plan.md")
+
+	storeRoot := filepath.Join(tmpDir, "store")
+	t.Setenv("ARCHIGRAPH_HOME", storeRoot)
+
+	// Pre-create the target so the idempotency guard triggers.
+	targetDocs := filepath.Join(storeRoot, "docs", "fixture-group", "client-fixture-a")
+	if err := os.MkdirAll(targetDocs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	seedRegistry(t, tmpDir, cfgPath)
+
+	root := newRoot()
+	root.SetArgs([]string{"docgen", "migrate-in-repo", "--group", "fixture-group", "--yes"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("migrate-in-repo failed: %v", err)
+	}
+
+	// Source should STILL exist because the target was already there.
+	if _, err := os.Stat(srcDocs); err != nil {
+		t.Errorf("source docs dir should NOT have been removed (target existed): %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// audit: detects without moving
+// ---------------------------------------------------------------------------
+
+func TestDocgenAudit_ReportsWithoutMoving(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath, repoA, _ := makeFixtureGroup(t, tmpDir)
+	srcDocs := plantDocgenMarker(t, repoA, ".inventory.json")
+
+	storeRoot := filepath.Join(tmpDir, "store")
+	t.Setenv("ARCHIGRAPH_HOME", storeRoot)
+	seedRegistry(t, tmpDir, cfgPath)
+
+	root := newRoot()
+	var out strings.Builder
+	root.SetOut(&out)
+	root.SetArgs([]string{"docgen", "audit", "--group", "fixture-group"})
+	err := root.Execute()
+
+	// audit returns a non-nil error (exit code 1) when offenders found.
+	if err == nil {
+		t.Error("audit should return non-nil error when offenders found")
+	}
+
+	// Source should still exist (audit never moves).
+	if _, statErr := os.Stat(srcDocs); statErr != nil {
+		t.Errorf("audit should not have moved source: %v", statErr)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "client-fixture-a") {
+		t.Errorf("audit output should mention the offending repo; got: %s", output)
+	}
+}
+
+func TestDocgenAudit_CleanGroupReturnsNil(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath, _, _ := makeFixtureGroup(t, tmpDir)
+	// No docgen markers planted.
+
+	storeRoot := filepath.Join(tmpDir, "store")
+	t.Setenv("ARCHIGRAPH_HOME", storeRoot)
+	seedRegistry(t, tmpDir, cfgPath)
+
+	root := newRoot()
+	root.SetArgs([]string{"docgen", "audit", "--group", "fixture-group"})
+	if err := root.Execute(); err != nil {
+		t.Errorf("audit on clean group should return nil, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// doctor --audit-docs integration
+// ---------------------------------------------------------------------------
+
+func TestDoctorAuditDocs_ReportsOffenders(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath, repoA, _ := makeFixtureGroup(t, tmpDir)
+	plantDocgenMarker(t, repoA, ".plan.md")
+
+	storeRoot := filepath.Join(tmpDir, "store")
+	t.Setenv("ARCHIGRAPH_HOME", storeRoot)
+	seedRegistry(t, tmpDir, cfgPath)
+
+	root := newRoot()
+	var out strings.Builder
+	root.SetOut(&out)
+	root.SetArgs([]string{"doctor", "--audit-docs"})
+	// doctor returns nil even with offenders (it's a report command).
+	if err := root.Execute(); err != nil {
+		t.Logf("doctor --audit-docs returned error (may be expected): %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Storage Discipline Audit") {
+		t.Errorf("expected audit header in output; got: %s", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DocsDirFor helper
+// ---------------------------------------------------------------------------
+
+func TestDocsDirFor(t *testing.T) {
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	t.Setenv("ARCHIGRAPH_HOME", storeRoot)
+
+	got, err := DocsDirFor("my-group")
+	if err != nil {
+		t.Fatalf("DocsDirFor: %v", err)
+	}
+	want := filepath.Join(storeRoot, "docs", "my-group")
+	if got != want {
+		t.Errorf("DocsDirFor = %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// seedRegistry writes a minimal registry.json pointing to cfgPath so that
+// resolveGroup("fixture-group") works in tests.
+func seedRegistry(t *testing.T, tmpDir, cfgPath string) {
+	t.Helper()
+	storeRoot := os.Getenv("ARCHIGRAPH_HOME")
+	if storeRoot == "" {
+		storeRoot = filepath.Join(tmpDir, "store")
+	}
+	if err := os.MkdirAll(storeRoot, 0o755); err != nil {
+		t.Fatalf("create store root: %v", err)
+	}
+	regPath := filepath.Join(storeRoot, "registry.json")
+	reg := map[string]interface{}{
+		"version": 1,
+		"groups": []map[string]interface{}{
+			{"name": "fixture-group", "config_path": cfgPath},
+		},
+	}
+	data, _ := json.Marshal(reg)
+	if err := os.WriteFile(regPath, data, 0o644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -24,6 +24,7 @@ const (
 
 func newDoctorCmd() *cobra.Command {
 	var killStale bool
+	var auditDocs bool
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Run health checks across all groups",
@@ -32,12 +33,60 @@ func newDoctorCmd() *cobra.Command {
 			if err := runDoctor(w); err != nil {
 				return err
 			}
+			if auditDocs {
+				if err := runDoctorAuditDocs(w); err != nil {
+					return err
+				}
+			}
 			return runDoctorStaleDaemons(w, killStale)
 		},
 	}
 	cmd.Flags().BoolVar(&killStale, "kill-stale", false,
 		"kill stale archigraph daemons (default: dry-run list only)")
+	cmd.Flags().BoolVar(&auditDocs, "audit-docs", false,
+		"detect in-repo docgen output (storage discipline #2190); reports without moving anything")
 	return cmd
+}
+
+// runDoctorAuditDocs checks every registered group for in-repo docgen output
+// and reports offending directories to w. It never moves or deletes anything.
+func runDoctorAuditDocs(w io.Writer) error {
+	groups, err := registry.Groups()
+	if err != nil {
+		fmt.Fprintf(w, "%s audit-docs: registry unavailable: %v\n", statusWarn, err)
+		return nil
+	}
+
+	fmt.Fprintf(w, "\n--- Storage Discipline Audit (#2190) ---\n")
+	totalOffenders := 0
+
+	for _, g := range groups {
+		dirs, err := auditDocgenForGroup(w, g.Name)
+		if err != nil {
+			fmt.Fprintf(w, "  %s group %s: %v\n", statusWarn, g.Name, err)
+			continue
+		}
+		if len(dirs) == 0 {
+			fmt.Fprintf(w, "  %s group %s: no in-repo docgen output\n", statusOK, g.Name)
+			continue
+		}
+		fmt.Fprintf(w, "  %s group %s: %d in-repo docgen director(ies) found\n", statusWarn, g.Name, len(dirs))
+		for _, d := range dirs {
+			var markers []string
+			for _, name := range docgenHeuristics {
+				if _, err := os.Stat(filepath.Join(d, name)); err == nil {
+					markers = append(markers, name)
+				}
+			}
+			fmt.Fprintf(w, "       %s  (markers: %s)\n", d, strings.Join(markers, ", "))
+		}
+		totalOffenders += len(dirs)
+	}
+
+	if totalOffenders > 0 {
+		fmt.Fprintf(w, "\nRun 'archigraph docgen migrate-in-repo' per group to move output to the archigraph store.\n")
+	}
+	return nil
 }
 
 // runDoctor runs every health check and reports to w. It returns nil

--- a/skills/generate-docs/SKILL.md
+++ b/skills/generate-docs/SKILL.md
@@ -100,16 +100,33 @@ single group-level directory `~/.archigraph/docs/<group>/business/`, regardless
 of how many repos make up the group. The webui surfaces this set directly under
 the Business tab.
 
-> **Storage location (#1624 — important).** The generate-docs skill NEVER
-> writes into a source repo's working tree. All generated markdown (technical
-> and business) lives under the archigraph-managed store
-> `~/.archigraph/docs/<group>/...`. This keeps the source repos clean (no
-> commit noise) and matches the #1626 principle that archigraph owns its
-> outputs. The daemon dashboard reads from this location; pre-#1624
-> `<repo>/docs/` directories produced by an earlier run are migrated into
-> the store transparently on first read. If you ever see a writer subagent
-> emitting a path that starts with the repo working tree, redirect it to
-> the store path documented here.
+## CRITICAL STORAGE DISCIPLINE (enforced on every pass — parallel to TOOL DISCIPLINE)
+===========================
+
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+This applies to BOTH the technical tier and the business tier. The `<group>` value
+comes from `archigraph_whoami` (called in the Pre-flight assertion above). Every pass
+computes `OUTPUT_ROOT=$HOME/.archigraph/docs/<group>/` and verifies it is writable
+before writing any file.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP and redirect to the
+store path. Writing elsewhere breaks the storage contract, pollutes the user's
+source repo with commit noise, and produces output invisible to the daemon dashboard.
+
+**Recovery:** If you encounter legacy in-repo docs from a pre-#1624 run, use
+`archigraph docgen migrate-in-repo <group>` to move them to the store. Use
+`archigraph docgen audit <group>` (or `archigraph doctor --audit-docs`) to detect
+in-repo docgen output without moving anything.
+
+The daemon dashboard reads exclusively from `~/.archigraph/docs/<group>/`.
+Closes #1624. Parallel to TOOL DISCIPLINE (#2177). Enforced by #2190.
 
 ## LLM-mode orchestrate (Pass 20)
 

--- a/skills/generate-docs/prompts/00-domain-qa.md
+++ b/skills/generate-docs/prompts/00-domain-qa.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/01-inventory.md
+++ b/skills/generate-docs/prompts/01-inventory.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/01a-residual-repair-sweep.md
+++ b/skills/generate-docs/prompts/01a-residual-repair-sweep.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/01b-repair-aware-qa.md
+++ b/skills/generate-docs/prompts/01b-repair-aware-qa.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/02-plan.md
+++ b/skills/generate-docs/prompts/02-plan.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/03-overview.md
+++ b/skills/generate-docs/prompts/03-overview.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/03a-generation-time-repair.md
+++ b/skills/generate-docs/prompts/03a-generation-time-repair.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/04-cluster.md
+++ b/skills/generate-docs/prompts/04-cluster.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/05-reference.md
+++ b/skills/generate-docs/prompts/05-reference.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/06-cross-cutting.md
+++ b/skills/generate-docs/prompts/06-cross-cutting.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/07-group-synthesis.md
+++ b/skills/generate-docs/prompts/07-group-synthesis.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/08-cross-link.md
+++ b/skills/generate-docs/prompts/08-cross-link.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/10-pattern-convergence.md
+++ b/skills/generate-docs/prompts/10-pattern-convergence.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/11-pattern-cross-link.md
+++ b/skills/generate-docs/prompts/11-pattern-cross-link.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/12-pattern-prose.md
+++ b/skills/generate-docs/prompts/12-pattern-prose.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/13-enrichment.md
+++ b/skills/generate-docs/prompts/13-enrichment.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/14-frontmatter-validation.md
+++ b/skills/generate-docs/prompts/14-frontmatter-validation.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/15-business-domain.md
+++ b/skills/generate-docs/prompts/15-business-domain.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/16-business-capabilities.md
+++ b/skills/generate-docs/prompts/16-business-capabilities.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/17-business-journeys.md
+++ b/skills/generate-docs/prompts/17-business-journeys.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/18-business-rules.md
+++ b/skills/generate-docs/prompts/18-business-rules.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/19-business-overview.md
+++ b/skills/generate-docs/prompts/19-business-overview.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 

--- a/skills/generate-docs/prompts/20-llm-orchestrate.md
+++ b/skills/generate-docs/prompts/20-llm-orchestrate.md
@@ -23,6 +23,40 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
+## CRITICAL STORAGE DISCIPLINE
+===========================
+All generated documentation MUST be written under:
+  `~/.archigraph/docs/<group>/...`
+
+Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
+above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
+
+You are STRICTLY FORBIDDEN from writing documentation files into:
+- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
+- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
+- Any path that is a git working directory
+
+If you find yourself about to write to a repo path, STOP. The skill assumes
+the archigraph-owned store. Writing elsewhere breaks the storage contract
+and pollutes the user's source repo.
+
+The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
+written elsewhere is invisible to it.
+
+### Pre-flight storage assertion -- SECOND action in this pass
+
+Compute and verify the output root immediately after the `archigraph_whoami` call:
+
+```bash
+OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
+mkdir -p "$OUTPUT_ROOT"
+echo "OUTPUT_ROOT=$OUTPUT_ROOT"
+```
+
+All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
+other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
+
+
 ---
 
 


### PR DESCRIPTION
## Summary

- **23 prompt files** (passes 00–20 + 01a/01b/03a) each receive a `CRITICAL STORAGE DISCIPLINE` block + `Pre-flight storage assertion` immediately after the existing TOOL DISCIPLINE section. The block forbids writing to any repo working tree and requires computing `OUTPUT_ROOT=$HOME/.archigraph/docs/<group>/` as the second action in every pass.
- **SKILL.md** top-level section promoted from a soft `>` blockquote to a `## CRITICAL STORAGE DISCIPLINE` section at the same visual weight as `## CRITICAL TOOL DISCIPLINE`, with migration/audit recovery guidance.
- **`archigraph docgen migrate-in-repo [--group] [--yes]`** — walks registered repos, detects in-repo docgen output via heuristic (`.plan.md` / `.inventory.json` / `.metadata.json`), prompts user, moves to `~/.archigraph/docs/<group>/<repo-slug>/`. Idempotent (skips if target exists).
- **`archigraph docgen audit [--group]`** — same detection, read-only, exits 1 when offenders found.
- **`archigraph doctor --audit-docs`** — runs the audit across all registered groups as part of the doctor health check.

## Test plan

- [x] `grep -L "CRITICAL STORAGE DISCIPLINE" skills/generate-docs/prompts/*.md` returns empty (all 23 files have the block)
- [x] `TestIsDocgenOutput_*` — heuristic detection unit tests (5 cases: empty, .plan.md, .inventory.json, .metadata.json, unrelated README.md)
- [x] `TestFindInRepoDocgenDirs_*` — 3 cases: none / one / both repos
- [x] `TestMigrateInRepo_MovesDir` — fixture in-repo docs + expected store path → move happens, source gone
- [x] `TestMigrateInRepo_IdempotentSkipsExisting` — pre-existing target → skipped, source preserved
- [x] `TestDocgenAudit_ReportsWithoutMoving` — offender reported, source untouched, exit 1
- [x] `TestDocgenAudit_CleanGroupReturnsNil` — clean group → exit 0
- [x] `TestDoctorAuditDocs_ReportsOffenders` — audit header appears in doctor output
- [x] `TestDocsDirFor` — canonical store path helper
- [x] Full `go test ./internal/cli/...` passes (no regressions)

## Edge cases discovered

1. **Unrelated `docs/` directories**: A repo with only hand-written `README.md` in `docs/` is NOT flagged — the heuristic is conservative (requires `.plan.md`, `.inventory.json`, or `.metadata.json`). A project whose `docs/` predates archigraph is safe.
2. **`ConfigPathFor` vs registry lookup**: The XDG config path (`~/.config/archigraph/`) is NOT the same as the registry-stored `config_path`. The subcommands use `loadGroupConfigFromRegistry()` (looks up via `registry.Groups()`) rather than `ConfigPathFor()`, which is test-safe and respects `ARCHIGRAPH_HOME` in CI.
3. **Idempotency**: If the user runs `migrate-in-repo` twice, the second run skips with `[warn] target already exists` rather than overwriting or erroring.

Closes #2190. Refs #1624 #2177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)