### PR TITLE
feat(bench): capture daemon [mcp-rpc] elapsed_ms per call in quality-check

### DIFF
--- a/skills/archigraph-graph-quality/SKILL.md
+++ b/skills/archigraph-graph-quality/SKILL.md
@@ -218,6 +218,7 @@ Source snippets are referenced by path+line, not embedded. The raw-data appendix
 - The orchestrator spawns Phase 2 and Phase 3 as independent subagents with no shared transcript.
 - The skill calls `archigraph_whoami` before generating any question, and questions reference only entities actually present in the group.
 - Token counts come from the host's `usage_info`, with a labeled estimation fallback.
+- Phase 3 captures `[mcp-rpc] tool=<X> elapsed=<N>ms` lines from `~/.archigraph/logs/daemon.log` during each question, aggregates them into `mcp_rpc_count` / `mcp_rpc_handler_ms_sum` / `mcp_rpc_handler_ms_p50` / `mcp_rpc_handler_ms_p99` per question, and the Phase 5 report includes a "Handler vs Transport" subsection splitting wall time into handler and transport (#2291).
 - Ground truth is established by an independent grep+read pass in Phase 4 before scoring either answer — Phase 4 does not read `without-mcp.json` or `with-mcp.json` until after its own grep pass is committed.
 - The report is written to `--output` (default `~/private/benchmarks/mcp-quality-bench-<date>.md`).
 - The skill never spawns a daemon and never names real competitor tools in any artifact.

--- a/skills/archigraph-graph-quality/prompts/03-with-mcp-run.md
+++ b/skills/archigraph-graph-quality/prompts/03-with-mcp-run.md
@@ -16,10 +16,40 @@ For each question in `questions.json`:
 
 1. Note the host's `usage_info` snapshot at question start (input/output/cache tokens emitted so far in this session).
 2. Note `wall_clock_start` (monotonic time, RFC3339 nanos).
-3. Answer the question using archigraph MCP tools. Take as many tool calls as needed but stop when you reach a defensible answer.
-4. Note `wall_clock_end`.
-5. Note the host's `usage_info` at question end.
-6. Compute the delta and record the metrics below.
+3. **Snapshot the daemon log byte-offset.** Read the current size of `~/.archigraph/logs/daemon.log` (`stat -f%z` on macOS, `stat -c%s` on Linux) and remember it as `log_start_offset`. If the file does not exist (rare; daemon may have just started and not yet flushed), set `log_start_offset = 0` and proceed.
+4. Answer the question using archigraph MCP tools. Take as many tool calls as needed but stop when you reach a defensible answer.
+5. Note `wall_clock_end`.
+6. Note the host's `usage_info` at question end.
+7. **Read daemon log lines emitted during this question.** `tail -c +<log_start_offset+1>` (or read from the snapshotted offset to current EOF). Filter to lines matching `[mcp-rpc] tool=<X> elapsed=<N>ms repo=<Y>` (the "elapsed" form, not the "received" form). Extract every `elapsed=<N>ms` integer and the tool name. These are the daemon-side handler durations for the RPC calls that ran while answering this question. See "Daemon RPC capture" below.
+8. Compute the delta and record the metrics below.
+
+## Daemon RPC capture (handler vs transport split)
+
+**Why:** the daemon logs `[mcp-rpc] tool=<name> elapsed=<N>ms repo=<repo>` at `internal/daemon/mcp_rpc.go:193` for every RPC call dispatched. The `elapsed` value is the **handler** time — what the daemon spent actually computing the answer, exclusive of the JSON-RPC bridge transport. Wall-clock per-question time minus the sum of `elapsed` values is the **transport** time (bridge serialization, stdio pipe, host overhead).
+
+This split is the whole point of the capture: a question with `wall=8000ms, handler_sum=7500ms` says the handler is the lever; a question with `wall=8000ms, handler_sum=400ms` says the transport is the lever.
+
+**Where to read:** `~/.archigraph/logs/daemon.log`. Format (one line per call):
+
+```
+archigraph-daemon: 2026/05/26 22:40:38.695982 [mcp-rpc] tool=archigraph_search_entities elapsed=8095ms repo=/path/to/repo
+```
+
+A `received` companion line is emitted **before** dispatch and must be ignored — it has no `elapsed=` field. Only count lines containing `elapsed=`.
+
+**Parsing regex:** `\[mcp-rpc\] tool=(\S+) elapsed=(\d+)ms repo=`. Two capture groups: tool name, integer milliseconds.
+
+**Bounding the window:** read the file slice `[log_start_offset, log_end_offset)` where `log_start_offset` was captured before the first MCP tool call of the question and `log_end_offset` is the file size at question end. This avoids cross-contamination if other sessions share the daemon. If the daemon log was rotated mid-question (file size shrank), reset `log_start_offset = 0` for that question and add a note in `notes`.
+
+**Aggregation per question:**
+
+- `mcp_rpc_count` = number of `elapsed=` lines captured in the window.
+- `mcp_rpc_handler_ms_sum` = sum of all elapsed_ms values.
+- `mcp_rpc_handler_ms_p50` = median (linear interpolation if even count). For `mcp_rpc_count == 0`, emit `null`.
+- `mcp_rpc_handler_ms_p99` = 99th percentile (same null rule).
+- `mcp_rpc_per_tool` (optional but recommended) = `{ "<tool>": { "count": N, "sum_ms": ... } }` — useful for spotting one slow tool dominating.
+
+If `~/.archigraph/logs/daemon.log` is unreadable (permissions, missing, host sandbox), record `mcp_rpc_count: null` for every question and add an `"mcp_rpc_capture_error": "<reason>"` field. Phase 5 will surface the failure in the report rather than silently drop the split.
 
 ## Output schema (`with-mcp.json`)
 
@@ -46,7 +76,16 @@ For each question in `questions.json`:
         "output_tokens": 678,
         "cache_read_tokens": 5000,
         "cache_creation_tokens": 0,
-        "wall_clock_ms": 8421
+        "wall_clock_ms": 8421,
+        "mcp_rpc_count": 4,
+        "mcp_rpc_handler_ms_sum": 7980,
+        "mcp_rpc_handler_ms_p50": 1850,
+        "mcp_rpc_handler_ms_p99": 2410,
+        "mcp_rpc_per_tool": {
+          "archigraph_search": {"count": 2, "sum_ms": 3600},
+          "archigraph_describe": {"count": 1, "sum_ms": 2120},
+          "archigraph_related": {"count": 1, "sum_ms": 2260}
+        }
       },
       "notes": "Mentioned archigraph_search returned 0 hits initially; widened query."
     }

