### PR TITLE
feat(install): post-checkout/merge/rewrite git hooks for ref-aware reindex (closes #2222, refs #2098, #2197)

### DIFF
--- a/internal/cli/hooks_install.go
+++ b/internal/cli/hooks_install.go
@@ -10,12 +10,14 @@ import (
 
 // newInstallHooksCmd returns the `archigraph install-hooks` subcommand.
 //
-// It installs a pre-push git hook into the current (or specified) repo's
-// .git/hooks/pre-push that runs `archigraph doctor --quick` before every
-// push. The hook warns on drift but never blocks the push.
+// It installs 4 git hooks into the current (or specified) repo's .git/hooks/:
+//   - pre-push        — runs `archigraph doctor --quick` before every push
+//   - post-checkout   — signals daemon on branch switch
+//   - post-merge      — signals daemon after merge
+//   - post-rewrite    — signals daemon after rebase/amend
 //
 // If husky, lefthook, or pre-commit is detected in the repo, the command
-// prints advice on how to add the hook via those tools instead of writing
+// prints advice on how to add the hooks via those tools instead of writing
 // directly to .git/hooks/.
 func newInstallHooksCmd() *cobra.Command {
 	var (
@@ -26,15 +28,23 @@ func newInstallHooksCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "install-hooks",
-		Short: "Install the archigraph pre-push hook into the current repo",
-		Long: `Install a pre-push git hook that runs 'archigraph doctor --quick'
-before every push. The hook warns on drift but never blocks the push.
+		Short: "Install archigraph git hooks into the current repo (pre-push, post-checkout, post-merge, post-rewrite)",
+		Long: `Install 4 archigraph-managed git hooks into the repo's .git/hooks/:
 
-If husky, lefthook, or pre-commit is detected in the repo, the command
-prints instructions for adding the hook via those tools instead.
+  pre-push        Runs 'archigraph doctor --quick' before every push.
+                  Warns on drift but never blocks the push.
+  post-checkout   Signals the daemon to mark the new ref as HOT when
+                  switching branches.
+  post-merge      Signals the daemon to trigger an incremental reindex
+                  after a git merge or git pull.
+  post-rewrite    Signals the daemon to trigger an incremental reindex
+                  after a git rebase or git commit --amend.
 
-The hook is idempotent: running install-hooks a second time replaces
-the existing managed block without touching user-written hook content.`,
+All hooks are idempotent: running install-hooks a second time replaces
+the managed block without touching user-written hook content.
+
+If husky, lefthook, or pre-commit is detected, the command prints
+instructions for adding the hooks via those tools instead.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
 
@@ -44,15 +54,17 @@ the existing managed block without touching user-written hook content.`,
 				Force:    force,
 			}
 
-			if err := install.InstallPrePushHook(opts); err != nil {
+			if err := install.InstallGitHooks(opts); err != nil {
 				fmt.Fprintf(out, "✗ install-hooks failed: %v\n", err)
 				return err
 			}
 
 			if !dryRun {
-				fmt.Fprintln(out, "✓ archigraph pre-push hook installed")
-				fmt.Fprintln(out, "  The hook runs 'archigraph doctor --quick' before every push.")
-				fmt.Fprintln(out, "  It warns on drift but never blocks the push.")
+				fmt.Fprintln(out, "✓ archigraph git hooks installed (pre-push, post-checkout, post-merge, post-rewrite)")
+				fmt.Fprintln(out, "  pre-push:      runs 'archigraph doctor --quick' before every push")
+				fmt.Fprintln(out, "  post-checkout: signals daemon on branch switch")
+				fmt.Fprintln(out, "  post-merge:    signals daemon after merge")
+				fmt.Fprintln(out, "  post-rewrite:  signals daemon after rebase/amend")
 			}
 			return nil
 		},
@@ -62,6 +74,6 @@ the existing managed block without touching user-written hook content.`,
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
 		"print what would be written without making changes")
 	cmd.Flags().BoolVar(&force, "force", false,
-		"overwrite an existing pre-push hook (replaces the managed block)")
+		"overwrite existing hooks (replaces the managed block)")
 	return cmd
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -83,6 +83,7 @@ func newInstallCmd() *cobra.Command {
 	var copyMode bool
 	var devMode bool
 	var force bool
+	var noHooks bool
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -143,6 +144,7 @@ Claude Code config directory's skills/ subdirectory.`,
 					SkillsSourceDir:  skillsSourceDir,
 					ClaudeConfigDirs: claudeConfigDirs,
 					Force:            force,
+					NoHooks:          noHooks,
 				})
 			}
 
