### PR TITLE
fix(extractors): register USES_SCHEMA kind (P1 of #2196)

### DIFF
--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -413,6 +413,15 @@ const (
 	// kept narrow today to the DRF extractor producer.
 	RelationshipKindResolvedBy RelationshipKind = "RESOLVED_BY"
 
+	// #2142: DRF plain serializer field → custom field class.
+	//   USES_SCHEMA : SCOPE.Schema/field → custom field class entity
+	// Emitted by the DRF serializer-fields extractor when a plain
+	// serializers.Serializer field references a capitalised, non-DRF-scalar
+	// type (e.g. MoneyField, PhoneField) that may be a project-local custom
+	// field class. Lets the resolver bind the field to its custom type entity
+	// and prevents the field from becoming an orphan node.
+	RelationshipKindUsesSchema RelationshipKind = "USES_SCHEMA"
+
 	// #2183 — Monorepo M6: Bazel BUILD-graph fusion.
 	//   BAZEL_DEPENDS_ON : bazel_target → bazel_target
 	//     Emitted for every entry in a BUILD rule's deps= list that can be
@@ -507,6 +516,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindConfigures,
 		// #2008 DRF SerializerMethodField → method link:
 		RelationshipKindResolvedBy,
+		// #2142 DRF plain serializer field → custom field class:
+		RelationshipKindUsesSchema,
 		// #2183 Bazel BUILD-graph fusion:
 		RelationshipKindBazelDependsOn,
 		RelationshipKindBazelDepStatus,


### PR DESCRIPTION
## Summary

- `drf_serializer_fields.go` (introduced in #2142) emits `Kind: "USES_SCHEMA"` as a raw string literal in `RelationshipRecord` composite literals.
- `USES_SCHEMA` was never declared in `internal/types/kinds.go`, so `TestProducerKindLiterals_AreValid` panics when scanning producer sources.
- Fix: add `RelationshipKindUsesSchema RelationshipKind = "USES_SCHEMA"` constant and include it in `AllRelationshipKinds()`.

Closes #2196. Introduced by #2142.

## Test plan

- [x] `go test -run TestProducerKindLiterals_AreValid ./internal/types/...` — was failing, now passes
- [x] `go test ./internal/types/... ./internal/extractors/python/...` — all pass (pre-existing incremental test failures in `internal/extractors` are unrelated to this change and reproduce on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)