### PR TITLE
chore(ci): deactivate auto-CI on PRs — manual + ci:full label only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,7 @@
 name: test
 
-# Default: runs automatically on PRs that touch Go source or config files.
-# Skip: PRs that only change docs/assets/skills/testdata — those run zero test
-#       jobs (board-hygiene still fires).
-# Opt-in: add label `ci:full` to force this workflow on any PR regardless of
-#         the path filter (e.g. a pure-docs PR that you still want validated).
+# Default: CI is OFF for PRs. No auto-trigger on code changes.
+# Opt-in: add label `ci:full` to force full 3-platform testing on any PR.
 # Manual: `workflow_dispatch` from the Actions tab runs unconditionally.
 # Post-merge: push to main always runs as a sanity check.
 
@@ -13,17 +10,6 @@ on:
 
   push:
     branches: [main]
-
-  pull_request:
-    branches: [main]
-    paths:
-      - 'cmd/**'
-      - 'internal/**'
-      - 'vendor/**'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Makefile'
-      - '.github/workflows/test.yml'
 
   pull_request_target:
     types: [labeled]
@@ -35,12 +21,10 @@ jobs:
   test:
     # Gate: run when —
     #   (a) workflow_dispatch / push to main, OR
-    #   (b) pull_request triggered by a path-matching diff, OR
-    #   (c) pull_request_target with the `ci:full` label just added.
+    #   (b) pull_request_target with the `ci:full` label.
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
       (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:full'))
 
     # Windows is allowed to fail until tree-sitter CGO bindings are confirmed

--- a/.github/workflows/windows-cgo-experiment.yml
+++ b/.github/workflows/windows-cgo-experiment.yml
@@ -2,17 +2,14 @@ name: Windows CGO Experiment
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/windows-cgo-experiment.yml"
-      - "internal/extractors/**"
-      - "internal/daemon/**"
-      - "cmd/archigraph/**"
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   build:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:full'))
     runs-on: windows-latest
     continue-on-error: true   # experimental until #937 closed
     timeout-minutes: 15

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,49 +2,42 @@
 
 ## CI overview
 
-CI is **minutes-aware**: workflows run only when they add signal. Full 3-platform tests are opt-in, not the default.
+CI is **fast by default**: PRs run zero CI except board-hygiene. Full 3-platform tests are manual or opt-in. Post-merge always validates.
 
 ### What runs on every PR
 
 | Workflow | Cost | Always? |
 |---|---|---|
 | `board-hygiene` (closure-keyword check) | ~5 s | Yes — all PRs |
-| `test` (3-platform: ubuntu / macos / windows) | ~30 min | Only when warranted (see below) |
+| `test` (3-platform: ubuntu / macos / windows) | ~30 min | No — manual or `ci:full` label only |
+| `windows-cgo-experiment` | ~5 min | No — manual or `ci:full` label only |
 | `linux-smoke` | ~3 min | Post-merge + tag only |
 
 ---
 
 ### When does `test` run on a PR?
 
-`test` fires automatically when your diff touches any of:
+`test` does **not** run automatically on any PR by default. To trigger it:
 
-```
-cmd/**
-internal/**
-vendor/**
-go.mod
-go.sum
-Makefile
-.github/workflows/test.yml
-```
-
-Pure-docs / pure-asset PRs (`.md`, `docs/**`, `*.png`, `skills/**`, `testdata/**`) run **zero** test jobs.
+1. Apply the **`ci:full`** label (see below), OR
+2. Use `workflow_dispatch` from the Actions tab
 
 ---
 
 ### Opt-in: `ci:full` label
 
-Apply the **`ci:full`** label to force full 3-platform CI on any PR, regardless of which files changed.
+Apply the **`ci:full`** label to trigger full 3-platform CI (`test` + `windows-cgo-experiment`) on any PR.
 
 **When to use it:**
 
-- You changed something outside the auto-trigger paths but still want cross-platform validation (e.g. a Makefile outside the root, a shell script that affects all platforms, a `webui-v2` change you want to confirm doesn't break the Go build).
-- You want to verify a docs-only PR's surrounding infrastructure hasn't regressed.
+- You want to validate code changes across all platforms before merge.
+- You're testing a fix for Windows-specific CGO issues (see #937).
 - You're about to merge and want extra confidence.
+- You changed something in `cmd/`, `internal/`, or `go.mod`/`go.sum` and want to test it before marking ready.
 
 **How to apply:**
 
-In the GitHub PR sidebar → Labels → select `ci:full`. The `pull_request_target: labeled` trigger will re-run `test` immediately after you apply the label.
+In the GitHub PR sidebar → Labels → select `ci:full`. The `pull_request_target: labeled` trigger will start CI jobs immediately.
 
 ---
 
@@ -94,10 +87,9 @@ Tags should only be pushed from `main` after all CI is green.
 
 | Scenario | Workflows triggered |
 |---|---|
-| PR with only `.md` / `docs/**` changes | `board-hygiene` only |
-| PR touching `internal/` or `cmd/` | `board-hygiene` + `test` (3 platforms) |
-| PR with `board:exempt` label (docs-only) | `board-hygiene` (passes via label), no `test` |
-| PR with `ci:full` label (any diff) | `board-hygiene` + `test` (3 platforms) |
-| Push to `main` | `linux-smoke` + `test` |
-| Tag push (`v1.2.3`) | `linux-smoke` + `release` pipeline |
-| `workflow_dispatch` from Actions UI | Whichever workflow you trigger |
+| Any PR (default) | `board-hygiene` only |
+| PR with `board:exempt` label | `board-hygiene` (passes via label) |
+| PR with `ci:full` label | `board-hygiene` + `test` (3 platforms) + `windows-cgo-experiment` |
+| Push to `main` | `board-hygiene` (passes) + `test` + `linux-smoke` |
+| Tag push (`v1.2.3`) | `board-hygiene` (passes) + `test` + `linux-smoke` + `release` pipeline |
+| `workflow_dispatch` from Actions UI | Whichever workflow(s) you trigger |


### PR DESCRIPTION
Refs #2229 (CI restructure — evolves the default further to OFF per user direction 2026-05-26).

## Summary

Per user feedback during overnight sequential grind: "let's deactivate CI completely and trigger manually ONLY when needed to test windows compatible code."

CI now fires ONLY via:
- `ci:full` label on a PR
- `workflow_dispatch` (manual UI trigger)
- Push to `main` (single post-merge sanity)
- Tag push (release validation)

## Changes

### `.github/workflows/test.yml`
Removed `pull_request:` auto-trigger. Kept `workflow_dispatch`, `push: branches: [main]`, `pull_request_target: types: [labeled]` with `ci:full` guard.

### `.github/workflows/windows-cgo-experiment.yml`
Same pattern — removed auto-PR trigger, kept manual + label.

### `CONTRIBUTING.md`
Trigger table updated.

## Trigger matrix (new default)

| Event | Workflows that run |
|---|---|
| PR opened (any code change) | board-hygiene only |
| PR with `ci:full` label | board-hygiene + test (3 platforms) + windows-cgo-experiment |
| Manual workflow_dispatch | whatever you choose |
| Push to main | test + linux-smoke (post-merge sanity) |
| Tag push (`v*`) | test + linux-smoke + release pipeline |

## Why

The sequential grind queue (15+ sub-tickets remaining) needs to move at agent-completion speed, not GitHub-Actions-queue speed. Trust local agent tests + post-merge sanity. Fix-forward if a regression slips through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)