### PR TITLE
fix(extractors/python): Django route prefix propagation (P6 of #2196)

### DIFF
--- a/internal/engine/django_urlconf_nested.go
+++ b/internal/engine/django_urlconf_nested.go
@@ -34,6 +34,7 @@
 package engine
 
 import (
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -316,30 +317,44 @@ func isPythonIdentifier(s string) bool {
 // "apps.users.urls") to a repo-relative file path (e.g. "api/urls.py").
 // Returns "" when the module path is not convertible (e.g. it references a
 // third-party package without a recognisable path component).
+//
+// We use path.Join (from "path", not "path/filepath") so the result always
+// uses forward slashes. Repo-relative paths are always forward-slash-separated
+// in the archigraph entity store and file-reader callbacks — using
+// filepath.Join here would produce backslash paths on Windows, breaking
+// fileReader lookups and causing all nested-include route composition to
+// silently produce zero entities on that platform (P6 of #2196).
 func modulePathToFilePath(modulePath string) string {
 	if modulePath == "" {
 		return ""
 	}
-	// Replace dots with path separators and append .py.
-	// "api.urls"       → "api/urls.py"
+	// Replace dots with forward slashes and append .py.
+	// "api.urls"        → "api/urls.py"
 	// "apps.users.urls" → "apps/users/urls.py"
 	parts := strings.Split(modulePath, ".")
-	return filepath.Join(parts...) + ".py"
+	return path.Join(parts...) + ".py"
 }
 
 // modulePathToFilePath_relToParent tries to resolve a Python module path
 // relative to the parent file's directory. This handles the common pattern
 // where include("urls") is used within the same app directory.
+//
+// Like modulePathToFilePath, we use path.Join (forward slashes) so the
+// resulting repo-relative path is consistent with the rest of the system on
+// all platforms.
 func modulePathToFilePath_relToParent(modulePath, parentPath string) string {
 	if modulePath == "" || parentPath == "" {
 		return ""
 	}
-	parentDir := filepath.Dir(parentPath)
+	// filepath.Dir is safe here: it normalises the parent path for the
+	// platform and we immediately convert back to forward slashes via
+	// path.Join for the returned value.
+	parentDir := filepath.ToSlash(filepath.Dir(parentPath))
 	if parentDir == "." {
 		return ""
 	}
 	parts := strings.Split(modulePath, ".")
-	return filepath.Join(append([]string{parentDir}, parts...)...) + ".py"
+	return path.Join(append([]string{parentDir}, parts...)...) + ".py"
 }
 
 // isDjangoURLFile reports whether the repo-relative path looks like a Django

--- a/internal/engine/django_urlconf_nested_test.go
+++ b/internal/engine/django_urlconf_nested_test.go
@@ -427,6 +427,9 @@ func TestResolveFBVHandler(t *testing.T) {
 }
 
 // TestModulePathToFilePath verifies the module-path to file-path conversion.
+// The output must always use forward slashes regardless of the host OS so that
+// fileReader lookups (which use the same forward-slash convention) succeed on
+// Windows (P6 of #2196).
 func TestModulePathToFilePath(t *testing.T) {
 	tests := []struct {
 		modulePath string
@@ -440,6 +443,32 @@ func TestModulePathToFilePath(t *testing.T) {
 		got := modulePathToFilePath(tt.modulePath)
 		if got != tt.want {
 			t.Errorf("modulePathToFilePath(%q) = %q, want %q", tt.modulePath, got, tt.want)
+		}
+	}
+}
+
+// TestModulePathToFilePath_relToParent verifies the relative-to-parent module
+// resolution. The output must always use forward slashes (P6 of #2196).
+func TestModulePathToFilePath_relToParent(t *testing.T) {
+	tests := []struct {
+		modulePath string
+		parentPath string
+		want       string
+	}{
+		// Standard case: child module inside same app directory.
+		{"urls", "myapp/urls.py", "myapp/urls.py"},
+		// Two-level parent: core/routers.py included from api/v1/urls.py.
+		{"routers", "api/v1/urls.py", "api/v1/routers.py"},
+		// Empty module path → empty result.
+		{"", "api/urls.py", ""},
+		// Parent with no directory component → empty result (no relative base).
+		{"urls", "urls.py", ""},
+	}
+	for _, tt := range tests {
+		got := modulePathToFilePath_relToParent(tt.modulePath, tt.parentPath)
+		if got != tt.want {
+			t.Errorf("modulePathToFilePath_relToParent(%q, %q) = %q, want %q",
+				tt.modulePath, tt.parentPath, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `modulePathToFilePath` and `modulePathToFilePath_relToParent` used `filepath.Join` to construct repo-relative paths from Python dot-separated module names (e.g. `"api.urls"` → `"api/urls.py"`). On Windows, `filepath.Join` emits backslash separators, so the resolved path (`api\urls.py`) never matches any `fileReader` key (all keys use forward slashes), causing every nested `include()` route composition to silently produce zero entities.
- **Symptom**: The 13 `TestApplyDjango*` tests that exercise prefix-stacking through nested `include()` chains were producing zero entities on Windows, so all assertions failed. On macOS/Linux they appeared to pass only because the package-level timeout cascade (fixed by P2/P4) masked their per-platform behaviour.
- **Fix**: Replace `filepath.Join` with `path.Join` (always forward-slash) in both helper functions. `modulePathToFilePath_relToParent` additionally converts the `filepath.Dir` result through `filepath.ToSlash` before passing it to `path.Join`.
- **Test added**: `TestModulePathToFilePath_relToParent` locks in the expected forward-slash output of the helper function.

## Test plan

- [ ] All 13 `TestApplyDjango*` listed in #2196 pass: `go test -run 'TestApplyDjango' ./internal/engine/... -count=1`
- [ ] Full engine package passes: `go test ./internal/engine/... -count=1`
- [ ] gofmt and go vet clean on changed files

Refs #2196 (P6 cluster). Introduced by #2004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)