### PR TITLE
feat(ci): minutes-aware CI — path filters + opt-in full runs (closes #2229)

### DIFF
--- a/.github/workflows/board-hygiene.yml
+++ b/.github/workflows/board-hygiene.yml
@@ -1,7 +1,7 @@
 name: board-hygiene
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   closure-keyword:

--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -1,17 +1,10 @@
 name: Linux Smoke Test
 
 on:
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+  workflow_dispatch:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-  workflow_dispatch:
+    tags: ['v*']
 
 jobs:
   smoke:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,23 +1,48 @@
 name: test
 
+# Default: runs automatically on PRs that touch Go source or config files.
+# Skip: PRs that only change docs/assets/skills/testdata — those run zero test
+#       jobs (board-hygiene still fires).
+# Opt-in: add label `ci:full` to force this workflow on any PR regardless of
+#         the path filter (e.g. a pure-docs PR that you still want validated).
+# Manual: `workflow_dispatch` from the Actions tab runs unconditionally.
+# Post-merge: push to main always runs as a sanity check.
+
 on:
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+  workflow_dispatch:
+
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-  workflow_dispatch:
+
+  pull_request:
+    branches: [main]
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'vendor/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '.github/workflows/test.yml'
+
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   contents: read
 
 jobs:
   test:
+    # Gate: run when —
+    #   (a) workflow_dispatch / push to main, OR
+    #   (b) pull_request triggered by a path-matching diff, OR
+    #   (c) pull_request_target with the `ci:full` label just added.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:full'))
+
     # Windows is allowed to fail until tree-sitter CGO bindings are confirmed
     # on windows-latest — tracked in #937. Remove continue-on-error once #937
     # and its prerequisites (#926, #928) are resolved.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to archigraph
+
+## CI overview
+
+CI is **minutes-aware**: workflows run only when they add signal. Full 3-platform tests are opt-in, not the default.
+
+### What runs on every PR
+
+| Workflow | Cost | Always? |
+|---|---|---|
+| `board-hygiene` (closure-keyword check) | ~5 s | Yes — all PRs |
+| `test` (3-platform: ubuntu / macos / windows) | ~30 min | Only when warranted (see below) |
+| `linux-smoke` | ~3 min | Post-merge + tag only |
+
+---
+
+### When does `test` run on a PR?
+
+`test` fires automatically when your diff touches any of:
+
+```
+cmd/**
+internal/**
+vendor/**
+go.mod
+go.sum
+Makefile
+.github/workflows/test.yml
+```
+
+Pure-docs / pure-asset PRs (`.md`, `docs/**`, `*.png`, `skills/**`, `testdata/**`) run **zero** test jobs.
+
+---
+
+### Opt-in: `ci:full` label
+
+Apply the **`ci:full`** label to force full 3-platform CI on any PR, regardless of which files changed.
+
+**When to use it:**
+
+- You changed something outside the auto-trigger paths but still want cross-platform validation (e.g. a Makefile outside the root, a shell script that affects all platforms, a `webui-v2` change you want to confirm doesn't break the Go build).
+- You want to verify a docs-only PR's surrounding infrastructure hasn't regressed.
+- You're about to merge and want extra confidence.
+
+**How to apply:**
+
+In the GitHub PR sidebar → Labels → select `ci:full`. The `pull_request_target: labeled` trigger will re-run `test` immediately after you apply the label.
+
+---
+
+### Opt-out: `board:exempt` label
+
+Apply **`board:exempt`** to skip the closure-keyword check on chore PRs that legitimately don't map to an open issue:
+
+- Typo fixes in docs
+- `.gitignore` / `.editorconfig` tweaks
+- CI formatting cleanups
+- Emergency hotfixes that predate issue tracking
+
+The label is checked in the `board-hygiene` workflow. Applying `board:exempt` (or removing it) re-triggers the workflow immediately via the `labeled`/`unlabeled` events, so the check resolves without requiring a re-push.
+
+---
+
+### Manual run: `workflow_dispatch`
+
+Any workflow that supports `workflow_dispatch` can be triggered from the **Actions tab** in GitHub:
+
+1. Go to `Actions` → select the workflow (e.g. `test`, `Linux Smoke Test`, `quality`).
+2. Click **Run workflow** → choose a branch → click the green button.
+
+Use this when you want to run CI on a branch that wouldn't otherwise trigger it automatically (e.g. a WIP branch, a branch that only touches docs).
+
+---
+
+### Where smoke runs
+
+`linux-smoke` runs **only on push to `main`** and on **tag pushes (`v*`)**. It is not a PR gate — its job is post-merge sanity: confirm the binary builds and indexes a golden fixture before the commit is considered stable.
+
+---
+
+### Release pipeline
+
+Pushing a tag matching `v*` triggers the full release pipeline (`release.yml`):
+
+- 5-platform binary builds (linux amd64/arm64, macos amd64/arm64, windows amd64)
+- Checksums + GitHub Release creation
+- Smoke also fires on the tag push
+
+Tags should only be pushed from `main` after all CI is green.
+
+---
+
+### Scenario reference
+
+| Scenario | Workflows triggered |
+|---|---|
+| PR with only `.md` / `docs/**` changes | `board-hygiene` only |
+| PR touching `internal/` or `cmd/` | `board-hygiene` + `test` (3 platforms) |
+| PR with `board:exempt` label (docs-only) | `board-hygiene` (passes via label), no `test` |
+| PR with `ci:full` label (any diff) | `board-hygiene` + `test` (3 platforms) |
+| Push to `main` | `linux-smoke` + `test` |
+| Tag push (`v1.2.3`) | `linux-smoke` + `release` pipeline |
+| `workflow_dispatch` from Actions UI | Whichever workflow you trigger |


### PR DESCRIPTION
## Summary

Stop burning GitHub Actions minutes on every PR. Full 3-platform CI is now opt-in; cheap checks (closure-keyword, gofmt, go vet) remain automatic.

- **`test.yml`**: path-filtered — auto-fires only when `cmd/**`, `internal/**`, `vendor/**`, `go.mod`, `go.sum`, `Makefile`, or `test.yml` itself changes. `pull_request_target: labeled` + job `if:` guard enables `ci:full` label to force a run on any PR.
- **`linux-smoke.yml`**: PR trigger removed entirely. Smoke is a post-merge sanity check — runs on push to `main` and tag pushes (`v*`) only.
- **`board-hygiene.yml`**: adds `labeled`/`unlabeled` to `pull_request.types` so applying `board:exempt` re-triggers the workflow immediately and resolves the check without requiring a re-push.
- **`CONTRIBUTING.md`**: new file documenting `ci:full`, `board:exempt`, `workflow_dispatch`, smoke trigger rules, and a full scenario table.
- **`ci:full` label**: created in the repo (color `#0E8A16`).

## Closes / Refs

Closes #2229

## Scenario reference

| Scenario | Workflows triggered |
|---|---|
| PR with only `.md` changes | `board-hygiene` only (closure-keyword) |
| PR touching `internal/` | `board-hygiene` + `test` (3 platforms) |
| PR with `board:exempt` label, only `.md` | `board-hygiene` (passes via label), no `test` |
| PR with `ci:full` label, even on `.md`-only | `board-hygiene` + `test` (3 platforms) |
| Push to `main` | `linux-smoke` + `test` |
| Tag push (`v1.2.3`) | `linux-smoke` + `release` pipeline |
| `workflow_dispatch` from UI | Whichever workflow you trigger |

## Testing

- [ ] All tests pass: `go test ./...`
- [ ] Relevant fixtures verified
- [ ] No regression in cross-language parity

## Notes

`pull_request_target` is used (not `pull_request`) for the `labeled` trigger so that adding the `ci:full` label actually re-queues the workflow. The job-level `if:` guard ensures the three-platform matrix only runs when the event is `workflow_dispatch`, `push`, `pull_request` (path-matched), or `pull_request_target` with the `ci:full` label present — preventing any accidental runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)