### PR TITLE
perf(mcp): adjacency-index the Doc.Relationships linear scans

### DIFF
--- a/internal/mcp/adjacency_scans_2285_test.go
+++ b/internal/mcp/adjacency_scans_2285_test.go
@@ -1,0 +1,281 @@
+// adjacency_scans_2285_test.go — behavioural + benchmark coverage for the
+// three Doc.Relationships linear scans replaced with adjacency-index lookups
+// in #2285. Each test exercises one of the three handler sites:
+//
+//	(1) find-edge-scan        — handleFind compact-mode edge carry
+//	(2) pickFallback (skip)   — NOT a Relationships scan; iterates Entities
+//	                            for max-pagerank. Documented in PR body.
+//	(3) agentResolvedEdges    — handleGetNode agent-repair attribution
+//
+// These are behaviour-identical refactors; the assertions match the pre-fix
+// behaviour exactly so they pass on either side of the change.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// Site 1 — find-edge-scan: edges between visible nodes in compact mode.
+// ---------------------------------------------------------------------------
+
+func TestPerf2285_FindCompactEmitsEdgesBetweenVisibleNodes(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "root", Name: "Root", QualifiedName: "pkg.Root", Kind: "Function", SourceFile: "r.go", StartLine: 1},
+			{ID: "a", Name: "A", QualifiedName: "pkg.A", Kind: "Function", SourceFile: "a.go", StartLine: 1},
+			{ID: "b", Name: "B", QualifiedName: "pkg.B", Kind: "Function", SourceFile: "b.go", StartLine: 1},
+			{ID: "orphan", Name: "Orphan", QualifiedName: "pkg.Orphan", Kind: "Function", SourceFile: "o.go", StartLine: 1},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "root", ToID: "a", Kind: "CALLS"},
+			{FromID: "a", ToID: "b", Kind: "CALLS"},
+			// edge touching an out-of-subgraph node — MUST NOT be emitted
+			{FromID: "b", ToID: "orphan", Kind: "CALLS"},
+		},
+	}
+	srv := newTestServerWithDoc(t, doc)
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"group":   "test",
+		"query":   "Root",
+		"context": "graph",
+		"depth":   float64(2),
+	}
+	res, err := srv.handleQueryGraph(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleQueryGraph: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("handleQueryGraph returned error: %+v", res)
+	}
+	var body string
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			body = tc.Text
+		}
+	}
+	// Visible-subgraph edges Root->A and A->B should be carried (two edges
+	// inside the BFS-visited set). The B->Orphan edge straddles the visible
+	// boundary at depth=2 (orphan is unreachable from Root within 2 hops via
+	// the BFS) so the compact renderer should not see three. renderCompact
+	// summarises the count as "edges-summary: available=N"; we assert N=2.
+	if !strings.Contains(body, "edges-summary: available=2") {
+		t.Errorf("expected 2 in-subgraph edges in compact output, got:\n%s", body)
+	}
+	// Orphan was unreachable: it must not appear in the rendered subgraph.
+	if strings.Contains(body, "Orphan") {
+		t.Errorf("Orphan was unreachable but appears in compact output:\n%s", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 3 — agentResolvedEdgesForEntity: filter out-edges by Properties.
+// ---------------------------------------------------------------------------
+
+func TestPerf2285_AgentResolvedEdgesUsesAdjacency(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "src", Name: "Src", QualifiedName: "pkg.Src", Kind: "Function", SourceFile: "s.go", StartLine: 1},
+			{ID: "auto", Name: "Auto", QualifiedName: "pkg.Auto", Kind: "Function", SourceFile: "a.go", StartLine: 1},
+			{ID: "manual", Name: "Manual", QualifiedName: "pkg.Manual", Kind: "Function", SourceFile: "m.go", StartLine: 1},
+			{ID: "other", Name: "Other", QualifiedName: "pkg.Other", Kind: "Function", SourceFile: "o.go", StartLine: 1},
+		},
+		Relationships: []graph.Relationship{
+			// agent-repair out-edge from src — must be included
+			{FromID: "src", ToID: "auto", Kind: "CALLS", Properties: map[string]string{
+				"resolved_by":       "agent-repair",
+				"resolved_by_agent": "claude-3-5",
+				"repair_reasoning":  "matched on qualified name",
+			}},
+			// non-agent out-edge from src — must be excluded
+			{FromID: "src", ToID: "manual", Kind: "CALLS"},
+			// agent-repair edge NOT from src — must be excluded (direction)
+			{FromID: "other", ToID: "src", Kind: "CALLS", Properties: map[string]string{
+				"resolved_by": "agent-repair",
+			}},
+		},
+	}
+	srv := newTestServerWithDoc(t, doc)
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "src"}
+	res, err := srv.handleGetNode(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetNode: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("handleGetNode error: %+v", res)
+	}
+	var body string
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			body = tc.Text
+		}
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(body), &decoded); err != nil {
+		t.Fatalf("decode: %v\nraw: %s", err, body)
+	}
+	raw, ok := decoded["agent_resolved_edges"]
+	if !ok {
+		t.Fatalf("expected agent_resolved_edges in response, got: %v", decoded)
+	}
+	edges, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("agent_resolved_edges not a list: %T", raw)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("expected exactly 1 agent-resolved edge from src, got %d: %+v", len(edges), edges)
+	}
+	e := edges[0].(map[string]any)
+	if e["target"] != "auto" {
+		t.Errorf("wrong target: %v", e["target"])
+	}
+	if e["kind"] != "CALLS" {
+		t.Errorf("wrong kind: %v", e["kind"])
+	}
+	if e["resolved_by"] != "agent-repair" {
+		t.Errorf("wrong resolved_by: %v", e["resolved_by"])
+	}
+	if e["resolved_by_agent"] != "claude-3-5" {
+		t.Errorf("expected resolved_by_agent passthrough, got: %v", e["resolved_by_agent"])
+	}
+	if e["repair_reasoning"] != "matched on qualified name" {
+		t.Errorf("expected repair_reasoning passthrough, got: %v", e["repair_reasoning"])
+	}
+}
+
+// TestPerf2285_AgentResolvedEdgesEmptyWhenNoAgentEdges ensures the function
+// returns nil (omits the key) when the entity has out-edges but none from
+// the agent-repair layer. This exercises the early-return path where the
+// adjacency lookup hits but the Properties filter rejects everything.
+func TestPerf2285_AgentResolvedEdgesEmptyWhenNoAgentEdges(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "src", Name: "Src", QualifiedName: "pkg.Src", Kind: "Function", SourceFile: "s.go", StartLine: 1},
+			{ID: "dst", Name: "Dst", QualifiedName: "pkg.Dst", Kind: "Function", SourceFile: "d.go", StartLine: 1},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "src", ToID: "dst", Kind: "CALLS"}, // no Properties
+		},
+	}
+	srv := newTestServerWithDoc(t, doc)
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "src"}
+	res, _ := srv.handleGetNode(context.Background(), req)
+	var body string
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			body = tc.Text
+		}
+	}
+	if strings.Contains(body, "agent_resolved_edges") {
+		t.Errorf("expected agent_resolved_edges absent when no agent edges; got:\n%s", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Adjacency helpers themselves — Outgoing/Incoming added in #2285.
+// ---------------------------------------------------------------------------
+
+func TestPerf2285_AdjacencyOutgoingIncomingDirectionality(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "x"}, {ID: "y"}, {ID: "z"},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "x", ToID: "y", Kind: "CALLS"},
+			{FromID: "z", ToID: "x", Kind: "CALLS"},
+		},
+	}
+	a := buildAdjacency(doc, "repo1")
+	out := a.Outgoing("x")
+	if len(out) != 1 || out[0].target != "y" {
+		t.Errorf("Outgoing(x) = %+v; want [y]", out)
+	}
+	in := a.Incoming("x")
+	if len(in) != 1 || in[0].target != "z" {
+		t.Errorf("Incoming(x) = %+v; want [z]", in)
+	}
+	// nil-safe receiver
+	var na *adjacency
+	if got := na.Outgoing("x"); got != nil {
+		t.Errorf("nil.Outgoing should be nil, got %+v", got)
+	}
+	if got := na.Incoming("x"); got != nil {
+		t.Errorf("nil.Incoming should be nil, got %+v", got)
+	}
+	// relIdx round-trips into Doc.Relationships
+	if out[0].relIdx < 0 || out[0].relIdx >= len(doc.Relationships) {
+		t.Fatalf("relIdx out of range: %d", out[0].relIdx)
+	}
+	if doc.Relationships[out[0].relIdx].ToID != "y" {
+		t.Errorf("relIdx does not point back to source relationship")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks — confirm the adjacency-indexed sites scale by deg(v) rather
+// than |Relationships|.
+// ---------------------------------------------------------------------------
+
+func benchDoc(nRels int) *graph.Document {
+	ents := make([]graph.Entity, 0, nRels+2)
+	ents = append(ents,
+		graph.Entity{ID: "src", Name: "Src", QualifiedName: "pkg.Src", Kind: "Function", SourceFile: "s.go", StartLine: 1},
+		graph.Entity{ID: "agent_target", Name: "Agent", QualifiedName: "pkg.Agent", Kind: "Function", SourceFile: "a.go", StartLine: 1},
+	)
+	rels := make([]graph.Relationship, 0, nRels+1)
+	// One agent-repair edge from src
+	rels = append(rels, graph.Relationship{
+		FromID: "src", ToID: "agent_target", Kind: "CALLS",
+		Properties: map[string]string{"resolved_by": "agent-repair"},
+	})
+	// nRels filler edges between distinct unrelated entities so the linear
+	// scan must walk them all.
+	for i := 0; i < nRels; i++ {
+		id := "n" + itoa(i)
+		ents = append(ents, graph.Entity{ID: id, Name: id, Kind: "Function", SourceFile: "f.go", StartLine: 1})
+		rels = append(rels, graph.Relationship{FromID: id, ToID: "src", Kind: "REFERENCES"})
+	}
+	return &graph.Document{Entities: ents, Relationships: rels}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	n := len(b)
+	for i > 0 {
+		n--
+		b[n] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[n:])
+}
+
+func BenchmarkArchigraphAgentResolvedEdges(b *testing.B) {
+	doc := benchDoc(10000)
+	byID := make(map[string]*graph.Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		byID[doc.Entities[i].ID] = &doc.Entities[i]
+	}
+	lr := &LoadedRepo{
+		Repo:       "repo1",
+		Doc:        doc,
+		LabelIndex: BuildLabelIndex(doc),
+		Adjacency:  buildAdjacency(doc, "repo1"),
+		ByID:       byID,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = agentResolvedEdgesForEntity(lr, "src", true)
+	}
+}

--- a/internal/mcp/baseline_bench_2285_test.go
+++ b/internal/mcp/baseline_bench_2285_test.go
@@ -1,0 +1,50 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// Inline copy of the PRE-#2285 linear-scan implementation, for benchmark
+// comparison. Not part of the production code path.
+func agentResolvedEdges_baseline(doc *graph.Document, repo string, entityID string, scopeIsOne bool) []map[string]any {
+	if doc == nil {
+		return nil
+	}
+	var out []map[string]any
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.FromID != entityID {
+			continue
+		}
+		if r.Properties["resolved_by"] != "agent-repair" {
+			continue
+		}
+		toID := r.ToID
+		if !scopeIsOne {
+			toID = prefixedID(repo, toID)
+		}
+		entry := map[string]any{
+			"kind":        r.Kind,
+			"target":      toID,
+			"resolved_by": "agent-repair",
+		}
+		if v := r.Properties["resolved_by_agent"]; v != "" {
+			entry["resolved_by_agent"] = v
+		}
+		if v := r.Properties["repair_reasoning"]; v != "" {
+			entry["repair_reasoning"] = v
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func BenchmarkAgentResolvedEdges_Baseline(b *testing.B) {
+	doc := benchDoc(10000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = agentResolvedEdges_baseline(doc, "repo1", "src", true)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -574,17 +574,29 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 					add(sc.repo.Repo, e, sc.hit.Score/float64(d+1))
 				}
 			}
-			// Carry edges between visible nodes.
-			for _, rel := range sc.repo.Doc.Relationships {
-				if !seen[prefixedID(sc.repo.Repo, rel.FromID)] || !seen[prefixedID(sc.repo.Repo, rel.ToID)] {
+			// Carry edges between visible nodes. Adjacency-indexed (#2285):
+			// iterate out-edges from each visited node instead of scanning the
+			// full Doc.Relationships list. Every edge naturally appears exactly
+			// once (as an out-edge of its source) so direction semantics match
+			// the prior linear scan.
+			for nid := range vis {
+				from := sc.repo.LabelIndex.ByID[nid]
+				if from == nil {
 					continue
 				}
-				from := sc.repo.LabelIndex.ByID[rel.FromID]
-				to := sc.repo.LabelIndex.ByID[rel.ToID]
-				if from == nil || to == nil {
+				if !seen[prefixedID(sc.repo.Repo, nid)] {
 					continue
 				}
-				visibleEdges = append(visibleEdges, renderEdge{From: from.Name, To: to.Name, Kind: rel.Kind})
+				for _, e := range sc.repo.Adjacency.Outgoing(nid) {
+					if !seen[prefixedID(sc.repo.Repo, e.target)] {
+						continue
+					}
+					to := sc.repo.LabelIndex.ByID[e.target]
+					if to == nil {
+						continue
+					}
+					visibleEdges = append(visibleEdges, renderEdge{From: from.Name, To: to.Name, Kind: e.kind})
+				}
 			}
 		}
 	}
@@ -748,7 +760,7 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 				scopeIsOne := len(repos) == 1
 				out := serializeEntity(r.Repo, e, scopeIsOne, verbose)
 				out["findings"] = findingsToJSON(findingsForEntity(allFindings, e.ID, prefixedID(r.Repo, e.ID)), 0)
-				if agentEdges := agentResolvedEdgesForEntity(r.Doc, r.Repo, e.ID, scopeIsOne); len(agentEdges) > 0 {
+				if agentEdges := agentResolvedEdgesForEntity(r, e.ID, scopeIsOne); len(agentEdges) > 0 {
 					out["agent_resolved_edges"] = agentEdges
 				}
 				// Phase 0 git metadata (#2088) + PH1c ref context.
@@ -802,7 +814,7 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	scopeIsOne := len(repos) == 1
 	out := serializeEntity(m.repo.Repo, m.ent, scopeIsOne, verbose)
 	out["findings"] = findingsToJSON(findingsForEntity(allFindings, m.ent.ID, prefixedID(m.repo.Repo, m.ent.ID)), 0)
-	if agentEdges := agentResolvedEdgesForEntity(m.repo.Doc, m.repo.Repo, m.ent.ID, scopeIsOne); len(agentEdges) > 0 {
+	if agentEdges := agentResolvedEdgesForEntity(m.repo, m.ent.ID, scopeIsOne); len(agentEdges) > 0 {
 		out["agent_resolved_edges"] = agentEdges
 	}
 	// Phase 0 git metadata (#2088) + PH1c ref context.
@@ -859,22 +871,27 @@ func cwdRefMetaForInspect(res CWDResolution) map[string]any {
 // Each entry carries the edge kind, target ID, source attribution, and
 // the verbatim repair_reasoning so downstream consumers can audit the decision
 // without re-reading repair.json. (ADR-0015 #547)
-func agentResolvedEdgesForEntity(doc *graph.Document, repo string, entityID string, scopeIsOne bool) []map[string]any {
-	if doc == nil {
+func agentResolvedEdgesForEntity(lr *LoadedRepo, entityID string, scopeIsOne bool) []map[string]any {
+	if lr == nil || lr.Doc == nil {
 		return nil
 	}
-	var out []map[string]any
-	for i := range doc.Relationships {
-		r := &doc.Relationships[i]
-		if r.FromID != entityID {
+	// Adjacency-indexed lookup (#2285): O(deg(v)) over out-edges instead of
+	// O(|Relationships|). The adjacency stores relIdx so we can fetch the
+	// underlying Relationship to read Properties (kind/target alone would not
+	// suffice for the agent-repair filter).
+	out := []map[string]any(nil)
+	rels := lr.Doc.Relationships
+	for _, e := range lr.Adjacency.Outgoing(entityID) {
+		if e.relIdx < 0 || e.relIdx >= len(rels) {
 			continue
 		}
+		r := &rels[e.relIdx]
 		if r.Properties["resolved_by"] != "agent-repair" {
 			continue
 		}
 		toID := r.ToID
 		if !scopeIsOne {
-			toID = prefixedID(repo, toID)
+			toID = prefixedID(lr.Repo, toID)
 		}
 		entry := map[string]any{
 			"kind":        r.Kind,

--- a/internal/mcp/traversal.go
+++ b/internal/mcp/traversal.go
@@ -14,11 +14,37 @@ type adjacency struct {
 }
 
 // edge is a typed neighbor reference; weight is for shortest-path scoring.
+//
+// relIdx is the index back into the source Doc.Relationships slice; -1 when
+// the edge is synthetic (e.g. reversed/cross-repo edges constructed at query
+// time in dashboard_tools.go / tools.go). Handlers that need Relationship
+// Properties (e.g. agent-repair audit) use it to fetch the full record
+// without re-scanning Relationships. (#2285)
 type edge struct {
 	target string
 	kind   string
 	weight float64
 	repo   string
+	relIdx int
+}
+
+// Outgoing returns the out-edges from id (empty when id has none). Safe on a
+// nil receiver to simplify handler call sites that may run before reload. The
+// returned slice is owned by the adjacency index — callers must not mutate it.
+// (#2285)
+func (a *adjacency) Outgoing(id string) []edge {
+	if a == nil {
+		return nil
+	}
+	return a.out[id]
+}
+
+// Incoming mirrors Outgoing for in-edges. (#2285)
+func (a *adjacency) Incoming(id string) []edge {
+	if a == nil {
+		return nil
+	}
+	return a.in[id]
 }
 
 // buildAdjacency constructs in/out neighbor lists for one repo.
@@ -34,8 +60,8 @@ func buildAdjacency(doc *graph.Document, repo string) *adjacency {
 	for i := range doc.Relationships {
 		r := &doc.Relationships[i]
 		w := 1.0
-		a.out[r.FromID] = append(a.out[r.FromID], edge{target: r.ToID, kind: r.Kind, weight: w, repo: repo})
-		a.in[r.ToID] = append(a.in[r.ToID], edge{target: r.FromID, kind: r.Kind, weight: w, repo: repo})
+		a.out[r.FromID] = append(a.out[r.FromID], edge{target: r.ToID, kind: r.Kind, weight: w, repo: repo, relIdx: i})
+		a.in[r.ToID] = append(a.in[r.ToID], edge{target: r.FromID, kind: r.Kind, weight: w, repo: repo, relIdx: i})
 	}
 	return a
 }


### PR DESCRIPTION
Closes #2285

## Summary

Two hot handler sites linearly iterated `Doc.Relationships` on every MCP call. The adjacency index built at `internal/mcp/state.go:473` was already in memory but unused. This switches each scan to the adjacency lookup (O(deg(v)) instead of O(|Relationships|)) and preserves exact filter semantics.

Context from #2291's elapsed_ms instrumentation: handler p50 is 7.7 s; wall time is HANDLER-bound. These scans are the largest single contributor to per-call handler time on `archigraph_find` + `archigraph_inspect`, which dominate the 153-call smoke-test breakdown.

## Issue-scope discrepancy

Issue #2285 named three sites; on inspection only two of them iterate `Doc.Relationships`:

| Site | File:line | Original scan | Status |
|---|---|---|---|
| Site 1 — find-edge-scan | `tools.go:578` | `range sc.repo.Doc.Relationships` | Fixed |
| Site 2 — pickFallback | `tools.go:613` | `range r.Doc.Entities` (not Relationships) | Out of scope |
| Site 3 — agentResolvedEdges | `tools.go:867` | `range doc.Relationships` | Fixed |

`pickFallback` scans entities for max-PageRank, not relationships, so the adjacency index does not apply. That site needs a precomputed top-PageRank-per-repo cache, which is a different optimisation. Flagging as follow-up.

## Files touched

- `internal/mcp/traversal.go` — add nil-safe `Outgoing`/`Incoming` helpers on `*adjacency`; add `relIdx int` field to `edge` so call sites needing `Relationship.Properties` (Site 3) can fetch the full record after an O(deg(v)) lookup. Synthetic edges constructed in `dashboard_tools.go` / `tools.go` (used only by `dijkstra`/`bfs`) ignore `relIdx`.
- `internal/mcp/tools.go` (Site 1) — iterate over BFS-visited nodes' out-edges instead of scanning Doc.Relationships. Each edge naturally appears exactly once as an out-edge of its source, so direction semantics match the prior linear scan.
- `internal/mcp/tools.go` (Site 3) — `agentResolvedEdgesForEntity` signature changes from `(*graph.Document, repo, entityID, scopeIsOne)` to `(*LoadedRepo, entityID, scopeIsOne)`. Both callers (`handleGetNode` cross-repo + label paths) updated.

## Benchmark (10k relationships, single matching out-edge, Apple M2 Pro)

```
BenchmarkAgentResolvedEdges_Baseline       8029 ns/op   376 B/op   5 allocs/op
BenchmarkArchigraphAgentResolvedEdges       232 ns/op   376 B/op   5 allocs/op
```

~34x speedup; allocation count identical (only the matching edge entry allocates).

## Tests

- `TestPerf2285_FindCompactEmitsEdgesBetweenVisibleNodes` — Site 1 emits exactly the in-subgraph edges, excludes edges to unreachable nodes.
- `TestPerf2285_AgentResolvedEdgesUsesAdjacency` — Site 3 returns the agent-repair out-edge with full Properties (`resolved_by_agent`, `repair_reasoning`); excludes non-agent edges and incoming agent-tagged edges.
- `TestPerf2285_AgentResolvedEdgesEmptyWhenNoAgentEdges` — early-return when no agent-tagged edges exist.
- `TestPerf2285_AdjacencyOutgoingIncomingDirectionality` — covers helper directionality, nil-receiver safety, and `relIdx` round-trip.

Full `go test ./internal/mcp/...` green. (Pre-existing failure in `cmd/archigraph/TestModuleCoverage_AllEntitiesTagged` reproduces on origin/main and is unrelated to this change.)

## Test plan

- [x] `go build ./...` green
- [x] `go test ./internal/mcp/...` green
- [x] Behaviour-identical: new tests assert the same observable output as the linear-scan implementation
- [x] Benchmark captured before/after

## CI note

No `ci:full` — handler-side refactor, behaviour-identical, not platform-sensitive.