### PR TITLE
fix(tests): drive skill-link tests from live SkillNames slice (no more drift)

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/install/skilllink"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
@@ -507,14 +508,8 @@ func TestInstallSkillsInClaudeConfigs(t *testing.T) {
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	skillNames := []string{
-		"archigraph-quality-check",
-		"archigraph-patterns-discover",
-		"archigraph-patterns-sync",
-		"archigraph-repair",
-		"extend-convention",
-		"using-archigraph",
-	}
+	// Use the live canonical slice so adding a new skill never breaks this test.
+	skillNames := skilllink.SkillNames
 	for _, skillName := range skillNames {
 		skillPath := filepath.Join(skillsDir, skillName)
 		if err := os.MkdirAll(skillPath, 0o755); err != nil {
@@ -597,7 +592,8 @@ func TestInstallSkillsIdempotent(t *testing.T) {
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	skillNames := []string{"archigraph-quality-check", "archigraph-repair"}
+	// Use the live canonical slice so adding a new skill never breaks this test.
+	skillNames := skilllink.SkillNames
 	for _, skillName := range skillNames {
 		if err := os.MkdirAll(filepath.Join(skillsDir, skillName), 0o755); err != nil {
 			t.Fatal(err)
@@ -655,7 +651,8 @@ func TestRemoveSkillsFromClaudeConfigs(t *testing.T) {
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	skillNames := []string{"archigraph-quality-check", "archigraph-repair"}
+	// Use the live canonical slice so adding a new skill never breaks this test.
+	skillNames := skilllink.SkillNames
 	for _, skillName := range skillNames {
 		if err := os.MkdirAll(filepath.Join(skillsDir, skillName), 0o755); err != nil {
 			t.Fatal(err)

--- a/internal/install/copy_test.go
+++ b/internal/install/copy_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/install"
+	"github.com/cajasmota/archigraph/internal/install/skilllink"
 )
 
 // TestRunCopy_HappyPath verifies the complete COPY-mode install transaction:
@@ -254,9 +255,10 @@ func newTestEnv(t *testing.T) *testEnv {
 		t.Fatalf("create fake bin: %v", err)
 	}
 
-	// Create a fake skills source dir with two skills from the canonical list.
+	// Create a fake skills source dir populated with every canonical skill name
+	// so the fixture stays in sync with skilllink.SkillNames automatically.
 	skillsSourceDir := filepath.Join(tmp, "skills")
-	for _, name := range []string{"archigraph-repair", "archigraph-quality-check"} {
+	for _, name := range skilllink.SkillNames {
 		skillDir := filepath.Join(skillsSourceDir, name)
 		if err := os.MkdirAll(skillDir, 0o755); err != nil {
 			t.Fatalf("create skill dir %s: %v", name, err)

--- a/internal/install/uninstall_test.go
+++ b/internal/install/uninstall_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/install"
+	"github.com/cajasmota/archigraph/internal/install/skilllink"
 )
 
 // TestRunUninstall_HappyPath verifies the full uninstall flow:
@@ -30,9 +31,9 @@ func TestRunUninstall_HappyPath(t *testing.T) {
 		t.Fatalf("RunCopy: %v", err)
 	}
 
-	// Confirm skills are present.
+	// Confirm skills are present (check all canonical skills).
 	destSkillsDir := filepath.Join(filepath.Dir(env.claudeJSON), "skills")
-	for _, name := range []string{"archigraph-repair", "archigraph-quality-check"} {
+	for _, name := range skilllink.SkillNames {
 		dst := filepath.Join(destSkillsDir, name)
 		if _, err := os.Stat(dst); err != nil {
 			t.Fatalf("skill %s should exist before uninstall: %v", name, err)


### PR DESCRIPTION
## Summary

- Test fixtures in \`copy_test.go\`, \`uninstall_test.go\`, and \`cli_test.go\` used hardcoded skill-name lists that fell out of sync when new skills were added via PRs #2261–#2268.
- All three files now reference \`skilllink.SkillNames\` directly, so fixture dirs are populated programmatically from the single source of truth.
- Adding a new skill to \`SkillNames\` is now the only required change — no test fixture update ever needed again.

## Root cause

\`newTestEnv()\` created a skills source dir with \`["archigraph-repair", "archigraph-quality-check"]\`. The install code iterates \`SkillNames\` (14 entries), finds none of those fixture dirs, and silently skips all skills → \`SkillsInstalled == 0\` → test fails.

The three CLI tests had the same problem with their own hardcoded \`skillNames\` slices.

## Test plan

- [x] \`go test ./internal/install/... ./internal/cli/... -run "TestRunCopy_HappyPath|TestRunDev_HappyPath|TestRunUninstall_HappyPath|TestInstallSkillsInClaudeConfigs|TestInstallSkillsIdempotent|TestRemoveSkillsFromClaudeConfigs"\` — all 6 PASS locally on macOS
- [x] Full \`go test ./internal/install/... ./internal/cli/...\` — all PASS, no regressions
- [ ] CI: \`ci:full\` label applied — Go test code with platform-sensitive path/symlink behavior warrants full CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)