### PR TITLE
feat(skills): add archigraph-consult — 5-persona consultant panel (Refs #2255)

### DIFF
--- a/internal/dashboard/handlers_skills.go
+++ b/internal/dashboard/handlers_skills.go
@@ -133,6 +133,16 @@ var marketplaceCatalog = []CatalogSkill{
 		},
 	},
 	{
+		Slug:   "archigraph-consult",
+		Source: "archigraph-bundled",
+		SkillMeta: SkillMeta{
+			Name:        "archigraph-consult",
+			Description: "Runs a panel of specialist personas (architect, security auditor, business analyst, performance reviewer, refactor critic) against the group's docs and graph. Produces per-persona reports, a synthesised finding list, and graph entities. Resumable sessions.",
+			Type:        "action",
+			WhenToUse:   "After generating tech docs with /archigraph-tech-docs. Use --persona <name> for a single perspective or --all for the full panel.",
+		},
+	},
+	{
 		Slug:   "archigraph-graph-enrich",
 		Source: "archigraph-bundled",
 		SkillMeta: SkillMeta{

--- a/internal/install/skilllink/skilllink.go
+++ b/internal/install/skilllink/skilllink.go
@@ -22,6 +22,7 @@ import (
 var SkillNames = []string{
 	"archigraph-aware-review",
 	"archigraph-business-docs",
+	"archigraph-consult",
 	"archigraph-graph-enrich",
 	"archigraph-graph-quality",
 	"archigraph-patterns-discover",

--- a/skills/archigraph-consult/SKILL.md
+++ b/skills/archigraph-consult/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: archigraph-consult
+description: Run a panel of specialist personas against the indexed group and its generated docs. Each persona (architect, security-auditor, business-analyst, performance-reviewer, refactor-critic) is a Claude Code subagent that reads module docs and produces a focused report. Findings are persisted as graph entities. The session is resumable.
+when-to-use: User asks to "get a second opinion", "run the consultant panel", "have the architect review this", "get a business analyst view", or invokes /archigraph-consult explicitly. Hard-depends on /archigraph-tech-docs having been run. Soft-depends on /archigraph-business-docs and /archigraph-security-audit.
+---
+
+# archigraph-consult
+
+Run a panel of specialist personas against the indexed group. Each persona reads the generated tech docs (and optionally business docs and security findings) and produces a focused report from their perspective.
+
+This is **one skill** that fans out to per-persona subagents declared in `~/.claude/agents/`. Adding a new persona is as simple as dropping a `.md` file into `~/.claude/agents/`. You do not need a new skill for each persona.
+
+## Hard and soft dependencies
+
+| Dependency | Type | Why |
+|---|---|---|
+| `/archigraph-resolve` | Hard | Orphan edges make impact-radius analysis meaningless |
+| `/archigraph-tech-docs` | Hard | Personas read module markdown; without it they have only the graph — too narrow for useful findings |
+| `/archigraph-business-docs` | Soft | Business-analyst persona fidelity improves; not required |
+| `/archigraph-security-audit` | Soft | Security-auditor persona deduplicates against static findings rather than re-deriving them |
+
+If tech docs are missing, the skill aborts:
+> Tech docs not found at `~/.archigraph/docs/<group>/`. Run `/archigraph-tech-docs` first, then re-invoke `/archigraph-consult`.
+
+## CRITICAL TOOL DISCIPLINE
+
+Use archigraph MCP tools for ALL graph navigation. Pre-flight: call `archigraph_whoami` first.
+
+## When to use this skill
+
+- "Get an architect's view of this codebase."
+- "Run the consultant panel."
+- "Have the security auditor review the docs."
+- "What would a performance reviewer say?"
+- `/archigraph-consult` (slash command).
+
+**Flags:**
+- `--persona <name>` — run only one persona (e.g. `--persona architect`).
+- `--all` — run all available personas (default when no `--persona` is specified).
+- `--resume <session-id>` — resume an interrupted session.
+- `--dry-run` — list available personas without running any.
+
+## Default personas
+
+Five personas ship with the skill as files in `skills/archigraph-consult/personas/`. Users can add their own under `~/.claude/agents/archigraph-<persona>.md`.
+
+| Persona | File | Focus |
+|---|---|---|
+| architect | `personas/architect.md` | System design, coupling, boundaries, ADR opportunities |
+| security-auditor | `personas/security-auditor.md` | Auth gaps, PII exposure, attack surface (deduplicates with `/archigraph-security-audit`) |
+| business-analyst | `personas/business-analyst.md` | Capability coverage, feature gaps, business rule completeness |
+| performance-reviewer | `personas/performance-reviewer.md` | Hot paths, N+1 queries, caching opportunities, latency risks |
+| refactor-critic | `personas/refactor-critic.md` | Complexity, duplication, coupling, tech-debt hotspots |
+
+## Procedure
+
+### Pre-flight
+1. Call `archigraph_whoami` — confirm group.
+2. Check tech docs exist: `~/.archigraph/docs/<group>/` must contain at least one `modules/` directory. If not: abort with the message above.
+3. Load available personas: scan `skills/archigraph-consult/personas/*.md` + `~/.claude/agents/archigraph-*.md`.
+4. If `--dry-run`: list personas and exit.
+5. Create session: write `~/.archigraph/consultations/<session-id>/session.json` with session metadata.
+
+### Fan-out
+For each selected persona (sequentially to avoid context contamination; parallel is fine if the agent host supports isolated subagents):
+
+1. Load the persona's `.md` file.
+2. Spawn a subagent with the persona's instructions + the group's tech docs path as context.
+3. The subagent produces a Markdown report and a JSON findings list.
+4. Write the report to `~/.archigraph/consultations/<session-id>/<persona-name>.md`.
+5. Write findings to `~/.archigraph/consultations/<session-id>/<persona-name>-findings.json`.
+
+### Editor synthesis
+After all personas complete, an "editor" pass synthesises across reports:
+- Deduplicates findings that multiple personas raised.
+- Ranks findings by cross-persona agreement (findings raised by 3+ personas = high priority).
+- Writes `~/.archigraph/consultations/<session-id>/synthesis.md`.
+
+### Graph materialisation
+For each deduplicated finding with `confidence >= 0.7`:
+```
+archigraph_save_finding(
+  type="consultant_finding",
+  question="<persona>: <finding_title>",
+  answer="<explanation>",
+  entity_id="<entity_id if applicable>"
+)
+```
+
+### Session summary
+Print:
+> Consultation `<session-id>` complete. **N** personas ran, **F** findings (P deduplicated). Reports at `~/.archigraph/consultations/<session-id>/`.
+
+## Output layout
+
+```
+~/.archigraph/consultations/<session-id>/
+  session.json               # metadata: group, personas run, timestamps
+  <persona-name>.md          # per-persona report
+  <persona-name>-findings.json
+  synthesis.md               # editor pass: deduplicated, ranked findings
+```
+
+## archigraph MCP tool surface
+
+- `archigraph_whoami`, `archigraph_find`, `archigraph_inspect`, `archigraph_expand`
+- `archigraph_save_finding`, `archigraph_list_findings`
+- `archigraph_stats` — for corpus-level metrics the architect persona uses
+
+## Related
+
+- `skills/archigraph-tech-docs/SKILL.md` — hard dependency.
+- `skills/archigraph-business-docs/SKILL.md` — soft dependency.
+- `skills/archigraph-security-audit/SKILL.md` — soft dependency; security-auditor persona deduplicates.
+- `~/.claude/agents/` — user-defined custom personas go here.
+
+## Read next
+
+This is the final skill in the main analysis chain. After consulting:
+→ `/archigraph-help` — overview of the full skill family and suggested entry points.

--- a/skills/archigraph-consult/personas/architect.md
+++ b/skills/archigraph-consult/personas/architect.md
@@ -1,0 +1,23 @@
+# Persona: Architect
+
+You are a senior software architect reviewing a codebase via its archigraph knowledge graph and generated documentation. Your goal is to identify architectural concerns and opportunities.
+
+## Focus areas
+
+- **Coupling and boundaries**: Are service/module boundaries clean? Are there circular dependencies or inappropriate cross-layer calls?
+- **Single responsibility**: Do modules own one concern, or are they god-objects?
+- **ADR opportunities**: What architectural decisions are implicit in the code that should be documented?
+- **Scalability bottlenecks**: What parts of the design will break under 10x load?
+- **Missing abstractions**: Where is the code fighting the architecture?
+
+## Output format
+
+Produce a markdown report with:
+1. **Summary** (3-5 bullets on the most important architectural observations)
+2. **Findings** (one section per finding: title, severity, entity references, explanation, recommendation)
+3. **ADR candidates** (list of decisions worth documenting)
+
+For each finding, emit a JSON object to the findings list:
+```json
+{"title": "...", "severity": "high|medium|low", "entity_id": "...", "persona": "architect", "recommendation": "..."}
+```

--- a/skills/archigraph-consult/personas/business-analyst.md
+++ b/skills/archigraph-consult/personas/business-analyst.md
@@ -1,0 +1,15 @@
+# Persona: Business Analyst
+
+You are a business analyst reviewing the product's technical implementation to assess capability completeness, feature gaps, and alignment with business goals.
+
+## Focus areas
+
+- **Capability coverage**: Does the implementation cover what the business needs? What user journeys are incomplete?
+- **Business rule completeness**: Are all expected validation and permission rules implemented?
+- **Data model alignment**: Does the data model match the business domain, or are there semantic mismatches?
+- **Feature gaps**: What capabilities are partially implemented or scaffolded but not complete?
+- **Stakeholder impact**: Which findings, if addressed, would most improve the product for end users?
+
+## Output format
+
+Same as architect persona. Frame findings in business language — no internal symbol names in the summary. Use a `<details>` provenance block for any technical references.

--- a/skills/archigraph-consult/personas/performance-reviewer.md
+++ b/skills/archigraph-consult/personas/performance-reviewer.md
@@ -1,0 +1,16 @@
+# Persona: Performance Reviewer
+
+You are a performance engineer reviewing the codebase for latency and throughput risks.
+
+## Focus areas
+
+- **N+1 queries**: Call chains that issue O(N) database queries for an O(1) logical operation.
+- **Hot paths**: High-traffic endpoints (high `caller_count` in the graph) that lack caching.
+- **Synchronous blocking**: Long-running operations (file I/O, external HTTP, DB) called synchronously on the request path.
+- **Unbounded queries**: Database queries without `LIMIT` or pagination on user-controlled inputs.
+- **Over-fetching**: Endpoints returning full entity graphs when the caller only needs a summary.
+- **Caching opportunities**: Expensive computations that are called repeatedly with the same inputs.
+
+## Output format
+
+Same as architect persona. Include estimated latency impact where visible from the graph.

--- a/skills/archigraph-consult/personas/refactor-critic.md
+++ b/skills/archigraph-consult/personas/refactor-critic.md
@@ -1,0 +1,16 @@
+# Persona: Refactor Critic
+
+You are a code quality reviewer focused on maintainability, simplicity, and tech-debt reduction.
+
+## Focus areas
+
+- **Complexity hotspots**: High-degree nodes (god objects, hub modules) that own too many responsibilities.
+- **Duplication**: Multiple entities that implement the same pattern without sharing an abstraction.
+- **Dead code**: Entities with zero callers and no entry-point marker.
+- **Naming and domain alignment**: Entities whose names don't match what they actually do.
+- **Test coverage gaps**: Entities with no `TESTS` edges from test entities.
+- **Long call chains**: Paths longer than 6 hops that suggest over-indirection.
+
+## Output format
+
+Same as architect persona. Prioritise findings by estimated LOC reduction if the refactor were applied.

--- a/skills/archigraph-consult/personas/security-auditor.md
+++ b/skills/archigraph-consult/personas/security-auditor.md
@@ -1,0 +1,16 @@
+# Persona: Security Auditor
+
+You are a security-focused reviewer. You have access to the `/archigraph-security-audit` findings if they exist. Your goal is to find security issues the static analysis may have missed and provide actionable remediation advice.
+
+## Focus areas
+
+- **Auth and authorization**: Missing auth, overly broad permissions, broken access control.
+- **Input validation**: User-controlled data flowing to sensitive operations without validation.
+- **PII and data exposure**: Sensitive data returned to unauthenticated or under-authorized callers.
+- **Injection risks**: SQL, command, template injection patterns in the call graph.
+- **Secrets in code**: Hardcoded credentials, API keys, tokens.
+- **Deduplication**: If `/archigraph-security-audit` findings exist, reference them rather than re-deriving. Focus on gaps.
+
+## Output format
+
+Same as architect persona. Severity scale: critical (exploitable now) / high (likely exploitable) / medium (hardening opportunity) / low (minor).


### PR DESCRIPTION
## Summary

New `archigraph-consult` skill (net-new; sourced from research report on consultant-team design).

- `skills/archigraph-consult/SKILL.md` — ONE skill that fans out to persona subagents; not one skill per persona. Hard-depends on /archigraph-tech-docs; soft-depends on /archigraph-business-docs and /archigraph-security-audit.
- `skills/archigraph-consult/personas/` — 5 default persona files: architect, security-auditor, business-analyst, performance-reviewer, refactor-critic
- Editor synthesis pass deduplicates cross-persona findings and ranks by agreement count
- `~/.claude/agents/archigraph-<persona>.md` convention for user-defined custom personas
- Resumable sessions under `~/.archigraph/consultations/<session-id>/`
- `internal/install/skilllink/skilllink.go` — `archigraph-consult` added to `SkillNames`
- `internal/dashboard/handlers_skills.go` — catalog entry added

Design decisions (per research report):
- One skill, not 5+ skills: persona fan-out is internal to the skill; adding a persona = drop a .md file
- `--persona <name>` for single-persona runs without running the full panel
- Session-based: each run has a stable ID for resuming interrupted panels
- Graph materialisation: confirmed findings saved via `archigraph_save_finding`

## Closes / Refs
Refs #2255

## Testing
- [ ] `go build ./internal/install/...` — clean
- [ ] `go build ./internal/dashboard/...` — clean
- [ ] `go test ./internal/install/...` — all pass