### PR TITLE
chore(indexer): make markdown heading emission opt-in (default off)

### DIFF
--- a/internal/extractors/markdown/markdown.go
+++ b/internal/extractors/markdown/markdown.go
@@ -47,6 +47,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"regexp"
 	"strings"
@@ -60,6 +61,26 @@ import (
 )
 
 const langName = "markdown"
+
+// emitHeadingsEnv is the env var that opts SCOPE.Heading emission back on.
+// Issue #2284: heading entities (one per ATX heading in every README, CHANGELOG,
+// and docs file) polluted the default code graph — on the UpVate bench corpus
+// they accounted for ~240 entities, dominating `find` results and clustering.
+// They remain useful for docs-search workflows, so we keep the code path but
+// gate it behind an opt-in flag. Default: OFF.
+//
+// Accepted truthy values: "1", "true" (case-sensitive). Anything else,
+// including unset, leaves heading emission disabled.
+const emitHeadingsEnv = "ARCHIGRAPH_MARKDOWN_EMIT_HEADINGS"
+
+// emitHeadingsEnabled reports whether SCOPE.Heading entities (and their
+// associated CONTAINS / REFERENCES relationships) should be emitted. Reads
+// the env var on every call — cheap, and lets tests toggle behavior via
+// t.Setenv without restarting the process.
+func emitHeadingsEnabled() bool {
+	v := os.Getenv(emitHeadingsEnv)
+	return v == "1" || v == "true"
+}
 
 func init() {
 	extractor.Register(langName, &Extractor{})
@@ -96,6 +117,15 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	}
 
 	headings, codeBlocks, links := scan(lines)
+
+	// Issue #2284: heading emission is opt-in. When disabled we drop the
+	// scanned heading slice so the downstream loops (entity build, hierarchy
+	// edges, code-block parent attachment) produce no heading entities and
+	// code blocks fall back to a Document parent. We never materialise
+	// heading entities or their CONTAINS / REFERENCES edges in this mode.
+	if !emitHeadingsEnabled() {
+		headings = nil
+	}
 
 	totalLines := len(lines)
 	docName := basename(file.Path)
@@ -239,7 +269,10 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		}
 		codeEntities = append(codeEntities, ent)
 
