### PR TITLE
fix(indexer): resolve bare-class-name FK strings to graph edges

### DIFF
--- a/internal/resolve/django_fk.go
+++ b/internal/resolve/django_fk.go
@@ -41,6 +41,36 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
+// lookupUniqueModelByName returns the entity ID of the unique entity with
+// kind=SCOPE.Model and the given Name. Used by the strategy-3 bare-class
+// FK fallback (issue #2280): when a Django string-FK has no app_label
+// qualifier ('User' instead of 'auth.User') the resolver probes the
+// global Model index. If exactly one Model matches we resolve; if zero
+// or two-plus match we leave the shadow stub in place — the caller falls
+// through to the existing External-synthesis safe fallback.
+//
+// The gate is strict against SCOPE.Model (NOT SCOPE.Component): #2281
+// tracks the double-emit where the same Django Model class can appear as
+// both a Model and a Component. Until that lands, restricting to Model
+// here avoids collapsing two distinct logical entities into one.
+func (idx Index) lookupUniqueModelByName(name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	realBucket := idx.nameKindsReal[name]
+	if len(realBucket) == 0 {
+		return "", false
+	}
+	// nameKindsReal[name][kind] = "" sentinel means ambiguous (>=2
+	// entities share that name+kind pair); a non-empty value is the
+	// unique entity ID for that pair.
+	id, ok := realBucket[string(types.EntityKindModel)]
+	if !ok || id == "" {
+		return "", false
+	}
+	return id, true
+}
+
 // djangoFKRefPrefix is the structural-ref prefix emitted by
 // buildDjangoModelClassRef in internal/extractors/python/django_relational.go.
 // We gate the late-binding pass to only these stubs to avoid touching
@@ -142,7 +172,28 @@ func (idx Index) ResolveDjangoStringFKRefs(records []types.EntityRecord) int {
 				// lookupUniqueRealComponentByName succeeds (globally unique
 				// model name); we don't duplicate that here since
 				// ReferencesEmbeddedWithAllowlist will handle it via
-				// lookupStructural → lookupUniqueRealComponentByName.
+				// lookupStructural -> lookupUniqueRealComponentByName.
+
+				// Strategy 3: global kind=Model fallback (issue #2280).
+				// When the dotted-form lookups missed, or the FK string is
+				// a bare class name ("User"), look up entities with
+				// kind=Model whose Name matches className. Resolve only
+				// when EXACTLY one such Model entity exists; ambiguous
+				// (0 or 2+) leaves the shadow stub in place. Intentionally
+				// gated on kind=Model (NOT SCOPE.Component) to avoid
+				// collapsing over the double-emit issue tracked separately
+				// as #2281.
+				//
+				// Suppression is at-creation in spirit: rewriting the stub
+				// to a hex entity ID before ReferencesEmbeddedWithAllowlist
+				// runs means the External-synthesis pass downstream never
+				// sees an unresolved stub for this edge, so no shadow
+				// FK-Constraint node is materialized.
+				if id, ok := idx.lookupUniqueModelByName(className); ok && id != "" {
+					r.ToID = id
+					rewrites++
+					continue
+				}
 			}
 		}
 	}

--- a/internal/resolve/django_fk_test.go
+++ b/internal/resolve/django_fk_test.go
@@ -394,3 +394,213 @@ func TestResolveDjangoStringFKRefs_NonScopeStubSkipped(t *testing.T) {
 		t.Errorf("ToID changed unexpectedly: %q", records[0].Relationships[0].ToID)
 	}
 }
