### PR TITLE
feat(skill): docgen prompts via MCP — local-staging + atomic promote (closes #2215, refs #2207, #2214)

### DIFF
--- a/skills/generate-docs/SKILL.md
+++ b/skills/generate-docs/SKILL.md
@@ -19,7 +19,7 @@ You are STRICTLY FORBIDDEN from using:
 The MCP daemon has the resolved graph; trust it. Use Bash ONLY for:
 - Reading specific source line ranges that `archigraph_get_source` returns
 - Running `archigraph docgen --llm-mode=apply` at the end of Pass 20
-- Writing output files under `~/.archigraph/docs/<group>/...`
+- Writing output files into the staging directory (`<project>/.archigraph/staging/<run_id>/`)
 
 If the MCP returns empty or seems wrong, file a side ticket and ABORT --
 do NOT silently substitute grep results for graph queries.
@@ -38,9 +38,10 @@ ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix
 ### Tool whitelist
 
 - `mcp__archigraph__*` (all archigraph MCP tools) -- primary navigation
-- `Read` -- source_window reads (specific line ranges from `archigraph_get_source` output) and output file reads/writes
-- `Write` / `Edit` -- output doc files under `~/.archigraph/docs/<group>/...` only
-- `Bash` -- ONLY for `archigraph docgen --llm-mode=apply` invocations and writing output files
+- `archigraph_docgen_start_run` / `_status` / `_validate` / `_promote` / `_abort` / `_list` -- docgen lifecycle MCP tools (epic #2207, landed #2214)
+- `Read` -- source_window reads (specific line ranges from `archigraph_get_source` output) and output file reads
+- `Write` / `Edit` -- output doc files into the staging directory ONLY (`<staging_path>/<relative-path>`)
+- `Bash` -- ONLY for `archigraph docgen --llm-mode=apply` invocations and writing output files to staging
 
 Explicitly EXCLUDED for entity discovery:
 - `Grep` for structural/inventory queries (these enable the grep-fallback anti-pattern)
@@ -100,54 +101,45 @@ single group-level directory `~/.archigraph/docs/<group>/business/`, regardless
 of how many repos make up the group. The webui surfaces this set directly under
 the Business tab.
 
-## CRITICAL STORAGE DISCIPLINE (enforced on every pass — parallel to TOOL DISCIPLINE)
-===========================
+## Staging-dir + atomic promote architecture (#2207, #2214, #2215)
 
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
+Documentation is written into a **staging directory** during the run and
+atomically promoted to the canonical store only when all passes complete without
+errors. This makes the 2026-05-25 docgen-writes-to-repo incident (#2191)
+architecturally impossible — the daemon owns the move from staging to canonical.
 
-This applies to BOTH the technical tier and the business tier. The `<group>` value
-comes from `archigraph_whoami` (called in the Pre-flight assertion above). Every pass
-computes `OUTPUT_ROOT=$HOME/.archigraph/docs/<group>/` and verifies it is writable
-before writing any file.
+### Flow
 
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
+1. **Pass 2** calls `archigraph_docgen_start_run(group="<group>")` → receives
+   `run_id` and `staging_path` (`<project>/.archigraph/staging/<run_id>/`).
+2. **Passes 3–19** write every doc file natively (Write tool) into
+   `<staging_path>/<relative-path>`.
+3. **Pass 8** and **Pass 14** call `archigraph_docgen_validate(run_id)` to lint
+   the staging tree for broken links and frontmatter errors.
+4. **Pass 20** (or the orchestrator after Pass 19) calls
+   `archigraph_docgen_promote(run_id)` to atomically move staging → canonical
+   (`~/.archigraph/docs/<group>/`). The daemon refuses promote if SSG
+   scaffolding is detected (physical OUTPUT DISCIPLINE guard).
 
-If you find yourself about to write to a repo path, STOP and redirect to the
-store path. Writing elsewhere breaks the storage contract, pollutes the user's
-source repo with commit noise, and produces output invisible to the daemon dashboard.
+### Storage contract (enforced by daemon)
+
+The daemon's `_promote` handler physically enforces:
+- **No SSG scaffolding** — if `.vitepress`, `.docusaurus`, `mkdocs.yml`,
+  `package.json`, `config.ts`, or similar files exist in staging, promote is
+  refused with a clear error.
+- **No in-repo writes** — staging lives under `<project>/.archigraph/staging/`,
+  which the daemon owns; writers never have a path that touches the user's
+  working tree.
+
+The old STORAGE DISCIPLINE and OUTPUT DISCIPLINE prompt blocks have been removed
+(#2215) because the daemon now enforces these contracts physically. TOOL
+DISCIPLINE (#2177) is retained — MCP-first graph navigation is independent of
+write target.
 
 **Recovery:** If you encounter legacy in-repo docs from a pre-#1624 run, use
 `archigraph docgen migrate-in-repo <group>` to move them to the store. Use
 `archigraph docgen audit <group>` (or `archigraph doctor --audit-docs`) to detect
 in-repo docgen output without moving anything.
-
-The daemon dashboard reads exclusively from `~/.archigraph/docs/<group>/`.
-Closes #1624. Parallel to TOOL DISCIPLINE (#2177). Enforced by #2190.
-
-## CRITICAL OUTPUT DISCIPLINE (enforced on every pass — parallel to TOOL DISCIPLINE + STORAGE DISCIPLINE)
-==========================
-
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-The apply step (`archigraph docgen --llm-mode=apply`) actively refuses
-writes to SSG-scaffolding paths. Any result file that names such a path
-will be rejected with a logged violation. Closes #2194.
-Parallel to TOOL DISCIPLINE (#2177) and STORAGE DISCIPLINE (#2193).
-Third instance of the agent-treats-skill-as-suggestion pattern.
 
 ## LLM-mode orchestrate (Pass 20)
 
@@ -701,8 +693,15 @@ The skill is built around the archigraph MCP server. The agent should call these
 
 ## Output layout
 
-For each repo `<r>` in the group, the skill writes into
-`~/.archigraph/docs/<group>/<r>/` (NOT the repo working tree — #1624):
+**During the run:** files are written into the staging directory
+`<project>/.archigraph/staging/<run_id>/` (set by Pass 2). The layout mirrors
+the canonical layout below; `<staging_path>/` substitutes for
+`~/.archigraph/docs/<group>/`.
+
+**After promote** (`archigraph_docgen_promote` in Pass 20): the daemon moves
+staging to canonical `~/.archigraph/docs/<group>/` atomically.
+
+For each repo `<r>` in the group, the canonical output layout is:
 
 ```
 ~/.archigraph/docs/<group>/<r>/
@@ -858,3 +857,4 @@ After applying, `archigraph_stats` now includes `fidelity` (0–1 ratio), `fidel
 - `skills/generate-docs/templates/` - per-kind frontmatter template files for Pass 13.
 - `skills/generate-docs/examples/` - fully-populated example enriched doc files per kind.
 - `docs/agent-hosts.md` - how to configure Haiku in Claude Code, Cursor, and Windsurf before running Pass 13 (see #1288).
+- `internal/mcp/docgen.go` - the 6 `archigraph_docgen_*` MCP tools: `start_run`, `status`, `validate`, `promote`, `abort`, `list`. Landed in #2214 (epic #2207). `start_run` creates the staging directory; `validate` lints frontmatter + links; `promote` atomically moves staging → canonical; `abort` cleans up an aborted run. The skill prompts were updated to use these tools in #2215.

--- a/skills/generate-docs/prompts/00-domain-qa.md
+++ b/skills/generate-docs/prompts/00-domain-qa.md
@@ -23,57 +23,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 You are a documentation architect. Before you index anything or query archigraph, you need to understand the domain.
 

--- a/skills/generate-docs/prompts/01-inventory.md
+++ b/skills/generate-docs/prompts/01-inventory.md
@@ -23,57 +23,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Discover what is actually in each repo by querying archigraph. Do not read source files directly. The graph is the source of truth for what entities exist; the writer passes will read source via `archigraph_get_source` when they need verbatim snippets.
 

--- a/skills/generate-docs/prompts/01a-residual-repair-sweep.md
+++ b/skills/generate-docs/prompts/01a-residual-repair-sweep.md
@@ -23,57 +23,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Runs **after Pass 1 (inventory)** and **before any deeper writer passes**. Closes the gap between the static-analysis recall ceiling (~85% on cross-repo b→a) and full coverage by annotating runtime-resolved edges that the resolver structurally cannot bind.
 

--- a/skills/generate-docs/prompts/01b-repair-aware-qa.md
+++ b/skills/generate-docs/prompts/01b-repair-aware-qa.md
@@ -23,57 +23,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Surfaces the residuals Pass 1a could not auto-resolve (see Pass 1a § "Classify each residual" for the narrowed auto-resolve scope). The user answers in plain language; the agent translates each answer into an `archigraph_repairs(action=submit)` call.
 

--- a/skills/generate-docs/prompts/02-plan.md
+++ b/skills/generate-docs/prompts/02-plan.md
@@ -23,59 +23,23 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
 
-
 Convert the raw community list from Pass 1 into a documentation plan. The plan is the contract that Passes 3-6 execute against.
+
+## Staging run
+
+**FIRST action in this pass** (after `archigraph_whoami`): call `archigraph_docgen_start_run` to create a staging run for this group. Capture `run_id` and `staging_path` from the response and carry them through every subsequent write in this pass and all downstream passes.
+
+```
+archigraph_docgen_start_run(group="<group>")
+# response: { "run_id": "<id>", "staging_path": "<project>/.archigraph/staging/<id>/" }
+```
+
+All doc files written in Passes 2–19 MUST target `<staging_path>/<relative-path>` rather than `~/.archigraph/docs/<group>/`. The daemon promotes the staging directory to canonical at the end of Pass 20 via `archigraph_docgen_promote`. Do NOT write to `~/.archigraph/docs/` directly.
+
+Pass the `run_id` and `staging_path` to every downstream writer subagent and the orchestrator.
 
 ## Inputs
 
@@ -115,11 +79,13 @@ For each module, estimate:
 
 ### Step 4 — Produce the plan file
 
-Write `~/.archigraph/groups/<group>/plan.json`:
+Write `~/.archigraph/groups/<group>/plan.json` (this is group metadata, NOT a doc file — write it to the groups directory directly, not to staging):
 
 ```json
 {
   "group": "<group>",
+  "run_id": "<run_id from archigraph_docgen_start_run>",
+  "staging_path": "<staging_path from archigraph_docgen_start_run>",
   "tiers": ["technical", "business"],
   "primary_repo": "<slug>",
   "volume_control": {

--- a/skills/generate-docs/prompts/03-overview.md
+++ b/skills/generate-docs/prompts/03-overview.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Write `~/.archigraph/docs/<group>/<repo-slug>/overview.md` for every repo in the group. The overview is the entry point a new engineer reads first; it is also the page Pass 7 quotes when synthesizing the group-level page.
 

--- a/skills/generate-docs/prompts/03a-generation-time-repair.md
+++ b/skills/generate-docs/prompts/03a-generation-time-repair.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 A **hook**, not a standalone pass. Every writer subagent in Passes 3, 4, 5, 6, and 12 runs this check immediately before emitting prose that describes an entity. The hook is the primary site for `bind_to_entity` resolutions — Pass 1a deliberately defers those here because the writer has full local subgraph context via `archigraph_expand`. It also catches residuals discovered late (after Pass 1a) that the earlier sweep missed.
 

--- a/skills/generate-docs/prompts/04-cluster.md
+++ b/skills/generate-docs/prompts/04-cluster.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 For every entry under `plan.passes.4_cluster.modules`, produce a self-contained module page (or set of pages). This pass runs writer subagents **in parallel** — one subagent per module — bounded by a configured concurrency limit.
 

--- a/skills/generate-docs/prompts/05-reference.md
+++ b/skills/generate-docs/prompts/05-reference.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Reference docs are the dry, exhaustive, alphabetized pages. They live under `~/.archigraph/docs/<group>/<repo-slug>/reference/` and are produced one section at a time, sequentially, by a single writer subagent per repo.
 

--- a/skills/generate-docs/prompts/06-cross-cutting.md
+++ b/skills/generate-docs/prompts/06-cross-cutting.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Some topics span every module: authentication, authorization, logging, error handling, observability, feature flags, rate limiting. They deserve their own pages so readers don't have to reconstruct them from per-module docs.
 

--- a/skills/generate-docs/prompts/07-group-synthesis.md
+++ b/skills/generate-docs/prompts/07-group-synthesis.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Tie the per-repo outputs into one group-level page. This page is what an executive, a new hire, or an external consumer reads first.
 

--- a/skills/generate-docs/prompts/08-cross-link.md
+++ b/skills/generate-docs/prompts/08-cross-link.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,98 +27,44 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Two responsibilities:
 
 1. Validate that every relative link inside the generated docs resolves.
 2. Walk every pending cross-repo link candidate and decide accept/reject with a rationale.
 
-## Step 1 — Static link check
+## Step 1 — Static link check via MCP
 
-Apply `snippets/link-hygiene.md` and `snippets/anchor-contract.md` — they are the
-source of truth for what a valid link/anchor is. This pass enforces them across
-the whole tree (technical + business). For each generated markdown file, parse
-every `[text](path)` and confirm:
+Call `archigraph_docgen_validate` to lint frontmatter and cross-links across the
+entire staging tree in a single structured response. Pass the `run_id` from
+`plan.json`:
 
-- The path resolves to an existing file under a `docs/` tree (relative paths) or
-  a known anchor (`#section-slug`).
-- **No link points into a source-code directory** (`src/`, `core/`,
-  `dockerfile`, etc.). Those must be backticked paths, not links — rewrite any
-  that slipped through (link-hygiene rule 2).
-- **No bare-directory link** (`](modules/)`, `](reference/)`) without a real
-  index file target. Either repoint to a concrete page or to a generated
-  `<dir>/README.md` that exists; if neither exists, drop the link and leave the
-  text in backticks (link-hygiene rule 3).
-- **Relative paths use the filesystem dirname, prose uses the slug.** The
-  registry slug (`upvate-core`) and the on-disk dir (`upvate_core`) can differ.
-  A link path with the slug where the directory uses an underscore is the
-  `core-mobile → ../../upvate-core/docs/` 404 from the audit. Resolve the real
-  dirname from `inventory.json` `repo.path` and rewrite (link-hygiene rule 4).
-- The anchor matches the heading slug exactly per `snippets/anchor-contract.md`
-  slugification. Additionally verify each file's declared `anchors:` frontmatter
-  list: every declared anchor MUST have a matching heading in that same file
-  (the 17-mismatch bug). If a file declares anchors with no matching heading,
-  the writer built the list by hand — re-derive `anchors:` from the actual
-  headings (anchor-contract procedure) and fix in place.
-- **Don't keep links to optional pages that were never generated**
-  (`how-to/local-dev.md`, a missing `reference/` index): drop them
-  (link-hygiene rule 6).
+```
+archigraph_docgen_validate(run_id="<run_id>")
+# response: { "frontmatter_errors": [...], "link_errors": [...], "ok": true|false }
+```
 
-Broken links are auto-fixed where the target is unambiguous; otherwise log them
-and report at the end. The report's "Broken intra-doc links" section must be
-empty for the run to be considered clean — every broken link is either repaired
-or downgraded to a backticked identifier.
+Report every entry in `link_errors` to the user; these are the broken intra-doc
+links. Broken links must be repaired (or downgraded to backticked identifiers)
+before the run can be considered clean — the report's "Broken intra-doc links"
+section must be empty.
+
+The `archigraph_docgen_validate` tool applies the same rules as
+`snippets/link-hygiene.md` and `snippets/anchor-contract.md` (which remain the
+source-of-truth documentation for WHAT constitutes a valid link/anchor). The
+tool enforces them across the whole staging tree including:
+
+- Paths that resolve to existing files (relative links)
+- No links into source-code directories (`src/`, `core/`, `dockerfile`, etc.)
+- No bare-directory links without a real index target
+- Relative paths using the filesystem dirname (not the registry slug)
+- Anchor slugs matching actual headings; declared `anchors:` frontmatter matching headings
+- No links to optional pages that were never generated
+
+For any `link_error` the tool flags, auto-fix where the target is unambiguous;
+otherwise log it and escalate to the user.
 
 ## Step 2 — Cross-repo link candidates
 

--- a/skills/generate-docs/prompts/10-pattern-convergence.md
+++ b/skills/generate-docs/prompts/10-pattern-convergence.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 You are the `/generate-docs` coordinator running after Passes 4–7 produced the prose docs. Your job here is to aggregate per-subagent pattern observations and promote those that converged into approved patterns.
 

--- a/skills/generate-docs/prompts/11-pattern-cross-link.md
+++ b/skills/generate-docs/prompts/11-pattern-cross-link.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 For every pattern approved in Pass 10 (or refined in this run), populate its `documentation_url` field so the graph holds a forward pointer to the markdown emitted in Pass 12.
 

--- a/skills/generate-docs/prompts/12-pattern-prose.md
+++ b/skills/generate-docs/prompts/12-pattern-prose.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Emit one markdown file per approved pattern under `docs/patterns/<category>/<pattern-id>.md`. Re-runs of `/generate-docs` overwrite these files from the current pattern store, so refinements and new applies propagate automatically.
 

--- a/skills/generate-docs/prompts/13-enrichment.md
+++ b/skills/generate-docs/prompts/13-enrichment.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Produce structured YAML frontmatter enrichments for every `http_endpoint`,
 `process_flow`, and `message_topic` entity in the group. The dashboard Paths,

--- a/skills/generate-docs/prompts/14-frontmatter-validation.md
+++ b/skills/generate-docs/prompts/14-frontmatter-validation.md
@@ -23,57 +23,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Validate every enriched doc file written by Pass 13. Catch schema drift between
 the skill output and the backend parser's expectations before the user sees a
@@ -82,24 +33,42 @@ blank panel in the dashboard.
 > **Read-only pass** — Pass 14 does not modify any doc file. It only reports.
 > Re-run Pass 13 to fix any entity with validation failures.
 
+> **Note:** Pass 14 and Pass 8 both call `archigraph_docgen_validate`. They are
+> not consolidated (out of scope for #2215) but the duplication is intentional:
+> Pass 8 focuses on link hygiene and cross-repo candidates; Pass 14 focuses on
+> enrichment frontmatter schema correctness. The `validate` response contains
+> both `frontmatter_errors` and `link_errors` — each pass reads the slice it owns.
+
 ## Inputs
 
-- `docgen-state.json` `GeneratedPaths` list — the set of files to validate.
-- The enriched doc files themselves.
+- `run_id` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2).
+- The enriched doc files in the staging directory.
 - The field matrix in `SKILL.md § Per-kind field matrix` — source of truth for
   which fields are consumed vs. prose-only.
 
 ## Procedure
 
-### Step 1 — Load file list
+### Step 1 — Run structured validation via MCP
 
-Read `docgen-state.json` for the group and collect all entries in `GeneratedPaths`.
+Call `archigraph_docgen_validate` with the `run_id` from `plan.json`:
+
+```
+archigraph_docgen_validate(run_id="<run_id>")
+# response: { "frontmatter_errors": [...], "link_errors": [...], "ok": true|false }
+```
+
+Each entry in `frontmatter_errors` includes: `path`, `entity_id`, `kind`, `check`, `detail`.
+Use these as the primary validation signal. The manual per-file checks below supplement the
+MCP result with daemon-aware context (entity kind lookup, merged_into integrity).
+
+Collect all entries in `frontmatter_errors`.
 Filter to files that contain a frontmatter block (i.e., the file begins with `---`).
 
 ### Step 2 — Per-file validation
 
-For each file in the filtered list, run all checks below. Record pass/fail per
-check per file.
+For each file flagged in `frontmatter_errors` (and for any additional enrichment
+file in the staging directory not yet covered), run all checks below. Record
+pass/fail per check per file.
 
 #### Check A — Structural validity
 

--- a/skills/generate-docs/prompts/15-business-domain.md
+++ b/skills/generate-docs/prompts/15-business-domain.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 The first business pass. Produce the product's business vocabulary: the nouns a
 PM uses (Inspection, Deficiency, Jurisdiction, Customer, Order), each defined in

--- a/skills/generate-docs/prompts/16-business-capabilities.md
+++ b/skills/generate-docs/prompts/16-business-capabilities.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Produce one page per product capability: what the system does and why, in
 business language. Capabilities are derived from the system's externally-visible

--- a/skills/generate-docs/prompts/17-business-journeys.md
+++ b/skills/generate-docs/prompts/17-business-journeys.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Produce end-to-end user journeys written as PLAIN-LANGUAGE narratives — a user
 accomplishing a goal across the whole product. This pass exists specifically to

--- a/skills/generate-docs/prompts/18-business-rules.md
+++ b/skills/generate-docs/prompts/18-business-rules.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Reverse-engineer the product's business rules — constraints, requirements,
 policies — from the implementation, and state them as PRODUCT REQUIREMENTS. This

--- a/skills/generate-docs/prompts/19-business-overview.md
+++ b/skills/generate-docs/prompts/19-business-overview.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Staging path
+
+Read `run_id` and `staging_path` from `~/.archigraph/groups/<group>/plan.json` (written by Pass 2). All doc files produced by this pass MUST be written into `<staging_path>/<relative-path>` — NOT directly to `~/.archigraph/docs/<group>/`. Wherever this prompt says `~/.archigraph/docs/<group>/`, substitute `<staging_path>/`. The daemon promotes staging to canonical at the end of Pass 20.
+
 ## CRITICAL TOOL DISCIPLINE
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
@@ -23,57 +27,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 The last business pass. Produce the single landing page a PM opens first: what
 the product does, who uses it, and an index into the capabilities, journeys,

--- a/skills/generate-docs/prompts/20-llm-orchestrate.md
+++ b/skills/generate-docs/prompts/20-llm-orchestrate.md
@@ -23,57 +23,8 @@ do NOT silently substitute grep results for graph queries.
 Call `archigraph_whoami` before doing anything else in this pass. If it errors:
 ABORT with: "archigraph MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
-## CRITICAL STORAGE DISCIPLINE
-===========================
-All generated documentation MUST be written under:
-  `~/.archigraph/docs/<group>/...`
-
-Determine `<group>` via the `archigraph_whoami` MCP call (the Pre-flight assertion
-above). Pass it through every subsequent file write as `${OUTPUT_ROOT}`.
-
-You are STRICTLY FORBIDDEN from writing documentation files into:
-- The source repo's working tree (anywhere under `<repo>/docs/`, `<repo>/doc/`, etc.)
-- The CWD unless CWD is already inside `~/.archigraph/docs/<group>/`
-- Any path that is a git working directory
-
-If you find yourself about to write to a repo path, STOP. The skill assumes
-the archigraph-owned store. Writing elsewhere breaks the storage contract
-and pollutes the user's source repo.
-
-The daemon dashboard reads from `~/.archigraph/docs/<group>/` -- any output
-written elsewhere is invisible to it.
-
-### Pre-flight storage assertion -- SECOND action in this pass
-
-Compute and verify the output root immediately after the `archigraph_whoami` call:
-
-```bash
-OUTPUT_ROOT="$HOME/.archigraph/docs/<group>/"   # substitute <group> from whoami
-mkdir -p "$OUTPUT_ROOT"
-echo "OUTPUT_ROOT=$OUTPUT_ROOT"
-```
-
-All file writes in this pass MUST use `${OUTPUT_ROOT}<relative-path>`. Never write to any
-other location. If `mkdir -p` fails, ABORT: "Cannot create output directory at $OUTPUT_ROOT."
-## CRITICAL OUTPUT DISCIPLINE
-==========================
-The generate-docs skill produces markdown files in the canonical store
-at `~/.archigraph/docs/<group>/`. It does NOT produce:
-- VitePress / Docusaurus / Sphinx / mkdocs scaffolding
-- `package.json` or any build manifests for static site generators
-- Any non-markdown asset that wraps the docs for publishing
-- `.gitignore` entries
-
-Publishing is downstream — handled by the archigraph dashboard or
-external tooling. If you find yourself about to write a `config.ts`,
-`package.json`, `mkdocs.yml`, `.vitepress/config.ts`, or any build
-manifest, STOP. The skill's job is content, not infrastructure.
-
-
-
 
 ---
-
 
 Read every `*-bundle.json` file in a docgen output directory, call the LLM
 section-by-section, assemble an `LLMRunResult`, write a matching
@@ -283,6 +234,35 @@ LLM orchestrate complete
   pages written:      N
   contract failures:  N
 ```
+
+### Step 8 — Promote staging to canonical
+
+Once all bundles are processed and `contract failures: 0`, call
+`archigraph_docgen_promote` to atomically move the staging directory to the
+canonical docs location. Read `run_id` from
+`~/.archigraph/groups/<group>/plan.json`.
+
+```
+archigraph_docgen_promote(run_id="<run_id>")
+# response: { "promoted": true, "canonical_path": "~/.archigraph/docs/<group>/",
+#             "files_promoted": N }
+```
+
+**If promote succeeds:** report the canonical path and file count to the user.
+The staging directory is automatically removed by the daemon.
+
+**If promote is refused** (e.g., `ssg_scaffolding_detected`): the daemon found
+SSG scaffolding (a `config.ts`, `package.json`, `.vitepress/`, etc.) in the
+staging directory. This means one of the writer passes created content it should
+not have. Report the exact error to the user:
+
+> "Promote refused: SSG scaffolding detected (`<file>`). The generate-docs skill
+> must not emit build manifests. Remove the offending file from the staging
+> directory and re-try promote, or run `archigraph_docgen_abort(run_id=...)` to
+> discard the run and start over."
+
+Do NOT silently remove the offending file. Surface it to the user so the writer
+pass can be fixed.
 
 ---
 


### PR DESCRIPTION
Closes #2215. Refs #2207, #2214.

## Summary

- Remove \`CRITICAL STORAGE DISCIPLINE\` blocks from all 23 prompts — the daemon now enforces storage contract physically via staging-dir isolation in \`archigraph_docgen_promote\`
- Remove \`CRITICAL OUTPUT DISCIPLINE\` blocks from all 23 prompts — the daemon's SSG-scaffolding refusal in \`archigraph_docgen_promote\` handles this physically
- Preserve \`CRITICAL TOOL DISCIPLINE\` blocks in all 23 prompts — MCP-first graph navigation is independent of write target and still required per #2177
- Wire all 23 prompts into the local-staging + atomic-promote pattern from #2214

## Per-prompt changes

| Pass | Change |
|------|--------|
| All 23 | \`CRITICAL STORAGE DISCIPLINE\` removed |
| All 23 | \`CRITICAL OUTPUT DISCIPLINE\` removed |
| All 23 | \`CRITICAL TOOL DISCIPLINE\` preserved |
| 02-plan | Added \`archigraph_docgen_start_run(group)\` call; captures \`run_id\` + \`staging_path\`; records both in \`plan.json\` for downstream passes |
| 03, 03a, 04, 05, 06, 07, 08, 10, 11, 12, 13, 15, 16, 17, 18, 19 | Added "Staging path" section directing writers to read \`run_id\`/\`staging_path\` from \`plan.json\` and use \`<staging_path>/\` for all doc writes |
| 08-cross-link | Replaced manual file-walk link check with \`archigraph_docgen_validate(run_id)\` call; structured \`frontmatter_errors\` + \`link_errors\` response drives the report |
| 14-frontmatter-validation | Added \`archigraph_docgen_validate(run_id)\` as Step 1; Step 2 now processes files flagged in \`frontmatter_errors\`; noted intentional duplication with Pass 08 |
| 20-llm-orchestrate | Added Step 8 — \`archigraph_docgen_promote(run_id)\` after all bundles processed; handles SSG-scaffolding refusal with a clear user-facing error |

## SKILL.md changes

- Replaced STORAGE DISCIPLINE + OUTPUT DISCIPLINE sections with new **"Staging-dir + atomic promote architecture (#2207, #2214, #2215)"** section
- Updated tool whitelist to include the 6 \`archigraph_docgen_*\` MCP tools
- Updated output layout section to explain staging vs canonical paths
- Added \`internal/mcp/docgen.go\` to the Related section

## Gap note

\`archigraph_docgen_write\` is not in the 6 tools shipped in #2214. The local-staging pattern (native \`Write\` tool targeting \`staging_path\`, then \`_promote\`) is the correct architecture. Per-file MCP writes are not needed — the daemon enforces the contract at promote time, not per-write.

## Why this matters

After this lands, the 2026-05-25 docgen-writes-to-repo incident (#2191) becomes architecturally impossible. STORAGE/OUTPUT DISCIPLINE go from "prompt heuristic" to "daemon physical guard."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>