### PR TITLE
fix(tests): two CI flakes — progressToken 16-bit suffix + SerialisesLargest racy sleep

### DIFF
--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -94,9 +94,16 @@ func newResetCmd() *cobra.Command {
 }
 
 // progressToken generates a short unique token for a rebuild session.
+//
+// Uses the full 64 bits of rand.Uint64 (was previously only 16 bits, which
+// caused collisions on Windows where time.Now().UnixNano() has lower
+// resolution — 100 tokens in a tight loop within the same clock tick
+// exhausted the 65k suffix space and triggered TestProgressToken_Unique
+// failures on windows-latest CI). 64-bit suffix is collision-resistant
+// for realistic session counts.
 func progressToken() string {
 	return strconv.FormatInt(time.Now().UnixNano(), 36) +
-		strconv.FormatUint(rand.Uint64()&0xffff, 36) //nolint:gosec
+		strconv.FormatUint(rand.Uint64(), 36) //nolint:gosec
 }
 
 // isTTY reports whether w is connected to a terminal.

--- a/internal/daemon/sched/integration_test.go
+++ b/internal/daemon/sched/integration_test.go
@@ -36,6 +36,11 @@ func TestIntegrationThreeRepoBudgetSerialisesLargest(t *testing.T) {
 		"/repo-small-b": make(chan struct{}),
 		"/repo-big-c":   make(chan struct{}),
 	}
+	// allStarted receives one notification per Index callback entry. With
+	// 3 enqueued repos and budget=500 that fits all three (60+60+280=400),
+	// we expect all 3 to dispatch concurrently and signal here.
+	// Buffered so workers never block on send.
+	allStarted := make(chan struct{}, 3)
 
 	var calls atomic.Int32
 	var sched *Scheduler
@@ -61,6 +66,7 @@ func TestIntegrationThreeRepoBudgetSerialisesLargest(t *testing.T) {
 				}
 			}
 			mu.Unlock()
+			allStarted <- struct{}{}
 			<-gates[p]
 			mu.Lock()
 			delete(concurrent, p)
@@ -76,8 +82,19 @@ func TestIntegrationThreeRepoBudgetSerialisesLargest(t *testing.T) {
 	s.Enqueue("/repo-small-b")
 	s.Enqueue("/repo-big-c")
 
-	// Give the admit loop time to dispatch.
-	time.Sleep(300 * time.Millisecond)
+	// Wait until all 3 Index callbacks have actually been entered before
+	// we take the mid-run snapshot. Deterministic under -race on any
+	// hardware — replaces the racy time.Sleep(300ms) that caused
+	// intermittent failures on ubuntu-latest CI (see sibling
+	// TestIntegrationThreeRepoTightBudgetDefersBig comment above for
+	// the same fix pattern).
+	for i := 0; i < 3; i++ {
+		select {
+		case <-allStarted:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("only %d of 3 Index callbacks entered after 10s", i)
+		}
+	}
 
 	// Verify the budget telemetry: usedMB should be <= 500.
 	snap := s.Snapshot()
@@ -94,7 +111,18 @@ func TestIntegrationThreeRepoBudgetSerialisesLargest(t *testing.T) {
 	for _, p := range []string{"/repo-small-a", "/repo-small-b", "/repo-big-c"} {
 		close(gates[p])
 	}
-	time.Sleep(300 * time.Millisecond)
+	// Wait for all 3 to actually complete (delete from concurrent map)
+	// instead of an arbitrary sleep. Poll briefly.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		done := len(concurrent) == 0 && calls.Load() == 3
+		mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if got := calls.Load(); got != 3 {
 		t.Errorf("expected 3 indexes total, got %d", got)
 	}


### PR DESCRIPTION
Refs #2196 (CI hygiene), #2211 (the doctor PR that surfaced these flakes today).

## Two pre-existing flakes surfaced on PR #2234

### 1. TestProgressToken_Unique (Windows-only)

`progressToken()` used only 16 bits of randomness as the suffix:
```go
strconv.FormatUint(rand.Uint64()&0xffff, 36)
```

On Windows, `time.Now().UnixNano()` has lower clock resolution than macOS/Linux. 100 tokens generated in a tight loop within the same clock tick exhaust the 65k suffix space → collision → test failure.

**Fix:** Use full 64 bits of `rand.Uint64()` — collision-resistant for any realistic session count.

### 2. TestIntegrationThreeRepoBudgetSerialisesLargest (Ubuntu CI flake)

Sibling test to `TestIntegrationThreeRepoTightBudgetDefersBig` which P4 (#2196) already fixed with the same pattern. Both used `time.Sleep(300 * time.Millisecond)` to wait for the scheduler to reach steady state. Under loaded CI runners with `-race`, 300ms isn't enough.

**Fix:** Mirror the channel-sync pattern P4 applied to the sibling:
- `allStarted` buffered channel (capacity 3) so workers signal entry
- Wait until all 3 Index callbacks have actually entered before snapshotting
- 10s deadline failsafe
- Tail wait: poll the `concurrent` map briefly instead of `Sleep(300ms)`

## Local verification

```
go test -run "TestProgressToken_Unique|TestIntegrationThreeRepoBudgetSerialisesLargest" \
  ./internal/cli/ ./internal/daemon/sched/
ok  github.com/cajasmota/archigraph/internal/cli  1.553s
ok  github.com/cajasmota/archigraph/internal/daemon/sched  0.682s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)