### PR TITLE
fix(ci): poll for daemon-indexed in smoke test (P3 of #2196)

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -63,14 +63,20 @@ jobs:
       - name: Check daemon indexed the repo
         run: |
           export ARCHIGRAPH_DAEMON_ROOT=${{ env.ARCHIGRAPH_DAEMON_ROOT }}
-          output=$(timeout 10 ./archigraph status)
-          echo "$output"
 
-          # Verify status shows indexed = true
-          if ! echo "$output" | grep -q '"indexed":true'; then
-            echo "Repository not indexed"
-            exit 1
-          fi
+          # Poll for indexed status (async subprocess indexer may need up to 60s)
+          for i in $(seq 1 60); do
+            output=$(./archigraph status 2>&1 || true)
+            if echo "$output" | grep -q '"indexed":true'; then
+              echo "✓ Indexed after ${i}s"
+              echo "$output"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "✗ Repository not indexed after 60s"
+          echo "$output"
+          exit 1
 
       - name: Kill daemon
         if: always()


### PR DESCRIPTION
## Summary
- Replace single daemon indexed check with 60s poll loop in smoke test
- Async subprocess indexer (PR #2163/#2165) finishes after the 7s check window
- Poll loop gives indexer adequate time to complete background work

Refs #2196 (P3 cluster). Introduced by #2163, #2165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)