### PR TITLE
fix(test): bump daemon-ready timeout 3s → 10s (TestDaemon_PingStatus flake)

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -92,7 +92,12 @@ func runDaemonForTest(t *testing.T, idx daemon.IndexFunc, rb daemon.RebuildFunc)
 	// On Unix we could stat the socket file, but named pipes on Windows are
 	// not filesystem objects — use a dial-based readiness probe that works on
 	// all platforms.
-	waitDaemonReady(t, layout.SocketPath, 3*time.Second)
+	//
+	// 10s timeout: a loaded ubuntu CI runner under -race occasionally exceeded
+	// the prior 3s window, causing TestDaemon_PingStatus and friends to flake
+	// even though the daemon log showed it was ready. 10s is generous enough
+	// for any reasonable CI runner while still failing fast on real bugs.
+	waitDaemonReady(t, layout.SocketPath, 10*time.Second)
 	return layout
 }
 


### PR DESCRIPTION
Refs #2196 (CI hygiene), #2214 (the docgen-MCP-tools PR where this flake surfaced).

A loaded ubuntu CI runner under `-race` occasionally exceeded the prior 3s window for the daemon to accept its first dial. The daemon log shows "ready socket=..." within ~10ms — the daemon IS ready, the polling probe just hadn't seen it yet under load.

Bumps `waitDaemonReady` timeout in `runDaemonForTest` from 3s to 10s. 10s is generous enough for any reasonable CI runner while still failing fast on real bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)