+
+// TestResolveDjangoStringFKRefs_BareNameGlobalModelUnique covers issue #2280:
+// a bare ForeignKey('User', ...) where the consumer's app does NOT define
+// User locally (strategy 1 misses) and the FK string carries no app_label
+// (strategy 2 misses). When exactly one entity with kind=SCOPE.Model named
+// "User" exists in the group, the strategy-3 global Model fallback must
+// resolve the stub to that Model's entity ID so no shadow FK-Constraint
+// node is materialized downstream.
+func TestResolveDjangoStringFKRefs_BareNameGlobalModelUnique(t *testing.T) {
+	// User defined once, as SCOPE.Model, in a different app directory.
+	userModel := types.EntityRecord{
+		ID:         "auth-user-model-id",
+		Name:       "User",
+		Kind:       "SCOPE.Model",
+		Subtype:    "class",
+		SourceFile: "auth/models.py",
+		Language:   "python",
+	}
+
+	// Permit field with a bare 'User' FK string. The consumer file lives
+	// in permits/models.py so strategy 1 probes byPackageComponent["permits"]
+	// and misses; the FK string has no dot so strategy 2's dotted branch
+	// also misses.
+	stub := buildDjangoFKStub("permits/models.py", "User")
+	permitField := types.EntityRecord{
+		ID:         "permit-field-id",
+		Name:       "Permit.owner",
+		Kind:       "SCOPE.Schema",
+		Subtype:    "field",
+		SourceFile: "permits/models.py",
+		Language:   "python",
+		Relationships: []types.RelationshipRecord{
+			{
+				ToID: stub,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"django_rel":       "ForeignKey",
+					"self_ref":         "false",
+					"django_fk_string": "User",
+				},
+			},
+		},
+	}
+
+	records := []types.EntityRecord{userModel, permitField}
+	idx := BuildIndex(records)
+	rewrites := idx.ResolveDjangoStringFKRefs(records)
+
+	if rewrites != 1 {
+		t.Errorf("rewrites = %d, want 1 (bare 'User' should bind to unique SCOPE.Model)", rewrites)
+	}
+	got := records[1].Relationships[0].ToID
+	if got != "auth-user-model-id" {
+		t.Errorf("ToID = %q, want auth-user-model-id (stub was %q)", got, stub)
+	}
+}
+
+// TestResolveDjangoStringFKRefs_BareNameGlobalModelAmbiguous covers #2280 ambiguity:
+// two entities with kind=SCOPE.Model both named "User" in the group. The
+// strategy-3 fallback must NOT resolve; the shadow stub stays in place so
+// the safe External-synthesis fallback runs.
+func TestResolveDjangoStringFKRefs_BareNameGlobalModelAmbiguous(t *testing.T) {
+	user1 := types.EntityRecord{
+		ID:         "auth-user-model-id",
+		Name:       "User",
+		Kind:       "SCOPE.Model",
+		Subtype:    "class",
+		SourceFile: "auth/models.py",
+		Language:   "python",
+	}
+	user2 := types.EntityRecord{
+		ID:         "accounts-user-model-id",
+		Name:       "User",
+		Kind:       "SCOPE.Model",
+		Subtype:    "class",
+		SourceFile: "accounts/models.py",
+		Language:   "python",
+	}
+
+	stub := buildDjangoFKStub("permits/models.py", "User")
+	permitField := types.EntityRecord{
+		ID:         "permit-field-id",
+		Name:       "Permit.owner",
+		Kind:       "SCOPE.Schema",
+		Subtype:    "field",
+		SourceFile: "permits/models.py",
+		Language:   "python",
+		Relationships: []types.RelationshipRecord{
+			{
+				ToID: stub,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"django_rel":       "ForeignKey",
+					"self_ref":         "false",
+					"django_fk_string": "User",
+				},
+			},
+		},
+	}
+
+	records := []types.EntityRecord{user1, user2, permitField}
+	idx := BuildIndex(records)
+	rewrites := idx.ResolveDjangoStringFKRefs(records)
+
+	if rewrites != 0 {
+		t.Errorf("rewrites = %d, want 0 (two SCOPE.Model 'User' entities are ambiguous)", rewrites)
+	}
+	if got := records[2].Relationships[0].ToID; got != stub {
+		t.Errorf("ToID = %q, want unchanged stub %q", got, stub)
+	}
+}
+
+// TestResolveDjangoStringFKRefs_BareNameNoModelMatch covers #2280: bare
+// FK string with no matching SCOPE.Model in the group (e.g. typo or
+// model defined as SCOPE.Component only). Strategy 3 must NOT resolve;
+// the stub stays untouched so the existing External-synthesis safe
+// fallback handles it.
+func TestResolveDjangoStringFKRefs_BareNameNoModelMatch(t *testing.T) {
+	// A SCOPE.Component (not Model) named "User" should NOT satisfy
+	// strategy 3 — the gate is strictly kind=SCOPE.Model per #2281.
+	userComp := types.EntityRecord{
+		ID:         "user-component-id",
+		Name:       "User",
+		Kind:       "SCOPE.Component",
+		Subtype:    "class",
+		SourceFile: "auth/models.py",
+		Language:   "python",
+	}
+
+	stub := buildDjangoFKStub("permits/models.py", "User")
+	permitField := types.EntityRecord{
+		ID:         "permit-field-id",
+		Name:       "Permit.owner",
+		Kind:       "SCOPE.Schema",
+		Subtype:    "field",
+		SourceFile: "permits/models.py",
+		Language:   "python",
+		Relationships: []types.RelationshipRecord{
+			{
+				ToID: stub,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"django_rel":       "ForeignKey",
+					"self_ref":         "false",
+					"django_fk_string": "User",
+				},
+			},
+		},
+	}
+
+	records := []types.EntityRecord{userComp, permitField}
+	idx := BuildIndex(records)
+	rewrites := idx.ResolveDjangoStringFKRefs(records)
+
+	if rewrites != 0 {
+		t.Errorf("rewrites = %d, want 0 (no SCOPE.Model named User; Component should not satisfy strategy 3)", rewrites)
+	}
+	if got := records[1].Relationships[0].ToID; got != stub {
+		t.Errorf("ToID = %q, want unchanged stub %q", got, stub)
+	}
+}
+
+// TestResolveDjangoStringFKRefs_AppLabelRegression is a regression guard
+// for the strategy-2 path: dotted ForeignKey('auth.User', ...) must still
+// resolve via byPackageComponent["auth"]["User"] after the strategy-3
+// addition. This mirrors TestResolveDjangoStringFKRefs_CrossApp but is
+// kept colocated with the #2280 tests for clarity.
+func TestResolveDjangoStringFKRefs_AppLabelRegression(t *testing.T) {
+	userEntity := types.EntityRecord{
+		ID:         "auth-user-entity-id",
+		Name:       "User",
+		Kind:       "SCOPE.Component",
+		Subtype:    "class",
+		SourceFile: "auth/models.py",
+		Language:   "python",
+	}
+
+	stub := buildDjangoFKStub("permits/models.py", "User")
+	permitField := types.EntityRecord{
+		ID:         "permit-field-id",
+		Name:       "Permit.owner",
+		Kind:       "SCOPE.Schema",
+		Subtype:    "field",
+		SourceFile: "permits/models.py",
+		Language:   "python",
+		Relationships: []types.RelationshipRecord{
+			{
+				ToID: stub,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"django_rel":       "ForeignKey",
+					"self_ref":         "false",
+					"django_fk_string": "auth.User",
+				},
+			},
+		},
+	}
+
+	records := []types.EntityRecord{userEntity, permitField}
+	idx := BuildIndex(records)
+	rewrites := idx.ResolveDjangoStringFKRefs(records)
+
+	if rewrites != 1 {
+		t.Errorf("rewrites = %d, want 1 (app-label-qualified path)", rewrites)
+	}
+	got := records[1].Relationships[0].ToID
+	if got != "auth-user-entity-id" {
+		t.Errorf("ToID = %q, want auth-user-entity-id (stub was %q)", got, stub)
+	}
+}


