### PR TITLE
feat(dashboard): ?ref= query on 6 endpoints + /api/groups/:g/refs (closes #2220, refs #2098)

### DIFF
--- a/internal/dashboard/handlers_ref_endpoints.go
+++ b/internal/dashboard/handlers_ref_endpoints.go
@@ -1,0 +1,753 @@
+// handlers_ref_endpoints.go — ?ref= query support on 6 read-only endpoints
+// and a new GET /api/groups/:g/refs listing endpoint (issue #2220).
+//
+// These endpoints are the API surface for the multi-branch UI introduced by
+// epic #2098. They are sibling to the CLI --ref flags added by #2219 and the
+// v2 /api/v2/groups/{group}/refs endpoint from PH1c (#2089).
+//
+// Endpoints:
+//
+//	GET /api/groups/:g/stats?ref=<ref>
+//	GET /api/groups/:g/repos/:r/entities?ref=<ref>
+//	GET /api/groups/:g/repos/:r/relationships?ref=<ref>
+//	GET /api/groups/:g/repos/:r/cross-repo-edges?ref=<ref>
+//	GET /api/groups/:g/repos/:r/orphans?ref=<ref>
+//	GET /api/groups/:g/repos/:r/patterns?ref=<ref>
+//	GET /api/groups/:g/refs
+//
+// ?ref= semantics (all 6 endpoints):
+//
+//	missing / "@current" → current HEAD ref (pre-#2220 default, backward compatible)
+//	"<name>"             → that specific ref's graph
+//	"@all"               → aggregate across all indexed refs for the repo/group
+//	invalid              → HTTP 400 {"error": "invalid ref", "available": [...]}
+//
+// Read-only — none of these endpoints trigger reindex.
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ── /api/groups/:g/stats ─────────────────────────────────────────────────────
+
+// handleGroupStats — GET /api/groups/:g/stats?ref=<ref>
+//
+// Returns aggregate entity + relationship counts for all repos in the group,
+// optionally scoped to a specific git ref. Supports ?ref=@all to sum across
+// all indexed refs.
+func (s *Server) handleGroupStats(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	ref, isAll, ok := resolveRefParam(w, r, group)
+	if !ok {
+		return
+	}
+
+	if isAll {
+		// Aggregate stats across all indexed refs.
+		refs := knownRefsForGroup(group)
+		if len(refs) == 0 {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"group":               group,
+				"ref":                 "@all",
+				"refs_included":       []string{},
+				"total_entities":      0,
+				"total_relationships": 0,
+				"repos":               []any{},
+			})
+			return
+		}
+		type repoStat struct {
+			Slug          string `json:"slug"`
+			Entities      int    `json:"entities"`
+			Relationships int    `json:"relationships"`
+		}
+		repoTotals := map[string]*repoStat{}
+		var totalEntities, totalRels int
+
+		for _, refName := range refs {
+			grp, err := s.graphs.GetGroupForRef(group, refName)
+			if err != nil {
+				continue
+			}
+			for slug, dr := range grp.Repos {
+				if dr == nil || dr.Doc == nil {
+					continue
+				}
+				if _, seen := repoTotals[slug]; !seen {
+					repoTotals[slug] = &repoStat{Slug: slug}
+				}
+				repoTotals[slug].Entities += len(dr.Doc.Entities)
+				repoTotals[slug].Relationships += len(dr.Doc.Relationships)
+				totalEntities += len(dr.Doc.Entities)
+				totalRels += len(dr.Doc.Relationships)
+			}
+		}
+
+		repoList := make([]repoStat, 0, len(repoTotals))
+		for _, rs := range repoTotals {
+			repoList = append(repoList, *rs)
+		}
+		sort.Slice(repoList, func(i, j int) bool { return repoList[i].Slug < repoList[j].Slug })
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"group":               group,
+			"ref":                 "@all",
+			"refs_included":       refs,
+			"total_entities":      totalEntities,
+			"total_relationships": totalRels,
+			"repos":               repoList,
+		})
+		return
+	}
+
+	grp, err := s.graphs.GetGroupForRef(group, ref)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	type repoStat struct {
+		Slug          string `json:"slug"`
+		Entities      int    `json:"entities"`
+		Relationships int    `json:"relationships"`
+	}
+	var totalEntities, totalRels int
+	repoList := make([]repoStat, 0, len(grp.Repos))
+	for slug, dr := range grp.Repos {
+		if dr == nil || dr.Doc == nil {
+			continue
+		}
+		repoList = append(repoList, repoStat{
+			Slug:          slug,
+			Entities:      len(dr.Doc.Entities),
+			Relationships: len(dr.Doc.Relationships),
+		})
+		totalEntities += len(dr.Doc.Entities)
+		totalRels += len(dr.Doc.Relationships)
+	}
+	sort.Slice(repoList, func(i, j int) bool { return repoList[i].Slug < repoList[j].Slug })
+
+	refLabel := ref
+	if refLabel == "" {
+		refLabel = "current"
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"group":               group,
+		"ref":                 refLabel,
+		"total_entities":      totalEntities,
+		"total_relationships": totalRels,
+		"repos":               repoList,
+	})
+}
+
+// ── /api/groups/:g/repos/:r/entities ─────────────────────────────────────────
+
+// handleRepoEntities — GET /api/groups/:g/repos/:r/entities?ref=<ref>
+//
+// Returns the entity list for a single repo, optionally scoped to a git ref.
+// ?ref=@all returns the union of entities across all indexed refs (by entity ID,
+// last-ref-wins for deduplication).
+func (s *Server) handleRepoEntities(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	repo := r.PathValue("repo")
+	if group == "" || repo == "" {
+		writeErr(w, http.StatusBadRequest, "group and repo required")
+		return
+	}
+
+	ref, isAll, ok := resolveRefParam(w, r, group)
+	if !ok {
+		return
+	}
+
+	if isAll {
+		refs := allRefsForGroupRepo(group, repo)
+		seen := map[string]map[string]any{}
+		for _, refName := range refs {
+			grp, err := s.graphs.GetGroupForRef(group, refName)
+			if err != nil {
+				continue
+			}
+			dr, ok := grp.Repos[repo]
+			if !ok || dr == nil || dr.Doc == nil {
+				continue
+			}
+			for i := range dr.Doc.Entities {
+				e := &dr.Doc.Entities[i]
+				seen[e.ID] = serializeEntity(repo, e)
+			}
+		}
+		entities := make([]map[string]any, 0, len(seen))
+		for _, e := range seen {
+			entities = append(entities, e)
+		}
+		sortEntitySlice(entities)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"group":    group,
+			"repo":     repo,
+			"ref":      "@all",
+			"entities": entities,
+			"count":    len(entities),
+		})
+		return
+	}
+
+	grp, err := s.graphs.GetGroupForRef(group, ref)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+	dr, ok2 := grp.Repos[repo]
+	if !ok2 || dr == nil {
+		writeErr(w, http.StatusNotFound, "repo not found: "+repo)
+		return
+	}
+	if dr.Doc == nil {
+		writeErr(w, http.StatusNotFound, "repo graph not loaded: "+repo)
+		return
+	}
+
+	entities := make([]map[string]any, 0, len(dr.Doc.Entities))
+	for i := range dr.Doc.Entities {
+		entities = append(entities, serializeEntity(repo, &dr.Doc.Entities[i]))
+	}
+	sortEntitySlice(entities)
+
+	refLabel := ref
+	if refLabel == "" {
+		refLabel = "current"
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"group":    group,
+		"repo":     repo,
+		"ref":      refLabel,
+		"entities": entities,
+		"count":    len(entities),
+	})
+}
+
+// ── /api/groups/:g/repos/:r/relationships ────────────────────────────────────
+
+// relEntry is the wire shape for a single relationship.
+type relEntry struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Kind   string `json:"kind"`
+}
+
+// handleRepoRelationships — GET /api/groups/:g/repos/:r/relationships?ref=<ref>
+func (s *Server) handleRepoRelationships(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	repo := r.PathValue("repo")
+	if group == "" || repo == "" {
+		writeErr(w, http.StatusBadRequest, "group and repo required")
+		return
+	}
+
+	ref, isAll, ok := resolveRefParam(w, r, group)
+	if !ok {
+		return
+	}
+
+	collectRels := func(doc *graph.Document) []relEntry {
+		out := make([]relEntry, 0, len(doc.Relationships))
+		for _, rel := range doc.Relationships {
+			out = append(out, relEntry{
+				Source: dashPrefixedID(repo, rel.FromID),
+				Target: dashPrefixedID(repo, rel.ToID),
+				Kind:   dashStripScopePrefix(rel.Kind),
+			})
+		}
+		return out
+	}
+
+	if isAll {
+		refs := allRefsForGroupRepo(group, repo)
+		type dedupeKey struct{ src, tgt, kind string }
+		seenRels := map[dedupeKey]bool{}
+		var rels []relEntry
+		for _, refName := range refs {
+			grp, err := s.graphs.GetGroupForRef(group, refName)
+			if err != nil {
+				continue
+			}
+			dr, ok2 := grp.Repos[repo]
+			if !ok2 || dr == nil || dr.Doc == nil {
+				continue
+			}
+			for _, rel := range collectRels(dr.Doc) {
+				k := dedupeKey{rel.Source, rel.Target, rel.Kind}
+				if !seenRels[k] {
+					seenRels[k] = true
+					rels = append(rels, rel)
+				}
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"group":         group,
+			"repo":          repo,
+			"ref":           "@all",
+			"relationships": rels,
+			"count":         len(rels),
+		})
+		return
+	}
+
+	grp, err := s.graphs.GetGroupForRef(group, ref)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+	dr, ok2 := grp.Repos[repo]
+	if !ok2 || dr == nil {
+		writeErr(w, http.StatusNotFound, "repo not found: "+repo)
+		return
+	}
+	if dr.Doc == nil {
+		writeErr(w, http.StatusNotFound, "repo graph not loaded: "+repo)
+		return
+	}
+
+	rels := collectRels(dr.Doc)
+	refLabel := ref
+	if refLabel == "" {
+		refLabel = "current"
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"group":         group,
+		"repo":          repo,
+		"ref":           refLabel,
+		"relationships": rels,
+		"count":         len(rels),
+	})
+}
+
+// ── /api/groups/:g/repos/:r/cross-repo-edges ─────────────────────────────────
+
+// handleRepoCrossRepoEdges — GET /api/groups/:g/repos/:r/cross-repo-edges?ref=<ref>
+//
+// Returns the cross-repo edges (from grp.Links) that involve the requested repo
+// as source or target. ?ref=@all is honoured (same link file, but groups edges
+// per indexed-ref set).
+func (s *Server) handleRepoCrossRepoEdges(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	repo := r.PathValue("repo")
+	if group == "" || repo == "" {
+		writeErr(w, http.StatusBadRequest, "group and repo required")
+		return
+	}
+
+	ref, isAll, ok := resolveRefParam(w, r, group)
+	if !ok {
+		return
+	}
+
+	// cross-repo links are stored group-wide, not per-ref. We still load the
+	// group for the requested ref so the node-existence check is ref-scoped.
+	loadRef := ref
+	if isAll {
+		loadRef = "" // load canonical ref; links are group-wide anyway
+	}
+
+	grp, err := s.graphs.GetGroupForRef(group, loadRef)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	// Filter links that touch this repo.
+	prefix := repo + "::"
+	type edgeEntry struct {
+		Source     string  `json:"source"`
+		Target     string  `json:"target"`
+		Kind       string  `json:"kind"`
+		Confidence float64 `json:"confidence,omitempty"`
+	}
+	edges := make([]edgeEntry, 0)
+	for _, l := range grp.Links {
+		if strings.HasPrefix(l.Source, prefix) || strings.HasPrefix(l.Target, prefix) {
+			edges = append(edges, edgeEntry{
+				Source:     l.Source,
+				Target:     l.Target,
+				Kind:       l.Kind,
+				Confidence: l.Confidence,
+			})
+		}
+	}
+
+	refLabel := ref
+	if isAll {
+		refLabel = "@all"
+	} else if refLabel == "" {
+		refLabel = "current"
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"group": group,
+		"repo":  repo,
+		"ref":   refLabel,
+		"edges": edges,
+		"count": len(edges),
+	})
+}
+
+// ── /api/groups/:g/repos/:r/orphans ──────────────────────────────────────────
+
+// handleRepoOrphans — GET /api/groups/:g/repos/:r/orphans?ref=<ref>
+//
+// Returns entities that have no inbound or outbound relationships within the
+// repo's graph. ?ref=@all unions orphans across all indexed refs.
+func (s *Server) handleRepoOrphans(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	repo := r.PathValue("repo")
+	if group == "" || repo == "" {
+		writeErr(w, http.StatusBadRequest, "group and repo required")
+		return
+	}
+
+	ref, isAll, ok := resolveRefParam(w, r, group)
+	if !ok {
+		return
+	}
+
+	findOrphans := func(doc *graph.Document) []map[string]any {
+		// Build a set of entity IDs that appear in at least one relationship.
+		connected := make(map[string]bool, len(doc.Relationships)*2)
+		for _, rel := range doc.Relationships {
+			connected[rel.FromID] = true
+			connected[rel.ToID] = true
+		}
+		var out []map[string]any
+		for i := range doc.Entities {
+			e := &doc.Entities[i]
+			if !connected[e.ID] {
+				out = append(out, serializeEntity(repo, e))
+			}
+		}
+		return out
+	}
+
+	if isAll {
+		refs := allRefsForGroupRepo(group, repo)
+		seen := map[string]map[string]any{}
+		for _, refName := range refs {
+			grp, err := s.graphs.GetGroupForRef(group, refName)
+			if err != nil {
+				continue
+			}
+			dr, ok := grp.Repos[repo]
+			if !ok || dr == nil || dr.Doc == nil {
+				continue
+			}
+			for _, e := range findOrphans(dr.Doc) {
+				id, _ := e["id"].(string)
+				seen[id] = e
+			}
+		}
+		orphans := make([]map[string]any, 0, len(seen))
+		for _, e := range seen {
+			orphans = append(orphans, e)
+		}
+		sortEntitySlice(orphans)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"group":   group,
+			"repo":    repo,
+			"ref":     "@all",
+			"orphans": orphans,
+			"count":   len(orphans),
+		})
+		return
+	}
+
+	grp, err := s.graphs.GetGroupForRef(group, ref)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+	dr, ok2 := grp.Repos[repo]
+	if !ok2 || dr == nil {
+		writeErr(w, http.StatusNotFound, "repo not found: "+repo)
+		return
+	}
+	if dr.Doc == nil {
+		writeErr(w, http.StatusNotFound, "repo graph not loaded: "+repo)
+		return
+	}
+
+	orphans := findOrphans(dr.Doc)
+	if orphans == nil {
+		orphans = []map[string]any{}
+	}
+	sortEntitySlice(orphans)
+
+	refLabel := ref
+	if refLabel == "" {
+		refLabel = "current"
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"group":   group,
+		"repo":    repo,
+		"ref":     refLabel,
+		"orphans": orphans,
+		"count":   len(orphans),
+	})
+}
+
+// ── /api/groups/:g/repos/:r/patterns ─────────────────────────────────────────
+
+// handleRepoPatterns — GET /api/groups/:g/repos/:r/patterns?ref=<ref>
+//
+// Patterns are stored group-wide (not per-repo, not per-ref) in the agent-
+// patterns store. ?ref= is accepted for API consistency but does not change
+// the returned data — patterns are ref-agnostic by design (they describe
+// coding idioms, not graph snapshots).
+func (s *Server) handleRepoPatterns(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	repo := r.PathValue("repo")
+	if group == "" || repo == "" {
+		writeErr(w, http.StatusBadRequest, "group and repo required")
+		return
+	}
+
+	ref, _, ok := resolveRefParam(w, r, group)
+	if !ok {
+		return
+	}
+
+	dir := groupPatternsDir(group)
+	patterns, err := loadAgentPatterns(dir)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "load patterns: "+err.Error())
+		return
+	}
+
+	refLabel := ref
+	if refLabel == "" {
+		refLabel = "current"
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"group":    group,
+		"repo":     repo,
+		"ref":      refLabel,
+		"patterns": patterns,
+		"count":    len(patterns),
+	})
+}
+
+// ── /api/groups/:g/refs ───────────────────────────────────────────────────────
+
+// groupRefEntry is one ref entry in the GET /api/groups/:g/refs response.
+type groupRefEntry struct {
+	Name          string     `json:"name"`
+	IsCanonical   bool       `json:"is_canonical"`
+	LastIndexedAt *time.Time `json:"last_indexed_at,omitempty"`
+	EntityCount   int        `json:"entity_count,omitempty"`
+	IsHot         bool       `json:"is_hot"`
+}
+
+// handleGroupRefs — GET /api/groups/:g/refs
+//
+// Lists all refs available for the group with last-indexed timestamp and entity
+// counts per ref. This is the simpler, non-v2-prefixed companion to
+// /api/v2/groups/{group}/refs (which carries per-repo detail and tier info).
+//
+// Response:
+//
+//	{
+//	  "group": "upvate",
+//	  "refs": [
+//	    {"name": "main", "is_canonical": true,  "last_indexed_at": "...", "entity_count": 12345, "is_hot": true},
+//	    {"name": "feat/foo", "is_canonical": false, "last_indexed_at": "...", "entity_count": 12400, "is_hot": false}
+//	  ]
+//	}
+func (s *Server) handleGroupRefs(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	groups, err := registry.Groups()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "registry error: "+err.Error())
+		return
+	}
+	var cfgPath string
+	for _, g := range groups {
+		if g.Name == group {
+			cfgPath = g.ConfigPath
+			break
+		}
+	}
+	if cfgPath == "" {
+		writeErr(w, http.StatusNotFound, "group not registered: "+group)
+		return
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "config error: "+err.Error())
+		return
+	}
+
+	// Aggregate per-ref stats across all repos in the group.
+	type refAgg struct {
+		lastIndexed time.Time
+		entities    int
+		hotCount    int // number of repos where this ref is "hot"
+		repoCount   int
+	}
+	agg := map[string]*refAgg{}
+
+	for _, repo := range cfg.Repos {
+		sentinel := daemon.StateDirForRepoRef(repo.Path, "")
+		refsDir := filepath.Dir(sentinel)
+		entries, err := os.ReadDir(refsDir)
+		if err != nil {
+			continue
+		}
+		// Determine the hot ref for this repo.
+		hotDir := daemon.StateDirForRepo(repo.Path)
+		hotRefSafe := filepath.Base(hotDir)
+
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			refSafe := e.Name()
+			refName := daemon.RefSafeDecode(refSafe)
+			if refName == "" {
+				continue
+			}
+
+			fbPath := filepath.Join(refsDir, refSafe, "graph.fb")
+			fi, ferr := os.Stat(fbPath)
+			if ferr != nil {
+				// No graph.fb — try graph.json.
+				jsonPath := filepath.Join(refsDir, refSafe, "graph.json")
+				fi, ferr = os.Stat(jsonPath)
+				if ferr != nil {
+					continue
+				}
+			}
+			mtime := fi.ModTime()
+
+			// Entity count from sidecar.
+			var entityCount int
+			statsPath := filepath.Join(refsDir, refSafe, "graph-stats.json")
+			if data, serr := os.ReadFile(statsPath); serr == nil {
+				var stats graph.GraphStatsSidecar
+				if jsonErr := json.Unmarshal(data, &stats); jsonErr == nil {
+					entityCount = stats.TotalEntities
+				}
+			}
+
+			if _, ok := agg[refName]; !ok {
+				agg[refName] = &refAgg{}
+			}
+			a := agg[refName]
+			a.repoCount++
+			a.entities += entityCount
+			if mtime.After(a.lastIndexed) {
+				a.lastIndexed = mtime
+			}
+			if refSafe == hotRefSafe {
+				a.hotCount++
+			}
+		}
+	}
+
+	// Determine canonical ref (the one that is "hot" for the most repos,
+	// defaulting to "main" when present).
+	canonicalRef := ""
+	if _, ok := agg["main"]; ok {
+		canonicalRef = "main"
+	}
+	if canonicalRef == "" {
+		// Pick the ref that is hot for the most repos.
+		maxHot := -1
+		for name, a := range agg {
+			if a.hotCount > maxHot {
+				maxHot = a.hotCount
+				canonicalRef = name
+			}
+		}
+	}
+
+	refs := make([]groupRefEntry, 0, len(agg))
+	for name, a := range agg {
+		entry := groupRefEntry{
+			Name:        name,
+			IsCanonical: name == canonicalRef,
+			EntityCount: a.entities,
+			IsHot:       a.hotCount > 0,
+		}
+		if !a.lastIndexed.IsZero() {
+			t := a.lastIndexed.UTC()
+			entry.LastIndexedAt = &t
+		}
+		refs = append(refs, entry)
+	}
+
+	// Sort: canonical first, then alphabetical.
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].IsCanonical != refs[j].IsCanonical {
+			return refs[i].IsCanonical
+		}
+		return refs[i].Name < refs[j].Name
+	})
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"group": group,
+		"refs":  refs,
+	})
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// allRefsForGroupRepo returns all indexed ref names for a specific repo slug
+// within a group. Falls back to all-group refs when the repo is not found.
+func allRefsForGroupRepo(groupName, repoSlug string) []string {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	for _, g := range groups {
+		if g.Name != groupName {
+			continue
+		}
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			return nil
+		}
+		for _, repo := range cfg.Repos {
+			if repo.Slug == repoSlug {
+				return allRefsForRepo(repo.Path)
+			}
+		}
+	}
+	return nil
+}
+
+// sortEntitySlice sorts a slice of serialized entity maps by the "id" field.
+func sortEntitySlice(entities []map[string]any) {
+	sort.Slice(entities, func(i, j int) bool {
+		a, _ := entities[i]["id"].(string)
+		b, _ := entities[j]["id"].(string)
+		return a < b
+	})
+}

