### PR TITLE
docs: ADR 0020 + user guide for multi-branch + worktree (closes #2225, refs #2098)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ and [milestones](https://github.com/cajasmota/archigraph/milestones).
 - **13 new MCP tools** — Topology v2, Flows v2, Quality, and graph
   traversal surfaces exposed to agents. See
   [`internal/mcp/SCHEMA.md`](internal/mcp/SCHEMA.md).
+- **Multi-branch + worktree support** — one graph snapshot per `(repo, ref)`;
+  branch switches are detected automatically via `.git/HEAD` watch and optional
+  git hooks; HOT/WARM/COLD tier management keeps RAM bounded; `--ref` flag on
+  all read commands; `?ref=` on dashboard APIs; graph diff view between any two
+  indexed refs. See [Multi-branch guide](docs/user-guide/multi-branch.md).
 
 ## Run it locally (testing build)
 
@@ -224,13 +229,17 @@ Other useful commands:
 
 ```sh
 archigraph index <repo>              # one-shot indexer (writes graph.fb, optionally graph.json)
+archigraph index <repo> --ref <ref>  # index a specific git ref
 archigraph reset <group> [slug]      # wipe .archigraph/ and rebuild
 archigraph remove <group> <slug>     # remove a repo from a group
 archigraph delete <group>            # delete entire group + state
 archigraph monorepo add <group> <p>  # opt a path inside a monorepo into indexing
 archigraph doctor                    # smoke-check install + tools (rich health report)
 archigraph status <group>            # show group health + stats (rich output)
+archigraph status <group> --all-refs # show per-ref tier + stats for every indexed branch
+archigraph branches                  # list all indexed refs with HOT/WARM/COLD tier + sizes
 archigraph uninstall <group>         # remove hooks/watchers from a group
+archigraph install-hooks             # install post-checkout/merge/rewrite git hooks (multi-branch)
 archigraph patterns list             # inspect agent-learned patterns (ADR-0018)
 archigraph patterns export --repo X  # write the CLAUDE.md marker block
 archigraph patterns config           # show / set pattern thresholds

--- a/docs/adrs/0020-multi-branch-worktree.md
+++ b/docs/adrs/0020-multi-branch-worktree.md
@@ -1,0 +1,290 @@
+# ADR-0020: Multi-branch and worktree graph snapshots
+
+- **Status**: Accepted (2026-05-26)
+- **Date**: 2026-05-26
+- **Deciders**: Jorge Cajas
+- **Related**: ADR-0017 (daemon architecture), ADR-0016 (binary graph format), ADR-0009 (cross-repo ID namespacing), epic #2087, #2098
+- **Shipped in**: #2126, #2129, #2132, #2137, #2138, #2139, #2143, #2144, #2146, #2148, #2158, #2219, #2220, #2221, #2222, #2223, #2224
+
+## Context
+
+Until this ADR, the archigraph daemon indexed exactly one git ref per registered
+repository — whichever ref was current when the last `archigraph index` or
+`archigraph rebuild` ran. This design has two concrete problems.
+
+**Branch-switch context loss.** Developers work on feature branches,
+hotfixes, and release cuts simultaneously. When a developer runs `git
+checkout feature/foo`, the graph stored on disk still reflects the previous
+branch. Any MCP query after the switch returns stale structure — entities
+that no longer exist in the working tree, or missing entities that the
+branch introduces. The agent has no way to know the graph is stale without
+manually triggering a full reindex.
+
+**Worktree blindness.** `git worktree add` creates a parallel checkout of the
+same repo at a different path, allowing concurrent work on two branches. The
+daemon had no concept of linked worktrees: it indexed the primary checkout
+only, and any work done inside a linked worktree was invisible to MCP queries
+until the user manually indexed the secondary path as a separate group.
+
+The product target is install-and-forget (ADR-0017): the graph stays correct
+without manual intervention. The single-ref design cannot meet that target for
+multi-branch workflows.
+
+The implementation was delivered as a phased epic (#2087) covering storage
+layout (PH1a–c), LRU tiered hibernation (PH2, PH2a), worktree discovery (PH3),
+dashboard UI (PH4), graph diff view (PH5), disk eviction (PH6), clone-from-parent
+(PH7), and embedding deduplication (PH8). The CLI `--ref` surface and dashboard
+`?ref=` query support shipped as a follow-on epic (#2098).
+
+## Decision
+
+**Index and retain one graph snapshot per `(repoPath, ref)` pair, stored in a
+per-ref sub-directory, with an LRU + tiered hibernation policy to bound RAM and
+disk usage.**
+
+### Storage layout
+
+Per-ref artifacts live under:
+
+```
+~/.archigraph/store/<slug>-<hash>/refs/<ref-safe>/graph.fb
+~/.archigraph/store/<slug>-<hash>/refs/<ref-safe>/graph.json  (opt-in)
+~/.archigraph/store/<slug>-<hash>/refs/<ref-safe>/graph-stats.json
+~/.archigraph/store/<slug>-<hash>/refs/<ref-safe>/embeddings.bin
+```
+
+`<ref-safe>` is the ref name percent-encoded with `%2F` for `/` so that branch
+names like `feature/foo` map to a valid directory name on all platforms
+(`feature%2Ffoo`). Encode/decode is provided by `RefSafeEncode` /
+`RefSafeDecode` in `internal/daemon/state_path.go`.
+
+`StateDirForRepo` (the pre-ADR-0020 helper that resolved to the flat-layout
+slot) is now a thin wrapper that reads the current HEAD via `gitmeta.Capture`
+and delegates to `StateDirForRepoRef(repoPath, ref)`. All indexer write paths,
+reader paths (MCP, dashboard, doctor, status, watch, links), and
+enrichment/repair persistence go through these helpers.
+
+Legacy flat-layout slots (`graph.fb` at the top level of a `<slug>-<hash>/`
+directory) are migrated automatically by `MigrateToRefStore(storeDir)` at
+daemon startup (before the first RPC is served). The migration reads the
+`indexed_ref` field from `graph.json` metadata to determine the correct
+sub-directory; slots with no metadata fall back to `refs/_unknown/`. Migration
+is idempotent (#2126).
+
+### HOT / WARM / COLD tier state machine
+
+Every `(repoPath, ref)` slot has a tier managed by `internal/daemon/tier.Manager`:
+
+| Tier    | In-RAM? | Disk present? | Transition rule                          |
+|---------|---------|---------------|------------------------------------------|
+| HOT     | yes     | yes           | Registered after indexing or access      |
+| WARM    | yes     | yes           | 5 min idle with no MCP / dashboard query |
+| COLD    | no      | yes           | 1 h idle; mmap released, GC eligible     |
+| EXPIRED | no      | no            | Disk eviction (non-pinned only)          |
+
+The default-branch slot for a repository (detected via `tier.IsDefaultBranch`
+using `git symbolic-ref refs/remotes/origin/HEAD` with a fallback to the common
+`main`/`master` names) is pinned HOT and never reaches EXPIRED. Feature-branch
+and worktree slots are subject to the full state machine.
+
+Worktree-class slots use a more aggressive WARM→COLD window (30 min instead of
+1 h) on the assumption that linked worktrees have higher churn and shorter
+useful lifetimes.
+
+A cold wake (COLD→HOT) is triggered by the first MCP query or dashboard HTTP
+request targeting the slot. The reload callback re-mmap's `graph.fb` by calling
+`daemonMCPCache.Get`; the measured cold-wake latency is ≤70 ms on a 108 MB
+graph and ≤121 ms on a 52 MB graph (#2137).
+
+Disk eviction (`COLD→EXPIRED`) deletes the `refs/<ref-safe>/` sub-directory for
+non-pinned slots when they pass the EXPIRED TTL. Freed bytes are logged (#2144).
+
+### .git/HEAD watching and ref-switch signalling
+
+The daemon's phase-B fsnotify watcher (ADR-0017 §Algorithm scheduling) was
+extended to watch `.git/HEAD` in addition to source files. A HEAD change event:
+
+1. Reads the new ref name via `gitmeta.Capture`.
+2. Marks the old slot as WARM (triggers the idle timer immediately).
+3. Triggers an incremental reindex for the new ref's slot. If the new ref has
+   never been indexed, the clone-from-parent optimisation is tried first (see
+   below). If clone fails or is not applicable, a full index runs (#2129).
+
+Git hooks (`post-checkout`, `post-merge`, `post-rewrite`) installed by
+`archigraph install-hooks` send an explicit signal to the daemon via the
+Unix-domain socket, providing a faster path than waiting for the fsnotify HEAD
+event. The hooks are idempotent and co-exist with husky / lefthook / pre-commit
+managed setups. The `pre-push` hook (existing) is retained unchanged (#2222).
+
+### Worktree auto-discovery
+
+At daemon startup and on every fsnotify cycle, the daemon calls
+`worktree.Discover(repoPath)` which runs `git worktree list --porcelain` and
+returns the set of linked worktrees for the primary checkout. Each discovered
+worktree is registered as an ephemeral child with its own `(path, ref)` slot.
+Worktree slots receive `SlotKindWorktree` in the tier manager, applying the
+aggressive eviction policy. Worktrees that are removed between two discovery
+cycles have their slots transitioned to COLD (#2138, watcher pause/resume #2139).
+
+### Clone-from-parent optimisation
+
+When a new ref has never been indexed (no `graph.fb` present), the daemon
+checks whether a close ancestor ref's graph can be seeded. If the diff between
+the ancestor and the new ref touches ≤ `ARCHIGRAPH_CLONE_MAX_FILES` files
+(default 20, hard cap 100), the optimisation:
+
+1. Copies the parent's `graph.fb` and side-cars to the new ref's store dir.
+2. Patches the metadata header (`indexed_ref`, `indexed_sha`, `computed_at`)
+   via a streaming read-modify-write (no in-place FlatBuffers mutation).
+3. Re-extracts only the changed files: removes stale entities/relationships,
+   runs the language extractor callback, merges new results.
+4. Persists the updated `graph.fb` atomically.
+
+Typical speedup on a 6 k-entity repo with 5 changed files: ~5 s → ~180 ms.
+If any precondition fails, the partially-built graph is removed and a full
+reindex runs (#2146).
+
+### CLI `--ref` flag
+
+The following CLI subcommands accept a `--ref <name>` flag to target a specific
+indexed ref instead of the current HEAD:
+
+```
+archigraph status   [--ref <name>]
+archigraph rebuild  [--ref <name>]
+archigraph index    [--ref <name>]
+archigraph list     [--ref <name>]
+archigraph doctor   [--ref <name>]
+archigraph remove   [--ref <name>]
+```
+
+`archigraph status` also accepts `--all-refs` to display all indexed refs for
+a group, with HOT/WARM/COLD tier annotation per slot (#2219).
+
+`archigraph branches` lists every indexed ref for a group, with tier, size-on-disk,
+last-indexed timestamp, and entity count (#2144).
+
+### Dashboard `?ref=` query parameter
+
+Six read-only API endpoints accept an optional `?ref=<name>` query parameter:
+
+```
+GET /api/groups/:g/stats?ref=<ref>
+GET /api/groups/:g/repos/:r/entities?ref=<ref>
+GET /api/groups/:g/repos/:r/relationships?ref=<ref>
+GET /api/groups/:g/repos/:r/cross-repo-edges?ref=<ref>
+GET /api/groups/:g/repos/:r/orphans?ref=<ref>
+GET /api/groups/:g/repos/:r/patterns?ref=<ref>
+GET /api/groups/:g/refs                  (listing; no ?ref=)
+```
+
+`?ref=` semantics:
+
+- Absent or `@current` → current HEAD ref (backward-compatible default).
+- `<name>` → that specific ref's graph (404 if not indexed).
+- `@all` → aggregate across all indexed refs for the repo/group.
+- Invalid → HTTP 400 `{"error": "invalid ref", "available": [...]}`.
+
+The topbar ref-selector (added in PH4, #2143) provides a UI dropdown that
+writes the `?ref=` param into the URL and persists the selection across
+navigation. Dashboard surfaces that read `?ref=` update automatically (#2220).
+
+### WebSocket ref-filtered subscription
+
+`WSEvent` now carries a `Ref` field. The server side evaluates per-connection
+subscription filters set by `subscribe` client→server messages; a client
+subscribed to `{group: "X", ref: "feature/foo"}` receives only events for that
+(group, ref) pair. Clients that send no subscription message continue to receive
+all events (firehose mode, backward-compatible default). The dashboard's
+connection manager subscribes to the active `?ref=` ref when one is selected
+(#2221).
+
+### Graph diff view
+
+`GET /api/v2/groups/:group/repos/:repo/diff?refA=<A>&refB=<B>` computes the
+structural diff between two indexed refs. The response lists added, removed, and
+modified entities and relationships, plus a summary counter block. Results are
+cached in a 10-entry in-process LRU keyed by `(group, repo, refA-sha, refB-sha)`
+(#2148).
+
+### Cross-repo link cache keying
+
+The cross-repo candidate pipeline cross-matches entities from repo A against
+repo B. With multi-ref indexing, this cache must be keyed by
+`(repoA, refA, repoB, refB)` — a 4-tuple — to avoid serving stale results
+after a ref switch. A secondary index maps `(repo, ref)` to affected cache
+entries for O(affected) invalidation on ref switch. `CrossLinkCache.InvalidateRepo(repo,
+oldRef)` is called by the daemon immediately after every successful ref switch
+detected via HEAD watch or git hook (#2224).
+
+### Embedding deduplication
+
+The content-hash dedupe cache introduced in ADR-0019 (Pass 9 / embeddings.bin)
+was extended in PH8 (#2158) to key by `(entity-content-hash, ref)` so that
+identical entities shared across branches (the common case for non-modified
+files) reuse the same embedding vector and skip the encoder entirely. This
+bounds the embedding re-encode cost on branch creation to only the files that
+actually differ.
+
+## Consequences
+
+### Positive
+
+- Branch switches are transparent to AI agents: the graph is correct for the
+  currently checked-out ref without any manual step.
+- Multi-branch PR review workflows become first-class: an agent can query two
+  refs and ask for the structural diff in a single session.
+- Linked worktrees are indexed automatically alongside the primary checkout.
+- Cold-wake latency is sub-100 ms for HOT → WARM transitions; ~1 s for a warm
+  reload from disk; ~5–10 s for a full cold reindex (mitigated by clone-from-parent
+  on small diffs).
+- The default-branch graph is always pinned HOT; there is no penalty for an
+  idle branch-feature switch back to `main`.
+
+### Negative / trade-offs
+
+- **Storage growth is linear in indexed branches.** Each `(repo, ref)` slot adds
+  one `graph.fb` (typically 5–25 MB per repo). The disk eviction policy (EXPIRED
+  TTL) bounds growth for long-lived feature branches that are no longer accessed.
+  Users can inspect and manually evict with `archigraph branches --evict <ref>`.
+- **Ref-switch latency window.** There is a brief window between a `git checkout`
+  and the daemon's HEAD watch firing where MCP queries land on the old ref's
+  graph. The git-hook path reduces this to near-zero when hooks are installed.
+- **Clone-from-parent is best-effort.** It is skipped when the ancestor diff
+  exceeds `ARCHIGRAPH_CLONE_MAX_FILES`, when the merge-base is too old (>7 days
+  by default), or when any step errors. The fallback is a full reindex.
+- **Worktree discovery requires `git worktree list`.** This is a subprocess call
+  at daemon startup and on each watcher cycle. On machines with hundreds of
+  registered repos this adds latency; the call is debounced alongside the
+  existing fsnotify debounce.
+
+### Migration
+
+Existing installs are migrated automatically at next daemon startup by
+`MigrateToRefStore`. No user action is required. The migration is idempotent and
+safe to interrupt — a partial migration leaves the old flat slot untouched, so
+the daemon can still serve from it on restart.
+
+## Alternatives considered
+
+**Single-ref-at-a-time (previous design).** The daemon indexed only the current
+HEAD and discarded the old ref's data on branch switch. Rejected: poor
+multi-branch UX — developers cannot query a feature branch while working on
+another branch, and PR review requires a manual `archigraph rebuild` step.
+
+**Ref-on-demand only (no background watch).** Index a ref only when an MCP query
+or CLI command explicitly targets it, with no background HEAD watching. Rejected:
+cold start on every branch switch; the install-and-forget contract requires that
+the graph is ready before the developer asks their first question on a branch.
+
+**Federated daemons (one daemon per branch).** Run a separate daemon process for
+each active ref. Rejected: too much complexity; process-level isolation multiplies
+socket, PID file, and MCP registration management by the number of active refs;
+memory is not shared across the daemon boundary, defeating the mmap-sharing
+benefit of ADR-0017.
+
+**Ref-indexed JSON store.** Keep `graph.json` as the canonical artifact (pre-ADR-0016)
+with a `refs/` sub-directory layout. Rejected: graph.json parse cost (130 ms /
+50 MB allocs per open on the 11 MB fixture) multiplied by ref count would
+dominate dashboard and MCP latency; ADR-0016's mmap'd FlatBuffers is the correct
+foundation for per-ref multi-reader access.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -21,6 +21,11 @@ decision itself, and the consequences we accepted.
 | [0013](0013-cross-file-import-aware-resolution.md) | Accepted | Cross-file import-aware resolution |
 | [0014](0014-corpus-expansion-strategy.md) | Accepted | Corpus expansion strategy — sample apps, not framework internals |
 | [0015](0015-residual-repair-agent-enrichment.md) | Proposed | Residual repair via agent-side enrichment |
+| [0016](0016-binary-graph-format.md) | Accepted | Binary graph format — FlatBuffers v2 |
+| [0017](0017-single-binary-daemon-architecture.md) | Accepted | Single-binary daemon architecture |
+| [0018](0018-agent-learned-patterns.md) | Accepted | Agent-learned patterns |
+| [0019](0019-semantic-embedding-search.md) | Accepted | Semantic embedding search via configurable backend + RRF fusion |
+| [0020](0020-multi-branch-worktree.md) | Accepted | Multi-branch and worktree graph snapshots |
 
 Numbers are append-only.
 

--- a/docs/user-guide/multi-branch.md
+++ b/docs/user-guide/multi-branch.md
@@ -1,0 +1,327 @@
+# Working with multiple branches in archigraph
+
+archigraph indexes one graph snapshot per `(repository, git ref)` pair. When
+you switch branches or use `git worktree`, the daemon detects the change,
+keeps the old graph in cache, and begins indexing the new ref — so your AI
+agent always queries the graph that matches the code it is looking at.
+
+This guide explains what the feature does, how to use it from the CLI, the
+dashboard, and MCP, and what to expect for storage and performance.
+
+---
+
+## How it works
+
+### Per-ref graph snapshots
+
+Each indexed `(repo, ref)` pair gets its own directory inside the archigraph
+store:
+
+```
+~/.archigraph/store/<repo-slug>/refs/<ref-safe>/graph.fb
+```
+
+`<ref-safe>` is the branch name with `/` replaced by `%2F` so that
+`feature/foo` stores as `feature%2Ffoo` on every OS. The store directory is
+determined by `StateDirForRepoRef` in `internal/daemon/state_path.go`.
+
+### Automatic ref tracking
+
+When you run:
+
+```sh
+git checkout feature/my-thing
+```
+
+…the daemon detects the HEAD change via its `.git/HEAD` watcher and
+automatically starts indexing `feature/my-thing`. The previous branch's graph
+stays in the cache during indexing, so you never have a gap.
+
+For faster detection, install the archigraph git hooks:
+
+```sh
+archigraph install-hooks
+```
+
+This adds `post-checkout`, `post-merge`, and `post-rewrite` hooks that signal
+the daemon immediately on branch switch, merge, or rebase — reducing the
+detection lag to near-zero.
+
+### HOT / WARM / COLD tiers
+
+archigraph keeps graphs in memory according to how recently they were used:
+
+| Tier    | Description                                                   |
+|---------|---------------------------------------------------------------|
+| HOT     | In RAM, graph.fb mmap'd. Instant queries.                    |
+| WARM    | In RAM, idle ≥5 min. Will be released soon.                  |
+| COLD    | On disk only. Auto-wakes in ≤100 ms on first query.          |
+| EXPIRED | Deleted from disk (non-pinned refs only, after long idle).   |
+
+The **default branch** (`main` / `master` / the branch set in
+`origin/HEAD`) is always pinned HOT and never evicted. Feature branches and
+worktree branches age through WARM → COLD → EXPIRED based on idle time.
+
+You can view the tier for every indexed ref:
+
+```sh
+archigraph branches              # lists all indexed refs with tier + stats
+archigraph branches --evict feature/old-branch   # force-evict a ref
+```
+
+---
+
+## CLI usage
+
+### Querying a specific ref
+
+Most read commands accept `--ref <name>`:
+
+```sh
+archigraph status --ref feature/my-thing        # status for that ref's graph
+archigraph index  --ref feature/my-thing        # force reindex that ref
+archigraph doctor --ref feature/my-thing        # health check for that ref
+archigraph remove --ref feature/my-thing        # delete that ref's snapshot
+```
+
+### Listing all indexed refs
+
+```sh
+archigraph branches                        # all indexed refs for all groups
+archigraph status --all-refs               # per-group status for every ref
+```
+
+Example output:
+
+```
+Group: my-api
+  main              HOT    23.4 MB   indexed 2 min ago   1 243 entities
+  feature/auth      WARM   24.1 MB   indexed 18 min ago  1 289 entities
+  hotfix/login-bug  COLD   23.5 MB   indexed 3 h ago     1 243 entities
+```
+
+### Forcing a reindex on branch switch
+
+The daemon reindexes automatically, but if you want to trigger it immediately:
+
+```sh
+archigraph rebuild --ref feature/my-thing
+```
+
+---
+
+## Dashboard usage
+
+### Switching refs in the UI
+
+The topbar in the dashboard contains a **ref selector** (labelled with the
+currently-active ref name). Click it to open a dropdown listing every indexed
+ref for the current group. Selecting a ref appends `?ref=<name>` to the URL
+and updates all dashboard surfaces (Graph, Paths, Topology, Flows, Quality,
+Pending) to show data for that ref.
+
+The selected ref persists across navigation within the group — navigate from
+Graph to Paths and back, the ref stays the same.
+
+To return to the current HEAD view, select **@current** from the dropdown or
+clear the `?ref=` parameter from the URL.
+
+### Comparing two refs (graph diff)
+
+Navigate to the **Graph** surface and click **Compare refs** in the toolbar.
+Select two refs and click **Compare**. The diff view shows:
+
+- Entities added, removed, or structurally modified between the two refs.
+- Relationships added or removed.
+- A summary counter (`+N entities / -M entities / ~K modified`).
+
+The underlying API endpoint is:
+
+```
+GET /api/v2/groups/:group/repos/:repo/diff?refA=main&refB=feature%2Fmy-thing
+```
+
+---
+
+## MCP / agent usage
+
+### How refs work in MCP queries
+
+The MCP server resolves the correct ref from the caller's current working
+directory. When an agent runs inside a repo that has `feature/my-thing`
+checked out (or inside a linked worktree for that branch), all
+`archigraph_*` tool calls automatically target the `feature/my-thing`
+graph. No flag or parameter is needed.
+
+To explicitly target a ref, pass `ref` in the tool arguments (supported by
+all graph-query tools):
+
+```json
+{
+  "tool": "archigraph_find",
+  "arguments": {
+    "query": "authentication handler",
+    "ref": "feature/auth"
+  }
+}
+```
+
+If the requested ref is COLD, the daemon wakes it automatically (≤100 ms).
+If it has never been indexed, the daemon returns a `ref_not_indexed` error
+with a list of available refs.
+
+### Cross-ref queries
+
+An agent can ask for the structural diff between two refs in a single call:
+
+```json
+{
+  "tool": "archigraph_diff",
+  "arguments": {
+    "repo": "my-repo",
+    "ref_a": "main",
+    "ref_b": "feature/auth"
+  }
+}
+```
+
+This is useful for PR review workflows: the agent can check what changed
+structurally before looking at the line-level diff.
+
+---
+
+## Git worktree workflows
+
+`git worktree add` creates a parallel checkout at a secondary path. archigraph
+detects linked worktrees automatically at daemon startup and on each watcher
+cycle via `git worktree list --porcelain`. Each discovered worktree is
+registered as a separate `(path, ref)` slot and indexed like any other branch.
+
+```sh
+# Create a worktree for a hotfix while staying on main
+git worktree add ../my-repo-hotfix hotfix/login-bug
+
+# The daemon detects the new worktree and begins indexing it.
+# You can confirm:
+archigraph branches
+#   main              HOT    23.4 MB   ...
+#   hotfix/login-bug  HOT    23.5 MB   indexing (42%)...
+```
+
+When you remove a worktree (`git worktree remove`), the daemon transitions the
+slot to COLD on the next discovery cycle and eventually evicts it (EXPIRED).
+
+Worktree slots use a more aggressive eviction schedule — WARM→COLD at 30 min
+instead of 1 h — because linked worktrees tend to be short-lived.
+
+---
+
+## Storage growth and eviction
+
+### How much storage does multi-branch indexing use?
+
+Each `(repo, ref)` slot stores one `graph.fb` file. Typical sizes:
+
+| Repo size  | graph.fb    |
+|------------|-------------|
+| Small (~500 entities)   | 1–3 MB   |
+| Medium (~5 k entities)  | 5–15 MB  |
+| Large (~50 k entities)  | 30–80 MB |
+
+If you have 5 indexed branches on a medium repo, expect 25–75 MB of extra
+store usage. The default-branch snapshot is always kept; the oldest
+non-default refs are evicted first.
+
+### Tuning the eviction schedule
+
+The tier TTLs are controlled by environment variables (set them in your shell
+profile or before starting the daemon):
+
+| Variable                             | Default | Effect                               |
+|--------------------------------------|---------|--------------------------------------|
+| `ARCHIGRAPH_TIER_HOT_TO_WARM_MIN`    | 5       | Minutes idle before HOT → WARM       |
+| `ARCHIGRAPH_TIER_WARM_TO_COLD_MIN`   | 60      | Minutes idle before WARM → COLD      |
+| `ARCHIGRAPH_TIER_COLD_TO_EXPIRED_H`  | 168     | Hours idle before COLD → EXPIRED (disk delete) |
+
+Setting `ARCHIGRAPH_TIER_COLD_TO_EXPIRED_H=0` disables disk eviction entirely
+(refs are kept on disk forever until manually removed).
+
+### Manually inspecting and evicting refs
+
+```sh
+# Show all indexed refs with size + tier
+archigraph branches
+
+# Evict (delete from disk) a specific ref
+archigraph branches --evict feature/old-branch
+
+# Remove all non-default refs for a group
+archigraph branches --evict-all --group my-api
+```
+
+---
+
+## Cache invalidation on cross-repo links
+
+When your group contains multiple repos, archigraph builds cross-repo links
+(import chains, shared type references, HTTP call graphs) between them.
+With multi-ref indexing, these links are keyed by `(repoA, refA, repoB,
+refB)`. When you switch a ref in any member repo, the daemon automatically
+invalidates the cache entries that involve that `(repo, old-ref)` pair.
+The next cross-repo query recomputes the links from the new ref's graph.
+
+No user action is required. The invalidation is synchronous — a query that
+races with a ref switch will find a cache miss and wait for the recompute
+rather than serving stale data.
+
+---
+
+## Troubleshooting
+
+**"ref not indexed" error in MCP**
+
+The ref you requested has never been indexed. Run:
+
+```sh
+archigraph index --ref feature/my-thing
+```
+
+Or wait for the daemon's background HEAD watcher to pick it up after the next
+`git checkout`.
+
+**Graph looks stale after branch switch**
+
+If the git hooks are not installed, the daemon relies on the fsnotify HEAD
+watcher, which has a short delay. Install the hooks for instant detection:
+
+```sh
+archigraph install-hooks
+```
+
+Check that the hooks were installed successfully:
+
+```sh
+archigraph doctor
+# Should show: git-hooks: post-checkout ✓  post-merge ✓  post-rewrite ✓
+```
+
+**Branches command shows an unexpected ref**
+
+Detached HEAD checkouts appear as the abbreviated commit SHA (e.g.
+`abc1234`). The daemon indexes them as a normal ref and evicts them following
+the same TTL schedule as feature branches.
+
+**Too much disk space used**
+
+Lower `ARCHIGRAPH_TIER_COLD_TO_EXPIRED_H` to evict stale refs sooner, or
+manually evict with `archigraph branches --evict-all`. The default-branch
+snapshot is never evicted regardless of this setting.
+
+---
+
+## See also
+
+- [ADR-0020](../adrs/0020-multi-branch-worktree.md) — architectural record for the multi-branch + worktree design
+- [ADR-0017](../adrs/0017-single-binary-daemon-architecture.md) — daemon architecture (tiered hibernation foundations)
+- [ADR-0016](../adrs/0016-binary-graph-format.md) — FlatBuffers graph format (the on-disk format for per-ref snapshots)
+- [SSE endpoints](../sse-endpoints.md) — real-time event stream; `WSEvent.Ref` carries the ref for filtering

--- a/skills/archigraph-aware-review/SKILL.md
+++ b/skills/archigraph-aware-review/SKILL.md
@@ -629,4 +629,9 @@ immediately via `archigraph_inspect` without re-running the trace.
 - ADR-0009 — Cross-repo ID namespacing.
 - ADR-0015 — Residual-edge repair flow.
 - ADR-0018 — Agent-learned pattern store.
+- ADR-0020 — Multi-branch + worktree graph snapshots. When reviewing a PR that
+  is not yet merged, the branch's graph may already be indexed; use
+  `archigraph_diff(ref_a="main", ref_b="feature/...")` to get a structural
+  summary before examining the line-level diff. See also
+  [docs/user-guide/multi-branch.md](../../docs/user-guide/multi-branch.md).
 - Issue #1269 — tracking issue for this skill.

--- a/skills/using-archigraph/SKILL.md
+++ b/skills/using-archigraph/SKILL.md
@@ -660,3 +660,6 @@ group — provide `group=` explicitly or navigate to a registered repo.
 - ADR-0009 — Cross-repo ID namespacing (`<repo>::<localId>`)
 - ADR-0015 — Residual-edge repair flow
 - ADR-0018 — Agent-learned pattern store
+- ADR-0020 — Multi-branch + worktree support. The MCP server automatically
+  resolves the ref from the agent's CWD; pass `ref=` explicitly to target a
+  specific branch. See [docs/user-guide/multi-branch.md](../../docs/user-guide/multi-branch.md).


### PR DESCRIPTION
Closes #2225. Refs #2098.

## Summary

- **`docs/adrs/0020-multi-branch-worktree.md`** — new ADR documenting the per-ref graph snapshot design, HOT/WARM/COLD/EXPIRED tier state machine, \`.git/HEAD\` watching + git hooks, worktree auto-discovery, clone-from-parent optimisation, CLI \`--ref\` flags, dashboard \`?ref=\` query, WebSocket ref-filtered subscriptions, graph diff view, cross-repo link cache keying, and embedding deduplication. Alternatives considered section covers the four rejected approaches. Shipped-in list traces all 17 PRs (#2126–#2224).
- **\`docs/user-guide/multi-branch.md\`** — new user-facing guide with concrete examples for CLI (\`--ref\`, \`archigraph branches\`), dashboard ref selector + graph diff view, MCP \`ref=\` parameter, git worktree workflows, storage growth + tier tuning, and a troubleshooting section.
- **\`README.md\`** — "Multi-branch support" bullet added to What's new; \`--ref\`, \`archigraph branches\`, and \`archigraph install-hooks\` added to the CLI command table.
- **\`docs/adrs/README.md\`** — rows 0016–0020 added (the table was missing them since ADR-0015).
- **\`skills/archigraph-aware-review/SKILL.md\`** — ADR-0020 cross-reference in References with \`archigraph_diff\` PR-review usage note.
- **\`skills/using-archigraph/SKILL.md\`** — ADR-0020 cross-reference in References with CWD-based ref resolution note.

## Test plan

- [ ] Read \`docs/adrs/0020-multi-branch-worktree.md\` — verify all PR/issue references are accurate against the commit log
- [ ] Read \`docs/user-guide/multi-branch.md\` — verify CLI commands match actual command surface (\`archigraph branches\`, \`--ref\`, \`--all-refs\`)
- [ ] Confirm README renders correctly on GitHub (no broken markdown)
- [ ] Confirm \`docs/adrs/README.md\` table links resolve

No Go code changes. CI full run not required (\`board:exempt\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>