-		// Attach to most recent heading whose start_line < cb.start.
+		// Attach to most recent heading whose start_line < cb.start. When
+		// heading emission is disabled (issue #2284), or when no heading
+		// precedes the code block, attach directly to the Document so the
+		// code block is not orphaned.
 		parentIdx := -1
 		for i := range headings {
 			if headings[i].line < cb.start {
@@ -251,6 +284,12 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		if parentIdx >= 0 {
 			headingEntities[parentIdx].Relationships = append(headingEntities[parentIdx].Relationships, types.RelationshipRecord{
 				FromID: headingEntities[parentIdx].QualifiedName,
+				ToID:   qname,
+				Kind:   "CONTAINS",
+			})
+		} else {
+			doc.Relationships = append(doc.Relationships, types.RelationshipRecord{
+				FromID: docQName,
 				ToID:   qname,
 				Kind:   "CONTAINS",
 			})

--- a/internal/extractors/markdown/markdown_test.go
+++ b/internal/extractors/markdown/markdown_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
+// TestMain opts the suite into heading emission. Issue #2284 made heading
+// emission opt-in (default off); existing tests assert on the legacy
+// behaviour, so we flip the gate on for the whole package by default and
+// let individual tests (TestHeadings_DisabledByDefault) override it.
+func TestMain(m *testing.M) {
+	if err := os.Setenv(emitHeadingsEnv, "1"); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
 func loadFixture(t *testing.T, name string) extractor.FileInput {
 	t.Helper()
 	p := filepath.Join("testdata", name)
@@ -387,5 +398,73 @@ func TestRegistration(t *testing.T) {
 		t.Errorf("markdown extractor not registered")
 	} else if e.Language() != "markdown" {
 		t.Errorf("extractor.Language() = %q, want markdown", e.Language())
+	}
+}
+
+// TestHeadings_DisabledByDefault verifies the issue #2284 fix: when the
+// ARCHIGRAPH_MARKDOWN_EMIT_HEADINGS gate is unset (the default), the
+// extractor emits NO SCOPE.Heading entities and NO Document→Heading
+// CONTAINS edges. Code blocks must still appear, attached to the Document.
+func TestHeadings_DisabledByDefault(t *testing.T) {
+	t.Setenv(emitHeadingsEnv, "")
+
+	ents := extract(t, "simple.md")
+
+	if c := countByKind(ents, "SCOPE.Heading"); c != 0 {
+		t.Errorf("default-off: expected 0 Headings, got %d", c)
+	}
+	if c := countByKind(ents, "SCOPE.Document"); c != 1 {
+		t.Errorf("default-off: expected 1 Document, got %d", c)
+	}
+	// Code block must still be emitted.
+	if c := countByKind(ents, "SCOPE.CodeBlock"); c != 1 {
+		t.Errorf("default-off: expected 1 CodeBlock, got %d", c)
+	}
+
+	// Document must NOT carry CONTAINS edges to any heading slug, and its
+	// CONTAINS edges (if any) should point only at the code block.
+	doc := findByQName(ents, "simple.md")
+	if doc == nil {
+		t.Fatalf("doc not found")
+	}
+	codeQ := "simple.md::block::L9"
+	for _, r := range doc.Relationships {
+		if r.Kind != "CONTAINS" {
+			continue
+		}
+		if r.ToID != codeQ {
+			t.Errorf("default-off: doc has unexpected CONTAINS->%q (expected only ->%q)", r.ToID, codeQ)
+		}
+	}
+	// Document must directly contain the code block as fallback parent.
+	if !hasContains(doc.Relationships, codeQ) {
+		t.Errorf("default-off: doc should contain code block %q as fallback parent; rels=%+v", codeQ, doc.Relationships)
+	}
+}
+
+// TestHeadings_OptInRestoresLegacy verifies that explicitly enabling
+// ARCHIGRAPH_MARKDOWN_EMIT_HEADINGS produces the legacy heading-rich
+// graph: Document→Heading CONTAINS, heading hierarchy, and Heading→CodeBlock
+// parent attachment all return.
+func TestHeadings_OptInRestoresLegacy(t *testing.T) {
+	t.Setenv(emitHeadingsEnv, "1")
+
+	ents := extract(t, "simple.md")
+
+	if c := countByKind(ents, "SCOPE.Heading"); c != 2 {
+		t.Fatalf("opt-in: expected 2 Headings, got %d", c)
+	}
+	doc := findByQName(ents, "simple.md")
+	if doc == nil {
+		t.Fatalf("doc not found")
+	}
+	if !hasContains(doc.Relationships, "simple.md::title") {
+		t.Errorf("opt-in: doc missing CONTAINS->title")
+	}
+	// Code block's parent is now the heading, not the doc.
+	codeQ := "simple.md::block::L9"
+	h2 := findByQName(ents, "simple.md::section")
+	if h2 == nil || !hasContains(h2.Relationships, codeQ) {
+		t.Errorf("opt-in: heading should contain code block %q", codeQ)
 	}
 }


### PR DESCRIPTION
Closes #2284

## Summary

The markdown extractor emitted one `SCOPE.Heading` entity per ATX heading in every README, CHANGELOG, and `docs/` file. On the UpVate bench corpus this produced ~240 heading entities, dominating `archigraph_find` results and clustering output. Headings remain useful for docs-search workflows, so the code path stays — it just becomes opt-in.

## Change

- New env-var gate: **`ARCHIGRAPH_MARKDOWN_EMIT_HEADINGS`** (truthy: `1` / `true`). Default off.
- When off: no `SCOPE.Heading` entities, no `Document --CONTAINS--> Heading` edges, no heading `REFERENCES` edges, no heading hierarchy edges.
- Fenced code blocks are still emitted in both modes. When headings are off, code blocks attach directly to the `SCOPE.Document` via `CONTAINS` (instead of being orphaned).
- Config plumbing pattern matches the existing `ARCHIGRAPH_INCREMENTAL_REINDEX` / `ARCHIGRAPH_INCREMENTAL_MAX_FILES` precedent in `internal/extractors/incremental.go` — package-local `os.Getenv` read at call time, no global config struct (none exists for extractors today).

## Before / after on a sample docs corpus

Per the issue, UpVate previously produced ~240 `SCOPE.Heading` entities from README/CHANGELOG/docs. With this change those drop to **0** by default. Opting in (`ARCHIGRAPH_MARKDOWN_EMIT_HEADINGS=1`) restores the prior count exactly — verified by `TestHeadings_OptInRestoresLegacy`.

## Files modified

- `internal/extractors/markdown/markdown.go` — gate + Document-fallback parent for code blocks
- `internal/extractors/markdown/markdown_test.go` — `TestMain` opts the existing suite into headings; two new tests cover default-off and explicit-on

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/extractors/...` (all extractor packages pass)
- [x] New `TestHeadings_DisabledByDefault` — 0 heading entities, code block re-parented to Document
- [x] New `TestHeadings_OptInRestoresLegacy` — opt-in restores legacy graph shape
- [x] Existing tests (`TestSimple`, `TestNested`, `TestSetextSkipped`, `TestEmptyHeadings_BackticksSlugCorrectly`, `TestCodeWithLang`, IMPORTS suite) unchanged — they opt in via `TestMain`

## CI

Default minimal CI (no `ci:full`).