### PR TITLE
fix(tests): Windows path-separator in TestClaudeSkillsDirForConfig (post-#2272)

### DIFF
--- a/internal/install/skilllink/skilllink_test.go
+++ b/internal/install/skilllink/skilllink_test.go
@@ -126,7 +126,9 @@ func TestClaudeSkillsDirForConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ClaudeSkillsDirForConfig(tt.in)
-			if got != tt.want {
+			// Normalize to forward slashes so the test data stays readable and
+			// the assertions hold on Windows (filepath.Join returns backslashes).
+			if filepath.ToSlash(got) != tt.want {
 				t.Errorf("ClaudeSkillsDirForConfig(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Summary

- `TestClaudeSkillsDirForConfig` (added by #2272) hardcoded Unix `/` separators in all `want` strings.
- On Windows, `filepath.Join` returns `\`-separated paths, so all 5 subtests failed — but the msys2 codeload flake (#2273, landed today) had been hiding the Windows CI run entirely. Once #2273 fixed the msys2 pin and Windows CI actually ran, the test bug surfaced.
- Fix: normalize the result with `filepath.ToSlash(got)` before comparing against the (still human-readable) `/`-separated `want` strings — Option B, no `runtime.GOOS` skip, no test-data reformatting.

## Audit

All other tests in the file (`MultipleConfigs`, `PrunesOrphans`, `Idempotent`, `SkipsManualInstall`, `Remove*`, `Validate*`) already build expected paths via `filepath.Join(t.TempDir(), ...)` — cross-platform clean. Only `TestClaudeSkillsDirForConfig` used hardcoded string literals.

## Test plan

- [x] `go test ./internal/install/skilllink/...` passes locally — all 11 tests, all 7 subtests of `TestClaudeSkillsDirForConfig`
- [ ] Windows CI confirms the 5 previously-failing subtests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)