### PR TITLE
fix(ci): unflake msys2 action download (v2 → v2.31.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       # Resolves #937 / #1796 — no vendor patch needed with CGO_ENABLED=1.
       - name: Setup MSYS2 + MinGW (Windows only)
         if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@v2.31.1
         with:
           msystem: MINGW64
           install: >-


### PR DESCRIPTION
## Summary
Pin `msys2/setup-msys2` from the floating `@v2` tag to the explicit `@v2.31.1` release tag. The `@v2` tag points to a SHA that GitHub's codeload returns a 404/error on during the action-download prep phase — and because GitHub Actions pre-fetches every referenced action on **all** matrix runners regardless of the `if: runner.os == 'Windows'` condition, this was failing CI on all 3 platforms (ubuntu, macos, windows), not just Windows. Pinning to the concrete release tag resolves the codeload error.

Refs #2272 (PR where all 3 platforms were failing due to this)

## Testing
- [ ] All tests pass: `go test ./...`
- [ ] Relevant fixtures verified
- [ ] No regression in cross-language parity

## Notes
- Single-line change: `msys2/setup-msys2@v2` → `msys2/setup-msys2@v2.31.1`
- `v2.31.1` is the current "Latest" release on https://github.com/msys2/setup-msys2/releases (released April 17)
- `ci:full` label applied — this fixes CI infrastructure itself, full 3-platform run is the right verification