@@ -158,6 +160,7 @@ Claude Code config directory's skills/ subdirectory.`,
 					SkillsSourceDir:  skillsSourceDir,
 					ClaudeConfigDirs: claudeConfigDirs,
 					Force:            force,
+					NoHooks:          noHooks,
 				})
 			}
 
@@ -246,6 +249,9 @@ Claude Code config directory's skills/ subdirectory.`,
 		"run the DEV-mode install transaction: symlinks skills from the repo working tree instead of copying them (for contributors; --dev takes precedence over --copy)")
 	cmd.Flags().BoolVar(&force, "force", false,
 		"bypass the partial-install guard; use after a failed install or 'archigraph uninstall && archigraph install'")
+	// #2222: git hooks opt-out.
+	cmd.Flags().BoolVar(&noHooks, "no-hooks", false,
+		"skip automatic git hook installation (post-checkout, post-merge, post-rewrite, pre-push)")
 	return cmd
 }
 

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -104,6 +104,10 @@ type CopyOptions struct {
 	// production implementation (service.Install + waitForHealthz) is used.
 	// Inject a stub in tests to avoid calling launchctl/systemctl.
 	RestartDaemon DaemonRestartFunc
+
+	// NoHooks skips automatic git hook installation (step 7).
+	// Equivalent to passing --no-hooks on the CLI.
+	NoHooks bool
 }
 
 // CopyResult reports what RunCopy accomplished.
@@ -290,6 +294,23 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 	}
 	result.StatePath = opts.StatePath
 	completedSteps = append(completedSteps, 6)
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Step 7: Git hook installation (post-checkout, post-merge, post-rewrite,
+	//         pre-push). Non-fatal: a hook install failure warns but does not
+	//         roll back the rest of the install.  Can be opted-out with
+	//         --no-hooks.
+	// ─────────────────────────────────────────────────────────────────────────
+	if !opts.NoHooks {
+		hookOpts := HookInstallOptions{
+			RepoPath: opts.WorkingDir,
+			DryRun:   opts.DryRun,
+		}
+		if err := InstallGitHooks(hookOpts); err != nil {
+			// Non-fatal: hooks are a convenience; don't abort a successful install.
+			fmt.Fprintf(os.Stderr, "archigraph install: step 7 warning – git hooks: %v\n", err)
+		}
+	}
 
 	return result, nil
 }

--- a/internal/install/dev.go
+++ b/internal/install/dev.go
@@ -74,6 +74,10 @@ type DevOptions struct {
 	// production implementation (service.Install + waitForHealthz) is used.
 	// Inject a stub in tests to avoid calling launchctl/systemctl.
 	RestartDaemon DaemonRestartFunc
+
+	// NoHooks skips automatic git hook installation (step 7).
+	// Equivalent to passing --no-hooks on the CLI.
+	NoHooks bool
 }
 
 // DevResult reports what RunDev accomplished.
@@ -261,6 +265,23 @@ func RunDev(opts DevOptions) (*DevResult, error) {
 	}
 	result.StatePath = opts.StatePath
 	completedSteps = append(completedSteps, 6)
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Step 7: Git hook installation (post-checkout, post-merge, post-rewrite,
+	//         pre-push). Non-fatal: a hook install failure warns but does not
+	//         roll back the rest of the install.  Can be opted-out with
+	//         --no-hooks.
+	// ─────────────────────────────────────────────────────────────────────────
+	if !opts.NoHooks {
+		hookOpts := HookInstallOptions{
+			RepoPath: opts.WorkingDir,
+			DryRun:   opts.DryRun,
+		}
+		if err := InstallGitHooks(hookOpts); err != nil {
+			// Non-fatal: hooks are a convenience; don't abort a successful install.
+			fmt.Fprintf(os.Stderr, "archigraph install --dev: step 7 warning – git hooks: %v\n", err)
+		}
+	}
 
 	return result, nil
 }

--- a/internal/install/hooks_install.go
+++ b/internal/install/hooks_install.go
@@ -1,9 +1,14 @@
-// hooks_install.go implements `archigraph install-hooks` (issue #2213).
+// hooks_install.go implements `archigraph install-hooks` (issues #2213, #2222).
 //
 // InstallPrePushHook writes a pre-push hook script into <repo>/.git/hooks/
 // (or delegates to husky / lefthook if detected). The hook runs
 // `archigraph doctor` before every push and warns on drift — it NEVER
 // blocks the push.