--- a/skills/archigraph-graph-quality/prompts/05-report.md
+++ b/skills/archigraph-graph-quality/prompts/05-report.md
@@ -50,6 +50,41 @@ At this token rate, a 1000-query session would cost roughly:
 | With MCP | ... | ... | ... | ... |
 | Without MCP | ... | ... | ... | ... |
 
+### Handler vs Transport (with-MCP only)
+
+The daemon logs handler-side latency per RPC at `internal/daemon/mcp_rpc.go:193`
+(`[mcp-rpc] tool=<X> elapsed=<N>ms`). Phase 3 captures every such line emitted
+during each question's MCP run and persists `mcp_rpc_count`,
+`mcp_rpc_handler_ms_sum`, `mcp_rpc_handler_ms_p50`, `mcp_rpc_handler_ms_p99` in
+`with-mcp.json`. This subsection splits the with-MCP wall-clock budget into
+handler time (work inside the daemon) and transport time (everything else —
+JSON-RPC bridge marshal, stdio pipe, host overhead, agent thinking between
+tool calls).
+
+| Metric | Value |
+|---|---:|
+| Total with-MCP wall-clock (ms) | `<sum of wall_clock_ms across questions>` |
+| Total handler time (ms) | `<sum of mcp_rpc_handler_ms_sum>` |
+| Total transport + agent gap (ms) | `<wall − handler>` |
+| Handler share of wall | `<handler / wall × 100>%` |
+| Transport share of wall | `<transport / wall × 100>%` |
+| Median per-call handler ms (p50) | `<median of mcp_rpc_handler_ms_p50>` |
+| Worst per-call handler ms (p99) | `<max of mcp_rpc_handler_ms_p99>` |
+
+| # | Question | Wall (ms) | RPC calls | Handler sum (ms) | Transport (ms) | Handler share |
+|---|---|---:|---:|---:|---:|---:|
+| q01 | ... | ... | ... | ... | ... | ...% |
+
+**Interpretation guide** (do not omit — paste verbatim into the report):
+
+- If **handler share ≥ 70%**, the lever is the handler path (graph traversal, marshaling inside the tool). Adjacency-indexing (#2285) and single-marshal (#2287) are the right next moves.
+- If **handler share ≤ 30%**, the lever is the bridge: a batch macro (#2286), keeping the daemon hot, or trimming per-call agent overhead.
+- If the split is **between 30% and 70%**, both levers matter; prioritise by absolute ms saved, not percentage.
+
+If `mcp_rpc_count` is `null` for any question (capture failure), call this out in
+a "Capture gaps" callout under this table and exclude those questions from the
+totals.
+
 ## Quality
 
 | Method | Full | Partial | Wrong | Unknown | Avg confidence | Net quality (full=1, partial=0.5, wrong=-0.5, unknown=0) |


### PR DESCRIPTION
Closes #2291

## Summary

The `/archigraph-quality-check` bench harness (`skills/archigraph-graph-quality`) measured only per-question wall-clock time. The daemon already emits `[mcp-rpc] tool=<X> elapsed=<N>ms repo=<Y>` per RPC at `internal/daemon/mcp_rpc.go:193`, but those lines were never joined into the bench artifact. As a result, the 7-9s/call latency we observed cannot be split between handler execution and the RPC bridge transport — a split that decides whether the right perf lever is adjacency-indexing (#2285) / single-marshal (#2287) or a batch macro for the bridge (#2286).

This is **step zero** before committing to that prioritization, and before re-running quality-check against the post-Phase-1 graph.

## What changed

- **Skill location:** `skills/archigraph-graph-quality/` (the bench skill, invoked as `/archigraph-quality-check` or `/archigraph-graph-quality`).
- **Daemon log destination:** `~/.archigraph/logs/daemon.log` (verified via `internal/daemon/paths.go:75` / `paths_unix.go:81`). The daemon already writes the `[mcp-rpc] ... elapsed=...ms` line there — no daemon-side change needed.
- **`prompts/03-with-mcp-run.md`** — per-question protocol now snapshots `daemon.log`'s byte offset before the first MCP call and re-reads the slice at question end. New "Daemon RPC capture" section documents the format, regex, window bounding, and aggregation.
- **`prompts/05-report.md`** — Speed section now includes a "Handler vs Transport" subsection with totals, per-question split table, and an interpretation guide that maps handler-share to the right next perf lever (#2285/#2286/#2287).
- **`SKILL.md`** — acceptance criteria updated.

## New artifact fields (per question in `with-mcp.json`)

- `metrics.mcp_rpc_count` — number of `[mcp-rpc] elapsed=` lines captured during the question.
- `metrics.mcp_rpc_handler_ms_sum` — sum of handler-side ms across those calls.
- `metrics.mcp_rpc_handler_ms_p50` — median per-call handler ms.
- `metrics.mcp_rpc_handler_ms_p99` — 99th-percentile per-call handler ms.
- `metrics.mcp_rpc_per_tool` (optional) — `{tool: {count, sum_ms}}` breakdown.

If `~/.archigraph/logs/daemon.log` is unreadable, `mcp_rpc_count` is `null` and `mcp_rpc_capture_error` carries the reason; Phase 5 surfaces this rather than silently dropping the split.

## Smoke test

Parsed a 50 KB tail of the live `~/.archigraph/logs/daemon.log` (153 calls, recent UpVate session) using the documented regex:

- `mcp_rpc_count`: 153
- `mcp_rpc_handler_ms_sum`: 1,228,153 ms
- `mcp_rpc_handler_ms_p50`: 7,741 ms
- `mcp_rpc_handler_ms_p99`: 14,085 ms
- top tools by sum: `archigraph_search_entities` (69 calls, 551 s), `archigraph_get_source` (36 calls, 283 s), `archigraph_endpoints` (19 calls, 148 s)

That preview already tells us **handler dominates wall** on this group — the median per-call handler latency alone is ~7.7s. Once the bench runs end-to-end with this change, we'll see the same split per question, scored against the wall-clock budget.

## CI

No `ci:full` — bench tooling only, no production code paths touched. `go build ./...` clean.