### PR TITLE
fix(mcp): sentinel tool emits valid inputSchema (closes #2257)

### DIFF
--- a/internal/mcp/cwd_gate_test.go
+++ b/internal/mcp/cwd_gate_test.go
@@ -11,6 +11,7 @@ package mcp
 //   - archigraph_status call from no-match cwd → expected guidance text.
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,5 +269,90 @@ func TestListToolsForCWD_MCPToolListArgs_CWDForwarded(t *testing.T) {
 	}
 	if entry.Name != sentinelToolName {
 		t.Errorf("MCPToolEntry name: %q", entry.Name)
+	}
+}
+
+// TestSentinelTool_HasValidInputSchema — sentinel tool must include a valid
+// JSON Schema inputSchema so strict MCP clients (Claude Code Zod validation)
+// do not reject the tools/list response (#2257).
+func TestSentinelTool_HasValidInputSchema(t *testing.T) {
+	srv := makeTestServer(t, map[string]map[string]string{})
+
+	entries, err := srv.ListToolsForCWD("/tmp")
+	if err != nil {
+		t.Fatalf("ListToolsForCWD: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != sentinelToolName {
+		t.Fatalf("expected only sentinel tool, got %v", toolNames(entries))
+	}
+
+	sentinel := entries[0]
+	if sentinel.InputSchema == nil {
+		t.Fatal("sentinel tool InputSchema is nil — strict MCP clients will reject this")
+	}
+
+	var schema map[string]json.RawMessage
+	if err := json.Unmarshal(sentinel.InputSchema, &schema); err != nil {
+		t.Fatalf("sentinel InputSchema is not valid JSON: %v — raw: %s", err, sentinel.InputSchema)
+	}
+
+	typeRaw, ok := schema["type"]
+	if !ok {
+		t.Fatal("sentinel InputSchema missing required 'type' field")
+	}
+	var typStr string
+	if err := json.Unmarshal(typeRaw, &typStr); err != nil || typStr != "object" {
+		t.Fatalf("sentinel InputSchema 'type' must be \"object\", got: %s", typeRaw)
+	}
+
+	if _, ok := schema["properties"]; !ok {
+		t.Fatal("sentinel InputSchema missing required 'properties' field")
+	}
+}
+
+// TestAllRegisteredTools_HaveValidInputSchema — every tool returned by
+// fullToolList must carry a non-nil inputSchema with type=object. This guards
+// against regressions in both the full-list path and any future tool addition
+// that forgets to set up a schema (#2257).
+func TestAllRegisteredTools_HaveValidInputSchema(t *testing.T) {
+	repoDir := t.TempDir()
+	srv := makeTestServer(t, map[string]map[string]string{
+		"testgroup": {"testrepo": repoDir},
+	})
+
+	entries, err := srv.ListToolsForCWD(repoDir)
+	if err != nil {
+		t.Fatalf("ListToolsForCWD: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one tool in the full list")
+	}
+
+	for _, e := range entries {
+		if e.Name == sentinelToolName {
+			t.Errorf("sentinel must not appear in full tool list")
+			continue
+		}
+		if e.InputSchema == nil {
+			t.Errorf("tool %q: InputSchema is nil — strict MCP clients will reject this", e.Name)
+			continue
+		}
+		var schema map[string]json.RawMessage
+		if err := json.Unmarshal(e.InputSchema, &schema); err != nil {
+			t.Errorf("tool %q: InputSchema is not valid JSON: %v", e.Name, err)
+			continue
+		}
+		typeRaw, ok := schema["type"]
+		if !ok {
+			t.Errorf("tool %q: InputSchema missing 'type' field", e.Name)
+			continue
+		}
+		var typStr string
+		if err := json.Unmarshal(typeRaw, &typStr); err != nil || typStr != "object" {
+			t.Errorf("tool %q: InputSchema 'type' must be \"object\", got: %s", e.Name, typeRaw)
+		}
+		if _, ok := schema["properties"]; !ok {
+			t.Errorf("tool %q: InputSchema missing 'properties' field", e.Name)
+		}
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -180,6 +180,12 @@ func (s *Server) ListToolsForCWD(cwd string) ([]MCPToolEntry, error) {
 	return s.fullToolList()
 }
 
+// sentinelEmptyInputSchema is the canonical MCP-compliant inputSchema for a
+// no-argument tool. Strict MCP clients (e.g. Claude Code with Zod validation)
+// reject a tool whose tools/list entry omits "inputSchema" entirely (#2257).
+// We pre-marshal this once to avoid repeated allocations on every list call.
+var sentinelEmptyInputSchema = json.RawMessage(`{"type":"object","properties":{},"required":[]}`)
+
 // sentinelToolList returns the single archigraph_status sentinel entry with a
 // context-aware description based on cwd, the (empty) group, and nearby groups.
 func (s *Server) sentinelToolList(cwd, group string, groupEmpty bool) []MCPToolEntry {
@@ -191,6 +197,7 @@ func (s *Server) sentinelToolList(cwd, group string, groupEmpty bool) []MCPToolE
 		{
 			Name:        sentinelToolName,
 			Description: desc,
+			InputSchema: sentinelEmptyInputSchema,
 		},
 	}
 }


### PR DESCRIPTION
Closes #2257.

## Summary

- `sentinelToolList` was returning `MCPToolEntry` with `InputSchema: nil`. Both `MCPToolInfo` and `mcpToolInfo` use `json:"inputSchema,omitempty"`, so nil was silently dropped from the wire JSON.
- Strict MCP clients (Claude Code with Zod validation) require `inputSchema` to be a valid JSON Schema object — its absence caused the `tools/list` response to be rejected, breaking every brand-new Claude Code session opened in a non-registered folder.
- Fix: populate `InputSchema` with the canonical empty JSON Schema `{"type":"object","properties":{},"required":[]}` in `sentinelToolList`. The value is pre-marshaled once into a package-level var (`sentinelEmptyInputSchema`) to avoid repeated allocations.

## Before / After (non-registered folder)

**BEFORE** — `inputSchema` key missing entirely:
\`\`\`json
{"name":"archigraph_status","description":"Archigraph: no indexed group covers cwd. Run install or cd to a repo."}
\`\`\`

**AFTER** — `inputSchema` present and valid:
\`\`\`json
{"name":"archigraph_status","description":"Archigraph: no indexed group covers cwd. Run install or cd to a repo.","inputSchema":{"type":"object","properties":{},"required":[]}}
\`\`\`

## Tests added

- `TestSentinelTool_HasValidInputSchema` — asserts the sentinel entry has a non-nil `inputSchema` with `type == "object"` and a `properties` field present.
- `TestAllRegisteredTools_HaveValidInputSchema` — walks the full tool list and asserts every registered tool carries a valid `inputSchema`, guarding against future regressions.

All existing `TestListToolsForCWD_*` tests continue to pass. `go test ./internal/mcp/...` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>