+//
+// InstallGitHooks (issue #2222) extends the above to also install
+// post-checkout, post-merge, and post-rewrite hooks that trigger
+// ref-aware reindex via the existing daemon. All 4 hooks are managed
+// idempotently and are tolerant of `archigraph` not being on PATH.
 package install
 
 import (
@@ -27,9 +32,44 @@ if command -v archigraph >/dev/null 2>&1; then
 fi
 %s
 `
+
+	// post-checkout hook: fires on branch switches; signals daemon via status RPC.
+	postCheckoutMarkerBegin = "# >>> archigraph post-checkout >>>"
+	postCheckoutMarkerEnd   = "# <<< archigraph post-checkout <<<"
+	postCheckoutHookScript  = `%s
+# Only act on branch switches (arg 3 == 1), not file checkouts.
+if [ "${3:-0}" = "1" ] && command -v archigraph >/dev/null 2>&1; then
+  archigraph status --ref @current >/dev/null 2>&1 &
+fi
+%s
+`
+
+	// post-merge hook: fires after git merge / git pull.
+	postMergeMarkerBegin = "# >>> archigraph post-merge >>>"
+	postMergeMarkerEnd   = "# <<< archigraph post-merge <<<"
+	postMergeHookScript  = `%s
+# Signal the daemon to reindex after the merge; run in background so the
+# hook returns immediately and never delays the user's merge workflow.
+if command -v archigraph >/dev/null 2>&1; then
+  archigraph status --ref @current >/dev/null 2>&1 &
+fi
+%s
+`
+
+	// post-rewrite hook: fires after git rebase / git commit --amend.
+	postRewriteMarkerBegin = "# >>> archigraph post-rewrite >>>"
+	postRewriteMarkerEnd   = "# <<< archigraph post-rewrite <<<"
+	postRewriteHookScript  = `%s
+# Signal the daemon to reindex after the rewrite; run in background so
+# the hook returns immediately and never delays the user's workflow.
+if command -v archigraph >/dev/null 2>&1; then
+  archigraph status --ref @current >/dev/null 2>&1 &
+fi
+%s
+`
 )
 
-// HookInstallOptions controls InstallPrePushHook behaviour.
+// HookInstallOptions controls InstallPrePushHook / InstallGitHooks behaviour.
 type HookInstallOptions struct {
 	// RepoPath is the root of the git repository.  Defaults to os.Getwd().
 	RepoPath string
@@ -77,6 +117,76 @@ func InstallPrePushHook(opts HookInstallOptions) error {
 	return writeHookBlock(hookPath, block)
 }
 
+// InstallGitHooks installs all 4 archigraph-managed git hooks into the repo:
+//
+//   - pre-push        (from #2213) — runs `archigraph doctor --quick`
+//   - post-checkout   (from #2222) — signals daemon on branch switch
+//   - post-merge      (from #2222) — signals daemon after merge
+//   - post-rewrite    (from #2222) — signals daemon after rebase/amend
+//
+// If husky, lefthook, or pre-commit is detected in the repo, advice is
+// printed instead and nil is returned (not an error). All hooks are
+// idempotent: re-running replaces the managed block without touching any
+// user-written content.
+func InstallGitHooks(opts HookInstallOptions) error {
+	if opts.RepoPath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("resolve working dir: %w", err)
+		}
+		opts.RepoPath = cwd
+	}
+
+	// ── detect hook managers ──────────────────────────────────────────────────
+	if detected, name := detectHookManager(opts.RepoPath); detected {
+		printHookManagerAdvice(name, opts.RepoPath)
+		return nil
+	}
+
+	// ── find .git/hooks ───────────────────────────────────────────────────────
+	hooksDir := filepath.Join(opts.RepoPath, ".git", "hooks")
+	if _, err := os.Stat(hooksDir); err != nil {
+		return fmt.Errorf("no .git/hooks directory found at %s (is this a git repo?): %w", opts.RepoPath, err)
+	}
+
+	type hookDef struct {
+		name   string
+		script string
+	}
+
+	hooks := []hookDef{
+		{
+			name:   "pre-push",
+			script: fmt.Sprintf(prePushHookScript, prePushMarkerBegin, prePushMarkerEnd),
+		},
+		{
+			name:   "post-checkout",
+			script: fmt.Sprintf(postCheckoutHookScript, postCheckoutMarkerBegin, postCheckoutMarkerEnd),
+		},
+		{
+			name:   "post-merge",
+			script: fmt.Sprintf(postMergeHookScript, postMergeMarkerBegin, postMergeMarkerEnd),
+		},
+		{
+			name:   "post-rewrite",
+			script: fmt.Sprintf(postRewriteHookScript, postRewriteMarkerBegin, postRewriteMarkerEnd),
+		},
+	}
+
+	for _, h := range hooks {
+		hookPath := filepath.Join(hooksDir, h.name)
+		if opts.DryRun {
+			fmt.Fprintf(os.Stdout, "archigraph install-hooks (dry-run): would write %s hook to %s\n", h.name, hookPath)
+			fmt.Fprintf(os.Stdout, "Block content:\n%s\n", h.script)
+			continue
+		}
+		if err := writeHookBlock(hookPath, h.script); err != nil {
+			return fmt.Errorf("write %s hook: %w", h.name, err)
+		}
+	}
+	return nil
+}
+
 // writeHookBlock writes the archigraph managed block into hookPath.
 // If the file does not exist it is created with a shebang.
 // If the block already exists it is replaced (idempotent).
@@ -100,14 +210,15 @@ func writeHookBlock(hookPath, block string) error {
 }
 
 // mergeHookBlock inserts or replaces the archigraph managed block in content.
-// If the block already exists (marked by prePushMarkerBegin/End) it is
-// replaced.  Otherwise the block is appended.
+// The begin/end markers are extracted from the first and last "# >>> / # <<<"
+// lines of block itself so the function works for any hook type.
 // The result always starts with a sh shebang if the file was empty.
 func mergeHookBlock(existing, block string) string {
 	const shebang = "#!/bin/sh\n"
 
-	// Remove any existing managed block.
-	cleaned := removeHookBlock(existing)
+	// Remove any existing managed block of the same type.
+	markerBegin, markerEnd := extractMarkers(block)
+	cleaned := removeHookBlockMarked(existing, markerBegin, markerEnd)
 
 	if cleaned == "" {
 		// New file: start with shebang.
@@ -124,19 +235,47 @@ func mergeHookBlock(existing, block string) string {
 	return cleaned + "\n" + block
 }
 
-// removeHookBlock strips the archigraph-managed block from content.
+// extractMarkers scans block for lines of the form "# >>> … >>>" and
+// "# <<< … <<<" and returns them as the begin and end markers.
+// Falls back to the pre-push markers when none are found (backward compat).
+func extractMarkers(block string) (begin, end string) {
+	for _, line := range splitByNewline(block) {
+		if len(line) > 4 && line[:4] == "# >>" {
+			begin = line
+		}
+		if len(line) > 4 && line[:4] == "# <<" {
+			end = line
+		}
+	}
+	if begin == "" {
+		begin = prePushMarkerBegin
+	}
+	if end == "" {
+		end = prePushMarkerEnd
+	}
+	return
+}
+
+// removeHookBlock strips the archigraph pre-push managed block from content.
+// Kept for backward compatibility with existing call sites.
 func removeHookBlock(content string) string {
-	startIdx := indexOf(content, prePushMarkerBegin)
+	return removeHookBlockMarked(content, prePushMarkerBegin, prePushMarkerEnd)
+}
+
+// removeHookBlockMarked strips the archigraph managed block delimited by
+// markerBegin and markerEnd from content.
+func removeHookBlockMarked(content, markerBegin, markerEnd string) string {
+	startIdx := indexOf(content, markerBegin)
 	if startIdx < 0 {
 		return content
 	}
-	endIdx := indexOf(content, prePushMarkerEnd)
+	endIdx := indexOf(content, markerEnd)
 	if endIdx < 0 {
 		// Malformed: no end marker — remove from start to end of file.
 		return content[:startIdx]
 	}
 	// Include the newline after the end marker.
-	after := endIdx + len(prePushMarkerEnd)
+	after := endIdx + len(markerEnd)
 	if after < len(content) && content[after] == '\n' {
 		after++
 	}
@@ -174,20 +313,35 @@ func detectHookManager(repoPath string) (bool, string) {
 }
 
 // printHookManagerAdvice prints instructions for adding the archigraph
-// pre-push hook via the detected hook manager.
+// hooks via the detected hook manager (pre-push + post-checkout/merge/rewrite).
 func printHookManagerAdvice(manager, repoPath string) {
 	fmt.Fprintf(os.Stdout, "Detected %s in %s.\n", manager, repoPath)
 	fmt.Fprintln(os.Stdout, "")
 	switch manager {
 	case "husky":
-		fmt.Fprintln(os.Stdout, "Add the archigraph pre-push hook to husky:")
+		fmt.Fprintln(os.Stdout, "Add the archigraph hooks to husky:")
 		fmt.Fprintln(os.Stdout, "  npx husky add .husky/pre-push \"archigraph doctor --quick 2>/dev/null || echo 'archigraph: drift detected — run archigraph doctor' >&2\"")
+		fmt.Fprintln(os.Stdout, "  npx husky add .husky/post-checkout \"if [ \\\"${3:-0}\\\" = '1' ]; then archigraph status --ref @current >/dev/null 2>&1 & fi\"")
+		fmt.Fprintln(os.Stdout, "  npx husky add .husky/post-merge \"archigraph status --ref @current >/dev/null 2>&1 &\"")
+		fmt.Fprintln(os.Stdout, "  npx husky add .husky/post-rewrite \"archigraph status --ref @current >/dev/null 2>&1 &\"")
 	case "lefthook":
 		fmt.Fprintln(os.Stdout, "Add to lefthook.yml:")
 		fmt.Fprintln(os.Stdout, "  pre-push:")
 		fmt.Fprintln(os.Stdout, "    commands:")
 		fmt.Fprintln(os.Stdout, "      archigraph-doctor:")
 		fmt.Fprintln(os.Stdout, "        run: archigraph doctor --quick 2>/dev/null || echo 'archigraph: drift detected' >&2")
+		fmt.Fprintln(os.Stdout, "  post-checkout:")
+		fmt.Fprintln(os.Stdout, "    commands:")
+		fmt.Fprintln(os.Stdout, "      archigraph-reindex:")
+		fmt.Fprintln(os.Stdout, "        run: archigraph status --ref @current >/dev/null 2>&1")
+		fmt.Fprintln(os.Stdout, "  post-merge:")
+		fmt.Fprintln(os.Stdout, "    commands:")
+		fmt.Fprintln(os.Stdout, "      archigraph-reindex:")
+		fmt.Fprintln(os.Stdout, "        run: archigraph status --ref @current >/dev/null 2>&1")
+		fmt.Fprintln(os.Stdout, "  post-rewrite:")
+		fmt.Fprintln(os.Stdout, "    commands:")
+		fmt.Fprintln(os.Stdout, "      archigraph-reindex:")
+		fmt.Fprintln(os.Stdout, "        run: archigraph status --ref @current >/dev/null 2>&1")
 	case "pre-commit":
 		fmt.Fprintln(os.Stdout, "Add to .pre-commit-config.yaml:")
 		fmt.Fprintln(os.Stdout, "  - repo: local")
@@ -197,6 +351,8 @@ func printHookManagerAdvice(manager, repoPath string) {
 		fmt.Fprintln(os.Stdout, "        entry: archigraph doctor --quick")
 		fmt.Fprintln(os.Stdout, "        language: system")
 		fmt.Fprintln(os.Stdout, "        stages: [pre-push]")
+		fmt.Fprintln(os.Stdout, "  Note: pre-commit does not support post-checkout/merge/rewrite hooks.")
+		fmt.Fprintln(os.Stdout, "        Run 'archigraph install-hooks --force' to install those directly.")
 	}
 	fmt.Fprintln(os.Stdout, "")
 	fmt.Fprintln(os.Stdout, "Or run 'archigraph install-hooks --force' to install directly into .git/hooks/ instead.")

--- a/internal/install/hooks_install_test.go
+++ b/internal/install/hooks_install_test.go
@@ -151,7 +151,221 @@ func TestInstallPrePushHook_NoGitRepo(t *testing.T) {
 	}
 }
 
+// ── InstallGitHooks tests (#2222) ─────────────────────────────────────────────
+
+// TestInstallGitHooks_AllFourHooks verifies that InstallGitHooks creates all
+// 4 hook files (pre-push, post-checkout, post-merge, post-rewrite).
+func TestInstallGitHooks_AllFourHooks(t *testing.T) {
+	repoDir := makeGitRepo(t)
+
+	opts := install.HookInstallOptions{RepoPath: repoDir}
+	if err := install.InstallGitHooks(opts); err != nil {
+		t.Fatalf("InstallGitHooks: %v", err)
+	}
+
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	for _, hookName := range []string{"pre-push", "post-checkout", "post-merge", "post-rewrite"} {
+		hookPath := filepath.Join(hooksDir, hookName)
+		assertHookExists(t, hookName, hookPath)
+	}
+}
+
+// TestInstallGitHooks_Idempotent verifies that running InstallGitHooks twice
+// does not duplicate any managed block.
+func TestInstallGitHooks_Idempotent(t *testing.T) {
+	repoDir := makeGitRepo(t)
+
+	opts := install.HookInstallOptions{RepoPath: repoDir}
+	if err := install.InstallGitHooks(opts); err != nil {
+		t.Fatalf("first InstallGitHooks: %v", err)
+	}
+	if err := install.InstallGitHooks(opts); err != nil {
+		t.Fatalf("second InstallGitHooks: %v", err)
+	}
+
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	for hookName, marker := range map[string]string{
+		"pre-push":      "# >>> archigraph pre-push >>>",
+		"post-checkout": "# >>> archigraph post-checkout >>>",
+		"post-merge":    "# >>> archigraph post-merge >>>",
+		"post-rewrite":  "# >>> archigraph post-rewrite >>>",
+	} {
+		hookPath := filepath.Join(hooksDir, hookName)
+		data, err := os.ReadFile(hookPath)
+		if err != nil {
+			t.Fatalf("read %s hook: %v", hookName, err)
+		}
+		count := strings.Count(string(data), marker)
+		if count != 1 {
+			t.Errorf("%s: expected exactly 1 managed block, found %d", hookName, count)
+		}
+	}
+}
+
+// TestInstallGitHooks_PreservesExistingContent verifies that pre-existing hook
+// content is preserved and the archigraph block is appended.
+func TestInstallGitHooks_PreservesExistingContent(t *testing.T) {
+	repoDir := makeGitRepo(t)
+
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	for _, hookName := range []string{"post-checkout", "post-merge", "post-rewrite"} {
+		hookPath := filepath.Join(hooksDir, hookName)
+		userContent := "#!/bin/sh\n# user's own " + hookName + " logic\nexit 0\n"
+		if err := os.WriteFile(hookPath, []byte(userContent), 0o755); err != nil {
+			t.Fatalf("write user %s hook: %v", hookName, err)
+		}
+	}
+
+	opts := install.HookInstallOptions{RepoPath: repoDir}
+	if err := install.InstallGitHooks(opts); err != nil {
+		t.Fatalf("InstallGitHooks: %v", err)
+	}
+
+	for _, hookName := range []string{"post-checkout", "post-merge", "post-rewrite"} {
+		hookPath := filepath.Join(hooksDir, hookName)
+		data, err := os.ReadFile(hookPath)
+		if err != nil {
+			t.Fatalf("read %s hook: %v", hookName, err)
+		}
+		content := string(data)
+		if !strings.Contains(content, "user's own "+hookName+" logic") {
+			t.Errorf("%s: user content was lost; got: %q", hookName, content)
+		}
+	}
+}
+
+// TestInstallGitHooks_DryRun verifies that dry-run does not create hook files.
+func TestInstallGitHooks_DryRun(t *testing.T) {
+	repoDir := makeGitRepo(t)
+
+	opts := install.HookInstallOptions{RepoPath: repoDir, DryRun: true}
+	if err := install.InstallGitHooks(opts); err != nil {
+		t.Fatalf("InstallGitHooks --dry-run: %v", err)
+	}
+
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	for _, hookName := range []string{"pre-push", "post-checkout", "post-merge", "post-rewrite"} {
+		hookPath := filepath.Join(hooksDir, hookName)
+		if _, err := os.Stat(hookPath); err == nil {
+			t.Errorf("dry-run should not create %s hook file", hookName)
+		}
+	}
+}
+
+// TestInstallGitHooks_HuskyDetection verifies that husky detection skips
+// all hook installations and returns nil.
+func TestInstallGitHooks_HuskyDetection(t *testing.T) {
+	repoDir := makeGitRepo(t)
+
+	huskyDir := filepath.Join(repoDir, ".husky")
+	if err := os.MkdirAll(huskyDir, 0o755); err != nil {
+		t.Fatalf("create .husky: %v", err)
+	}
+
+	opts := install.HookInstallOptions{RepoPath: repoDir}
+	if err := install.InstallGitHooks(opts); err != nil {
+		t.Fatalf("InstallGitHooks with husky: %v", err)
+	}
+
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	for _, hookName := range []string{"pre-push", "post-checkout", "post-merge", "post-rewrite"} {
+		hookPath := filepath.Join(hooksDir, hookName)
+		if _, err := os.Stat(hookPath); err == nil {
+			t.Errorf("%s hook should not be written when husky is detected", hookName)
+		}
+	}
+}
+
+// TestInstallGitHooks_NoGitRepo verifies that an error is returned when there
+// is no .git directory.
+func TestInstallGitHooks_NoGitRepo(t *testing.T) {
+	noGitDir := t.TempDir()
+	opts := install.HookInstallOptions{RepoPath: noGitDir}
+	if err := install.InstallGitHooks(opts); err == nil {
+		t.Error("expected error when .git/hooks does not exist")
+	}
+}
+
+// TestInstallGitHooks_PostCheckoutBranchOnly verifies that the post-checkout
+// hook contains the branch-switch guard (arg $3 == 1).
+func TestInstallGitHooks_PostCheckoutBranchOnly(t *testing.T) {
+	repoDir := makeGitRepo(t)
+
+	opts := install.HookInstallOptions{RepoPath: repoDir}
+	if err := install.InstallGitHooks(opts); err != nil {
+		t.Fatalf("InstallGitHooks: %v", err)
+	}
+
+	hookPath := filepath.Join(repoDir, ".git", "hooks", "post-checkout")
+	data, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("read post-checkout hook: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, `${3:-0}`) {
+		t.Errorf("post-checkout hook should guard on arg $3 (branch switch), got: %q", content)
+	}
+}
+
+// TestInstallGitHooks_DoesNotBreakPrePush verifies that the existing
+// InstallPrePushHook still works correctly after #2222 changes.
+func TestInstallGitHooks_DoesNotBreakPrePush(t *testing.T) {
+	repoDir := makeGitRepo(t)
+
+	opts := install.HookInstallOptions{RepoPath: repoDir}
+	if err := install.InstallPrePushHook(opts); err != nil {
+		t.Fatalf("InstallPrePushHook: %v", err)
+	}
+
+	hookPath := filepath.Join(repoDir, ".git", "hooks", "pre-push")
+	assertPrePushHookExists(t, hookPath)
+
+	// Verify the other 3 hooks were NOT installed by InstallPrePushHook.
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	for _, hookName := range []string{"post-checkout", "post-merge", "post-rewrite"} {
+		p := filepath.Join(hooksDir, hookName)
+		if _, err := os.Stat(p); err == nil {
+			t.Errorf("InstallPrePushHook should not create %s hook", hookName)
+		}
+	}
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+// assertHookExists checks that a hook file exists, is executable, and contains
+// the archigraph managed block markers.
+func assertHookExists(t *testing.T, hookName, hookPath string) {
+	t.Helper()
+
+	info, err := os.Stat(hookPath)
+	if err != nil {
+		t.Fatalf("%s hook not found at %s: %v", hookName, hookPath, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("%s hook at %s is not executable (mode %v)", hookName, hookPath, info.Mode())
+	}
+
+	data, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("read %s hook: %v", hookName, err)
+	}
+	content := string(data)
+
+	if !strings.HasPrefix(content, "#!/bin/sh") {
+		t.Errorf("%s hook does not start with shebang", hookName)
+	}
+
+	beginMarker := "# >>> archigraph " + hookName + " >>>"
+	endMarker := "# <<< archigraph " + hookName + " <<<"
+	if !strings.Contains(content, beginMarker) {
+		t.Errorf("%s hook missing begin marker %q; content: %q", hookName, beginMarker, content)
+	}
+	if !strings.Contains(content, endMarker) {
+		t.Errorf("%s hook missing end marker %q; content: %q", hookName, endMarker, content)
+	}
+}
+
+// ── legacy helpers (unchanged) ────────────────────────────────────────────────
 
 // makeGitRepo creates a temporary directory with a minimal .git structure.
 func makeGitRepo(t *testing.T) string {

--- a/scripts/git-hooks/post-checkout
+++ b/scripts/git-hooks/post-checkout
@@ -1,0 +1,26 @@
+#!/bin/sh
+# archigraph post-checkout hook
+#
+# Fires when the user runs `git checkout <branch>` (or `git switch`).
+# When the checkout changes the HEAD ref (arg 3 == 1), signals the
+# archigraph daemon to mark the new ref as HOT and trigger an
+# incremental reindex if needed.
+#
+# Git passes 3 arguments:
+#   $1 = previous HEAD (SHA)
+#   $2 = new HEAD (SHA)
+#   $3 = 1 if branch checkout (ref switch), 0 if file checkout
+#
+# Install this hook via:
+#   archigraph install-hooks
+#
+# Or copy it manually to .git/hooks/post-checkout and make it executable:
+#   cp scripts/git-hooks/post-checkout .git/hooks/post-checkout
+#   chmod +x .git/hooks/post-checkout
+
+# >>> archigraph post-checkout >>>
+# Only act on branch switches (arg 3 == 1), not file checkouts.
+if [ "${3:-0}" = "1" ] && command -v archigraph >/dev/null 2>&1; then
+  archigraph status --ref @current >/dev/null 2>&1 &
+fi
+# <<< archigraph post-checkout <<<

--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -1,0 +1,24 @@
+#!/bin/sh
+# archigraph post-merge hook
+#
+# Fires after a successful `git merge` (including `git pull`).
+# Signals the archigraph daemon to trigger an incremental reindex on
+# the new HEAD so the graph reflects merged code immediately.
+#
+# Git passes 1 argument:
+#   $1 = 1 if it was a squash merge, 0 otherwise
+#
+# Install this hook via:
+#   archigraph install-hooks
+#
+# Or copy it manually to .git/hooks/post-merge and make it executable:
+#   cp scripts/git-hooks/post-merge .git/hooks/post-merge
+#   chmod +x .git/hooks/post-merge
+
+# >>> archigraph post-merge >>>
+# Signal the daemon to reindex after the merge; run in background so the
+# hook returns immediately and never delays the user's merge workflow.
+if command -v archigraph >/dev/null 2>&1; then
+  archigraph status --ref @current >/dev/null 2>&1 &
+fi
+# <<< archigraph post-merge <<<

--- a/scripts/git-hooks/post-rewrite
+++ b/scripts/git-hooks/post-rewrite
@@ -1,0 +1,24 @@
+#!/bin/sh
+# archigraph post-rewrite hook
+#
+# Fires after a `git rebase` or `git commit --amend` that rewrites
+# commit history. Signals the archigraph daemon to trigger an
+# incremental reindex so the graph reflects the rewritten commits.
+#
+# Git passes 1 argument:
+#   $1 = "rebase" | "amend"
+#
+# Install this hook via:
+#   archigraph install-hooks
+#
+# Or copy it manually to .git/hooks/post-rewrite and make it executable:
+#   cp scripts/git-hooks/post-rewrite .git/hooks/post-rewrite
+#   chmod +x .git/hooks/post-rewrite
+
+# >>> archigraph post-rewrite >>>
+# Signal the daemon to reindex after the rewrite; run in background so
+# the hook returns immediately and never delays the user's workflow.
+if command -v archigraph >/dev/null 2>&1; then
+  archigraph status --ref @current >/dev/null 2>&1 &
+fi
+# <<< archigraph post-rewrite <<<


### PR DESCRIPTION
Closes #2222. Refs #2098, #2197.

## What this PR does

Installs 3 new git hooks that signal the archigraph daemon when the user switches branches, merges, or rebases — so the graph stays up to date without requiring a manual `archigraph index` call.

### New hook scripts (`scripts/git-hooks/`)

| Hook | Fires on | Action |
|---|---|---|
| `post-checkout` | `git checkout <branch>` / `git switch` | Signals daemon on branch switch (guards on `$3==1` to skip file-only checkouts) |
| `post-merge` | `git merge` / `git pull` | Signals daemon to reindex new HEAD |
| `post-rewrite` | `git rebase` / `git commit --amend` | Signals daemon to reindex rewritten history |

All hooks run `archigraph status --ref @current` in the background — returning immediately, never blocking the user's workflow. They silently skip when `archigraph` is not on PATH.

### `InstallGitHooks()` in `internal/install/hooks_install.go`

- New function that installs all 4 hooks (pre-push + the 3 above) idempotently
- `InstallPrePushHook()` preserved unchanged (no regressions for #2213 callers)
- Marker extraction refactored to be generic across hook types (`extractMarkers`)
- husky / lefthook / pre-commit detection updated to print advice for all 4 hooks

### `--no-hooks` opt-out

Added to `CopyOptions`, `DevOptions`, and the `archigraph install` CLI flag surface. When set, step 7 (hook installation) is skipped entirely.

### `archigraph install` wiring

`RunCopy` and `RunDev` now run hook installation as a non-fatal **step 7** after state persistence. A hook failure prints a warning but never aborts an otherwise successful install.

### `archigraph install-hooks` CLI update

Now installs all 4 hooks (was: pre-push only). Help text and hook-manager advice updated accordingly.

## Tests

7 new tests in `internal/install/hooks_install_test.go`:

- `TestInstallGitHooks_AllFourHooks` — all 4 hook files created
- `TestInstallGitHooks_Idempotent` — no duplicate blocks on second run
- `TestInstallGitHooks_PreservesExistingContent` — user hook content survives
- `TestInstallGitHooks_DryRun` — no files written in dry-run
- `TestInstallGitHooks_HuskyDetection` — skips install, returns nil, prints advice
- `TestInstallGitHooks_PostCheckoutBranchOnly` — `$3` guard present
- `TestInstallGitHooks_DoesNotBreakPrePush` — `InstallPrePushHook` still installs only pre-push

All existing tests in `./internal/install/...` pass.

## Acceptance criteria checklist

- [x] 3 hook scripts in `scripts/git-hooks/` (plus existing pre-push = 4 total)
- [x] `InstallGitHooks()` installs all 4 idempotently
- [x] `archigraph install` calls `InstallGitHooks()` automatically (with `--no-hooks` opt-out)
- [x] husky / lefthook / pre-commit detected: skip with advice
- [x] Doesn't break existing pre-push hook from #2213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>