--- a/internal/dashboard/handlers_ref_endpoints_test.go
+++ b/internal/dashboard/handlers_ref_endpoints_test.go
@@ -1,0 +1,563 @@
+// handlers_ref_endpoints_test.go — integration tests for the ?ref= endpoints
+// added by issue #2220.
+//
+// Endpoints under test:
+//
+//	GET /api/groups/:g/refs
+//	GET /api/groups/:g/stats?ref=
+//	GET /api/groups/:g/repos/:r/entities?ref=
+//	GET /api/groups/:g/repos/:r/relationships?ref=
+//	GET /api/groups/:g/repos/:r/cross-repo-edges?ref=
+//	GET /api/groups/:g/repos/:r/orphans?ref=
+//	GET /api/groups/:g/repos/:r/patterns?ref=
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ── test fixture builder ─────────────────────────────────────────────────────
+
+// refEndpointFixture builds a minimal on-disk layout for the ref-endpoint tests:
+//
+//   - One group with one repo.
+//   - Two indexed refs: "main" and "feat/foo".
+//   - Each ref has a graph.fb (empty sentinel) + graph-stats.json.
+//
+// Returns the httptest.Server and a cleanup function.
+func buildRefEndpointFixture(t *testing.T) (ts *httptest.Server, groupName, repoSlug string) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", home)
+	// Use daemon-root for deterministic store paths.
+	storeRoot := filepath.Join(home, "store")
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", storeRoot)
+
+	groupName = "testgroup"
+	repoSlug = "testrepo"
+	repoPath := filepath.Join(home, "myrepo")
+	_ = os.MkdirAll(repoPath, 0o755)
+
+	// Write group config + registry.
+	cfg := &registry.GroupConfig{
+		Name:  groupName,
+		Repos: []registry.Repo{{Slug: repoSlug, Path: repoPath}},
+	}
+	cfgDir := filepath.Join(home, "groups")
+	_ = os.MkdirAll(cfgDir, 0o755)
+	cfgPath := filepath.Join(cfgDir, groupName+".fleet.json")
+	raw, _ := json.Marshal(cfg)
+	_ = os.WriteFile(cfgPath, raw, 0o644)
+
+	regRaw, _ := json.Marshal(map[string]any{
+		"version": 1,
+		"groups":  []map[string]any{{"name": groupName, "config_path": cfgPath}},
+	})
+	_ = os.WriteFile(filepath.Join(home, "registry.json"), regRaw, 0o644)
+
+	// Write graph.fb + graph-stats.json for each ref.
+	// Also write a graph for the _unknown sentinel so that the "no ?ref="
+	// default path (which reads the current HEAD via gitmeta and falls back
+	// to _unknown when the temp dir has no git repo) finds a valid graph.
+	for _, ref := range []string{"", "main", "feat/foo"} {
+		stateDir := daemon.StateDirForRepoRef(repoPath, ref)
+		_ = os.MkdirAll(stateDir, 0o755)
+
+		// Write a minimal FlatBuffers graph file (just needs to exist on disk
+		// for the refs endpoint; the graphstate loader handles empty files by
+		// falling back gracefully). We write a real graph.json instead so
+		// LoadGraphFromDir can parse it.
+		doc := &graph.Document{
+			Entities: []graph.Entity{
+				{
+					ID:   "e1",
+					Name: "EntityOne",
+					Kind: "Function",
+				},
+				{
+					ID:   "e2",
+					Name: "EntityTwo",
+					Kind: "Function",
+				},
+			},
+			Relationships: []graph.Relationship{
+				{ID: "r1", FromID: "e1", ToID: "e2", Kind: "calls"},
+			},
+		}
+		docBytes, err := json.Marshal(doc)
+		if err != nil {
+			t.Fatalf("marshal doc: %v", err)
+		}
+		_ = os.WriteFile(filepath.Join(stateDir, "graph.json"), docBytes, 0o644)
+
+		// Write graph-stats.json sidecar.
+		stats := graph.GraphStatsSidecar{TotalEntities: 2}
+		statsBytes, _ := json.Marshal(stats)
+		_ = os.WriteFile(filepath.Join(stateDir, "graph-stats.json"), statsBytes, 0o644)
+	}
+
+	st := newFakeStore()
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts = httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts, groupName, repoSlug
+}
+
+// ── GET /api/groups/:g/refs ───────────────────────────────────────────────────
+
+func TestHandleGroupRefs_OK(t *testing.T) {
+	ts, group, _ := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(ts.URL + "/api/groups/" + group + "/refs")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Group string `json:"group"`
+		Refs  []struct {
+			Name        string `json:"name"`
+			IsCanonical bool   `json:"is_canonical"`
+			EntityCount int    `json:"entity_count"`
+			IsHot       bool   `json:"is_hot"`
+		} `json:"refs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Group != group {
+		t.Errorf("group: want %q, got %q", group, body.Group)
+	}
+	if len(body.Refs) < 1 {
+		t.Errorf("want ≥1 ref, got %d", len(body.Refs))
+	}
+	// Check that "main" is listed.
+	found := false
+	for _, r := range body.Refs {
+		if r.Name == "main" {
+			found = true
+			if !r.IsCanonical {
+				t.Error("main should be canonical")
+			}
+		}
+	}
+	if !found {
+		t.Error("main ref not found in response")
+	}
+}
+
+func TestHandleGroupRefs_NotFound(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", home)
+	reg := map[string]any{"version": 1, "groups": []any{}}
+	raw, _ := json.Marshal(reg)
+	_ = os.WriteFile(filepath.Join(home, "registry.json"), raw, 0o644)
+
+	st := newFakeStore()
+	srv, _ := NewServer(DefaultConfig(), st)
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/api/groups/does-not-exist/refs")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+// ── GET /api/groups/:g/stats ─────────────────────────────────────────────────
+
+func TestHandleGroupStats_NoRef(t *testing.T) {
+	ts, group, _ := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(ts.URL + "/api/groups/" + group + "/stats")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["group"] != group {
+		t.Errorf("group field: want %q, got %v", group, body["group"])
+	}
+}
+
+func TestHandleGroupStats_NamedRef(t *testing.T) {
+	ts, group, _ := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(ts.URL + "/api/groups/" + group + "/stats?ref=main")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["ref"] != "main" {
+		t.Errorf("ref: want main, got %v", body["ref"])
+	}
+}
+
+func TestHandleGroupStats_AtAll(t *testing.T) {
+	ts, group, _ := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(ts.URL + "/api/groups/" + group + "/stats?ref=@all")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["ref"] != "@all" {
+		t.Errorf("ref: want @all, got %v", body["ref"])
+	}
+}
+
+func TestHandleGroupStats_InvalidRef(t *testing.T) {
+	ts, group, _ := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(ts.URL + "/api/groups/" + group + "/stats?ref=nonexistent-branch")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["error"] != "invalid ref" {
+		t.Errorf("error field: want 'invalid ref', got %v", body["error"])
+	}
+	if body["available"] == nil {
+		t.Error("response should include 'available' refs list")
+	}
+}
+
+// ── GET /api/groups/:g/repos/:r/entities ─────────────────────────────────────
+
+func TestHandleRepoEntities_NoRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/entities", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["group"] != group {
+		t.Errorf("group field mismatch")
+	}
+	if body["repo"] != repo {
+		t.Errorf("repo field mismatch")
+	}
+}
+
+func TestHandleRepoEntities_NamedRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/entities?ref=main", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["ref"] != "main" {
+		t.Errorf("ref: want main, got %v", body["ref"])
+	}
+}
+
+func TestHandleRepoEntities_AtAll(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/entities?ref=@all", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["ref"] != "@all" {
+		t.Errorf("ref: want @all, got %v", body["ref"])
+	}
+}
+
+func TestHandleRepoEntities_InvalidRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/entities?ref=missing-branch", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["error"] != "invalid ref" {
+		t.Errorf("error field: want 'invalid ref', got %v", body["error"])
+	}
+}
+
+// ── GET /api/groups/:g/repos/:r/relationships ─────────────────────────────────
+
+func TestHandleRepoRelationships_NoRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/relationships", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["relationships"] == nil {
+		t.Error("missing relationships field")
+	}
+}
+
+func TestHandleRepoRelationships_InvalidRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/relationships?ref=bad-ref", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// ── GET /api/groups/:g/repos/:r/cross-repo-edges ─────────────────────────────
+
+func TestHandleRepoCrossRepoEdges_NoRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/cross-repo-edges", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	// edges should be present (may be an empty array when no cross-repo links exist)
+	if _, ok := body["count"]; !ok {
+		t.Error("missing count field in response")
+	}
+}
+
+func TestHandleRepoCrossRepoEdges_AtAll(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/cross-repo-edges?ref=@all", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["ref"] != "@all" {
+		t.Errorf("ref: want @all, got %v", body["ref"])
+	}
+}
+
+func TestHandleRepoCrossRepoEdges_InvalidRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/cross-repo-edges?ref=bad-ref", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// ── GET /api/groups/:g/repos/:r/orphans ──────────────────────────────────────
+
+func TestHandleRepoOrphans_NoRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/orphans", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["orphans"] == nil {
+		t.Error("missing orphans field")
+	}
+}
+
+func TestHandleRepoOrphans_NamedRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/orphans?ref=main", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["ref"] != "main" {
+		t.Errorf("ref: want main, got %v", body["ref"])
+	}
+}
+
+func TestHandleRepoOrphans_InvalidRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/orphans?ref=ghost-branch", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// ── GET /api/groups/:g/repos/:r/patterns ─────────────────────────────────────
+
+func TestHandleRepoPatterns_NoRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/patterns", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["patterns"] == nil {
+		t.Error("missing patterns field")
+	}
+}
+
+func TestHandleRepoPatterns_NamedRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/patterns?ref=main", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["ref"] != "main" {
+		t.Errorf("ref: want main, got %v", body["ref"])
+	}
+}
+
+func TestHandleRepoPatterns_InvalidRef(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/groups/%s/repos/%s/patterns?ref=ghost", ts.URL, group, repo))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// ── CORS: verify no regression ───────────────────────────────────────────────
+
+func TestRefEndpoints_CORSNotRegressed(t *testing.T) {
+	ts, group, repo := buildRefEndpointFixture(t)
+
+	endpoints := []string{
+		"/api/groups/" + group + "/refs",
+		"/api/groups/" + group + "/stats",
+		fmt.Sprintf("/api/groups/%s/repos/%s/entities", group, repo),
+		fmt.Sprintf("/api/groups/%s/repos/%s/relationships", group, repo),
+		fmt.Sprintf("/api/groups/%s/repos/%s/cross-repo-edges", group, repo),
+		fmt.Sprintf("/api/groups/%s/repos/%s/orphans", group, repo),
+		fmt.Sprintf("/api/groups/%s/repos/%s/patterns", group, repo),
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodOptions, ts.URL+ep, nil)
+			req.Header.Set("Origin", "http://localhost:3000")
+			req.Header.Set("Access-Control-Request-Method", "GET")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("OPTIONS: %v", err)
+			}
+			resp.Body.Close()
+			// The server should handle OPTIONS without a 405.
+			// 200 or 204 is fine; 405 indicates a CORS regression.
+			if resp.StatusCode == http.StatusMethodNotAllowed {
+				t.Errorf("CORS regression: OPTIONS %s returned 405", ep)
+			}
+		})
+	}
+}

--- a/internal/dashboard/ref_helper.go
+++ b/internal/dashboard/ref_helper.go
@@ -1,0 +1,146 @@
+// ref_helper.go — shared ?ref= query parameter resolution for dashboard handlers.
+//
+// All 6 endpoints added by issue #2220 share the same resolution semantics:
+//
+//   - Missing ?ref= or ?ref=@current → use current HEAD (empty string, same as
+//     pre-#2220 behaviour).
+//   - ?ref=<name> → load that specific ref's graph. Returns HTTP 400 with an
+//     "available" list if the ref has no indexed graph for the requested repo.
+//   - ?ref=@all → aggregate across all indexed refs for the repo/group.
+//
+// resolveRefParam extracts the raw query value and returns (ref, isAll) or
+// writes an error response itself and returns (_, true-as-sentinel) — callers
+// check ok==false to bail out.
+package dashboard
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// resolveRefParam parses the ?ref= query parameter.
+//
+// Returns (resolvedRef, isAll, ok):
+//   - ok=false means the handler already wrote an error response; caller must return.
+//   - resolvedRef="" means "use current HEAD" (default, backward compatible).
+//   - isAll=true means ?ref=@all was requested.
+func resolveRefParam(w http.ResponseWriter, r *http.Request, groupName string) (ref string, isAll bool, ok bool) {
+	raw := r.URL.Query().Get("ref")
+	switch raw {
+	case "", "@current":
+		return "", false, true
+	case "@all":
+		return "", true, true
+	}
+
+	// Named ref — validate it exists for at least one repo in this group.
+	known := knownRefsForGroup(groupName)
+	for _, k := range known {
+		if k == raw {
+			return raw, false, true
+		}
+	}
+
+	// Not found.
+	writeJSON(w, http.StatusBadRequest, map[string]any{
+		"error":     "invalid ref",
+		"available": known,
+	})
+	return "", false, false
+}
+
+// knownRefsForGroup returns all ref names that have an indexed graph for any
+// repo in the given group. The list is sorted and deduplicated. Returns nil
+// when the store is empty or the group is not registered.
+func knownRefsForGroup(groupName string) []string {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	var cfgPath string
+	for _, g := range groups {
+		if g.Name == groupName {
+			cfgPath = g.ConfigPath
+			break
+		}
+	}
+	if cfgPath == "" {
+		return nil
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, repo := range cfg.Repos {
+		// Get the refs/ directory for this repo.
+		// StateDirForRepoRef(<path>, "_unknown") → <base>/refs/_unknown
+		// so filepath.Dir gives <base>/refs.
+		sentinel := daemon.StateDirForRepoRef(repo.Path, "")
+		refsDir := filepath.Dir(sentinel)
+		entries, err := os.ReadDir(refsDir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			ref := daemon.RefSafeDecode(e.Name())
+			if ref == "" {
+				continue // skip _unknown sentinel
+			}
+			// Only count refs that have an actual graph.
+			if _, ferr := os.Stat(filepath.Join(refsDir, e.Name(), "graph.fb")); ferr != nil {
+				if _, ferr2 := os.Stat(filepath.Join(refsDir, e.Name(), "graph.json")); ferr2 != nil {
+					continue
+				}
+			}
+			seen[ref] = struct{}{}
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(seen))
+	for k := range seen {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// allRefsForRepo returns all ref names with an indexed graph for a single repo path.
+func allRefsForRepo(repoPath string) []string {
+	sentinel := daemon.StateDirForRepoRef(repoPath, "")
+	refsDir := filepath.Dir(sentinel)
+	entries, err := os.ReadDir(refsDir)
+	if err != nil {
+		return nil
+	}
+	var refs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		ref := daemon.RefSafeDecode(e.Name())
+		if ref == "" {
+			continue
+		}
+		if _, ferr := os.Stat(filepath.Join(refsDir, e.Name(), "graph.fb")); ferr != nil {
+			if _, ferr2 := os.Stat(filepath.Join(refsDir, e.Name(), "graph.json")); ferr2 != nil {
+				continue
+			}
+		}
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	return refs
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -556,6 +556,18 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/source", s.handleSource)
 	mux.HandleFunc("GET /api/findings", s.handleListFindings)
 
+	// Multi-ref surface (#2220) — 6 read-only endpoints + /refs listing.
+	// All accept ?ref=<name>|@all|@current (missing ?ref= == current HEAD).
+	// NOTE: /refs must be registered before the wildcard /{repo}/... below so
+	// Go 1.22 ServeMux picks the more-specific static path first.
+	mux.HandleFunc("GET /api/groups/{group}/refs", s.handleGroupRefs)
+	mux.HandleFunc("GET /api/groups/{group}/stats", s.handleGroupStats)
+	mux.HandleFunc("GET /api/groups/{group}/repos/{repo}/entities", s.handleRepoEntities)
+	mux.HandleFunc("GET /api/groups/{group}/repos/{repo}/relationships", s.handleRepoRelationships)
+	mux.HandleFunc("GET /api/groups/{group}/repos/{repo}/cross-repo-edges", s.handleRepoCrossRepoEdges)
+	mux.HandleFunc("GET /api/groups/{group}/repos/{repo}/orphans", s.handleRepoOrphans)
+	mux.HandleFunc("GET /api/groups/{group}/repos/{repo}/patterns", s.handleRepoPatterns)
+
 	// WebSocket push
 	mux.HandleFunc("/ws/events", s.handleWSEvents)
 


### PR DESCRIPTION
Closes #2220. Refs #2098.

## Summary

- Adds \`?ref=\` query parameter support to 6 new read-only dashboard endpoints, scoping graph data to a specific git branch/tag
- Adds \`GET /api/groups/:g/refs\` listing endpoint (simpler non-v2 companion to the existing \`/api/v2/groups/{group}/refs\`)
- New shared \`ref_helper.go\` with \`resolveRefParam\` + \`knownRefsForGroup\` for consistent resolution across all handlers
- 22 integration tests covering valid ref, missing ref, invalid ref (→ 400 + available list), \`@all\` aggregation, and CORS non-regression

## New endpoints

| Endpoint | ?ref= support | @all |
|----------|--------------|------|
| \`GET /api/groups/:g/refs\` | N/A (lists all refs) | — |
| \`GET /api/groups/:g/stats\` | yes | yes (sum across refs) |
| \`GET /api/groups/:g/repos/:r/entities\` | yes | yes (union by ID) |
| \`GET /api/groups/:g/repos/:r/relationships\` | yes | yes (dedup by src+tgt+kind) |
| \`GET /api/groups/:g/repos/:r/cross-repo-edges\` | yes | yes |
| \`GET /api/groups/:g/repos/:r/orphans\` | yes | yes (union by ID) |
| \`GET /api/groups/:g/repos/:r/patterns\` | yes (ref-agnostic by design) | yes |

## ?ref= semantics

- Missing / \`@current\` → current HEAD (backward-compatible default, no regressions)
- \`<name>\` → that ref's graph; HTTP 400 + \`{"error": "invalid ref", "available": [...]}\` if not indexed
- \`@all\` → aggregate/union across all indexed refs

## Files

- \`internal/dashboard/ref_helper.go\` — shared resolver
- \`internal/dashboard/handlers_ref_endpoints.go\` — 7 handler functions
- \`internal/dashboard/handlers_ref_endpoints_test.go\` — 22 integration tests
- \`internal/dashboard/server.go\` — route registration

## Test plan

- [x] \`go test ./internal/dashboard/... -count=1\` passes (all 22 new tests + full suite)
- [x] \`go vet ./internal/dashboard/...\` clean
- [x] \`gofmt\` applied to all new files
- [x] CORS: existing \`withAuth(withGzip(mux))\` chain unchanged; OPTIONS returns non-405 for all new routes
- [x] No reindex triggered from any endpoint (read-only — only calls \`GetGroupForRef\`)
- [x] Backward-compatible: missing \`?ref=\` behaves exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>