### PR TITLE
fix(ci): pull_request_target must check out PR HEAD, not base ref

### DIFF
--- a/.github/workflows/install-gate.yml
+++ b/.github/workflows/install-gate.yml
@@ -25,7 +25,16 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # SECURITY NOTE: pull_request_target runs with write permissions but defaults
+      # to checking out the BASE branch (main), not the PR's HEAD. This means CI
+      # would test main's code, not the PR's changes — a silent correctness failure.
+      # We explicitly ref the PR HEAD here. This is safe because the workflow is
+      # gated by the `ci:full` label (line 23 above), which only collaborators with
+      # write access can apply — making this functionally equivalent to pull_request.
+      # The `|| github.sha` fallback handles workflow_dispatch and push-to-main.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,16 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      # SECURITY NOTE: pull_request_target runs with write permissions but defaults
+      # to checking out the BASE branch (main), not the PR's HEAD. This means CI
+      # would test main's code, not the PR's changes — a silent correctness failure.
+      # We explicitly ref the PR HEAD here. This is safe because the workflow is
+      # gated by the `ci:full` label (line 28 above), which only collaborators with
+      # write access can apply — making this functionally equivalent to pull_request.
+      # The `|| github.sha` fallback handles workflow_dispatch and push-to-main.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       # MinGW is required on Windows for CGO (tree-sitter bindings).
       # Resolves #937 / #1796 — no vendor patch needed with CGO_ENABLED=1.

--- a/.github/workflows/windows-cgo-experiment.yml
+++ b/.github/workflows/windows-cgo-experiment.yml
@@ -17,7 +17,16 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
+      # SECURITY NOTE: pull_request_target runs with write permissions but defaults
+      # to checking out the BASE branch (main), not the PR's HEAD. This means CI
+      # would test main's code, not the PR's changes — a silent correctness failure.
+      # We explicitly ref the PR HEAD here. This is safe because the workflow is
+      # gated by the `ci:full` label (line 16 above), which only collaborators with
+      # write access can apply — making this functionally equivalent to pull_request.
+      # The `|| github.sha` fallback handles workflow_dispatch and push-to-main.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup MSYS2 + MinGW
         uses: msys2/setup-msys2@v2


### PR DESCRIPTION
## Bug

Every PR CI run was silently testing **main's code**, not the PR's changes.

**Root cause:** `.github/workflows/test.yml` (and two sibling workflows) use `pull_request_target` with a bare `actions/checkout@v4` — no `ref:` parameter. GitHub's security default for `pull_request_target` is to check out the **base branch** (main), not the PR HEAD. This prevents untrusted PRs from reading repo secrets, but it means our CI was always compiling and running main.

**Smoking gun:** PR #2276 added 2 comment lines, shifting a `t.Errorf` from line 130 → 132. Windows CI kept reporting failure at `skilllink_test.go:130` — which in the PR's source is a blank comment line. That line number only makes sense if main's copy of the file (where line 130 IS the `Errorf`) was being compiled and run.

## Fix

Added `ref: ${{ github.event.pull_request.head.sha || github.sha }}` to the checkout step in all three affected workflows:

- `.github/workflows/test.yml`
- `.github/workflows/install-gate.yml`
- `.github/workflows/windows-cgo-experiment.yml`

The `|| github.sha` fallback ensures `workflow_dispatch` and `push` to main continue to work (those events have no `pull_request.head.sha`).

## Security rationale

Explicitly checking out the PR HEAD under `pull_request_target` is safe here because:

1. **Label gate** — all three workflows only run when the `ci:full` label is applied. Only collaborators with write access can add labels, so untrusted forks can never trigger this workflow.
2. **`permissions: contents: read`** — already set on the test and install-gate workflows, limiting blast radius.

This is documented with inline comments in each updated checkout step.

## Important paradox

`pull_request_target` reads the **workflow file from the base branch** — so the first CI run after labeling this PR will still use the old (broken) checkout from main. The fix cannot self-validate. Once merged to main, all subsequent PR CI runs will correctly test the PR's code.

## What was affected

Every PR that received the `ci:full` label before this fix was merged had its CI run against main, not the PR's HEAD. CI pass/fail results for those PRs were not meaningful for the PR's own changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)