### PR TITLE
fix(install): symlink skills into all Claude config dirs + prune orphans

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -538,8 +538,8 @@ func TestInstallSkillsInClaudeConfigs(t *testing.T) {
 		t.Fatalf("expected 2 installed dirs, got %d: %v", len(installed), installed)
 	}
 
-	// Verify symlinks in primary Claude config.
-	primarySkillsDir := filepath.Join(filepath.Dir(claudeDir), "skills")
+	// Verify symlinks in primary Claude config (HOME/.claude.json → HOME/.claude/skills).
+	primarySkillsDir := skilllink.ClaudeSkillsDirForConfig(claudeDir)
 	for _, skillName := range skillNames {
 		skillPath := filepath.Join(primarySkillsDir, skillName)
 		info, err := os.Lstat(skillPath)
@@ -561,8 +561,8 @@ func TestInstallSkillsInClaudeConfigs(t *testing.T) {
 		}
 	}
 
-	// Verify symlinks in secondary Claude config.
-	secondarySkillsDir := filepath.Join(filepath.Dir(claudePersonalJSON), "skills")
+	// Verify symlinks in secondary Claude config (sidecar layout).
+	secondarySkillsDir := skilllink.ClaudeSkillsDirForConfig(claudePersonalJSON)
 	for _, skillName := range skillNames {
 		skillPath := filepath.Join(secondarySkillsDir, skillName)
 		info, err := os.Lstat(skillPath)
@@ -618,7 +618,7 @@ func TestInstallSkillsIdempotent(t *testing.T) {
 	}
 
 	// Verify symlinks still exist and point correctly.
-	skillsSubdir := filepath.Join(filepath.Dir(claudeDir), "skills")
+	skillsSubdir := skilllink.ClaudeSkillsDirForConfig(claudeDir)
 	for _, skillName := range skillNames {
 		skillPath := filepath.Join(skillsSubdir, skillName)
 		target, err := os.Readlink(skillPath)
@@ -665,7 +665,7 @@ func TestRemoveSkillsFromClaudeConfigs(t *testing.T) {
 	installSkillsInClaudeConfigs(installOut, "/fake/bin", skillsDir, []string{claudeDir})
 
 	// Verify skills are installed.
-	skillsSubdir := filepath.Join(filepath.Dir(claudeDir), "skills")
+	skillsSubdir := skilllink.ClaudeSkillsDirForConfig(claudeDir)
 	for _, skillName := range skillNames {
 		_, err := os.Lstat(filepath.Join(skillsSubdir, skillName))
 		if err != nil {

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -208,18 +208,38 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 		return nil, fmt.Errorf("step 2 – no Claude Code config directories detected")
 	}
 
-	// We install skills into the FIRST detected config dir (the primary
-	// ~/.claude/). Future improvement (#2213) could iterate over all dirs.
-	primaryClaudeDir := filepath.Dir(claudeDirs[0])
-	skillsDestDir := filepath.Join(primaryClaudeDir, "skills")
-
-	skillRecords, installedSkills, err := copySkills(skillsDir, skillsDestDir, opts.DryRun)
-	if err != nil {
-		rollback(2)
-		return nil, fmt.Errorf("step 2 – copy skills: %w", err)
+	// Copy skills into EVERY detected Claude config dir's skills/ subdir so
+	// users running multiple Claude profiles (~/.claude, ~/.claude-personal,
+	// etc.) see the skills in all of them.  The SkillRecord/Files manifest
+	// is identical regardless of how many destinations receive a copy.
+	skillRecords := map[string]SkillRecord{}
+	installedSet := map[string]bool{}
+	for _, cfgPath := range claudeDirs {
+		skillsDestDir := skilllink.ClaudeSkillsDirForConfig(cfgPath)
+		if skillsDestDir == "" {
+			fmt.Fprintf(os.Stderr,
+				"archigraph install: cannot derive skills dir for %s; skipping\n",
+				cfgPath)
+			continue
+		}
+		recs, installed, err := copySkills(skillsDir, skillsDestDir, opts.DryRun)
+		if err != nil {
+			rollback(2)
+			return nil, fmt.Errorf("step 2 – copy skills into %s: %w", skillsDestDir, err)
+		}
+		for name, rec := range recs {
+			skillRecords[name] = rec
+		}
+		for _, name := range installed {
+			installedSet[name] = true
+		}
 	}
 	state.Skills = skillRecords
-	result.SkillsInstalled = installedSkills
+	for _, name := range skilllink.SkillNames {
+		if installedSet[name] {
+			result.SkillsInstalled = append(result.SkillsInstalled, name)
+		}
+	}
 	completedSteps = append(completedSteps, 2)
 
 	// ─────────────────────────────────────────────────────────────────────────
@@ -400,6 +420,11 @@ func copySkills(srcDir, destDir string, dryRun bool) (map[string]SkillRecord, []
 		if err := os.MkdirAll(destDir, 0o755); err != nil {
 			return nil, nil, fmt.Errorf("create skills dir %s: %w", destDir, err)
 		}
+		// Prune orphan symlinks left behind by an earlier DEV install (or a
+		// previously-shipped skill that has since been renamed/retired).  We
+		// only remove symlinks here; regular directories are left intact in
+		// case a user installed a skill manually.
+		skilllink.PruneOrphanSkillSymlinks(os.Stderr, destDir)
 	}
 
 	records := make(map[string]SkillRecord)
@@ -565,18 +590,21 @@ func waitForHealthz(port int, timeout time.Duration) (string, error) {
 // ── rollback helpers ──────────────────────────────────────────────────────────
 
 // rollbackSkillsCopy removes any skill directories that were copied to
-// the destination during step 2.
+// every detected Claude config dir during step 2.
 func rollbackSkillsCopy(opts CopyOptions, state *State) {
 	claudeDirs := mcpreg.DetectClaudeConfigDirs(opts.ClaudeConfigDirs)
 	if len(claudeDirs) == 0 {
 		return
 	}
-	primaryClaudeDir := filepath.Dir(claudeDirs[0])
-	skillsDestDir := filepath.Join(primaryClaudeDir, "skills")
-
-	for skillName := range state.Skills {
-		dst := filepath.Join(skillsDestDir, skillName)
-		_ = os.RemoveAll(dst)
+	for _, cfgPath := range claudeDirs {
+		skillsDestDir := skilllink.ClaudeSkillsDirForConfig(cfgPath)
+		if skillsDestDir == "" {
+			continue
+		}
+		for skillName := range state.Skills {
+			dst := filepath.Join(skillsDestDir, skillName)
+			_ = os.RemoveAll(dst)
+		}
 	}
 }
 

--- a/internal/install/dev.go
+++ b/internal/install/dev.go
@@ -183,17 +183,46 @@ func RunDev(opts DevOptions) (*DevResult, error) {
 		return nil, fmt.Errorf("step 2 – no Claude Code config directories detected")
 	}
 
-	primaryClaudeDir := filepath.Dir(claudeDirs[0])
-	skillsDestDir := filepath.Join(primaryClaudeDir, "skills")
-
-	skillRecords, linked, fallbackCopied, err := symlinkSkills(skillsDir, skillsDestDir, opts.DryRun)
-	if err != nil {
-		rollback(2)
-		return nil, fmt.Errorf("step 2 – symlink skills: %w", err)
+	// Symlink into EVERY detected Claude config dir's skills/ subdir so users
+	// running multiple Claude profiles (~/.claude, ~/.claude-personal, etc.)
+	// see the skills in all of them.  Records are merged across configs;
+	// each skill is keyed by name and the DevTarget is identical regardless
+	// of how many configs contain it.
+	skillRecords := map[string]SkillRecord{}
+	linkedSet := map[string]bool{}
+	fallbackSet := map[string]bool{}
+	for _, cfgPath := range claudeDirs {
+		skillsDestDir := skilllink.ClaudeSkillsDirForConfig(cfgPath)
+		if skillsDestDir == "" {
+			fmt.Fprintf(os.Stderr,
+				"archigraph install --dev: cannot derive skills dir for %s; skipping\n",
+				cfgPath)
+			continue
+		}
+		recs, linked, fallback, err := symlinkSkills(skillsDir, skillsDestDir, opts.DryRun)
+		if err != nil {
+			rollback(2)
+			return nil, fmt.Errorf("step 2 – symlink skills into %s: %w", skillsDestDir, err)
+		}
+		for name, rec := range recs {
+			skillRecords[name] = rec
+		}
+		for _, name := range linked {
+			linkedSet[name] = true
+		}
+		for _, name := range fallback {
+			fallbackSet[name] = true
+		}
 	}
 	state.Skills = skillRecords
-	result.SkillsLinked = linked
-	result.SkillsFallbackCopied = fallbackCopied
+	for _, name := range skilllink.SkillNames {
+		if linkedSet[name] {
+			result.SkillsLinked = append(result.SkillsLinked, name)
+		}
+		if fallbackSet[name] {
+			result.SkillsFallbackCopied = append(result.SkillsFallbackCopied, name)
+		}
+	}
 	completedSteps = append(completedSteps, 2)
 
 	// ─────────────────────────────────────────────────────────────────────────
@@ -335,6 +364,10 @@ func symlinkSkills(srcDir, destDir string, dryRun bool) (map[string]SkillRecord,
 		if err := os.MkdirAll(destDir, 0o755); err != nil {
 			return nil, nil, nil, fmt.Errorf("create skills dir %s: %w", destDir, err)
 		}
+		// Prune orphan symlinks (renamed/retired skills from earlier installs)
+		// BEFORE adding the current set, so a stale entry never survives a
+		// re-install.
+		skilllink.PruneOrphanSkillSymlinks(os.Stderr, destDir)
 	}
 
 	records := make(map[string]SkillRecord)
@@ -393,17 +426,20 @@ func symlinkSkills(srcDir, destDir string, dryRun bool) (map[string]SkillRecord,
 }
 
 // rollbackSkillsSymlinks removes any skill symlinks or directories that were
-// created under destDir during step 2 of a DEV install.
+// created under each detected Claude config dir during step 2 of a DEV install.
 func rollbackSkillsSymlinks(opts DevOptions, state *State) {
 	claudeDirs := mcpreg.DetectClaudeConfigDirs(opts.ClaudeConfigDirs)
 	if len(claudeDirs) == 0 {
 		return
 	}
-	primaryClaudeDir := filepath.Dir(claudeDirs[0])
-	skillsDestDir := filepath.Join(primaryClaudeDir, "skills")
-
-	for skillName := range state.Skills {
-		dst := filepath.Join(skillsDestDir, skillName)
-		_ = os.RemoveAll(dst)
+	for _, cfgPath := range claudeDirs {
+		skillsDestDir := skilllink.ClaudeSkillsDirForConfig(cfgPath)
+		if skillsDestDir == "" {
+			continue
+		}
+		for skillName := range state.Skills {
+			dst := filepath.Join(skillsDestDir, skillName)
+			_ = os.RemoveAll(dst)
+		}
 	}
 }

--- a/internal/install/dev_test.go
+++ b/internal/install/dev_test.go
@@ -565,6 +565,103 @@ func TestDoctorDevMode_NoPanicOnFileModification(t *testing.T) {
 	}
 }
 
+// TestRunDev_MultipleConfigsAndOrphanPruning verifies the #2269 fix:
+//
+//  1. When multiple Claude config dirs are passed, skill symlinks are
+//     created in EVERY config dir's skills/ subdir (primary HOME/.claude.json
+//     + sidecar HOME/.claude-*/.claude.json layouts).
+//  2. Pre-existing stale symlinks for renamed/retired skills are pruned
+//     before the current skill set is installed.
+//
+// Both bugs share a fix path so we cover them in one integration test.
+func TestRunDev_MultipleConfigsAndOrphanPruning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink-based assertions only meaningful on non-Windows")
+	}
+	env := newDevTestEnv(t)
+
+	// Build the three real-world Claude config layouts: HOME/.claude.json
+	// (primary), HOME/.claude-personal/.claude.json and
+	// HOME/.claude-extra/.claude.json (sidecars).  newTestEnv already
+	// configured the primary at HOME/.claude/.claude.json — we add the
+	// sidecars and override ClaudeConfigDirs.
+	homeDir := filepath.Dir(filepath.Dir(env.claudeJSON)) // tmp
+	primaryCfg := env.claudeJSON                          // tmp/.claude/.claude.json
+	personalCfg := filepath.Join(homeDir, ".claude-personal", ".claude.json")
+	extraCfg := filepath.Join(homeDir, ".claude-extra", ".claude.json")
+	for _, p := range []string{personalCfg, extraCfg} {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("create sidecar dir: %v", err)
+		}
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write sidecar .claude.json: %v", err)
+		}
+	}
+
+	// Pre-seed the primary skills dir with three stale orphan symlinks
+	// (renamed/retired skills from earlier installs).
+	primarySkillsDir := filepath.Join(filepath.Dir(primaryCfg), "skills")
+	if err := os.MkdirAll(primarySkillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir primary skills dir: %v", err)
+	}
+	dummyTarget := filepath.Join(homeDir, "dummy-target")
+	if err := os.MkdirAll(dummyTarget, 0o755); err != nil {
+		t.Fatalf("mkdir dummy target: %v", err)
+	}
+	stale := []string{"archigraph-quality-check", "archigraph-repair", "generate-docs"}
+	for _, name := range stale {
+		if err := os.Symlink(dummyTarget, filepath.Join(primarySkillsDir, name)); err != nil {
+			t.Fatalf("seed orphan %s: %v", name, err)
+		}
+	}
+
+	opts := defaultDevOpts(env)
+	opts.ClaudeConfigDirs = []string{primaryCfg, personalCfg, extraCfg}
+
+	result, err := install.RunDev(opts)
+	if err != nil {
+		t.Fatalf("RunDev: %v", err)
+	}
+
+	// Every config dir should have the full skill set as symlinks.
+	configsAndSkillsDirs := map[string]string{
+		primaryCfg:  filepath.Join(filepath.Dir(primaryCfg), "skills"),
+		personalCfg: filepath.Join(filepath.Dir(personalCfg), "skills"),
+		extraCfg:    filepath.Join(filepath.Dir(extraCfg), "skills"),
+	}
+	for cfg, skillsSubdir := range configsAndSkillsDirs {
+		for _, name := range result.SkillsLinked {
+			dst := filepath.Join(skillsSubdir, name)
+			info, err := os.Lstat(dst)
+			if err != nil {
+				t.Errorf("config %s: skill %s missing at %s: %v", cfg, name, dst, err)
+				continue
+			}
+			if info.Mode()&os.ModeSymlink == 0 {
+				t.Errorf("config %s: skill %s at %s is not a symlink", cfg, name, dst)
+			}
+		}
+	}
+
+	// Stale orphan symlinks must be gone from the primary skills dir.
+	for _, name := range stale {
+		if _, err := os.Lstat(filepath.Join(primarySkillsDir, name)); !os.IsNotExist(err) {
+			t.Errorf("orphan symlink %s should have been pruned (err=%v)", name, err)
+		}
+	}
+
+	// The state file should record every current skill.
+	state := readState(t, result.StatePath)
+	if state == nil {
+		t.Fatal("install.json not written")
+	}
+	for _, name := range result.SkillsLinked {
+		if _, ok := state.Skills[name]; !ok {
+			t.Errorf("install.json missing skill record for %s", name)
+		}
+	}
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 // errorf is a test helper that returns a simple error value.

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/install/mcpreg"
+	"github.com/cajasmota/archigraph/internal/install/skilllink"
 )
 
 // DoctorSchemaVersion is the JSON schema version for DoctorReport.
@@ -167,7 +168,7 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 	if skillsDir == "" {
 		claudeDirs := mcpreg.DetectClaudeConfigDirs(opts.ClaudeConfigDirs)
 		if len(claudeDirs) > 0 {
-			skillsDir = filepath.Join(filepath.Dir(claudeDirs[0]), "skills")
+			skillsDir = skilllink.ClaudeSkillsDirForConfig(claudeDirs[0])
 		}
 	}
 

--- a/internal/install/skilllink/skilllink.go
+++ b/internal/install/skilllink/skilllink.go
@@ -36,6 +36,86 @@ var SkillNames = []string{
 	"using-archigraph",
 }
 
+// ClaudeSkillsDirForConfig derives the skills directory associated with a
+// Claude Code config file.
+//
+// Claude Code's layout has two flavours:
+//
+//   - Primary config at HOME/.claude.json — skills live at HOME/.claude/skills/
+//     (the parent of the config file is HOME, NOT the instance dir).
+//   - Sidecar config at HOME/.claude-X/.claude.json — skills live at
+//     HOME/.claude-X/skills/ (the parent of the config IS the instance dir).
+//
+// The unifying rule is: if the config's parent directory basename already
+// starts with ".claude" (sidecar layout), the parent IS the instance dir
+// and skills sit alongside the config.  Otherwise, the instance dir is
+// derived by stripping ".json" from the config's basename and treating the
+// remainder as a subdirectory of the parent.
+//
+// Examples:
+//
+//	~/.claude.json                       → ~/.claude/skills
+//	~/.claude-personal/.claude.json      → ~/.claude-personal/skills
+//	~/.claude-extra/.claude.json         → ~/.claude-extra/skills
+//	/abs/path/.claude.json               → /abs/path/.claude/skills
+//	~/.claude-personal.json (flat)       → ~/.claude-personal/skills
+//
+// If configPath does not end in ".json", the empty string is returned.
+func ClaudeSkillsDirForConfig(configPath string) string {
+	if !strings.HasSuffix(configPath, ".json") {
+		return ""
+	}
+	parent := filepath.Dir(configPath)
+	if strings.HasPrefix(filepath.Base(parent), ".claude") {
+		// Sidecar layout — parent dir is the Claude instance dir.
+		return filepath.Join(parent, "skills")
+	}
+	// Primary / flat layout — derive the instance dir by stripping ".json".
+	stem := strings.TrimSuffix(filepath.Base(configPath), ".json")
+	return filepath.Join(parent, stem, "skills")
+}
+
+// PruneOrphanSkillSymlinks removes any *symlink* entries in skillsSubdir
+// whose basename is not in the current SkillNames set. This cleans up after
+// renamed or retired skills from earlier installs.
+//
+// Defensive: only symlinks are removed; regular directories (manual
+// installs) are left untouched.  Errors are reported via out but do not
+// abort the caller.
+func PruneOrphanSkillSymlinks(out io.Writer, skillsSubdir string) {
+	entries, err := os.ReadDir(skillsSubdir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(out, "    ⚠ scan for orphan skills in %s: %v\n", skillsSubdir, err)
+		}
+		return
+	}
+	current := make(map[string]bool, len(SkillNames))
+	for _, name := range SkillNames {
+		current[name] = true
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if current[name] {
+			continue
+		}
+		full := filepath.Join(skillsSubdir, name)
+		info, err := os.Lstat(full)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			// Don't touch regular directories — those are manual installs.
+			continue
+		}
+		if err := os.Remove(full); err != nil {
+			fmt.Fprintf(out, "    ⚠ remove orphan skill symlink %s: %v\n", full, err)
+			continue
+		}
+		fmt.Fprintf(out, "    ⓘ removed orphan skill symlink: %s\n", name)
+	}
+}
+
 // DiscoverSkillsDir finds the source directory containing the archigraph
 // skills. It tries these locations in order:
 //
@@ -104,11 +184,20 @@ func InstallSkillsInClaudeConfigs(out io.Writer, binPath, skillsSourceDir string
 
 	installed := []string{}
 	for _, cfgPath := range claudeConfigDirs {
-		skillsSubdir := filepath.Join(filepath.Dir(cfgPath), "skills")
+		skillsSubdir := ClaudeSkillsDirForConfig(cfgPath)
+		if skillsSubdir == "" {
+			fmt.Fprintf(out, "  ⚠ cannot derive skills dir for %s (not a .json config); skipping\n", cfgPath)
+			continue
+		}
 		if err := os.MkdirAll(skillsSubdir, 0o755); err != nil {
 			fmt.Fprintf(out, "  ⚠ create skills dir %s: %v\n", skillsSubdir, err)
 			continue
 		}
+
+		// Prune orphan symlinks (renamed/retired skills from earlier installs)
+		// BEFORE adding the current set, so a stale entry never survives a
+		// re-install.
+		PruneOrphanSkillSymlinks(out, skillsSubdir)
 
 		allOK := true
 		for _, skillName := range SkillNames {
@@ -170,7 +259,11 @@ func InstallSkillsInClaudeConfigs(out io.Writer, binPath, skillsSourceDir string
 func RemoveSkillsFromClaudeConfigs(out io.Writer, claudeConfigDirs []string) []string {
 	removed := []string{}
 	for _, cfgPath := range claudeConfigDirs {
-		skillsSubdir := filepath.Join(filepath.Dir(cfgPath), "skills")
+		skillsSubdir := ClaudeSkillsDirForConfig(cfgPath)
+		if skillsSubdir == "" {
+			fmt.Fprintf(out, "  ⚠ cannot derive skills dir for %s (not a .json config); skipping\n", cfgPath)
+			continue
+		}
 
 		// Check if skills subdir exists.
 		info, err := os.Stat(skillsSubdir)

--- a/internal/install/skilllink/skilllink_test.go
+++ b/internal/install/skilllink/skilllink_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -68,11 +69,78 @@ func TestDiscoverSkillsDir(t *testing.T) {
 	}
 }
 
-func TestInstallSkillsInClaudeConfigs(t *testing.T) {
+// TestClaudeSkillsDirForConfig table-drives the path-derivation helper.
+//
+// The Claude Code conventions covered here:
+//
+//   - HOME/.claude.json (primary, file directly in HOME)
+//     → HOME/.claude/skills
+//   - HOME/.claude-X/.claude.json (sidecar profile, file inside a dir
+//     whose basename already starts with ".claude")
+//     → HOME/.claude-X/skills
+//   - Hypothetical flat sidecar HOME/.claude-X.json
+//     → HOME/.claude-X/skills
+//   - Non-".json" inputs return "".
+func TestClaudeSkillsDirForConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "primary config in HOME",
+			in:   "/home/u/.claude.json",
+			want: "/home/u/.claude/skills",
+		},
+		{
+			name: "sidecar config inside .claude-personal dir",
+			in:   "/home/u/.claude-personal/.claude.json",
+			want: "/home/u/.claude-personal/skills",
+		},
+		{
+			name: "sidecar config inside .claude-extra dir",
+			in:   "/home/u/.claude-extra/.claude.json",
+			want: "/home/u/.claude-extra/skills",
+		},
+		{
+			name: "config in a non-Claude parent dir",
+			in:   "/abs/path/.claude.json",
+			want: "/abs/path/.claude/skills",
+		},
+		{
+			name: "hypothetical flat sidecar (~/.claude-personal.json)",
+			in:   "/home/u/.claude-personal.json",
+			want: "/home/u/.claude-personal/skills",
+		},
+		{
+			name: "no .json suffix → empty string",
+			in:   "/home/u/.claude",
+			want: "",
+		},
+		{
+			name: "empty string → empty string",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClaudeSkillsDirForConfig(tt.in)
+			if got != tt.want {
+				t.Errorf("ClaudeSkillsDirForConfig(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestInstallSkillsInClaudeConfigs_MultipleConfigs verifies that the install
+// loop places symlinks in EVERY detected config dir's skills/ subdir, using
+// the correct derivation (primary vs sidecar layout).
+func TestInstallSkillsInClaudeConfigs_MultipleConfigs(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create source skills directory with dummy skill dirs.
-	skillsDir := filepath.Join(dir, "skills")
+	// Source skills.
+	skillsDir := filepath.Join(dir, "src-skills")
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -81,74 +149,146 @@ func TestInstallSkillsInClaudeConfigs(t *testing.T) {
 		if err := os.MkdirAll(skillPath, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		// Write a marker file so we can verify the symlink target.
 		if err := os.WriteFile(filepath.Join(skillPath, "skill.yaml"), []byte("name: "+skillName), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// Create Claude config directories.
-	claudeDir := filepath.Join(dir, "claude", ".claude.json")
-	claudePersonalDir := filepath.Join(dir, "claude-personal", ".claude.json")
-	for _, p := range []string{
-		filepath.Dir(claudeDir),
-		filepath.Dir(claudePersonalDir),
-	} {
+	// Three configs covering the primary + two sidecar profiles.
+	primaryCfg := filepath.Join(dir, ".claude.json")
+	personalCfg := filepath.Join(dir, ".claude-personal", ".claude.json")
+	extraCfg := filepath.Join(dir, ".claude-extra", ".claude.json")
+	for _, p := range []string{filepath.Dir(personalCfg), filepath.Dir(extraCfg)} {
 		if err := os.MkdirAll(p, 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// Call the installation function.
 	out := &bytes.Buffer{}
-	installed := InstallSkillsInClaudeConfigs(out, "", skillsDir, []string{claudeDir, claudePersonalDir})
+	installed := InstallSkillsInClaudeConfigs(out, "", skillsDir, []string{primaryCfg, personalCfg, extraCfg})
 
-	if len(installed) != 2 {
-		t.Fatalf("expected 2 installed dirs, got %d: %v", len(installed), installed)
+	if len(installed) != 3 {
+		t.Fatalf("expected 3 installed dirs, got %d: %v\noutput:\n%s", len(installed), installed, out.String())
 	}
 
-	// Verify symlinks were created in the primary Claude config.
-	primarySkillsDir := filepath.Join(filepath.Dir(claudeDir), "skills")
+	wantDirs := map[string]string{
+		"primary":  filepath.Join(dir, ".claude", "skills"),
+		"personal": filepath.Join(dir, ".claude-personal", "skills"),
+		"extra":    filepath.Join(dir, ".claude-extra", "skills"),
+	}
+	for label, want := range wantDirs {
+		info, err := os.Stat(want)
+		if err != nil {
+			t.Fatalf("%s: skills dir %s missing: %v", label, want, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s: %s is not a directory", label, want)
+		}
+		for _, skillName := range SkillNames {
+			dst := filepath.Join(want, skillName)
+			linkInfo, err := os.Lstat(dst)
+			if err != nil {
+				t.Errorf("%s: symlink not created for %s at %s: %v", label, skillName, dst, err)
+				continue
+			}
+			if linkInfo.Mode()&os.ModeSymlink == 0 {
+				t.Errorf("%s: %s is not a symlink", label, dst)
+				continue
+			}
+			target, err := os.Readlink(dst)
+			if err != nil {
+				t.Errorf("%s: readlink %s: %v", label, dst, err)
+				continue
+			}
+			expected := filepath.Join(skillsDir, skillName)
+			if target != expected {
+				t.Errorf("%s: symlink target mismatch for %s: got %q want %q", label, skillName, target, expected)
+			}
+		}
+	}
+}
+
+// TestInstallSkillsInClaudeConfigs_PrunesOrphans verifies that stale symlinks
+// for renamed/retired skills are removed before the current skill set is
+// installed.  Regular directories (manual installs) are left intact.
+func TestInstallSkillsInClaudeConfigs_PrunesOrphans(t *testing.T) {
+	dir := t.TempDir()
+
+	// Source skills (current set).
+	skillsDir := filepath.Join(dir, "src-skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	for _, skillName := range SkillNames {
-		skillPath := filepath.Join(primarySkillsDir, skillName)
-		info, err := os.Lstat(skillPath)
-		if err != nil {
-			t.Fatalf("symlink not created for %s: %v", skillName, err)
-		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			t.Fatalf("%s is not a symlink", skillName)
-		}
-
-		// Verify the symlink target.
-		target, err := os.Readlink(skillPath)
-		if err != nil {
-			t.Fatalf("failed to read symlink %s: %v", skillName, err)
-		}
-		expectedTarget := filepath.Join(skillsDir, skillName)
-		if target != expectedTarget {
-			t.Errorf("symlink target mismatch: expected %q, got %q", expectedTarget, target)
-		}
-
-		// Verify we can read through the symlink.
-		content, err := os.ReadFile(filepath.Join(skillPath, "skill.yaml"))
-		if err != nil {
-			t.Fatalf("failed to read through symlink %s: %v", skillName, err)
-		}
-		if !stringContains(string(content), skillName) {
-			t.Errorf("symlink didn't resolve correctly for %s", skillName)
+		skillPath := filepath.Join(skillsDir, skillName)
+		if err := os.MkdirAll(skillPath, 0o755); err != nil {
+			t.Fatal(err)
 		}
 	}
 
-	// Also verify symlinks in the secondary Claude config.
-	secondarySkillsDir := filepath.Join(filepath.Dir(claudePersonalDir), "skills")
-	for _, skillName := range SkillNames {
-		skillPath := filepath.Join(secondarySkillsDir, skillName)
-		info, err := os.Lstat(skillPath)
+	// Pre-seed the destination skills dir with three stale orphan symlinks
+	// (renamed/retired skills) plus one manual install (regular directory).
+	primaryCfg := filepath.Join(dir, ".claude.json")
+	skillsSubdir := ClaudeSkillsDirForConfig(primaryCfg)
+	if err := os.MkdirAll(skillsSubdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := []string{"archigraph-quality-check", "archigraph-repair", "generate-docs"}
+	dummyTarget := filepath.Join(dir, "dummy-target")
+	if err := os.MkdirAll(dummyTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range stale {
+		if err := os.Symlink(dummyTarget, filepath.Join(skillsSubdir, name)); err != nil {
+			t.Fatalf("seed orphan symlink %s: %v", name, err)
+		}
+	}
+	manualSkill := filepath.Join(skillsSubdir, "my-custom-skill")
+	if err := os.MkdirAll(manualSkill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(manualSkill, "marker"), []byte("manual"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run install.
+	out := &bytes.Buffer{}
+	installed := InstallSkillsInClaudeConfigs(out, "", skillsDir, []string{primaryCfg})
+	if len(installed) != 1 {
+		t.Fatalf("expected 1 installed dir, got %d: %v", len(installed), installed)
+	}
+
+	// Orphan symlinks must be gone.
+	for _, name := range stale {
+		_, err := os.Lstat(filepath.Join(skillsSubdir, name))
+		if !os.IsNotExist(err) {
+			t.Errorf("orphan symlink %s should have been pruned (err=%v)", name, err)
+		}
+	}
+
+	// Manual install (regular dir) must be untouched.
+	if _, err := os.Stat(filepath.Join(manualSkill, "marker")); err != nil {
+		t.Errorf("manual install was clobbered: %v", err)
+	}
+
+	// All current SkillNames must be present as symlinks.
+	for _, name := range SkillNames {
+		info, err := os.Lstat(filepath.Join(skillsSubdir, name))
 		if err != nil {
-			t.Fatalf("symlink not created for %s in secondary config: %v", skillName, err)
+			t.Errorf("current skill %s missing after install: %v", name, err)
+			continue
 		}
 		if info.Mode()&os.ModeSymlink == 0 {
-			t.Fatalf("%s is not a symlink in secondary config", skillName)
+			t.Errorf("current skill %s is not a symlink", name)
+		}
+	}
+
+	// The output should mention each pruned orphan so the user knows what
+	// happened (one line per orphan).
+	outStr := out.String()
+	for _, name := range stale {
+		if !strings.Contains(outStr, name) {
+			t.Errorf("output should mention pruned orphan %s; got:\n%s", name, outStr)
 		}
 	}
 }
@@ -157,7 +297,7 @@ func TestInstallSkillsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create source skills directory.
-	skillsDir := filepath.Join(dir, "skills")
+	skillsDir := filepath.Join(dir, "src-skills")
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -168,41 +308,32 @@ func TestInstallSkillsIdempotent(t *testing.T) {
 		}
 	}
 
-	// Create Claude config directory.
-	claudeDir := filepath.Join(dir, "claude", ".claude.json")
-	if err := os.MkdirAll(filepath.Dir(claudeDir), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	// Primary config (file directly in tmp/).
+	primaryCfg := filepath.Join(dir, ".claude.json")
+	skillsSubdir := ClaudeSkillsDirForConfig(primaryCfg)
 
 	// First install.
 	out1 := &bytes.Buffer{}
-	installed1 := InstallSkillsInClaudeConfigs(out1, "", skillsDir, []string{claudeDir})
+	installed1 := InstallSkillsInClaudeConfigs(out1, "", skillsDir, []string{primaryCfg})
 	if len(installed1) != 1 {
 		t.Fatalf("first install: expected 1 installed dir, got %d", len(installed1))
 	}
 
-	// Get the modification time of one symlink.
-	skillPath1 := filepath.Join(filepath.Dir(claudeDir), "skills", SkillNames[0])
-	_, err := os.Lstat(skillPath1)
-	if err != nil {
+	// Verify a symlink was created.
+	skillPath1 := filepath.Join(skillsSubdir, SkillNames[0])
+	if _, err := os.Lstat(skillPath1); err != nil {
 		t.Fatal(err)
 	}
 
 	// Re-run install (should be idempotent).
 	out2 := &bytes.Buffer{}
-	installed2 := InstallSkillsInClaudeConfigs(out2, "", skillsDir, []string{claudeDir})
+	installed2 := InstallSkillsInClaudeConfigs(out2, "", skillsDir, []string{primaryCfg})
 	if len(installed2) != 1 {
 		t.Fatalf("second install: expected 1 installed dir, got %d", len(installed2))
 	}
 
-	// Verify symlinks still exist and point correctly.
-	skillPath2 := filepath.Join(filepath.Dir(claudeDir), "skills", SkillNames[0])
-	if _, err := os.Lstat(skillPath2); err != nil {
-		t.Fatal(err)
-	}
-
-	// The symlink should have been replaced (new mtime), but target should be the same.
-	target, err := os.Readlink(skillPath2)
+	// Symlinks still point at the source.
+	target, err := os.Readlink(skillPath1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +342,6 @@ func TestInstallSkillsIdempotent(t *testing.T) {
 		t.Errorf("symlink target mismatch after re-install: expected %q, got %q", expectedTarget, target)
 	}
 
-	// Verify both installs reported success.
 	if !stringContains(out1.String(), "Skills linked in:") {
 		t.Errorf("first install didn't report success: %s", out1.String())
 	}
@@ -223,8 +353,8 @@ func TestInstallSkillsIdempotent(t *testing.T) {
 func TestInstallSkillsSkipsManualInstall(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create source skills directory.
-	skillsDir := filepath.Join(dir, "skills")
+	// Source skills.
+	skillsDir := filepath.Join(dir, "src-skills")
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -235,27 +365,21 @@ func TestInstallSkillsSkipsManualInstall(t *testing.T) {
 		}
 	}
 
-	// Create Claude config directory with one manually-installed skill.
-	claudeDir := filepath.Join(dir, "claude", ".claude.json")
-	if err := os.MkdirAll(filepath.Dir(claudeDir), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	skillsSubdir := filepath.Join(filepath.Dir(claudeDir), "skills")
+	primaryCfg := filepath.Join(dir, ".claude.json")
+	skillsSubdir := ClaudeSkillsDirForConfig(primaryCfg)
 	if err := os.MkdirAll(skillsSubdir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	// Create a regular directory for the first skill (manual install).
+	// Manually-installed skill at the first canonical name (regular dir).
 	manualSkillPath := filepath.Join(skillsSubdir, SkillNames[0])
 	if err := os.MkdirAll(manualSkillPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	// Install should create symlinks for the other skills but warn about the manual one.
 	out := &bytes.Buffer{}
-	_ = InstallSkillsInClaudeConfigs(out, "", skillsDir, []string{claudeDir})
+	_ = InstallSkillsInClaudeConfigs(out, "", skillsDir, []string{primaryCfg})
 
-	// We still return the dir as installed, but with a warning.
 	outStr := out.String()
 	if !stringContains(outStr, "Skills linked in:") {
 		t.Errorf("should report partial success: %s", outStr)
@@ -264,27 +388,22 @@ func TestInstallSkillsSkipsManualInstall(t *testing.T) {
 		t.Errorf("should warn about manual install: %s", outStr)
 	}
 
-	// Verify the manual skill was not replaced.
-	_, err := os.Lstat(filepath.Join(skillsSubdir, SkillNames[0]))
-	if err != nil {
-		t.Fatalf("manual skill was deleted: %v", err)
-	}
+	// Manual skill must NOT have been replaced with a symlink.
 	info, err := os.Lstat(filepath.Join(skillsSubdir, SkillNames[0]))
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("manual skill was deleted: %v", err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		t.Errorf("manual skill was replaced with a symlink")
 	}
 
-	// Verify other skills were installed as symlinks.
+	// Other skills should be symlinks.
 	for _, skillName := range SkillNames[1:] {
-		skillPath := filepath.Join(skillsSubdir, skillName)
-		info, err := os.Lstat(skillPath)
+		linkInfo, err := os.Lstat(filepath.Join(skillsSubdir, skillName))
 		if err != nil {
 			t.Fatalf("symlink not created for %s: %v", skillName, err)
 		}
-		if info.Mode()&os.ModeSymlink == 0 {
+		if linkInfo.Mode()&os.ModeSymlink == 0 {
 			t.Fatalf("%s is not a symlink", skillName)
 		}
 	}
@@ -293,8 +412,8 @@ func TestInstallSkillsSkipsManualInstall(t *testing.T) {
 func TestRemoveSkillsFromClaudeConfigs(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create source skills directory.
-	skillsDir := filepath.Join(dir, "skills")
+	// Source skills.
+	skillsDir := filepath.Join(dir, "src-skills")
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -305,34 +424,26 @@ func TestRemoveSkillsFromClaudeConfigs(t *testing.T) {
 		}
 	}
 
-	// Create Claude config directory and install skills.
-	claudeDir := filepath.Join(dir, "claude", ".claude.json")
-	if err := os.MkdirAll(filepath.Dir(claudeDir), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	primaryCfg := filepath.Join(dir, ".claude.json")
 
 	out := &bytes.Buffer{}
-	InstallSkillsInClaudeConfigs(out, "", skillsDir, []string{claudeDir})
+	InstallSkillsInClaudeConfigs(out, "", skillsDir, []string{primaryCfg})
 
-	// Now remove the skills.
 	out2 := &bytes.Buffer{}
-	removed := RemoveSkillsFromClaudeConfigs(out2, []string{claudeDir})
+	removed := RemoveSkillsFromClaudeConfigs(out2, []string{primaryCfg})
 
 	if len(removed) != 1 {
 		t.Fatalf("expected 1 removed dir, got %d", len(removed))
 	}
 
-	// Verify symlinks were removed.
-	skillsSubdir := filepath.Join(filepath.Dir(claudeDir), "skills")
+	skillsSubdir := ClaudeSkillsDirForConfig(primaryCfg)
 	for _, skillName := range SkillNames {
-		skillPath := filepath.Join(skillsSubdir, skillName)
-		_, err := os.Lstat(skillPath)
+		_, err := os.Lstat(filepath.Join(skillsSubdir, skillName))
 		if !os.IsNotExist(err) {
 			t.Fatalf("symlink not removed for %s", skillName)
 		}
 	}
 
-	// Verify the output mentions removal.
 	if !stringContains(out2.String(), "Skills removed from:") {
 		t.Errorf("should report removal: %s", out2.String())
 	}
@@ -341,23 +452,18 @@ func TestRemoveSkillsFromClaudeConfigs(t *testing.T) {
 func TestRemoveSkillsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create Claude config directory (no skills installed).
-	claudeDir := filepath.Join(dir, "claude", ".claude.json")
-	if err := os.MkdirAll(filepath.Dir(claudeDir), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	primaryCfg := filepath.Join(dir, ".claude.json")
 
 	// Remove should succeed silently (idempotent) even if no skills exist.
 	out := &bytes.Buffer{}
-	removed := RemoveSkillsFromClaudeConfigs(out, []string{claudeDir})
+	removed := RemoveSkillsFromClaudeConfigs(out, []string{primaryCfg})
 
 	if len(removed) != 0 {
 		t.Fatalf("expected 0 removed dirs, got %d", len(removed))
 	}
 
-	// Second removal should also succeed.
 	out2 := &bytes.Buffer{}
-	removed2 := RemoveSkillsFromClaudeConfigs(out2, []string{claudeDir})
+	removed2 := RemoveSkillsFromClaudeConfigs(out2, []string{primaryCfg})
 	if len(removed2) != 0 {
 		t.Fatalf("expected 0 removed dirs on second call, got %d", len(removed2))
 	}
@@ -366,8 +472,7 @@ func TestRemoveSkillsIdempotent(t *testing.T) {
 func TestValidateSkillSymlinks(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create source skills directory.
-	skillsDir := filepath.Join(dir, "skills")
+	skillsDir := filepath.Join(dir, "src-skills")
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -415,12 +520,10 @@ func TestValidateSkillSymlinks(t *testing.T) {
 	}
 	for i, skillName := range SkillNames {
 		if i == 0 {
-			// First skill is a regular directory.
 			if err := os.MkdirAll(filepath.Join(skillsSubdir3, skillName), 0o755); err != nil {
 				t.Fatal(err)
 			}
 		} else {
-			// Others are symlinks.
 			src := filepath.Join(skillsDir, skillName)
 			dst := filepath.Join(skillsSubdir3, skillName)
 			if err := os.Symlink(src, dst); err != nil {
@@ -439,10 +542,5 @@ func TestValidateSkillSymlinks(t *testing.T) {
 
 // stringContains checks if a string contains a substring.
 func stringContains(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(s, substr)
 }

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/daemon/service"
 	"github.com/cajasmota/archigraph/internal/install/mcpreg"
+	"github.com/cajasmota/archigraph/internal/install/skilllink"
 )
 
 // UninstallOptions controls RunUninstall behaviour.
@@ -108,26 +109,33 @@ func RunUninstall(opts UninstallOptions) (*UninstallResult, error) {
 		return result, nil
 	}
 
-	// ── resolve skills destination ────────────────────────────────────────────
-	skillsDestDir := resolveSkillsDestDir(state)
+	// ── resolve skills destinations (every registered Claude config) ──────────
+	skillsDestDirs := resolveAllSkillsDestDirs(state)
 
 	// ── Step 1: Remove skills ─────────────────────────────────────────────────
-	if skillsDestDir != "" {
+	removedSet := map[string]bool{}
+	for _, skillsDestDir := range skillsDestDirs {
+		if skillsDestDir == "" {
+			continue
+		}
 		for skillName := range state.Skills {
 			dst := filepath.Join(skillsDestDir, skillName)
 			if opts.DryRun {
 				fmt.Fprintf(os.Stderr, "archigraph uninstall (dry-run): would remove skill %s\n", dst)
-				result.SkillsRemoved = append(result.SkillsRemoved, skillName)
+				removedSet[skillName] = true
 				continue
 			}
 			if _, err := os.Lstat(dst); err == nil {
 				if err := os.RemoveAll(dst); err != nil {
 					fmt.Fprintf(os.Stderr, "archigraph uninstall: remove skill %s: %v\n", dst, err)
 				} else {
-					result.SkillsRemoved = append(result.SkillsRemoved, skillName)
+					removedSet[skillName] = true
 				}
 			}
 		}
+	}
+	for skillName := range removedSet {
+		result.SkillsRemoved = append(result.SkillsRemoved, skillName)
 	}
 
 	// ── Step 2: Deregister MCP ────────────────────────────────────────────────
@@ -225,15 +233,18 @@ func RunUninstall(opts UninstallOptions) (*UninstallResult, error) {
 	return result, nil
 }
 
-// resolveSkillsDestDir derives the skills destination directory from the
-// install state.  The primary Claude config path is the first element in
-// MCP.RegisteredPaths; the skills dir is its parent + "/skills".
-func resolveSkillsDestDir(state *State) string {
-	if len(state.MCP.RegisteredPaths) == 0 {
-		return ""
+// resolveAllSkillsDestDirs returns the skills directory for every Claude
+// config recorded in state.MCP.RegisteredPaths.  Each entry is mapped via
+// skilllink.ClaudeSkillsDirForConfig so primary vs sidecar layouts are
+// handled correctly.
+func resolveAllSkillsDestDirs(state *State) []string {
+	out := make([]string, 0, len(state.MCP.RegisteredPaths))
+	for _, cfgPath := range state.MCP.RegisteredPaths {
+		if d := skilllink.ClaudeSkillsDirForConfig(cfgPath); d != "" {
+			out = append(out, d)
+		}
 	}
-	primaryClaudeDir := filepath.Dir(state.MCP.RegisteredPaths[0])
-	return filepath.Join(primaryClaudeDir, "skills")
+	return out
 }
 
 // promptConfirm is the production confirmation prompt.


### PR DESCRIPTION
## Summary

Fixes two related bugs in `archigraph install --dev` (and the COPY mode equivalent):

**Bug 1 — wrong target directory + only first config dir used.** Symlinks landed in `~/skills/` (the parent of the *first* detected config) instead of every detected config's `skills/` subdir (`~/.claude/skills/`, `~/.claude-personal/skills/`, `~/.claude-extra/skills/`, …). Root cause: `filepath.Dir(claudeDirs[0])` of `~/.claude.json` is `~`, plus the install loop only used `claudeDirs[0]`.

**Bug 2 — stale renamed/retired skill symlinks never cleaned up.** After renames (`archigraph-quality-check` → `archigraph-graph-quality`, `archigraph-repair` → `archigraph-resolve`) and retirement (`generate-docs`), the old entries lingered because the install loop only iterates current `SkillNames`.

## Fix

- New helper `skilllink.ClaudeSkillsDirForConfig(cfg)` derives the correct `skills/` subdir for both primary (`HOME/.claude.json`) and sidecar (`HOME/.claude-X/.claude.json`) Claude Code layouts.
- DEV mode (`internal/install/dev.go`) and COPY mode (`internal/install/copy.go`) both loop over every detected config dir and aggregate per-skill state. Rollback walks all destinations.
- New helper `skilllink.PruneOrphanSkillSymlinks` removes any symlinks in `skills/` whose basename is not in `SkillNames`. Defensive — regular directories (manual installs) are left untouched. Called from both install paths before re-creating the current set.
- `internal/install/uninstall.go` and `internal/install/doctor.go` updated to use the new helper.

## Closes / Refs
- Closes #2269

## Testing
- [x] `go test -race -count=1 ./internal/install/... ./internal/cli/...` — all green locally
- [x] New tests:
  - `TestClaudeSkillsDirForConfig` — table-driven primary/sidecar/flat/no-suffix cases
  - `TestInstallSkillsInClaudeConfigs_MultipleConfigs` — three configs, every `skills/` subdir populated
  - `TestInstallSkillsInClaudeConfigs_PrunesOrphans` — orphans gone, manual install untouched, current set installed
  - `TestRunDev_MultipleConfigsAndOrphanPruning` — end-to-end DEV mode with three configs and pre-seeded orphans
- [x] `internal/cli/cli_test.go` adjusted to use the new derivation helper (the previous expectations encoded the bug)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

## Notes
- Touches Go code in the install path — `ci:full` label should be applied.
- No backwards-compat shim retained; the only previous external-looking helper (`resolveSkillsDestDir` in `uninstall.go`) was unused.