### PR TITLE
fix(daemon): register Go extractor in incremental engine (P2 of #2196)

### DIFF
--- a/internal/extractor/testing.go
+++ b/internal/extractor/testing.go
@@ -9,3 +9,30 @@ func ClearForTesting() {
 		delete(registry, k)
 	}
 }
+
+// SnapshotForTesting captures the current registry state and returns a restore
+// function that reinstates it. Pair with t.Cleanup to guarantee restoration even
+// on test failure:
+//
+//	t.Cleanup(extractor.SnapshotForTesting())
+//
+// Only for use in unit tests — do NOT call in production code.
+func SnapshotForTesting() func() {
+	mu.RLock()
+	snap := make(map[string]Extractor, len(registry))
+	for k, v := range registry {
+		snap[k] = v
+	}
+	mu.RUnlock()
+
+	return func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for k := range registry {
+			delete(registry, k)
+		}
+		for k, v := range snap {
+			registry[k] = v
+		}
+	}
+}

--- a/internal/extractors/custom_dispatch_test.go
+++ b/internal/extractors/custom_dispatch_test.go
@@ -8,14 +8,13 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
-	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
 // ---- CustomExtractorsFor -----------------------------------------------------
 
 func TestCustomExtractorsForPythonReturnsPythonPrefixedKeys(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 
 	// Base python extractor should NOT be returned (exact key match excluded).
 	Register("python", &mockExtractor{language: "python"})
@@ -39,7 +38,7 @@ func TestCustomExtractorsForPythonReturnsPythonPrefixedKeys(t *testing.T) {
 }
 
 func TestCustomExtractorsForGoReturnsCustomGoPrefixedKeys(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 
 	Register("go", &mockExtractor{language: "go"})
 	Register("custom_go_gin", &mockExtractor{language: "custom_go_gin"})
@@ -59,7 +58,7 @@ func TestCustomExtractorsForGoReturnsCustomGoPrefixedKeys(t *testing.T) {
 }
 
 func TestCustomExtractorsForTypescriptSharesJavascriptPrefix(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	Register("custom_js_react", &mockExtractor{language: "custom_js_react"})
 	Register("custom_js_nextjs", &mockExtractor{language: "custom_js_nextjs"})
 
@@ -70,7 +69,7 @@ func TestCustomExtractorsForTypescriptSharesJavascriptPrefix(t *testing.T) {
 }
 
 func TestCustomExtractorsForUnknownLanguageReturnsEmpty(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	Register("custom_go_gin", &mockExtractor{language: "custom_go_gin"})
 
 	got := CustomExtractorsFor("cobol")
@@ -83,7 +82,7 @@ func TestCustomExtractorsForUnknownLanguageReturnsEmpty(t *testing.T) {
 }
 
 func TestCustomExtractorsForLanguageWithoutRegisteredCustomsReturnsEmpty(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	// Only base extractor registered, no prefix hits.
 	Register("swift", &mockExtractor{language: "swift"})
 
@@ -98,7 +97,7 @@ func TestCustomExtractorsForLanguageWithoutRegisteredCustomsReturnsEmpty(t *test
 // new language is added to the map without fixture registration here, the
 // test helps catch drift.
 func TestCustomExtractorsForEveryMappedLanguageIsReachable(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 
 	// Register exactly one custom extractor per prefix.
 	fixtures := map[string]string{
@@ -136,7 +135,7 @@ func TestCustomExtractorsForEveryMappedLanguageIsReachable(t *testing.T) {
 // ---- RunCustomExtractors -----------------------------------------------------
 
 func TestRunCustomExtractorsDispatchesAllMatchingExtractors(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 
 	Register("python_django", &mockExtractor{
 		language: "python_django",
@@ -177,7 +176,7 @@ func TestRunCustomExtractorsDispatchesAllMatchingExtractors(t *testing.T) {
 }
 
 func TestRunCustomExtractorsRecoversFromPanic(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 
 	Register("python_django", &mockExtractor{
 		language: "python_django",
@@ -214,7 +213,7 @@ func TestRunCustomExtractorsRecoversFromPanic(t *testing.T) {
 }
 
 func TestRunCustomExtractorsWithNoMatchingExtractorsReturnsEmpty(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	Register("python_django", &mockExtractor{language: "python_django"})
 
 	ctx := context.Background()
@@ -231,7 +230,7 @@ func TestRunCustomExtractorsWithNoMatchingExtractorsReturnsEmpty(t *testing.T) {
 }
 
 func TestRunCustomExtractorsEmitsOTelSpanWithCustomExtractorCount(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	Register("python_django", &mockExtractor{
 		language: "python_django",
 		records:  []types.EntityRecord{{Name: "V1"}},
@@ -279,7 +278,7 @@ func TestRunCustomExtractorsEmitsOTelSpanWithCustomExtractorCount(t *testing.T) 
 }
 
 func TestRunCustomExtractorsCollectsErrorsButPreservesPartialOutput(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 
 	Register("python_django", &mockExtractor{
 		language: "python_django",
@@ -398,6 +397,7 @@ func extractNames(recs []types.EntityRecord) []string {
 }
 
 // Guard: assert the registry testing hook exists (catch refactors that remove it).
+// Uses cleanRegistry so the snapshot/restore cycle is also exercised here.
 func TestClearForTestingExists(t *testing.T) {
-	extractor.ClearForTesting()
+	cleanRegistry(t)
 }

--- a/internal/extractors/registry_test.go
+++ b/internal/extractors/registry_test.go
@@ -35,8 +35,13 @@ func (m *mockExtractor) Extract(_ context.Context, _ FileInput) ([]types.EntityR
 	return m.records, m.err
 }
 
-// cleanRegistry resets the global registry between tests.
-func cleanRegistry() {
+// cleanRegistry snapshots the current global registry, clears it for the
+// duration of the test, and schedules a restore via t.Cleanup so that
+// real-extractor registrations (from registry_gen.go init functions) are
+// intact when other test packages run in the same binary.
+func cleanRegistry(t *testing.T) {
+	t.Helper()
+	t.Cleanup(extractor.SnapshotForTesting())
 	extractor.ClearForTesting()
 }
 
@@ -50,7 +55,7 @@ func newTestTracer() (trace.Tracer, *tracetest.SpanRecorder) {
 // ---- tests ------------------------------------------------------------------
 
 func TestRegisterAndGet(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	ext := &mockExtractor{language: "python"}
 	Register("python", ext)
 
@@ -64,7 +69,7 @@ func TestRegisterAndGet(t *testing.T) {
 }
 
 func TestGetUnregisteredLanguage(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 
 	_, ok := Get("cobol")
 	if ok {
@@ -73,7 +78,7 @@ func TestGetUnregisteredLanguage(t *testing.T) {
 }
 
 func TestExtractDispatchesToRegisteredExtractor(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	want := []types.EntityRecord{{Name: "Foo", Kind: "function", SourceFile: "foo.go"}}
 	Register("go", &mockExtractor{language: "go", records: want})
 
@@ -91,7 +96,7 @@ func TestExtractDispatchesToRegisteredExtractor(t *testing.T) {
 }
 
 func TestExtractUnknownLanguageReturnsErrNoExtractor(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 
 	ctx := context.Background()
 	_, err := Extract(ctx, FileInput{Path: "x.xyz", Language: "xyz"})
@@ -104,7 +109,7 @@ func TestExtractUnknownLanguageReturnsErrNoExtractor(t *testing.T) {
 }
 
 func TestExtractPanicRecoveredAsError(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	Register("rust", &mockExtractor{language: "rust", panic: true})
 
 	ctx := context.Background()
@@ -119,7 +124,7 @@ func TestExtractPanicRecoveredAsError(t *testing.T) {
 }
 
 func TestExtractPanicSpanHasErrorAttribute(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	Register("rust", &mockExtractor{language: "rust", panic: true})
 
 	tr, rec := newTestTracer()
@@ -143,7 +148,7 @@ func TestExtractPanicSpanHasErrorAttribute(t *testing.T) {
 }
 
 func TestExtractSuccessSpanEmitted(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	records := []types.EntityRecord{{Name: "Bar", Kind: "class", SourceFile: "bar.py"}}
 	Register("python", &mockExtractor{language: "python", records: records})
 
@@ -179,7 +184,7 @@ func TestExtractSuccessSpanEmitted(t *testing.T) {
 }
 
 func TestListReturnsSortedLanguages(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	for _, lang := range []string{"typescript", "go", "python", "java", "rust"} {
 		Register(lang, &mockExtractor{language: lang})
 	}
@@ -197,7 +202,7 @@ func TestListReturnsSortedLanguages(t *testing.T) {
 }
 
 func TestListEmptyRegistry(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 	got := List()
 	if len(got) != 0 {
 		t.Errorf("expected empty list, got %v", got)
@@ -205,7 +210,7 @@ func TestListEmptyRegistry(t *testing.T) {
 }
 
 func TestConcurrentRegisterAndGet(t *testing.T) {
-	cleanRegistry()
+	cleanRegistry(t)
 
 	const n = 100
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Summary

- **Root cause:** `registry_test.go` and `custom_dispatch_test.go` called `extractor.ClearForTesting()` (via `cleanRegistry()`) without restoring the global extractor registry afterward. Any `TestIncremental_*` test that ran after one of these internal-registry tests in the same test binary saw an empty registry and logged `incremental: no extractor for language=go`, causing 6+ tests to fail with assertion errors and the macOS 5m suite to cascade-timeout.
- **Resolution:** Added `SnapshotForTesting()` to `internal/extractor/testing.go` that captures and restores the full registry state. Updated `cleanRegistry()` to call `t.Cleanup(extractor.SnapshotForTesting())` before `ClearForTesting()` so every internal-registry test automatically restores real-extractor registrations on completion. Converted the lone bare `ClearForTesting()` call in `TestClearForTestingExists` to use `cleanRegistry(t)` for the same guarantee.
- **Effect:** All 22 `TestIncremental_*` tests now pass consistently on both macOS and Windows. The macOS 5m suite timeout was a cascade of this issue.

## Failing test output (before fix — reproduced locally)

```
% go test -v -run "TestConcurrentRegisterAndGet|TestIncremental_SingleFileEdit" ./internal/extractors/
=== RUN   TestConcurrentRegisterAndGet
--- PASS: TestConcurrentRegisterAndGet (0.00s)
=== RUN   TestIncremental_SingleFileEdit_FunctionBodyChange
incremental: 2026/05/25 15:26:48 incremental: no extractor for language=go file=svc/service.go
--- FAIL: TestIncremental_SingleFileEdit_FunctionBodyChange (0.04s)
    incremental_test.go:258: NewFunc should appear in graph after incremental reindex, names=[]
FAIL
FAIL    github.com/cajasmota/archigraph/internal/extractors 0.845s
```

## Passing test output (after fix)

```
% go test -run "TestIncremental" ./internal/extractors/ -v -race -count=1 -timeout 5m
--- PASS: TestIncrementalEnabled_DefaultOff (0.00s)
--- PASS: TestIncrementalEnabled_OptIn (0.00s)
--- PASS: TestIncrementalEnabled_TrueVariant (0.00s)
--- PASS: TestIncremental_WhitespaceOnlyEdit_Skipped (0.12s)
--- PASS: TestIncremental_SingleFileEdit_FunctionBodyChange (0.10s)
--- PASS: TestIncremental_AddNewFile_EntitiesAppear (0.10s)
--- PASS: TestIncremental_DeleteFile_EntitiesDisappear (0.08s)
--- PASS: TestIncremental_TooManyChangedFiles_Fallback (0.08s)
--- PASS: TestIncremental_EnvOverrideLimit (0.04s)
--- PASS: TestIncremental_MainBranchHotPath_30Files (0.35s)
--- PASS: TestIncremental_FeatureBranch_50Files_Fallback (0.07s)
--- PASS: TestIncremental_SignatureChange_InboundCallersRewired (0.08s)
--- PASS: TestIncremental_ManifestCorruption_FallsBackToFull (0.05s)
--- PASS: TestIncremental_ManifestGC_DeletedEntryRemoved (0.11s)
--- PASS: TestIncremental_NoExistingGraph_Fallback (0.03s)
--- PASS: TestIncremental_NoChanges_DoneWithoutWork (0.07s)
--- PASS: TestIncremental_GoldenSemanticEquivalence (0.15s)
--- PASS: TestIncrementalResult_FallbackPreservesReason (0.03s)
--- PASS: TestIncremental_ScopedResolver_FallbackOnUnresolvableRel (0.00s)
--- PASS: TestIncremental_Performance_SingleFileEdit (0.10s)
--- PASS: TestIncremental_GraphFBReadableAfterWrite (0.08s)
--- PASS: TestIncremental_ManifestUpdatedAfterSuccess (0.12s)
PASS
ok      github.com/cajasmota/archigraph/internal/extractors   3.287s
```

## Broader sanity check

```
% go test ./internal/daemon/... -timeout 5m
ok  github.com/cajasmota/archigraph/internal/daemon         17.665s
ok  github.com/cajasmota/archigraph/internal/daemon/algo    1.672s
ok  github.com/cajasmota/archigraph/internal/daemon/clone   2.883s
ok  github.com/cajasmota/archigraph/internal/daemon/extract 19.684s
ok  github.com/cajasmota/archigraph/internal/daemon/mcp     3.320s
ok  github.com/cajasmota/archigraph/internal/daemon/mode    5.652s
ok  github.com/cajasmota/archigraph/internal/daemon/sched   15.100s
ok  github.com/cajasmota/archigraph/internal/daemon/service 1.196s
ok  github.com/cajasmota/archigraph/internal/daemon/tier    0.736s
ok  github.com/cajasmota/archigraph/internal/daemon/transport 2.464s
ok  github.com/cajasmota/archigraph/internal/daemon/walk    3.320s
ok  github.com/cajasmota/archigraph/internal/daemon/watch   27.201s
ok  github.com/cajasmota/archigraph/internal/daemon/worktree 9.754s
```

## Test plan

- [x] Reproduce the failure: `go test -v -run "TestConcurrentRegisterAndGet|TestIncremental_SingleFileEdit" ./internal/extractors/` → `FAIL: no extractor for language=go`
- [x] Verify fix: same command after patch → both PASS
- [x] Full incremental suite: `go test -run TestIncremental ./internal/extractors/ -race -count=1 -timeout 5m` → 22/22 PASS
- [x] Daemon sanity: `go test ./internal/daemon/... -timeout 5m` → all pass
- [x] gofmt: all 3 changed files gofmt-clean
- [x] No `t.Skip` added, no tests bypassed

Refs #2196, introduced by #2167 (S3 incremental reindex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)