### PR TITLE
fix(daemon): Unix socket → named pipe on Windows IPC (closes #2218)

### DIFF
--- a/internal/cli/delete_test.go
+++ b/internal/cli/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -14,9 +13,7 @@ import (
 // TestDelete_JSONOutputShape verifies the --json flag produces the expected
 // shape and forwards the correct args to the daemon.
 func TestDelete_JSONOutputShape(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
@@ -71,9 +68,7 @@ func TestDelete_JSONOutputShape(t *testing.T) {
 // TestDelete_UnknownGroupReturnsClearError verifies that an unknown group is
 // caught before the daemon is contacted.
 func TestDelete_UnknownGroupReturnsClearError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
@@ -92,9 +87,7 @@ func TestDelete_UnknownGroupReturnsClearError(t *testing.T) {
 
 // TestDelete_KeepCachesPropagatedToDaemon verifies --keep-caches is forwarded.
 func TestDelete_KeepCachesPropagatedToDaemon(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
@@ -119,9 +112,7 @@ func TestDelete_KeepCachesPropagatedToDaemon(t *testing.T) {
 // TestDelete_JSONRemovedReposNotNull verifies the removed_repos field is never
 // null in JSON output (even when the daemon returns an empty slice).
 func TestDelete_JSONRemovedReposNotNull(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
@@ -155,9 +146,7 @@ func TestDelete_JSONRemovedReposNotNull(t *testing.T) {
 
 // TestDelete_HumanOutputFormat verifies non-JSON output is readable.
 func TestDelete_HumanOutputFormat(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))

--- a/internal/cli/remove_test.go
+++ b/internal/cli/remove_test.go
@@ -3,18 +3,20 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
-	"net"
+	"fmt"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/daemon/transport"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
@@ -41,26 +43,35 @@ func (m *mockLifecycleService) DeleteGroup(args *proto.DeleteGroupArgs, reply *p
 	return m.deleteErr
 }
 
-// stubLifecycleDaemon starts a minimal JSON-RPC server over a Unix-domain
-// socket and returns the socket path. The server responds only to
+// stubLifecycleDaemon starts a minimal JSON-RPC server over the
+// platform-appropriate IPC transport (Unix socket on Linux/macOS, named pipe
+// on Windows) and returns the address. The server responds only to
 // RemoveRepo and DeleteGroup.
 //
-// macOS limits Unix socket paths to 104 characters, so we use os.MkdirTemp
-// with a short base-dir rather than t.TempDir (which produces long paths
-// under /var/folders/…).
+// On Unix, macOS limits socket paths to 104 characters, so we use
+// os.MkdirTemp with a short base-dir rather than t.TempDir (which produces
+// long paths under /var/folders/…). On Windows the address is a named-pipe
+// path of the form \\.\pipe\<name>, which has no path-length restriction.
 func stubLifecycleDaemon(t *testing.T, svc *mockLifecycleService) string {
 	t.Helper()
-	// Use /tmp directly to keep the path short (≤104 chars on macOS).
-	dir, err := os.MkdirTemp("", "ag-stub-")
-	if err != nil {
-		t.Fatalf("mkdirtemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	sock := filepath.Join(dir, "d.sock")
 
-	ln, err := net.Listen("unix", sock)
+	var addr string
+	if runtime.GOOS == "windows" {
+		// Named-pipe path — unique per test using the test name hash.
+		addr = fmt.Sprintf(`\\.\pipe\ag-stub-%d`, stubPipeSeq(t))
+	} else {
+		// Use /tmp directly to keep the path short (≤104 chars on macOS).
+		dir, err := os.MkdirTemp("", "ag-stub-")
+		if err != nil {
+			t.Fatalf("mkdirtemp: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+		addr = filepath.Join(dir, "d.sock")
+	}
+
+	ln, err := transport.Listen(addr)
 	if err != nil {
-		t.Fatalf("listen: %v", err)
+		t.Fatalf("listen %s: %v", addr, err)
 	}
 	t.Cleanup(func() { _ = ln.Close() })
 
@@ -77,7 +88,17 @@ func stubLifecycleDaemon(t *testing.T, svc *mockLifecycleService) string {
 			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
 		}
 	}()
-	return sock
+	return addr
+}
+
+// stubPipeSeqCounter is a monotonically increasing counter used to generate
+// unique named-pipe names for Windows test stubs. Accessed via sync/atomic
+// so parallel tests each get a distinct pipe name.
+var stubPipeSeqCounter int64
+
+// stubPipeSeq returns a unique integer for pipe name generation.
+func stubPipeSeq(_ *testing.T) int64 {
+	return atomic.AddInt64(&stubPipeSeqCounter, 1)
 }
 
 // makeTestRegistryGroup writes a minimal group config and registry entry under
@@ -113,9 +134,7 @@ func newTestCmd(buf *bytes.Buffer) *cobra.Command {
 // TestRemove_JSONOutputShape verifies the --json flag produces the expected
 // JSON shape and forwards the correct args to the daemon.
 func TestRemove_JSONOutputShape(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
@@ -168,9 +187,7 @@ func TestRemove_JSONOutputShape(t *testing.T) {
 // TestRemove_LastRepoBlockedWhenForced verifies that removing the last repo
 // with --force is rejected with a clear error (to avoid orphaned empty groups).
 func TestRemove_LastRepoBlockedWhenForced(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
@@ -195,9 +212,7 @@ func TestRemove_LastRepoBlockedWhenForced(t *testing.T) {
 // TestRemove_UnknownGroupReturnsClearError verifies that an unknown group is
 // caught before the daemon is contacted.
 func TestRemove_UnknownGroupReturnsClearError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
@@ -216,9 +231,7 @@ func TestRemove_UnknownGroupReturnsClearError(t *testing.T) {
 
 // TestRemove_KeepCachePropagatedToDaemon verifies --keep-cache is forwarded.
 func TestRemove_KeepCachePropagatedToDaemon(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
@@ -244,9 +257,7 @@ func TestRemove_KeepCachePropagatedToDaemon(t *testing.T) {
 // TestRemove_HumanOutputContainsFreedBytes verifies the non-JSON output
 // includes the freed-bytes value.
 func TestRemove_HumanOutputContainsFreedBytes(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
+
 	home := t.TempDir()
 	t.Setenv("ARCHIGRAPH_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))

--- a/internal/daemon/boot_watcher_async_test.go
+++ b/internal/daemon/boot_watcher_async_test.go
@@ -2,7 +2,6 @@ package daemon_test
 
 import (
 	"context"
-	"runtime"
 	"testing"
 	"time"
 
@@ -27,9 +26,6 @@ import (
 // deadline; with the old synchronous code Dial would never succeed until the
 // stall cleared.
 func TestBoot_WatcherSubscriptionDoesNotBlockBind(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
 	root := shortTempRoot(t)
 	t.Setenv(daemon.EnvRoot, root)
 	layout, err := daemon.DefaultLayout()

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -16,6 +16,23 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 )
 
+// waitDaemonReady polls until the daemon at socketPath accepts a dial.
+// On Unix this is equivalent to os.Stat + Dial; on Windows named pipes are
+// not filesystem objects so only the dial attempt is meaningful.
+func waitDaemonReady(t *testing.T, socketPath string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		c, err := client.DialPath(socketPath)
+		if err == nil {
+			c.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("daemon never became ready at %s within %s", socketPath, timeout)
+}
+
 // shortTempRoot returns a directory short enough for macOS's AF_UNIX
 // sun_path limit (~103 bytes). On macOS, t.TempDir() routes through
 // TMPDIR (/var/folders/...) which can exceed the limit when combined
@@ -71,15 +88,11 @@ func runDaemonForTest(t *testing.T, idx daemon.IndexFunc, rb daemon.RebuildFunc)
 			t.Logf("daemon did not exit within 3s")
 		}
 	})
-	// Wait for the socket to appear.
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(layout.SocketPath); err == nil {
-			return layout
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("daemon never bound socket at %s", layout.SocketPath)
+	// Wait for the daemon to become ready.
+	// On Unix we could stat the socket file, but named pipes on Windows are
+	// not filesystem objects — use a dial-based readiness probe that works on
+	// all platforms.
+	waitDaemonReady(t, layout.SocketPath, 3*time.Second)
 	return layout
 }
 
@@ -87,9 +100,6 @@ func runDaemonForTest(t *testing.T, idx daemon.IndexFunc, rb daemon.RebuildFunc)
 // Status reports a sensible RSS/pid/uptime. Anything reporting "RSS=0"
 // would be a clear sign the daemon never warmed up memstats.
 func TestDaemon_PingStatus(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
 	layout := runDaemonForTest(t, nil, nil)
 	c, err := client.DialPath(layout.SocketPath)
 	if err != nil {
@@ -111,9 +121,6 @@ func TestDaemon_PingStatus(t *testing.T) {
 // TestDaemon_IndexRPC stubs an IndexFunc and asserts the wire surface
 // (arg shape, stats handoff) before any real extractor runs.
 func TestDaemon_IndexRPC(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
 	idx := func(args proto.IndexArgs) (string, string, error) {
 		if args.RepoPath == "" {
 			return "", "", errors.New("empty repo")
@@ -143,9 +150,6 @@ func TestDaemon_IndexRPC(t *testing.T) {
 // subsequent dial reports ErrDaemonNotRunning, exactly as the CLI's
 // thin clients depend on.
 func TestDaemon_StopRPC(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
 	layout := runDaemonForTest(t, nil, nil)
 	c, err := client.DialPath(layout.SocketPath)
 	if err != nil {
@@ -155,25 +159,41 @@ func TestDaemon_StopRPC(t *testing.T) {
 		t.Fatalf("stop: %v", err)
 	}
 	_ = c.Close()
-	// Give the listener a moment to close.
+	// Wait for the daemon to stop accepting connections.
+	// On Unix we could check os.Stat(socketPath) for absence, but named pipes
+	// on Windows are not filesystem objects. Instead we poll until DialPath
+	// returns ErrDaemonNotRunning, which works on all platforms.
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if _, err := os.Stat(layout.SocketPath); os.IsNotExist(err) {
-			return // happy path: socket gone, daemon exited cleanly
+		if runtime.GOOS != "windows" {
+			// Fast path on Unix: socket file disappears on clean shutdown.
+			if _, err := os.Stat(layout.SocketPath); os.IsNotExist(err) {
+				return
+			}
+		} else {
+			// Windows: poll until the pipe rejects new connections.
+			if _, err := client.DialPath(layout.SocketPath); errors.Is(err, client.ErrDaemonNotRunning) {
+				return
+			}
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	t.Fatalf("socket %s still present after stop", layout.SocketPath)
+	t.Fatalf("daemon at %s did not shut down after stop", layout.SocketPath)
 }
 
 // TestDaemon_ClientReportsNotRunning probes the canonical "no daemon"
 // case: dialing a socket path that doesn't exist returns
 // ErrDaemonNotRunning, not some opaque syscall error.
 func TestDaemon_ClientReportsNotRunning(t *testing.T) {
+	var addr string
 	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
+		// Named pipes that are not listening return ErrDaemonNotRunning.
+		// Use a test-specific pipe name that will never be listening.
+		addr = `\\.\pipe\archigraph-test-notrunning-` + t.Name()
+	} else {
+		addr = filepath.Join(shortTempRoot(t), "nope.sock")
 	}
-	_, err := client.DialPath(filepath.Join(shortTempRoot(t), "nope.sock"))
+	_, err := client.DialPath(addr)
 	if !errors.Is(err, client.ErrDaemonNotRunning) {
 		t.Fatalf("want ErrDaemonNotRunning, got %v", err)
 	}
@@ -185,9 +205,6 @@ func TestDaemon_ClientReportsNotRunning(t *testing.T) {
 // counting peak concurrency inside the stub RebuildFunc and asserting it
 // never exceeds 1.
 func TestDaemon_RebuildGroupSerialisedUnderLoad(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
 	if testing.Short() {
 		t.Skip("group-serialisation test skipped in short mode")
 	}
@@ -246,9 +263,6 @@ func TestDaemon_RebuildGroupSerialisedUnderLoad(t *testing.T) {
 // StatusReply: RebuildInFlight and RebuildGroupsActive are non-negative and
 // consistent while a rebuild is in flight.
 func TestDaemon_RebuildStatusObservability(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
 	if testing.Short() {
 		t.Skip("rebuild observability test skipped in short mode")
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -134,12 +134,14 @@ func TestDaemon_IndexRPC(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	defer c.Close()
-	reply, err := c.Index(proto.IndexArgs{RepoPath: "/tmp/fake-repo"})
+	repoPath := filepath.Join(string(filepath.Separator)+"tmp", "fake-repo")
+	reply, err := c.Index(proto.IndexArgs{RepoPath: repoPath})
 	if err != nil {
 		t.Fatalf("index: %v", err)
 	}
-	if reply.GraphPath != "/tmp/fake-repo/.archigraph/graph.json" {
-		t.Fatalf("graph path: %q", reply.GraphPath)
+	wantGraphPath := filepath.Join(repoPath, ".archigraph", "graph.json")
+	if reply.GraphPath != wantGraphPath {
+		t.Fatalf("graph path: got %q want %q", reply.GraphPath, wantGraphPath)
 	}
 	if reply.StatsJSON == "" {
 		t.Fatalf("stats empty")

--- a/internal/daemon/mcp_rpc_integration_test.go
+++ b/internal/daemon/mcp_rpc_integration_test.go
@@ -15,15 +15,13 @@ package daemon_test
 import (
 	"context"
 	"encoding/json"
-	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
-	"os"
-	"runtime"
 	"testing"
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/daemon/transport"
 )
 
 // ── stub MCP functions ────────────────────────────────────────────────────────
@@ -93,15 +91,9 @@ func runDaemonWithConfig(t *testing.T, cfg daemon.Config) daemon.Layout {
 			t.Logf("daemon did not exit within 3s")
 		}
 	})
-	// Wait for socket.
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(cfg.Layout.SocketPath); err == nil {
-			return cfg.Layout
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("daemon never bound socket at %s", cfg.Layout.SocketPath)
+	// Wait for the daemon to become ready using a dial-based probe.
+	// os.Stat is not usable for Windows named pipes.
+	waitDaemonReady(t, cfg.Layout.SocketPath, 3*time.Second)
 	return cfg.Layout
 }
 
@@ -135,32 +127,29 @@ func runDaemonWithMCP(t *testing.T) string {
 	return layout.SocketPath
 }
 
-// dialRPC opens a net/rpc JSON-RPC 1.0 client on the given Unix socket.
+// dialRPC opens a net/rpc JSON-RPC 1.0 client on the given socket/pipe path.
+// Uses the platform-appropriate transport (Unix socket on Linux/macOS, named
+// pipe on Windows) so the test runs unchanged on all platforms.
 func dialRPC(t *testing.T, socketPath string) *rpc.Client {
 	t.Helper()
-	// Wait up to 3 s for the socket.
+	// Wait up to 3 s for the endpoint to become available.
 	deadline := time.Now().Add(3 * time.Second)
-	var conn net.Conn
 	var lastErr error
 	for time.Now().Before(deadline) {
-		conn, lastErr = net.Dial("unix", socketPath)
-		if lastErr == nil {
-			break
+		conn, err := transport.Dial(socketPath)
+		if err == nil {
+			return rpc.NewClientWithCodec(jsonrpc.NewClientCodec(conn))
 		}
+		lastErr = err
 		time.Sleep(20 * time.Millisecond)
 	}
-	if lastErr != nil {
-		t.Fatalf("dial %s: %v", socketPath, lastErr)
-	}
-	return rpc.NewClientWithCodec(jsonrpc.NewClientCodec(conn))
+	t.Fatalf("dial %s: %v", socketPath, lastErr)
+	return nil
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 func TestMCPToolList_Integration_Returns14Tools(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
 	socketPath := runDaemonWithMCP(t)
 	c := dialRPC(t, socketPath)
 	defer c.Close()
@@ -196,9 +185,6 @@ func TestMCPToolList_Integration_Returns14Tools(t *testing.T) {
 }
 
 func TestMCPToolCall_Integration_StatsReturnsContent(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
 	socketPath := runDaemonWithMCP(t)
 	c := dialRPC(t, socketPath)
 	defer c.Close()
@@ -230,9 +216,6 @@ func TestMCPToolCall_Integration_StatsReturnsContent(t *testing.T) {
 }
 
 func TestMCPToolCall_Integration_NilCallTool_ReturnsErrorBlock(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("windows: TODO #2121-B (Unix socket not supported)")
-	}
 	// Start a daemon where MCPCallTool is nil — the service should return
 	// a structured error block (IsError=true) rather than a protocol error.
 	root := shortTempRoot(t)


### PR DESCRIPTION
## Summary

Closes #2218. Removes all 18 \`t.Skip("windows: TODO #2121-B (Unix socket not supported)")\` guards across 5 test files.

The IPC transport layer already supported Windows named pipes via \`github.com/Microsoft/go-winio\` (SDDL \`"D:P(A;;GA;;;OW)"\` — Generic All for owner only, equivalent to Unix mode 0600). The skips existed because the test scaffolding hard-coded Unix-specific assumptions.

### Root causes fixed

| File | Problem | Fix |
|---|---|---|
| \`daemon/daemon_test.go\` | \`os.Stat(socketPath)\` used as readiness probe; named pipes aren't filesystem objects | Add \`waitDaemonReady()\` using \`client.DialPath()\` as platform-neutral probe |
| \`daemon/mcp_rpc_integration_test.go\` | Same \`os.Stat\` probe; \`net.Dial("unix", ...)\` hard-coded in \`dialRPC()\` | Use \`waitDaemonReady()\`; replace with \`transport.Dial()\` |
| \`daemon/boot_watcher_async_test.go\` | Skip guard only; test body already uses \`client.Dial()\` | Remove skip + unused \`runtime\` import |
| \`cli/remove_test.go\` | \`stubLifecycleDaemon()\` called \`net.Listen("unix", ...)\` directly | Rewrite to use \`transport.Listen()\`; generate unique named-pipe addresses on Windows via atomic counter |
| \`cli/delete_test.go\` | Skip guards only; shares \`stubLifecycleDaemon\` from \`remove_test.go\` | Remove skips + unused \`runtime\` import |

### Skips removed (18 total)

- \`internal/daemon/daemon_test.go\` — 6 skips (TestDaemon_PingStatus, TestDaemon_IndexRPC, TestDaemon_StopRPC, TestDaemon_ClientReportsNotRunning, TestDaemon_RebuildGroupSerialisedUnderLoad, TestDaemon_RebuildStatusObservability)
- \`internal/daemon/mcp_rpc_integration_test.go\` — 3 skips (TestMCPToolList_Integration_Returns14Tools, TestMCPToolCall_Integration_StatsReturnsContent, TestMCPToolCall_Integration_NilCallTool_ReturnsErrorBlock)
- \`internal/daemon/boot_watcher_async_test.go\` — 1 skip (TestBoot_WatcherSubscriptionDoesNotBlockBind)
- \`internal/cli/remove_test.go\` — 5 skips (TestRemove_*)
- \`internal/cli/delete_test.go\` — 5 skips (TestDelete_*)

### Security note

Named pipes are created with SDDL \`"D:P(A;;GA;;;OW)"\` (owner-only Generic All) — equivalent to Unix mode 0600 on a socket file. No additional security changes are required.

## Test plan

- [x] \`go test ./internal/cli/... -run "TestDelete|TestRemove"\` — pass on Linux
- [x] \`go test ./internal/daemon/... -run "TestDaemon_|TestBoot_|TestMCPTool"\` — pass on Linux
- [x] \`go build ./...\` — clean
- [x] \`gofmt -l\` — clean
- [ ] CI Windows runner — validates named pipe end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>