### PR DESCRIPTION
Closes #2280

## Summary
- `ResolveDjangoStringFKRefs` already handled app-label-qualified FK strings (`ForeignKey('auth.User', ...)`) via `byPackageComponent`, but bare-class FK strings (`ForeignKey('User', ...)`) fell through with no global fallback. Every such reference materialized as a shadow FK-Constraint node downstream — on the UpVate bench corpus, `User` ballooned to 281 entities (1 legit Model + 280 shadows).
- New strategy 3 in `internal/resolve/django_fk.go`: when strategies 1 and 2 miss, probe `nameKindsReal[name][SCOPE.Model]`. If exactly one Model matches, rewrite the stub to that hex ID — the External-synthesis pass downstream then never sees an unresolved stub for the edge, so no shadow node is created. Suppression is at-creation in effect (we never emit the shadow), achieved by intercepting before `ReferencesEmbeddedWithAllowlist`.
- Uniqueness gate is strict against `kind=SCOPE.Model` (not `SCOPE.Component`) — ambiguous (0 or 2+) leaves the stub alone. The gate avoids collapsing over the double-emit issue tracked separately as #2281.

## Files touched
- `internal/resolve/django_fk.go` — new `lookupUniqueModelByName` helper + strategy-3 branch inside `ResolveDjangoStringFKRefs`.
- `internal/resolve/django_fk_test.go` — 4 new tests: bare-name unique-Model resolve, ambiguous-Model skip, no-Model skip (SCOPE.Component does NOT satisfy the gate), app-label-qualified regression guard.

## Test results
- `go build ./...` clean.
- `go test ./internal/resolve/... ./internal/engine/...` PASS.
- `TestResolveDjangoStringFKRefs_*` — 12/12 PASS (8 existing + 4 new).

## CI note
No `ci:full` label — pure indexer logic change, not platform-sensitive. Default minimal CI is sufficient.