### PR TITLE
fix(indexer): propagate url_prefix on Django nested-include synthetics

### DIFF
--- a/internal/engine/django_urlconf_nested.go
+++ b/internal/engine/django_urlconf_nested.go
@@ -156,6 +156,16 @@ func ApplyDjangoNestedURLConf(
 					"framework":    "django",
 					"pattern_type": "urlconf_nested_include",
 				}
+				if parentPrefix != "" {
+					// Record the parent include() prefix so downstream consumers
+					// (cross-repo HTTP resolver in internal/links/http_pass.go)
+					// can strip it when matching against client-side API calls
+					// that use a baseURL (e.g. Axios baseURL = "/api/v1").
+					// Mirrors the non-nested emitter in django_drf_actions.go
+					// (fix #800) — without this, 95% of cross-repo HTTP calls
+					// fail to resolve on real corpora (issue #2278).
+					props["url_prefix"] = "/" + strings.Trim(parentPrefix, "/")
+				}
 				// Issue #527 — wire FBV view functions as source_handler so
 				// the ResolveHTTPEndpointHandlers pass emits an IMPLEMENTS
 				// edge from the view function to this http_endpoint entity.

--- a/internal/engine/django_urlconf_nested_test.go
+++ b/internal/engine/django_urlconf_nested_test.go
@@ -401,6 +401,21 @@ urlpatterns = [
 	if h := byID["http:ANY:/api/articles"]; h != "" {
 		t.Errorf("http:ANY:/api/articles source_handler = %q, want empty (CBV)", h)
 	}
+
+	// Issue #2278 — every synthetic emitted under a parent include() prefix
+	// must carry the url_prefix property so the cross-repo HTTP resolver in
+	// internal/links/http_pass.go can strip it when matching client paths.
+	for _, e := range got {
+		if e.Kind != httpEndpointKind {
+			continue
+		}
+		if e.Properties["pattern_type"] != "urlconf_nested_include" {
+			continue
+		}
+		if got := e.Properties["url_prefix"]; got != "/api" {
+			t.Errorf("entity %q: url_prefix=%q, want %q", e.ID, got, "/api")
+		}
+	}
 }
 
 // TestResolveFBVHandler verifies the handler name extraction logic.


### PR DESCRIPTION
Closes #2278

## Summary

The nested-include extractor in `internal/engine/django_urlconf_nested.go` builds `http_endpoint` synthetics for sub-routed URLConfs but never sets `url_prefix` on the props bag. The cross-repo resolver at `internal/links/http_pass.go` (lines 85-97 and 376-386) relies on that prop to strip the API mount prefix before matching client paths.

Without it, 95% of cross-repo HTTP calls fail to resolve on real corpora — 5.1% link rate on UpVate, frontend 0/331.

This change writes `url_prefix` at the synthetic-emit site using the same inline normaliser (`"/" + strings.Trim(parentPrefix, "/")`) used by the non-nested DRF router emitter in `django_drf_actions.go:298` (fix #800), restoring symmetry between the two emit paths.

## Files touched

- `internal/engine/django_urlconf_nested.go` (lines 158-168): set `url_prefix` when `parentPrefix != ""`.
- `internal/engine/django_urlconf_nested_test.go` (extended `TestApplyDjangoNestedURLConf_FBVSourceHandler`): asserts every emitted nested-include synthetic carries `url_prefix=/api`.

## Manual verification

- `go build ./...` — clean.
- `go test ./internal/engine/... ./internal/links/...` — all three packages pass (`internal/engine`, `internal/engine/httproutes`, `internal/links`).
- Confirmed the consumer side (`http_pass.go:97`, `:376-386`) reads `url_prefix` from props.
- Confirmed the matching non-nested emitter (`django_drf_actions.go:294-298`) uses the same inline normaliser — no separate `normaliseAPIMountPrefix` helper exists; the strategy doc's guess at a named helper was incorrect, but the inline form is the established pattern.

## CI policy

no `ci:full` label — change is pure indexer logic, not platform-sensitive.