### PR TITLE
docs: rewrite README as product pitch + reorganize docs/ for depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,447 +1,154 @@
 # archigraph
 
-> **Status: Preview (v0.x).** Active development. APIs, MCP tool names, and graph schema may change between minor versions. macOS is the primary supported platform; Linux is being tested; Windows works via MinGW build (#937). See [CHANGELOG.md](CHANGELOG.md) for breaking changes. See [CLAUDE.md](CLAUDE.md) for "When to use archigraph MCP vs grep" — these are paired tools, not a grep replacement.
+> A local code-knowledge-graph daemon that gives AI agents structural navigation — call graphs, cross-repo dependency traces, HTTP surface maps, and process flows — across one or many repositories, exposed via 29 MCP tools.
 
-Multi-repo code knowledge graphs for AI agents.
+[![Build](https://github.com/cajasmota/archigraph/actions/workflows/test.yml/badge.svg)](https://github.com/cajasmota/archigraph/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Status: Preview v0.x](https://img.shields.io/badge/status-preview_v0.x-orange.svg)](CHANGELOG.md)
 
-## Status
+---
 
-Approaching v1.0.0. The full v1 post-mortem and migration runbook lives
-at [`docs/migration/v1.md`](docs/migration/v1.md). Architectural
-decisions are in [`docs/adrs/`](docs/adrs/). Track progress and roadmap
-via the [issue tracker](https://github.com/cajasmota/archigraph/issues)
-and [milestones](https://github.com/cajasmota/archigraph/milestones).
+## Why archigraph
 
-## What's new (v0.9 → v1.0-rc)
+AI coding agents are good at reading files. They are not good at navigating relationships between files — especially across multiple repositories. Ask an agent "what calls `PaymentService.charge`?" and it will grep, guess, and sometimes hallucinate. Ask it to trace a request from the mobile app through the API gateway to the database — across three repos — and it will read dozens of files it doesn't need.
 
-- **Paths v2, Topology v2, Flows v2** — rich list + detail panel surfaces
-  for HTTP endpoints, message-bus topics, and process flows.
-- **12 dashboard surfaces** — see [Surfaces map](#surfaces-map) below.
-- **Explore / Operate nav** — grouped dropdown menus replace the flat nav bar.
-- **Cmd+K command palette** — fuzzy search all surfaces and actions from
-  anywhere in the dashboard.
-- **Real-time indexing progress** — SSE stream at `/api/index-progress`
-  drives an in-dashboard progress modal during `archigraph rebuild`.
-- **MCP Activity surface (Jarvis)** — live view of every MCP tool call,
-  with real-time graph node highlighting for the returned entities.
-- **AGENTS.md auto-injection** — after each rebuild, archigraph writes an
-  Architecture Map block directly into `AGENTS.md` in every indexed repo.
-- **`http_endpoint_definition` + `http_endpoint_call`** — the legacy
-  `http_endpoint` kind is split into two distinct entity kinds for
-  precise orphan-caller detection (#1217).
-- **13 new MCP tools** — Topology v2, Flows v2, Quality, and graph
-  traversal surfaces exposed to agents. See
-  [`internal/mcp/SCHEMA.md`](internal/mcp/SCHEMA.md).
-- **Multi-branch + worktree support** — one graph snapshot per `(repo, ref)`;
-  branch switches are detected automatically via `.git/HEAD` watch and optional
-  git hooks; HOT/WARM/COLD tier management keeps RAM bounded; `--ref` flag on
-  all read commands; `?ref=` on dashboard APIs; graph diff view between any two
-  indexed refs. See [Multi-branch guide](docs/user-guide/multi-branch.md).
+archigraph pre-builds the relationship map. It indexes your codebase into an in-memory graph (entities, call edges, import edges, HTTP routes, message-bus topics) and keeps it fresh via file watchers. When an agent asks a structural question, it gets a precise answer in one round-trip instead of twenty file reads.
 
-## Run it locally (testing build)
+The graph lives entirely on your machine. No cloud indexing, no account, no data sent anywhere. One binary, one daemon process, one port.
 
-> **There is no hosted release yet.** The `curl … | bash` installer and the
-> GitHub Releases binaries referenced under [Install](#install) are **not
-> published during the testing phase** — build and run from source as shown
-> here. This is the path to share with testers right now.
+---
 
-### Prerequisites
+## What you get
 
-- **Go 1.25.5+** with **CGO enabled** — tree-sitter needs a C compiler
-  (Xcode Command Line Tools on macOS: `xcode-select --install`; `build-essential`
-  on Debian/Ubuntu).
-- **Node.js 20+** and npm — used to build the dashboard.
-- **git**.
+- **Call graph navigation** — find every caller of a function, walk dependency chains, trace paths between any two entities. Works across repos in a single query.
+- **HTTP surface mapping** — enumerate every route definition and every call-site that references it; surface orphan callers (client calls with no matching server handler) without manually auditing both sides.
+- **Process flow tracing** — pre-computed BFS from entry points (route handlers, `main`, framework hooks) stored as traceable chains; ad-hoc follow from any entity on demand.
+- **Message-bus topology** — topic/broker/service groupings for event-driven systems; publisher and subscriber orphan detection.
+- **Cross-repo dependency graph** — index a folder of repos as one group; edges span repo boundaries with confidence scores; diff graph state between any two indexed refs.
+- **Documentation and analysis skills** — a 14-skill family (tech docs, business docs, security audit, consultant panel, patterns) all driven off the graph, invokable from Claude Code as slash commands.
+- **Real-time dashboard** — 12 surfaces (Graph, Flows, Topology, Paths, Docs, Quality, Patterns, ...) embedded in the daemon, no separate server, at `http://127.0.0.1:47274`.
 
-### 1. Clone and build
+---
+
+## How it works
+
+archigraph runs as a background daemon. The daemon manages a tree-sitter-based indexer (50+ languages), an in-memory graph loaded from `.archigraph/graph.fb` per repo, an MCP server on stdio, live file watchers, and the embedded dashboard — all as one process.
+
+```
+your repos
+    |
+    v  archigraph index (tree-sitter + resolver)
+ .archigraph/graph.fb   <-- per-repo binary graph snapshot
+    |
+    v  daemon (in-memory, mtime-driven reload)
+ MCP server (stdio) -- AI agent (Claude Code, Cursor, Windsurf, ...)
+ Dashboard (HTTP)   -- browser at http://127.0.0.1:47274
+```
+
+When an agent calls `archigraph_find(query="payment processing")`, the daemon runs BM25 against entity labels and qualified names, then expands outward via BFS — returning a ranked, token-budgeted subgraph in one call. No files are read at query time.
+
+After `archigraph install <group>`, the daemon registers itself as an MCP server in your Claude Code config automatically. No manual JSON editing.
+
+---
+
+## Quickstart
+
+> The binary must be built from source during the current preview phase — the installer script and GitHub Releases binaries are not yet published. See [docs/install.md](docs/install.md) for the full install matrix.
 
 ```sh
-git clone https://github.com/cajasmota/archigraph.git
-cd archigraph
-make build                 # builds the embedded dashboard + the ./archigraph binary
-./archigraph --version
-```
-
-Optional — put it on your `PATH` so you can call `archigraph` from anywhere:
-
-```sh
-go install -ldflags="-X main.commit=$(git rev-parse --short HEAD)" ./cmd/archigraph
-# installs to ~/go/bin/archigraph — make sure ~/go/bin is on your PATH
-```
-
-### 2. Start the daemon
-
-```sh
-./archigraph install       # registers + starts the daemon as a background service
-# (or run it in the foreground:  ./archigraph start)
-./archigraph status        # confirm it's up — it serves http://127.0.0.1:47274
-```
-
-### 3. Index your code
-
-```sh
-./archigraph wizard        # interactive: point it at a repo or a monorepo folder
-```
-
-A monorepo is auto-split into its modules; point it at a folder containing
-several git repos and they become one multi-repo group. (You can also click
-**Add group** from the dashboard.)
-
-### 4. Open the dashboard
-
-The full dashboard is **embedded in the daemon** — `make build` bundles it into
-the binary and `archigraph install` serves it. Just open:
-
-```
-http://127.0.0.1:47274
-```
-
-No separate dev server is needed for testing. Deep links and browser reloads
-work on every screen (Graph, Topology, Flows, Paths, Docs, Operations, Pending,
-Settings) — the daemon SPA-falls-back to the app for client-side routes.
-
-> **Developing the dashboard?** The UI source lives in `webui-v2`. For hot-reload
-> dev iteration, run a dev server that proxies `/api/*` to the daemon:
->
-> ```sh
-> cd webui-v2
-> npm install
-> npm run dev              # → http://localhost:47280 (dev only)
-> ```
->
-> For testing the shipped build, use the embedded UI at http://127.0.0.1:47274.
-
-### Stop / clean up
-
-```sh
-./archigraph uninstall     # stops and removes the daemon service
-```
-
-## Install
-
-> **Not yet published** — see [Run it locally](#run-it-locally-testing-build)
-> above until the first release ships.
-
-### macOS / Linux
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/cajasmota/archigraph/main/install.sh | bash
-```
-
-### Windows (PowerShell)
-
-```powershell
-irm https://raw.githubusercontent.com/cajasmota/archigraph/main/install.ps1 | iex
-```
-
-### Manual download
-
-Pre-built binaries for every release are published at
-https://github.com/cajasmota/archigraph/releases — pick the matching
-`<os>_<arch>` archive (`linux_x86_64`, `linux_arm64`, `macos_x86_64`,
-`macos_arm64`, or `windows_x86_64`).
-
-### Build from source
-
-Requires Go 1.25.5+. CGO is required (tree-sitter dependency). See
-[Run it locally](#run-it-locally-testing-build) for the full testing
-walkthrough including the dashboard.
-
-```sh
+# 1. Build (requires Go 1.25.5+, CGO, Node 20+)
 git clone https://github.com/cajasmota/archigraph.git
 cd archigraph
 make build
-./archigraph --version
+
+# 2. Point it at your code (interactive)
+./archigraph wizard
+
+# 3. Start the daemon + register MCP + install skills
+./archigraph install <group>
+
+# 4. Confirm everything is wired
+./archigraph status <group>
+
+# 5. Open the dashboard
+./archigraph dashboard
 ```
 
-## Quick start
+The dashboard is at `http://127.0.0.1:47274`. Your AI agent picks up the MCP server automatically after the next session restart.
 
-```sh
-# 1. Create a group and index your repos
-archigraph wizard
-archigraph install <group>
-
-# 2. Open the dashboard
-archigraph dashboard
-
-# 3. Generate docs (in Claude Code)
-/generate-docs
+To verify from inside Claude Code:
+```
+archigraph_whoami()
+archigraph_stats()
+archigraph_clusters()
 ```
 
-The `/generate-docs` skill produces per-repo documentation (overview, module guides, API reference, patterns) and a cross-repo synthesis. It runs a 12-pass pipeline that typically takes 25–60 minutes for small repos, 1–2 hours for medium repos, and 2–4 hours for large repos. Estimates and pass details are in the [generate-docs skill docs](skills/generate-docs/SKILL.md).
+For per-agent setup instructions see [docs/agent-hosts.md](docs/agent-hosts.md).
 
-Pass 13 (LLM enrichment) should run with Haiku to avoid high costs. See
-[`docs/agent-hosts.md`](docs/agent-hosts.md) for per-host setup instructions
-(Claude Code, Cursor, Windsurf, Continue, Aider, Cline).
+---
 
-### LLM-mode docgen and the 5-tier ladder
+## When you'd reach for it
 
-Docgen uses a deterministic 5-tier validation ladder (Tier 0 → section stub,
-Tier 1 → full page, Tier 2 → coherent slice, Tier 3 → full repo, Tier 4 →
-full group). LLM prose-fill is an optional overlay via `--llm-mode=emit/apply`
-currently wired for Tier 0 and Tier 1. Pass 20 of the skill provides the
-Claude Code orchestrator half of the emit → orchestrate → apply loop.
+**Onboarding to an unfamiliar codebase** — run `archigraph wizard`, index, then ask your agent to orient you with `archigraph_clusters` and `archigraph_traces`. You get a module map and top-level flows in minutes instead of hours.
 
-See [`docs/docgen-llm-mode.md`](docs/docgen-llm-mode.md) for the full workflow,
-command recipes, section cache details, and troubleshooting reference.
+**Doing a code review and want to know the blast radius** — `archigraph_expand` from the changed entity shows every caller and downstream dependency. The `/archigraph-aware-review` skill surfaces this automatically during review.
 
-## Usage
+**Generating documentation** — `/archigraph-tech-docs` produces per-module READMEs, API reference, cross-cutting concerns, and a group synthesis. `/archigraph-business-docs` produces PM-facing capability descriptions and user journeys from the same graph.
 
-> **Using archigraph MCP with an AI agent?** See [`CLAUDE.md`](CLAUDE.md#when-to-use-archigraph-mcp-vs-grep) for the MCP + grep pairing philosophy: when to use MCP for structural questions vs grep for raw enumeration, and how to combine them.
+**Auditing security** — `/archigraph-security-audit` runs deterministic static checks (auth coverage, reachability, orphan endpoints, PII exposure paths) then an LLM confirmation pass.
 
-archigraph is a CLI plus a unified daemon process that manages indexing,
-the MCP server, embedded dashboard, and file watchers. The common path:
+**Working across a monorepo or multi-repo group** — archigraph cross-links repos in a group and resolves edges across repo boundaries, so `archigraph_trace(source="mobile-app::UICheckout", target="payments-api::ChargeHandler")` works even though those entities live in different repositories.
 
-```sh
-# 1. Set up a group (interactive). Creates the group config and a
-#    cross-repo links file scaffold.
-archigraph wizard
+---
 
-# 2. One-shot setup: daemon, MCP, indexer, and dashboard.
-archigraph install <group>
+## What's inside
 
-# 3. Confirm everything is wired.
-archigraph status <group>
+| Resource | Contents |
+|----------|----------|
+| [docs/README.md](docs/README.md) | Documentation index |
+| [docs/quickstart.md](docs/quickstart.md) | Install + first index + first query |
+| [docs/concepts.md](docs/concepts.md) | Knowledge graph, entities, edges, residual edges, repair |
+| [docs/mcp-tools.md](docs/mcp-tools.md) | MCP tool catalogue and pointer to full schema |
+| [docs/install.md](docs/install.md) | Full install matrix (script, binary, source, dev mode) |
+| [docs/agent-hosts.md](docs/agent-hosts.md) | Per-agent setup (Claude Code, Cursor, Windsurf, Continue, Aider, Cline) |
+| [skills/README.md](skills/README.md) | Skill family — chains, dependencies, install |
+| [internal/mcp/SCHEMA.md](internal/mcp/SCHEMA.md) | Full MCP tool schema (canonical) |
+| [docs/adrs/](docs/adrs/) | Architectural decision records (ADR-0001 through ADR-0020) |
+| [CHANGELOG.md](CHANGELOG.md) | Version history and breaking changes |
+| [CLAUDE.md](CLAUDE.md) | When to use MCP vs grep (agent pairing guide) |
 
-# 4. Open the dashboard in your browser (auto-starts daemon if needed).
-archigraph dashboard
-```
-
-The daemon process manages everything — MCP server, indexing, live file
-watchers, and the embedded dashboard on http://127.0.0.1:47274/. Control it
-via:
-
-```sh
-archigraph start                # start the daemon
-archigraph stop                 # stop the daemon
-archigraph restart              # restart the daemon
-archigraph dashboard            # open dashboard in browser (auto-starts daemon)
-archigraph dashboard serve      # run dashboard server standalone
-```
-
-After upgrading archigraph, materialize indexed data:
-
-```sh
-archigraph rebuild <group> [slug]    # force AST rebuild, no cache; outputs summary
-```
-
-Other useful commands:
-
-```sh
-archigraph index <repo>              # one-shot indexer (writes graph.fb, optionally graph.json)
-archigraph index <repo> --ref <ref>  # index a specific git ref
-archigraph reset <group> [slug]      # wipe .archigraph/ and rebuild
-archigraph remove <group> <slug>     # remove a repo from a group
-archigraph delete <group>            # delete entire group + state
-archigraph monorepo add <group> <p>  # opt a path inside a monorepo into indexing
-archigraph doctor                    # smoke-check install + tools (rich health report)
-archigraph status <group>            # show group health + stats (rich output)
-archigraph status <group> --all-refs # show per-ref tier + stats for every indexed branch
-archigraph branches                  # list all indexed refs with HOT/WARM/COLD tier + sizes
-archigraph uninstall <group>         # remove hooks/watchers from a group
-archigraph install-hooks             # install post-checkout/merge/rewrite git hooks (multi-branch)
-archigraph patterns list             # inspect agent-learned patterns (ADR-0018)
-archigraph patterns export --repo X  # write the CLAUDE.md marker block
-archigraph patterns config           # show / set pattern thresholds
-```
-
-`archigraph help advanced` lists the full set.
-
-## Surfaces map
-
-The dashboard at http://127.0.0.1:47274/ has 12 surfaces grouped into two
-menus.
-
-```
-Dashboard (http://127.0.0.1:47274/)
-│
-├── Explore
-│   ├── Graph        /graph          — Cosmograph node-link canvas + 6-band LoD
-│   ├── Flows        /flows          — Process-flow DAG list + per-flow detail panel
-│   ├── Topology     /topology       — Message-bus topics + broker/service grouping
-│   ├── Pending      /pending        — Tiered enrichment queue (Critical/High/Med/Low)
-│   ├── Paths        /paths          — HTTP endpoint definitions grouped by backend
-│   └── Docs         /docs           — Indexed markdown document tree
-│
-└── Operate
-    ├── Diagnostics  /diagnostics    — Daemon + per-group health checks
-    ├── Quality      /quality        — Orphan audit + recall measurement + history trend
-    ├── Patterns     /patterns       — Agent-learned patterns list/edit/delete/export
-    ├── System       /system         — Daemon control panel (restart, stop, logs)
-    ├── Update       /update         — Version check + apply + refresh-rules-lite
-    └── Settings     /settings       — Theme, auto-update, telemetry, MCP config, log level
-
-Special
-    └── MCP Activity /mcp-activity   — Live Jarvis view of MCP tool calls + graph highlighting
-```
-
-### Keyboard shortcuts
-
-| Shortcut | Action |
-|----------|--------|
-| `Cmd+K` (macOS) / `Ctrl+K` (Linux/Win) | Open command palette |
-| `Esc` | Close command palette / close detail panel |
-| `↑` / `↓` | Navigate palette results |
-| `Enter` | Activate selected result |
-
-## How agents use archigraph
-
-archigraph exposes a Model Context Protocol (MCP) server that AI agents
-connect to over stdio. The daemon registers one MCP server per machine;
-multiple groups can be active simultaneously.
-
-### MCP setup
-
-After `archigraph install <group>`, the daemon writes an MCP server entry
-to your Claude Code `~/.claude/claude.json` (or equivalent for other
-clients). No manual configuration is needed.
-
-To verify the wiring:
-
-```sh
-archigraph status <group>     # shows MCP: connected / disconnected
-```
-
-### What agents can do
-
-The MCP server exposes 19 tools prefixed `archigraph_`. Common workflows:
-
-| Goal | Tool |
-|------|------|
-| Orient to codebase | `archigraph_whoami` → `archigraph_stats` |
-| Find a symbol | `archigraph_find` (BM25 + BFS) |
-| Inspect an entity | `archigraph_inspect` |
-| Walk the call graph | `archigraph_expand` |
-| Trace a data path | `archigraph_trace` |
-| Understand flows | `archigraph_traces` |
-| Find HTTP endpoints | `archigraph_endpoint_definitions` |
-| Find orphan callers | `archigraph_endpoint_calls` |
-| Save a finding | `archigraph_save_finding` |
-
-Full tool reference: [`internal/mcp/SCHEMA.md`](internal/mcp/SCHEMA.md).
-
-### Real-time MCP activity
-
-The Jarvis MCP Activity surface (`/mcp-activity`) shows every tool call in
-real time. The graph canvas subscribes to the SSE stream at
-`/api/mcp-activity/stream` and pulses the returned nodes — so you can watch
-the agent's graph exploration as it happens.
-
-### AGENTS.md auto-injection
-
-After every `archigraph rebuild`, archigraph writes a fenced Architecture
-Map block into `AGENTS.md` (or creates the file if absent) in each indexed
-repo. Agents reading `AGENTS.md` at session start automatically receive the
-latest structure without any manual step.
-
-## Real-time indexing progress
-
-During `archigraph rebuild`, the indexer emits progress events to an
-in-process pub/sub broker. The dashboard subscribes via:
-
-```
-GET /api/index-progress           — progress across all groups (SSE)
-GET /api/index-progress/{group}   — progress for a specific group (SSE)
-```
-
-Each SSE event is a JSON object:
-
-```json
-{
-  "group": "my-group",
-  "repo": "api-server",
-  "phase": "resolve",
-  "pct": 62,
-  "elapsed_ms": 4210
-}
-```
-
-The dashboard shows a live `IndexingProgressModal` while any rebuild is
-running.
-
-## Settings file
-
-User preferences are persisted to `~/.archigraph/settings.json`. All
-fields are optional; missing keys fall back to defaults.
-
-```json
-{
-  "theme": "light",
-  "default_group": "",
-  "auto_check_updates": true,
-  "update_channel": "stable",
-  "refresh_schedule": "",
-  "telemetry_enabled": false,
-  "daemon_rss_budget_mb": 512,
-  "watcher_debounce_secs": 2,
-  "indexer_parallelism": 4,
-  "log_level": "info"
-}
-```
-
-| Field | Values | Default | Notes |
-|-------|--------|---------|-------|
-| `theme` | `light` \| `dark` \| `auto` | `light` | |
-| `default_group` | group slug | `""` | Shown on first dashboard load |
-| `auto_check_updates` | bool | `true` | |
-| `update_channel` | `stable` \| `dev` | `stable` | |
-| `refresh_schedule` | cron or `""` | `""` | Empty = manual only |
-| `telemetry_enabled` | bool | `false` | |
-| `daemon_rss_budget_mb` | 100–2000 | `512` | Requires daemon restart |
-| `watcher_debounce_secs` | 1–60 | `2` | |
-| `indexer_parallelism` | 1–32 | `4` | Requires daemon restart |
-| `log_level` | `debug` \| `info` \| `warn` \| `error` | `info` | |
-
-The Settings surface (`/settings`) in the dashboard edits this file
-through `GET/PUT /api/settings`. A `POST /api/settings/reset` restores
-factory defaults.
-
-## Contributing
-
-If you're an AI agent contributing to archigraph, see [AGENTS.md](AGENTS.md) for conventions.
-End-user-facing agent docs are delivered via the MCP `instructions` handshake — there is no per-user setup.
+---
 
 ## Languages
 
-archigraph supports ~50 languages with custom extractors and resolver slices:
+Core extractors for 50+ languages including Go, Python, TypeScript/JavaScript, Java, C#, C++, Rust, Ruby, PHP, Swift, Kotlin, Scala, Dart, Elixir, and more. Infrastructure: Terraform/HCL, Solidity, Verilog/SystemVerilog. Frontend: Vue SFC, Svelte, Astro. Cross-cutting: SQL, GraphQL, Protocol Buffers, Dockerfile.
 
-**Core (30+):** Go · Python · TypeScript/JavaScript · Java · C# · C++ · Rust · Ruby · PHP · Swift · Kotlin · Scala · Groovy · Lua · Dart · Elixir · Clojure · Erlang · Crystal · Nim · F# · Haskell · OCaml · Elm · Lisp family · Standard ML · ReasonML · ReScript · Pony · Idris
+Each extractor emits language-specific edges (HTTP endpoints, ORM queries, dynamic dispatch, framework hooks). Full list in [AGENTS.md](AGENTS.md).
 
-**Frontend + Templates:** Vue SFC · Svelte SFC · Astro · Razor
+---
 
-**Infrastructure & Hardware:** Terraform/HCL · Solidity · Verilog/SystemVerilog · VHDL
+## Status
 
-**Cross-cutting:** CSS · HTML · SQL · GraphQL · Protocol Buffers · Shell · Dockerfile · YAML · Markdown · Just · Fish
+Preview (v0.x). Approaching v1.0. APIs, MCP tool names, and graph schema may change between minor versions. macOS is the primary supported platform; Linux is tested; Windows works via MinGW build.
 
-Each extractor emits language-specific edges (HTTP endpoints, ORM queries, dynamic dispatch, framework hooks). See [AGENTS.md](AGENTS.md) for architecture details.
-
-## Corpus & coverage
-
-archigraph is validated against a curated corpus of small-to-medium
-sample applications, one per supported language family. Framework
-internals are deliberately excluded as primary fixtures — see
-[ADR-0014](docs/adrs/0014-corpus-expansion-strategy.md). New language
-support lands together with the sample apps that exercise it.
-
-## Roadmap
+See [CHANGELOG.md](CHANGELOG.md) for breaking changes.
+See [docs/migration/v1.md](docs/migration/v1.md) for the v1 migration runbook.
+Track the v1.0 milestone: https://github.com/cajasmota/archigraph/milestone/1
 
 ### v1.0 ship-gate
 
 - [ ] Bug-rate below 10% on the full validation corpus
-- [ ] Daemon determinism (#481) resolved — reliable measurement across runs
+- [ ] Daemon determinism (#481) resolved
 - [ ] HTTP overhaul — unified HTTP client/server pairing
 - [ ] Per-language quality pass (residual orphan elimination)
 
-Track the v1.0 milestone: https://github.com/cajasmota/archigraph/milestone/1
+---
 
-### v1.1 plan
+## Contributing
 
-- **Paths v2 epic** — cross-repo endpoint stitching, prefix-aware dedup
-  (#1082, not yet dispatched)
-- **Embedding strategy** — bundled MiniLM (`hugot` + `simplego`) + BYO
-  endpoint for semantic search
-- **BYO extractor pipeline** — custom-extractor registration without a
-  daemon restart
+See [CONTRIBUTING.md](CONTRIBUTING.md). If you're an AI agent contributing to archigraph, see [AGENTS.md](AGENTS.md) for conventions.
+
+---
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# archigraph docs
+
+Reference documentation for archigraph. The [README.md](../README.md) at the repo root covers the pitch and quickstart; this tree is the manual.
+
+---
+
+## Getting started
+
+| Doc | Contents |
+|-----|----------|
+| [quickstart.md](quickstart.md) | Install, first index, first query — 5 commands |
+| [install.md](install.md) | Full install matrix: script, binary, source, dev mode, troubleshooting |
+| [agent-hosts.md](agent-hosts.md) | Per-agent MCP setup (Claude Code, Cursor, Windsurf, Continue, Aider, Cline) |
+
+## Core concepts
+
+| Doc | Contents |
+|-----|----------|
+| [concepts.md](concepts.md) | Knowledge graph model, entity kinds, edge kinds, residual edges, repair |
+| [modes.md](modes.md) | Single-repo vs multi-repo groups, monorepo splitting, group lifecycle |
+| [graph-format.md](graph-format.md) | On-disk graph format (`.archigraph/graph.fb`), binary schema, JSON export |
+| [embedding.md](embedding.md) | Semantic search embedding strategy (BM25 + optional MiniLM / BYO endpoint) |
+
+## Using with AI agents
+
+| Doc | Contents |
+|-----|----------|
+| [mcp-tools.md](mcp-tools.md) | MCP tool catalogue and pointer to the full canonical schema |
+| [skills.md](skills.md) | Skill family overview and pointer to `skills/README.md` |
+| [../CLAUDE.md](../CLAUDE.md) | When to use MCP vs grep (pairing guide for agents) |
+| [../skills/using-archigraph/SKILL.md](../skills/using-archigraph/SKILL.md) | Day-to-day agent orientation: Pass-based workflows, anti-patterns, examples |
+
+## Advanced
+
+| Doc | Contents |
+|-----|----------|
+| [user-guide/multi-branch.md](user-guide/multi-branch.md) | Multi-branch + worktree support, HOT/WARM/COLD tier, branch switching |
+| [docgen-llm-mode.md](docgen-llm-mode.md) | LLM docgen emit/apply loop, 5-tier ladder, section cache, troubleshooting |
+| [settings.md](settings.md) | `~/.archigraph/settings.json` reference (all fields, defaults, API) |
+| [sse-endpoints.md](sse-endpoints.md) | Server-sent event endpoints (index progress, MCP activity stream) |
+| [troubleshooting.md](troubleshooting.md) | Symptoms, diagnoses, and fixes |
+
+## Reference
+
+| Doc | Contents |
+|-----|----------|
+| [../internal/mcp/SCHEMA.md](../internal/mcp/SCHEMA.md) | Full MCP tool schema — canonical source of truth for all 29 tools |
+| [adrs/README.md](adrs/README.md) | Architectural decision records index (ADR-0001 through ADR-0020) |
+| [migration/v1.md](migration/v1.md) | v0.x to v1.0 migration runbook |
+| [RELEASING.md](RELEASING.md) | Release process (maintainer reference) |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,100 @@
+# Concepts
+
+This page explains the mental model behind archigraph: what the graph contains, how it gets built, and what happens when the indexer cannot fully resolve a relationship.
+
+---
+
+## The knowledge graph
+
+archigraph represents a codebase as a directed graph of **entities** (nodes) connected by **edges** (relationships). The graph is built once during indexing and reloaded from disk on every tool call (lazy, mtime-driven). There is no external database — the graph lives in memory as a loaded `.archigraph/graph.fb` file per repo.
+
+Multiple repos can be indexed together as a **group**. Cross-repo edges are stored as overlay links with a confidence score (default 0.7 for cross-repo edges vs. 0.95 for intra-repo edges).
+
+---
+
+## Entity kinds
+
+The indexer extracts entities using tree-sitter grammars plus per-language resolver slices. Entity kinds are defined in [ADR-0003](adrs/0003-scope-entity-taxonomy.md).
+
+Common kinds you will encounter:
+
+| Kind | What it represents |
+|------|-------------------|
+| `Component` | Class, struct, module, or named type |
+| `Operation` | Function, method, or handler |
+| `Schema` | Database model, serializer, or data shape |
+| `Queue` | Message-bus topic, queue, or stream |
+| `http_endpoint_definition` | Server-side HTTP route handler |
+| `http_endpoint_call` | Client-side HTTP call-site |
+| `Process` | Pre-computed BFS flow chain from an entry point |
+
+Each entity carries: a stable ID, a qualified name, a source file and line range, a PageRank score (pre-baked at index time), a Louvain community ID, and an optional set of saved findings.
+
+---
+
+## Edge kinds
+
+Edges represent relationships extracted by the resolvers. Common kinds:
+
+| Kind | Meaning |
+|------|---------|
+| `CALLS` | A calls B (function call, method dispatch) |
+| `IMPORTS` | A imports B (module-level dependency) |
+| `USES` | A uses B (field access, type reference) |
+| `PUBLISHES_TO` | A publishes a message to topic B |
+| `SUBSCRIBES_TO` | A subscribes to topic B |
+| `EXTENDS` | A extends or implements B |
+| `OVERRIDES` | A overrides method B |
+
+Each edge has a **confidence** value between 0 and 1. Statically resolved edges default to 0.95. Edges that required heuristic resolution or cross-repo linking are lower.
+
+---
+
+## Residual edges
+
+Not every call can be resolved at index time. Dynamic dispatch, string-keyed lookups, reflection, and cross-repo calls where the target repo has not been indexed all produce **residual edges** — stubs in the graph that point to an unresolved target.
+
+The indexer records these stubs in the enrichment queue rather than dropping them. The `/archigraph-resolve` skill surfaces the queue, automatically resolves unambiguous cases via pattern matching, and walks you through the rest interactively.
+
+Residual edges are not failures — they are honest signals that the relationship exists but the target is not yet certain. A high residual count on a specific entity means that entity has significant dynamic behavior that is worth resolving manually.
+
+---
+
+## Repair and enrichment
+
+Beyond residual edges, the enrichment queue holds three types of candidates:
+
+- **Residual repairs** — unresolved stubs from the indexer (`archigraph_repairs`)
+- **Cross-repo link candidates** — edges where the target might be in a sibling repo (`archigraph_cross_links`)
+- **Enrichment candidates** — `http_endpoint`, `process_flow`, and `message_topic` entities that the indexer flagged for LLM annotation (`archigraph_enrichments`)
+
+The dashboard **Pending** surface (`/pending`) shows the full queue tiered by priority (Critical / High / Medium / Low).
+
+The `/archigraph-graph-enrich` skill emits YAML frontmatter for HTTP endpoints, flows, and topics — this makes the **Paths**, **Flows**, and **Topology** dashboard panels display data.
+
+---
+
+## Groups and repos
+
+A **group** is archigraph's unit of multi-repo management. A group has:
+- A slug (name) used in all CLI commands and MCP routing
+- One or more repo entries, each pointing at a local directory
+- A `cross-repo-links.yaml` file that declares known cross-repo relationships
+
+The daemon resolves which group to use for a given agent session by matching the agent's working directory against registered repo paths (see [ADR-0008](adrs/0008-caller-cwd-aware-routing-for-multi-group-setups.md)).
+
+---
+
+## Multi-branch support
+
+archigraph stores one graph snapshot per `(repo, ref)` pair. When you switch branches, the daemon detects the change via `.git/HEAD` watch and loads the appropriate snapshot. Snapshots are tiered HOT/WARM/COLD to keep RAM bounded.
+
+See [user-guide/multi-branch.md](user-guide/multi-branch.md) for the full guide.
+
+---
+
+## Patterns
+
+As agents work with the graph, they can save findings via `archigraph_save_finding`. Over time, recurring structural patterns are extracted and stored as first-class entities. These are visible in the **Patterns** dashboard surface and manageable via the `/archigraph-patterns-discover` and `/archigraph-patterns-sync` skills.
+
+See [ADR-0018](adrs/0018-agent-learned-patterns.md) for the full design.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,130 @@
+# Install
+
+Full install matrix for archigraph. For the five-command path see [quickstart.md](quickstart.md).
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| Go 1.25.5+ | CGO must be enabled (tree-sitter uses a C library) |
+| C compiler | macOS: `xcode-select --install` / Debian-Ubuntu: `apt install build-essential` / Windows: MinGW via MSYS2 |
+| Node.js 20+ + npm | Dashboard build only — not needed at runtime after `make build` |
+| git | Required for indexing |
+
+---
+
+## macOS / Linux — installer script
+
+> **Not yet published.** The script below will work after the first release ships. During the preview phase, build from source (see below).
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cajasmota/archigraph/main/install.sh | bash
+```
+
+---
+
+## Windows — PowerShell installer
+
+> **Not yet published.** During the preview phase, build from source with MinGW.
+
+```powershell
+irm https://raw.githubusercontent.com/cajasmota/archigraph/main/install.ps1 | iex
+```
+
+Windows builds require MSYS2/MinGW64. The installer handles this. Shipped binaries link statically against MinGW — users do not need MinGW installed at runtime.
+
+---
+
+## Pre-built binary (manual download)
+
+> **Not yet published.** Will be at https://github.com/cajasmota/archigraph/releases after the first release.
+
+Archives per platform: `linux_x86_64`, `linux_arm64`, `macos_x86_64`, `macos_arm64`, `windows_x86_64`.
+
+Extract the archive and move the `archigraph` binary to a directory on your `PATH`.
+
+---
+
+## Build from source
+
+This is the correct path during the preview phase.
+
+```sh
+git clone https://github.com/cajasmota/archigraph.git
+cd archigraph
+make build           # builds dashboard (npm ci + vite build) + Go binary
+./archigraph --version
+```
+
+`make build` runs `dashboard-build` (npm) then `go build`. If you only want the Go binary and the dashboard is already built:
+
+```sh
+make build-go-only
+```
+
+To install the binary system-wide:
+
+```sh
+go install -ldflags="-X main.commit=$(git rev-parse --short HEAD)" ./cmd/archigraph
+# installs to ~/go/bin -- ensure ~/go/bin is on PATH
+```
+
+---
+
+## Dev mode (symlinked skills)
+
+For contributors who want to edit skills in-place and see changes without reinstalling:
+
+```sh
+archigraph install --dev
+```
+
+This creates symlinks in `~/.claude/skills/` pointing back to `skills/` in the source checkout instead of copying files.
+
+---
+
+## Post-install steps
+
+```sh
+archigraph doctor               # smoke-check install + tools
+archigraph wizard               # create a group (interactive)
+archigraph install <group>      # start daemon, register MCP, install skills
+archigraph status <group>       # confirm MCP: connected
+```
+
+---
+
+## Upgrade
+
+```sh
+archigraph update               # fetch latest stable, atomic replace, re-run install
+archigraph update --pre         # latest pre-release
+archigraph update --tag v1.2.3  # pin a specific version
+```
+
+If the upgrade fails, the binary is automatically restored from the pre-update stash.
+
+---
+
+## Uninstall
+
+```sh
+archigraph uninstall            # removes skills, MCP entries, stops daemon; leaves graphs
+archigraph uninstall --purge    # also removes ~/.archigraph/store/ and docs/
+```
+
+Uninstall reads `install.json` to remove only what archigraph owns — it will not touch other tools' MCP registrations.
+
+---
+
+## Configuration file
+
+User preferences are persisted to `~/.archigraph/settings.json`. See [settings.md](settings.md) for the full field reference.
+
+---
+
+## Troubleshooting
+
+See [troubleshooting.md](troubleshooting.md).

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,125 @@
+# MCP tools
+
+archigraph exposes 29 MCP tools, all prefixed `archigraph_`. The canonical source of truth for inputs, outputs, and response shapes is:
+
+**[`internal/mcp/SCHEMA.md`](../internal/mcp/SCHEMA.md)**
+
+This page is an orientation-level catalogue. For parameter details, response field lists, and deprecation notices, read SCHEMA.md directly.
+
+---
+
+## Setup
+
+After `archigraph install <group>`, the MCP server is registered automatically in your agent's config. The daemon registers one server per machine; multiple groups can be active simultaneously. The server uses stdio transport.
+
+To verify the wiring:
+
+```sh
+archigraph status <group>    # shows MCP: connected / disconnected
+```
+
+For per-agent config details see [agent-hosts.md](agent-hosts.md).
+
+---
+
+## Tool catalogue
+
+### Orientation
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_whoami` | Resolve group and repo for the agent's current working directory. Call this first. |
+| `archigraph_stats` | Entity + relationship counts per repo. Use to scope token budgets. |
+| `archigraph_clusters` | Louvain communities with top-ranked entities. Fast module map. |
+
+### Discovery
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_find` | BM25-ranked graph query with optional BFS expansion. Primary discovery tool. |
+| `archigraph_inspect` | Look up a single entity by ID, qualified name, or label. Returns full record + attached findings. |
+
+### Traversal
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_expand` | BFS neighbour expansion from a single node. |
+| `archigraph_trace` | Confidence-weighted shortest path (Dijkstra) between two nodes. |
+| `archigraph_traces` | Pre-computed process flow traces. Actions: `list`, `get`, `follow`. |
+| `archigraph_module_analysis` | Module-level cycle detection, centrality, and cluster analysis. |
+
+### Source
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_get_source` | Return actual source lines for a node, by entity ID or label. |
+| `archigraph_recent_activity` | Entities whose source files changed after a given RFC3339 timestamp. |
+
+### HTTP endpoints
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_endpoints` | Action-dispatched: `definitions` (server routes), `calls` (client call-sites), `stats`. |
+
+### Topology (message bus)
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_topology` | Action-dispatched: `topics`, `topic_detail`, `orphan_publishers`, `orphan_subscribers`. |
+
+### Flows
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_flows` | Action-dispatched: `list`, `detail`, `dead_ends`, `truncated`. |
+
+### Patterns
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_graph_patterns` | Action-dispatched: `list`, `get`. Agent-learned structural patterns. |
+
+### Queue management
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_enrichments` | List, submit, or reject enrichment candidates (endpoints, flows, topics). |
+| `archigraph_cross_links` | List, accept, or reject cross-repo link candidates. |
+| `archigraph_repairs` | List or submit residual-edge repair resolutions. |
+
+### Quality
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_quality` | Action-dispatched: `orphan_audit`, `recall_measurement`, `history`. |
+| `archigraph_auth_coverage` | Map authentication coverage across HTTP endpoints. |
+
+### Documentation (docgen)
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_docgen_start_run` | Start a local-staging docgen run; returns `run_id` and `staging_path`. |
+| `archigraph_docgen_validate` | Validate a staging run (frontmatter errors, broken links). |
+| `archigraph_docgen_promote` | Atomically promote staging docs to canonical path. |
+| `archigraph_docgen_status` | Status and progress of a docgen run. |
+| `archigraph_docgen_list` | List all docgen runs for a group. |
+| `archigraph_docgen_cancel` | Cancel a running docgen run. |
+
+### Memory
+
+| Tool | One-line purpose |
+|------|-----------------|
+| `archigraph_save_finding` | Persist a Q/A pair to the group's memory directory. |
+| `archigraph_list_findings` | Read back saved findings, optionally filtered by entity or timestamp. |
+
+---
+
+## Renamed tools (pre-#668)
+
+Tool names changed significantly in #668 and #1281. If you are using a saved configuration with old names, see the deprecation table in `internal/mcp/SCHEMA.md` — old names return a clear "tool not found" error (no silent fallback, per ADR-0017).
+
+---
+
+## Pairing with grep
+
+archigraph MCP and grep are complementary. Use MCP for structural questions (who calls X, trace a flow, find callers). Use grep for raw enumeration (every `if err != nil`, every import line). See [CLAUDE.md](../CLAUDE.md) for the pairing guide with three worked examples.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,117 @@
+# Quickstart
+
+This page gets you from zero to a running graph in five commands. For a full install matrix (pre-built binaries, dev mode, Windows) see [install.md](install.md).
+
+---
+
+## Prerequisites
+
+- **Go 1.25.5+** with CGO enabled. CGO is required because the tree-sitter extractor uses a C library.
+  - macOS: `xcode-select --install` (Xcode Command Line Tools)
+  - Debian/Ubuntu: `apt install build-essential`
+- **Node.js 20+** and npm (used to build the embedded dashboard)
+- **git**
+
+> **Preview note:** Pre-built binaries and the `curl | bash` installer are not yet published. Build from source as shown below.
+
+---
+
+## 1. Build
+
+```sh
+git clone https://github.com/cajasmota/archigraph.git
+cd archigraph
+make build          # builds dashboard + binary -> ./archigraph
+./archigraph --version
+```
+
+Optional — add to `PATH`:
+
+```sh
+go install -ldflags="-X main.commit=$(git rev-parse --short HEAD)" ./cmd/archigraph
+# installs to ~/go/bin -- make sure ~/go/bin is on your PATH
+```
+
+---
+
+## 2. Index your code
+
+```sh
+./archigraph wizard
+```
+
+The wizard asks you to point at a folder. It accepts:
+- A single git repo
+- A folder containing several git repos (they become one multi-repo group)
+- A monorepo (auto-split into modules)
+
+You can also use the **Add group** button in the dashboard after step 3.
+
+---
+
+## 3. Start the daemon + register MCP
+
+```sh
+./archigraph install <group>
+```
+
+This starts the daemon as a background service, registers the MCP server in your AI agent's config (Claude Code's `~/.claude/claude.json`, or equivalent for other clients), and installs the skill family to `~/.claude/skills/`.
+
+To verify:
+
+```sh
+./archigraph status <group>
+```
+
+Output shows `MCP: connected` when the wiring is complete.
+
+---
+
+## 4. Open the dashboard
+
+```sh
+./archigraph dashboard    # opens http://127.0.0.1:47274 in your browser
+```
+
+The dashboard is embedded in the daemon binary — no separate server needed. Deep links and browser reloads work on every surface.
+
+---
+
+## 5. Query from your agent
+
+Open a new Claude Code session in one of your indexed repos. The MCP server is auto-registered, so you can call archigraph tools immediately:
+
+```
+archigraph_whoami()      -- confirm group + repo
+archigraph_stats()       -- entity counts, any unavailable repos
+archigraph_clusters()    -- module map (Louvain communities)
+```
+
+For a complete guide to navigating with the MCP tools, see [../skills/using-archigraph/SKILL.md](../skills/using-archigraph/SKILL.md).
+
+---
+
+## Daemon control
+
+```sh
+archigraph start          # start daemon in background
+archigraph stop           # stop daemon
+archigraph restart        # restart daemon
+archigraph status         # health check all groups
+archigraph doctor         # full install smoke-check
+```
+
+After upgrading archigraph:
+
+```sh
+archigraph rebuild <group>    # force AST rebuild, no cache
+```
+
+---
+
+## Uninstall
+
+```sh
+archigraph uninstall          # removes skills, MCP entry, stops daemon
+archigraph uninstall --purge  # also removes ~/.archigraph/store/ (your graphs)
+```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,60 @@
+# Skills
+
+archigraph ships a family of Claude Code slash-command skills. Each skill owns one concern and is idempotent — safe to re-run after any graph change.
+
+The canonical reference is:
+
+**[`skills/README.md`](../skills/README.md)**
+
+This page is a pointer and summary. Do not duplicate the skills/README.md content here.
+
+---
+
+## Install
+
+Skills are installed automatically by `archigraph install`. To refresh after an upgrade:
+
+```sh
+archigraph install --skills    # refresh skills only
+archigraph doctor              # check which skills are installed and up-to-date
+```
+
+Skills land in `~/.claude/skills/` where Claude Code discovers them.
+
+---
+
+## Skill chain (summary)
+
+```
+/archigraph-resolve            -- fix residual edges (run first)
+    |
+    +-- /archigraph-graph-quality   -- benchmark graph health
+    +-- /archigraph-graph-enrich    -- populate Paths/Flows/Topology panels
+    |
+    +-- /archigraph-tech-docs       -- engineer-facing module docs (13 passes)
+    +-- /archigraph-business-docs   -- PM-facing capabilities + journeys
+    |
+    +-- /archigraph-security-audit  -- static + LLM security audit
+    +-- /archigraph-consult         -- 5-persona consultant panel
+```
+
+For the full chain diagram, hard vs. soft dependencies, all 14 skills, and the decision table ("which skill for my goal?"), see [skills/README.md](../skills/README.md).
+
+---
+
+## Minimum useful run (first time, ~30 min, ~$5-$20)
+
+```
+/archigraph-resolve
+/archigraph-graph-enrich
+```
+
+Result: a queryable, dashboard-rich graph. No prose docs yet.
+
+## Add documentation
+
+```
+/archigraph-tech-docs
+```
+
+Produces per-module READMEs, API reference, cross-cutting concerns, and group synthesis. Runs in 25 min to 4 h depending on repo size.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,111 @@
+# Troubleshooting
+
+Symptoms, likely causes, and fixes. Run `archigraph doctor` first — it catches the most common issues automatically.
+
+---
+
+## Daemon issues
+
+### `archigraph status` shows the daemon is not running
+
+```sh
+archigraph start             # start the daemon
+archigraph doctor            # check for port conflicts, permission errors
+```
+
+The daemon listens on `http://127.0.0.1:47274`. If that port is occupied by another process, change it in `~/.archigraph/settings.json` (`daemon_port`) and restart.
+
+### Dashboard shows a blank page or fails to load
+
+The dashboard is embedded in the binary. If it shows a blank page:
+1. Check the daemon is running: `archigraph status`
+2. Rebuild after an upgrade: `make build` then `archigraph restart`
+3. Check the daemon logs: `archigraph doctor` prints the log path
+
+---
+
+## MCP issues
+
+### Agent shows "archigraph MCP not found" or no `archigraph_*` tools
+
+1. Confirm the daemon is running: `archigraph status`
+2. Confirm the MCP entry exists: `archigraph status <group>` should show `MCP: connected`
+3. If not connected, re-run: `archigraph install <group>`
+4. Restart your agent session — MCP servers are loaded at session start
+
+### Agent is in the wrong group or returns `source: "none"` from `archigraph_whoami`
+
+The daemon resolves the group from the agent's working directory. If your CWD is not inside a registered repo:
+- Run `archigraph wizard` to register the repo
+- Or pass `group=` explicitly in tool calls
+
+### Tools return "tool not found" errors with old names
+
+Tool names changed in #668 and #1281. There is no backwards-compatible fallback (ADR-0017). See the renamed-tools table in [mcp-tools.md](mcp-tools.md) or `internal/mcp/SCHEMA.md`.
+
+---
+
+## Indexing issues
+
+### `archigraph rebuild` completes but entity count is much lower than expected
+
+1. Check language support: `archigraph doctor` lists extractors and their status
+2. Check the `.archigraph/` directory: `ls .archigraph/` should contain `graph.fb` and optionally `graph.json`
+3. Verify CGO is enabled: `go env CGO_ENABLED` should print `1`. Without CGO, tree-sitter cannot compile and falls back to a reduced extractor set.
+
+### Index hangs or the daemon uses too much RAM
+
+- Adjust parallelism: `daemon_rss_budget_mb` and `indexer_parallelism` in `~/.archigraph/settings.json`
+- For large repos, increase `daemon_rss_budget_mb` beyond the default 512 MB
+- Check for cycles in the graph that inflate BFS depth: run `/archigraph-graph-quality` and inspect the `orphan_audit` output
+
+### Multi-branch: wrong graph loaded after branch switch
+
+archigraph watches `.git/HEAD` for branch changes. If the reload did not happen:
+
+```sh
+archigraph rebuild <group>    # force a reload
+archigraph branches           # list all indexed refs with HOT/WARM/COLD tier
+```
+
+See [user-guide/multi-branch.md](user-guide/multi-branch.md) for the full guide.
+
+---
+
+## Build issues
+
+### `make build` fails on `dashboard-build`
+
+```sh
+node --version    # must be 20+
+npm --version     # 8+ recommended
+cd webui-v2 && npm ci && npx vite build    # run the dashboard build manually to see errors
+```
+
+### CGO errors on Linux
+
+```sh
+apt install build-essential    # install gcc and libc dev headers
+CGO_ENABLED=1 go build ./...   # verify CGO is active
+```
+
+### CGO errors on Windows
+
+Install MSYS2/MinGW64 and set `CC=x86_64-w64-mingw32-gcc` in your environment. The CI workflow in `.github/workflows/test.yml` shows the exact setup steps.
+
+---
+
+## Skills
+
+### Slash commands not available in Claude Code
+
+```sh
+archigraph doctor              # checks skill install status
+archigraph install --skills    # reinstall skills
+```
+
+Skills land in `~/.claude/skills/`. Confirm that directory is not excluded by your Claude Code config.
+
+### Skill runs but produces no output or errors on MCP tools
+
+Ensure the daemon is running and the group is registered before invoking any skill. Start with `/archigraph-help` to get an orientation and confirm the MCP connection.


### PR DESCRIPTION
## Summary

The README was a 450-line wall of technical text that mixed the pitch, install instructions, release notes, CLI reference, settings tables, and dashboard surface maps. It was hard to evaluate at a glance and buried the “why”.

This PR splits the content into two tiers:

- **README.md = sells the product.** ~220 lines. Covers what archigraph is, the pain it removes, 7 concrete capabilities, a diagram, a 5-command quickstart, and when you’d reach for it. Ends with a map into docs/.
- **docs/ = the manual.** Seven new files that cover everything that was stripped from the README in depth.

## Files changed

### Modified
- `README.md` — rewritten from scratch (~450 lines → ~220 lines)

### Created
- `docs/README.md` — table of contents for the docs/ tree (getting started, concepts, agent usage, advanced, reference)
- `docs/quickstart.md` — install + first index + first query in 5 steps; all commands verified against Makefile and CLI
- `docs/concepts.md` — knowledge graph model, entity kinds, edge kinds, residual edges, repair and enrichment, groups, multi-branch, patterns
- `docs/mcp-tools.md` — orientation-level tool catalogue (all 29 tools by category) + pointer to `internal/mcp/SCHEMA.md` for full contract; pairing guide pointer
- `docs/skills.md` — pointer to `skills/README.md` + summary chain + minimum-useful-run
- `docs/install.md` — full install matrix: script (not yet published), Windows PowerShell, pre-built binary, build from source, dev mode, post-install, upgrade, uninstall
- `docs/troubleshooting.md` — symptoms → diagnoses for daemon, MCP, indexing, build, and skills issues

### Not touched
- `skills/` — zero changes (owned by the skills epic PRs)
- `internal/` — zero Go code changes
- `.github/` — untouched
- `Makefile` — untouched

## Testing
- No code changes — documentation only.
- All commands in quickstart.md and install.md verified against the Makefile and existing CLI command list in the current README.

## Notes / judgment calls flagged for review
- The tool count in the README pitch says “29 MCP tools” — this matches the SCHEMA.md header. If that number changes before v1.0, update both.
- `docs/mcp-tools.md` lists the docgen tools (`archigraph_docgen_*`) as a group even though SCHEMA.md shows 6 tools. If that set changes, update the catalogue.
- The quickstart says the installer script is “not yet published” — remove that note when the first release ships.
- `docs/agent-instructions-draft.md` is left in place (not linked from docs/README.md) — it looks like a work-in-progress draft, not user-facing content. Flag if it should be promoted or deleted.