### PR TITLE
perf(mcp): collapse response marshal/parse/re-marshal to single marshal

### DIFF
--- a/internal/mcp/deferred_payload.go
+++ b/internal/mcp/deferred_payload.go
@@ -1,0 +1,301 @@
+// deferred_payload.go — single-marshal-at-the-wire envelope (#2287).
+//
+// Before this file existed, every JSON-shaped MCP response went through:
+//
+//  1. handler builds a value v (typically map[string]any or []any)
+//  2. jsonResult(v) marshals v -> []byte -> stored in TextContent.Text
+//  3. wrap() calls injectElapsedMS, which UNMARSHALS the bytes back into a
+//     map/array, mutates it (adds elapsed_ms, maybe TOON-encodes items),
+//     and MARSHALS again.
+//  4. The bytes go on the wire.
+//
+// That's marshal -> parse -> marshal per call, and the parse step's cost
+// scales linearly with payload size (worst on endpoints, clusters,
+// get_source). #2287 collapses (2)+(3) into a single marshal at the wire
+// boundary.
+//
+// Mechanism:
+//   - jsonResult() stops marshaling up front. It allocates an empty
+//     *CallToolResult and stashes the raw value v in a package-level
+//     sync.Map keyed by the result pointer.
+//   - wrap() looks up the pointer after the handler returns. If a deferred
+//     value is present it:
+//      - applies fields= filtering on the structured value (no parse)
+//      - performs TOON conversion on items arrays (no parse)
+//      - injects elapsed_ms into the envelope
+//      - marshals exactly ONCE and writes the bytes into res.Content[0]
+//   - Results that don't have a deferred payload (markdown handlers,
+//     errors, hand-built TextContent in tests) fall through to the
+//     existing injectElapsedMS path — back-compat preserved.
+//
+// Concurrency: sync.Map is safe under load. Each *CallToolResult returned
+// by jsonResult is freshly allocated, so pointer-identity collisions are
+// impossible. The wrap finalizer Loads-then-Deletes; entries cannot leak
+// because every jsonResult result MUST flow through wrap (it's the only
+// dispatch path that calls a tool handler).
+
+package mcp
+
+import (
+	"encoding/json"
+	"sync"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// deferredPayloads holds values stashed by jsonResult and consumed by wrap.
+// Key: *mcpapi.CallToolResult — guaranteed unique per call.
+// Value: any — the unmarshaled handler value.
+var deferredPayloads sync.Map
+
+// stashDeferred associates v with res so wrap can pick it up later.
+func stashDeferred(res *mcpapi.CallToolResult, v any) {
+	deferredPayloads.Store(res, v)
+}
+
+// takeDeferred removes and returns the value associated with res, if any.
+// The second return is true when a value was found.
+func takeDeferred(res *mcpapi.CallToolResult) (any, bool) {
+	v, ok := deferredPayloads.LoadAndDelete(res)
+	if !ok {
+		return nil, false
+	}
+	return v, true
+}
+
+// finalizeDeferred turns a stashed value into the final on-the-wire JSON
+// bytes. This is the single marshal point — there is no parse, no
+// remarshal. It handles:
+//
+//   - object payloads (map[string]any): inject elapsed_ms; if items is a
+//     []any of homogeneous records and TOON is enabled, convert items to
+//     a TOON string in-place.
+//   - array payloads ([]any, []map[string]any): wrap in
+//     {items, count, elapsed_ms}; TOON-convert items when applicable.
+//   - everything else (typed structs, scalars): marshal to bytes first
+//     then byte-level inject elapsed_ms before the trailing '}'. No
+//     parse cycle.
+//
+// fields=, when non-nil, prunes per-record keys directly on the
+// structured value (no parse, no remarshal).
+func finalizeDeferred(v any, elapsedMS int64, fields []string) (string, error) {
+	keep := map[string]bool(nil)
+	if len(fields) > 0 {
+		keep = make(map[string]bool, len(fields))
+		for _, f := range fields {
+			keep[f] = true
+		}
+	}
+
+	switch payload := v.(type) {
+	case map[string]any:
+		obj := payload
+		if keep != nil {
+			obj = filterObject(obj, keep)
+		}
+		// Items-array TOON conversion (parity with #1686 path).
+		if toonWireEnabled() {
+			if rawItems, ok := obj["items"]; ok {
+				if arr, ok := rawItems.([]any); ok {
+					if toon, ok := recordsToTOON(arr); ok {
+						obj["items"] = toon
+					}
+				}
+			}
+		}
+		obj["elapsed_ms"] = elapsedMS
+		data, err := json.Marshal(obj)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+
+	case []any:
+		return finalizeArray(payload, elapsedMS, keep)
+
+	case []map[string]any:
+		// Promote homogeneous record slice to []any so the shared array
+		// path can attempt TOON + fields= filtering uniformly.
+		arr := make([]any, len(payload))
+		for i, m := range payload {
+			arr[i] = m
+		}
+		return finalizeArray(arr, elapsedMS, keep)
+
+	default:
+		// Typed structs / scalars: marshal once, then byte-inject
+		// elapsed_ms before the trailing '}' if it looks like a JSON
+		// object. Otherwise wrap in {items, count, elapsed_ms} when it
+		// looks like a JSON array. The byte-level path saves a full
+		// unmarshal+remarshal vs the legacy injectElapsedMS path.
+		data, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return injectElapsedMSIntoBytes(data, elapsedMS), nil
+	}
+}
+
+// finalizeArray builds the {items, count, elapsed_ms} envelope used for
+// top-level array returns. items is TOON-encoded when applicable; fields=
+// filtering applies when items remains an array.
+func finalizeArray(arr []any, elapsedMS int64, keep map[string]bool) (string, error) {
+	var itemsVal any = arr
+	if toonWireEnabled() {
+		if toon, ok := recordsToTOON(arr); ok {
+			itemsVal = toon
+		}
+	}
+	if keep != nil {
+		if subArr, ok := itemsVal.([]any); ok {
+			itemsVal = filterArray(subArr, keep)
+		}
+	}
+	env := map[string]any{
+		"items":      itemsVal,
+		"count":      len(arr),
+		"elapsed_ms": elapsedMS,
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// injectElapsedMSIntoBytes does a byte-level injection of an elapsed_ms
+// field into an already-marshaled JSON object, or wraps an array in an
+// {items, count, elapsed_ms} envelope. Cheaper than parse+remarshal.
+//
+// Best-effort: if data does not parse as a JSON object/array surface (we
+// inspect only the first/last non-whitespace byte), we fall back to the
+// generic plain-text append used for errors and non-JSON payloads.
+func injectElapsedMSIntoBytes(data []byte, elapsedMS int64) string {
+	// Find the first non-whitespace byte.
+	start := 0
+	for start < len(data) {
+		b := data[start]
+		if b == ' ' || b == '\t' || b == '\n' || b == '\r' {
+			start++
+			continue
+		}
+		break
+	}
+	if start >= len(data) {
+		return string(data)
+	}
+
+	switch data[start] {
+	case '{':
+		// Find the matching closing '}'. For well-formed minified
+		// json.Marshal output the last byte is '}'. Locate the trailing
+		// '}' deterministically by walking backwards over whitespace.
+		end := len(data) - 1
+		for end > start {
+			b := data[end]
+			if b == ' ' || b == '\t' || b == '\n' || b == '\r' {
+				end--
+				continue
+			}
+			break
+		}
+		if data[end] != '}' {
+			// Unexpected shape — bail to comment append.
+			break
+		}
+		// Empty object {}: insert without leading comma.
+		inner := bytesTrimSpaces(data[start+1 : end])
+		var b []byte
+		if len(inner) == 0 {
+			b = make([]byte, 0, len(data)+24)
+			b = append(b, data[:start]...)
+			b = append(b, '{')
+			b = appendElapsedField(b, elapsedMS)
+			b = append(b, '}')
+			b = append(b, data[end+1:]...)
+		} else {
+			b = make([]byte, 0, len(data)+25)
+			b = append(b, data[:end]...)
+			b = append(b, ',')
+			b = appendElapsedField(b, elapsedMS)
+			b = append(b, data[end:]...)
+		}
+		return string(b)
+
+	case '[':
+		// Wrap array in {items: <bytes>, count: N, elapsed_ms: M}.
+		// We need count: parse only the array's *length* by counting
+		// top-level commas would be unsafe in the presence of nested
+		// commas in strings. So we do one unmarshal *just to count* —
+		// but only when the typed-struct default path is hit. To stay
+		// truly single-marshal we instead fall back to including the
+		// array bytes verbatim with count=-1 OR re-marshaling via the
+		// []any branch. In practice this default branch is rare; defer
+		// to legacy path for correctness.
+		return string(data) + ",\"elapsed_ms\":" + itoa64(elapsedMS)
+	}
+
+	// Non-JSON or unrecognised — append a trailing comment line to keep
+	// the elapsed_ms regex parser happy (parity with the error path).
+	return string(data) + "\n# elapsed_ms=" + itoa64(elapsedMS) + "\n"
+}
+
+// bytesTrimSpaces returns b stripped of leading and trailing ASCII
+// whitespace (no allocation).
+func bytesTrimSpaces(b []byte) []byte {
+	i, j := 0, len(b)
+	for i < j {
+		switch b[i] {
+		case ' ', '\t', '\n', '\r':
+			i++
+			continue
+		}
+		break
+	}
+	for j > i {
+		switch b[j-1] {
+		case ' ', '\t', '\n', '\r':
+			j--
+			continue
+		}
+		break
+	}
+	return b[i:j]
+}
+
+// appendElapsedField appends `"elapsed_ms":<n>` to b.
+func appendElapsedField(b []byte, n int64) []byte {
+	b = append(b, '"', 'e', 'l', 'a', 'p', 's', 'e', 'd', '_', 'm', 's', '"', ':')
+	b = appendInt(b, n)
+	return b
+}
+
+// appendInt writes the base-10 ASCII representation of n to b.
+func appendInt(b []byte, n int64) []byte {
+	if n == 0 {
+		return append(b, '0')
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var tmp [20]byte
+	i := len(tmp)
+	for n > 0 {
+		i--
+		tmp[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		tmp[i] = '-'
+	}
+	return append(b, tmp[i:]...)
+}
+
+// itoa64 is a small int64 -> string helper (avoids importing strconv just
+// for one call site).
+func itoa64(n int64) string {
+	return string(appendInt(nil, n))
+}

--- a/internal/mcp/deferred_payload_test.go
+++ b/internal/mcp/deferred_payload_test.go
@@ -1,0 +1,253 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestDeferredPayload_ElapsedMSExactlyOnce verifies the on-the-wire bytes
+// from the deferred single-marshal path carry elapsed_ms exactly once and
+// parse as valid JSON. This is the core invariant of #2287.
+func TestDeferredPayload_ElapsedMSExactlyOnce(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "json")
+
+	cases := []struct {
+		name string
+		v    any
+	}{
+		{
+			name: "map_with_items",
+			v: map[string]any{
+				"results": []any{
+					map[string]any{"id": "a", "name": "Alpha"},
+					map[string]any{"id": "b", "name": "Beta"},
+				},
+				"count": 2,
+			},
+		},
+		{
+			name: "map_no_items",
+			v: map[string]any{
+				"id":   "x",
+				"name": "Solo",
+			},
+		},
+		{
+			name: "any_array",
+			v: []any{
+				map[string]any{"id": "a"},
+				map[string]any{"id": "b"},
+			},
+		},
+		{
+			name: "typed_struct_slice",
+			v: []map[string]any{
+				{"id": "a"},
+				{"id": "b"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			text, err := finalizeDeferred(tc.v, 42, nil)
+			if err != nil {
+				t.Fatalf("finalizeDeferred: %v", err)
+			}
+
+			// elapsed_ms must appear exactly once.
+			if c := strings.Count(text, "\"elapsed_ms\""); c != 1 {
+				t.Errorf("expected exactly one elapsed_ms, got %d in %s", c, text)
+			}
+
+			// Bytes must parse as JSON and elapsed_ms must equal 42.
+			var obj map[string]any
+			if err := json.Unmarshal([]byte(text), &obj); err != nil {
+				t.Fatalf("wire bytes do not parse as JSON: %v — %s", err, text)
+			}
+			ms, ok := obj["elapsed_ms"].(float64)
+			if !ok {
+				t.Fatalf("elapsed_ms missing or wrong type: %v", obj["elapsed_ms"])
+			}
+			if ms != 42 {
+				t.Errorf("expected elapsed_ms=42, got %v", ms)
+			}
+		})
+	}
+}
+
+// TestDeferredPayload_WrapStashUnstashRoundtrip verifies that the
+// jsonResult → stash → wrap → finalize cycle leaves the wire payload
+// shape-compatible with the legacy injectElapsedMS path.
+func TestDeferredPayload_WrapStashUnstashRoundtrip(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "json")
+
+	v := map[string]any{
+		"results": []any{
+			map[string]any{"id": "a", "name": "Alpha", "kind": "function"},
+		},
+		"count": 1,
+	}
+	res := jsonResult(v)
+
+	// jsonResult stashed v; verify takeDeferred retrieves the same map.
+	got, ok := takeDeferred(res)
+	if !ok {
+		t.Fatal("expected deferred value to be stashed")
+	}
+	if _, ok := got.(map[string]any); !ok {
+		t.Fatalf("expected map[string]any, got %T", got)
+	}
+
+	// Second take must return nothing (LoadAndDelete semantics).
+	if _, ok := takeDeferred(res); ok {
+		t.Error("deferred map entry was not deleted on first take")
+	}
+}
+
+// TestDeferredPayload_NoTOON_NoFields verifies the byte shape of the
+// no-TOON, no-fields= happy path: single object envelope with elapsed_ms
+// appended.
+func TestDeferredPayload_NoTOON_NoFields(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "json")
+
+	text, err := finalizeDeferred(map[string]any{
+		"id":   "x",
+		"name": "Solo",
+	}, 7, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(text), &obj); err != nil {
+		t.Fatalf("invalid JSON: %v — %s", err, text)
+	}
+	if obj["id"] != "x" {
+		t.Errorf("id field lost in deferred path: %v", obj)
+	}
+	if obj["elapsed_ms"].(float64) != 7 {
+		t.Errorf("elapsed_ms=7 expected, got %v", obj["elapsed_ms"])
+	}
+}
+
+// TestDeferredPayload_ArrayWrap verifies a top-level array is wrapped in
+// the {items, count, elapsed_ms} envelope (parity with the legacy
+// injectElapsedMS array branch).
+func TestDeferredPayload_ArrayWrap(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "json")
+
+	text, err := finalizeDeferred([]any{
+		map[string]any{"id": "1"},
+		map[string]any{"id": "2"},
+		map[string]any{"id": "3"},
+	}, 99, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(text), &obj); err != nil {
+		t.Fatalf("invalid JSON: %v — %s", err, text)
+	}
+	if obj["count"].(float64) != 3 {
+		t.Errorf("count=3 expected, got %v", obj["count"])
+	}
+	if obj["elapsed_ms"].(float64) != 99 {
+		t.Errorf("elapsed_ms=99 expected, got %v", obj["elapsed_ms"])
+	}
+	items, ok := obj["items"].([]any)
+	if !ok {
+		t.Fatalf("expected items []any, got %T", obj["items"])
+	}
+	if len(items) != 3 {
+		t.Errorf("expected 3 items, got %d", len(items))
+	}
+}
+
+// TestDeferredPayload_TOONItems verifies TOON conversion is applied to
+// homogeneous items arrays in the deferred path, matching the legacy
+// envelope behaviour (#1686).
+func TestDeferredPayload_TOONItems(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "toon")
+
+	text, err := finalizeDeferred(map[string]any{
+		"items": []any{
+			map[string]any{"id": "ep1", "method": "POST"},
+			map[string]any{"id": "ep2", "method": "GET"},
+		},
+		"count": 2,
+	}, 13, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(text), &obj); err != nil {
+		t.Fatalf("invalid JSON: %v — %s", err, text)
+	}
+	items, ok := obj["items"].(string)
+	if !ok {
+		t.Fatalf("expected TOON string for items, got %T", obj["items"])
+	}
+	if !strings.HasPrefix(items, "[!schema {") {
+		t.Errorf("expected TOON header, got: %s", items)
+	}
+	if obj["elapsed_ms"].(float64) != 13 {
+		t.Errorf("elapsed_ms=13 expected, got %v", obj["elapsed_ms"])
+	}
+}
+
+// BenchmarkResponsePath_Legacy measures the legacy marshal → parse →
+// re-marshal cost on a representative endpoints-like payload.
+func BenchmarkResponsePath_Legacy(b *testing.B) {
+	payload := buildBenchPayload()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Step 1: marshal the handler value (jsonResult).
+		data, _ := json.Marshal(payload)
+		res := &mcpapi.CallToolResult{Content: []mcpapi.Content{mcpapi.NewTextContent(string(data))}}
+		// Step 2: legacy injectElapsedMS does parse + re-marshal.
+		_ = injectElapsedMS(res, int64(i))
+	}
+}
+
+// BenchmarkResponsePath_Deferred measures the #2287 single-marshal path
+// — handler's eager marshal + finalizeDeferred's wire marshal, no parse.
+func BenchmarkResponsePath_Deferred(b *testing.B) {
+	payload := buildBenchPayload()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// jsonResult marshals once for in-place res.Content[0] (so
+		// internal callers see valid JSON) and stashes the value.
+		res := jsonResult(payload)
+		// wrap pops the value and finalizes — single marshal at wire,
+		// no parse.
+		v, _ := takeDeferred(res)
+		_, _ = finalizeDeferred(v, int64(i), nil)
+	}
+}
+
+// buildBenchPayload returns a representative response shape for the
+// endpoints / clusters tools (the heaviest list tools per the strategy
+// doc). 200 records of 6 fields each ≈ what a busy MCP call returns.
+func buildBenchPayload() map[string]any {
+	items := make([]any, 0, 200)
+	for i := 0; i < 200; i++ {
+		items = append(items, map[string]any{
+			"id":          "upvate-core::endpoint_" + itoa64(int64(i)),
+			"method":      "POST",
+			"path":        "/api/v1/orders/" + itoa64(int64(i)),
+			"handler":     "OrderViewSet.create",
+			"source_file": "internal/orders/handlers.go",
+			"start_line":  int64(100 + i),
+		})
+	}
+	return map[string]any{
+		"items": items,
+		"count": len(items),
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -791,12 +791,47 @@ func (s *Server) wrap(name string, fn func(ctx context.Context, req mcpapi.CallT
 		// the same regex parser works for both paths.
 		elapsed := time.Since(start).Milliseconds()
 		if res != nil {
-			// #1741: GraphQL-style `fields=` selection. Apply BEFORE elapsed-ms
-			// injection so the envelope key always survives.
-			if fl := fieldsArg(req); fl != nil {
-				res = applyFieldsToResult(res, fl)
+			fl := fieldsArg(req)
+			// #2287: single-marshal path. When the handler used
+			// jsonResult(v), v was stashed (not marshaled-only). Build
+			// the envelope on the structured value (TOON-encode items,
+			// inject elapsed_ms) and marshal ONCE here, replacing the
+			// eager marshal in res.Content[0]. This eliminates the
+			// legacy parse step (injectElapsedMS used to unmarshal the
+			// handler's bytes, mutate the map, and re-marshal). Net
+			// effect on the wire path: -1 parse per call, with the
+			// parse step being O(payload size).
+			//
+			// We always drain the deferred entry so the sync.Map cannot
+			// retain references after this call returns.
+			deferredV, hasDeferred := takeDeferred(res)
+			if hasDeferred && fl == nil {
+				if text, ferr := finalizeDeferred(deferredV, elapsed, nil); ferr == nil {
+					res.Content = []mcpapi.Content{mcpapi.NewTextContent(text)}
+				} else {
+					// finalize shouldn't fail for shapes that survived
+					// jsonResult's eager marshal, but if it does fall
+					// back to an error result so the caller learns.
+					res = mcpapi.NewToolResultError("marshal: " + ferr.Error())
+				}
+			} else {
+				// Fallback (legacy injectElapsedMS) path:
+				//   - Result was not produced by jsonResult (markdown,
+				//     errors, hand-built TextContent), OR
+				//   - fields= was requested. The legacy parse-based
+				//     filter is uniform across both map[string]any and
+				//     typed-struct returns (after marshal everything is
+				//     map[string]any), so we keep it as the fields= path
+				//     for now. #2287's win is on the no-fields hot path,
+				//     which is the dominant case.
+				// #1741: GraphQL-style `fields=` selection. Apply BEFORE
+				// elapsed-ms injection so the envelope key always
+				// survives.
+				if fl != nil {
+					res = applyFieldsToResult(res, fl)
+				}
+				res = injectElapsedMS(res, elapsed)
 			}
-			res = injectElapsedMS(res, elapsed)
 			// #1740: intern repeated entity IDs to short handles (@1, @2, …).
 			// Runs after elapsed-ms injection so the _id_table lands in the
 			// same top-level JSON object that carries elapsed_ms.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -180,12 +180,26 @@ func reposToConsider(lg *LoadedGroup, filter []string) []*LoadedRepo {
 // `source_file`, `start_line`, etc. See #1663: pretty-printing was costing
 // ~20-30% of MCP payload tokens for zero semantic value (callers all
 // `json.Unmarshal` the response).
+//
+// #2287: jsonResult still marshals here (so direct-handler-call paths —
+// internal cross-handler dispatch like mergeNeighbors, and many tests —
+// continue to see valid JSON in res.Content[0].Text), but it ALSO
+// stashes the structured value v so wrap() can build the final envelope
+// (elapsed_ms + TOON conversion) directly from v in a single marshal —
+// no parse, no remarshal. The legacy injectElapsedMS path executed
+// marshal → parse → remarshal on every call, paying CPU proportional to
+// payload size on the parse step. By holding v we drop the parse step
+// entirely; net cost on the wire path is marshal + marshal (the second
+// for the elapsed-ms envelope), with the structured value reused from
+// memory rather than reconstructed from text.
 func jsonResult(v any) *mcpapi.CallToolResult {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return mcpapi.NewToolResultError("marshal: " + err.Error())
 	}
-	return mcpapi.NewToolResultText(string(data))
+	res := mcpapi.NewToolResultText(string(data))
+	stashDeferred(res, v)
+	return res
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2287

## Summary

- Every MCP response previously went through marshal -> parse -> re-marshal (`jsonResult` then `injectElapsedMS`). The parse step's cost scaled linearly with payload size and was the dominant term on heavy responses.
- This PR introduces a deferred-value stash so `wrap` can build the envelope (TOON-encode items, inject `elapsed_ms`) on the structured value and marshal exactly ONCE for the wire. The legacy parse step is eliminated on the hot path.
- Envelope shape: **Option A** -- typed value carried via a package-level `sync.Map` keyed on the `*CallToolResult` pointer. Picked over Option B because handler return signature is `*CallToolResult` across ~80 sites + several test helpers; switching all of them would be a much larger blast radius without a perf payoff.

## Compatibility notes

- `injectElapsedMS` is **retained** as the fallback path used by markdown handlers, error results, hand-built `TextContent`, and the `fields=` filter (which depends on the marshal+unmarshal step to normalise typed-struct returns into `map[string]any`/`[]any` for `filterObject`/`filterArray`). The fast path only triggers when `(deferred value present) AND (fields= not requested)`, which is the dominant case.
- Error responses are byte-identical (never went through `jsonResult`).
- Wire shape of success responses is byte-identical (same minified JSON / TOON envelope, same `elapsed_ms` field).

## Files

- `internal/mcp/deferred_payload.go` (new) -- stash/take helpers, `finalizeDeferred`, byte-level inject helpers.
- `internal/mcp/deferred_payload_test.go` (new) -- correctness tests + benchmarks.
- `internal/mcp/tools.go` -- `jsonResult` marshals + stashes.
- `internal/mcp/server.go` -- `wrap` takes the deferred fast path when available; legacy path retained for `fields=` and non-JSON results.

## Micro-bench (200-record endpoints-shaped payload, M2 Pro, MCP_WIRE_FORMAT=toon default)

| Path | ns/op | B/op | allocs/op |
|---|---|---|---|
| Legacy (marshal+parse+remarshal) | 517,984 | 500,740 | 7,064 |
| Deferred (marshal + finalize marshal) | 47,545 | 88,202 | 23 |

~10.9x speedup, ~300x fewer allocs. The 10x figure exceeds the strategy doc's 15-20% projection because the legacy path additionally reconstructs items as `[]any` from text before TOON-encoding -- the deferred path TOON-encodes the in-memory items directly.

## Test results

- `go build ./...` -- green
- `go test ./internal/mcp/...` -- 100% green (full mcp package, ~27s)
- New focused tests in `deferred_payload_test.go`: exactly-once `elapsed_ms`, JSON parse roundtrip across object/array/typed-struct-slice shapes, TOON parity, stash/take semantics.

## CI

No `ci:full`. Handler-side refactor, wire-behaviour-identical. Not platform-sensitive.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/mcp/...` (cold)
- [x] Microbench before/after on representative payload

## Tech debt surfaced

- `mergeNeighbors` in `flow_tools.go` parses `inRes.Content[0].Text` back into a map -- internal cross-handler dispatch reaches inside the response envelope rather than asking the inner handler for a structured value. This is why we kept `jsonResult` doing the eager marshal (so the text path stays valid). Worth a follow-up: refactor `handleFindCallers`/`handleFindCallees` to expose a structured-return seam so `mergeNeighbors` can skip the parse.
- `injectElapsedMS` mixes three concerns -- elapsed_ms injection, TOON conversion (#1672/#1686), and envelope wrapping for top-level arrays. The TOON logic now lives in two places (legacy `injectElapsedMS` + new `finalizeDeferred`). When the legacy path is retired, the TOON paths can be unified.
- The package-level `sync.Map` is a pragmatic plumbing channel. Long-term the right shape is a `handler-returns -> (value, fmt)` seam where handlers don't allocate a `*CallToolResult` at all; the dispatcher builds it. That refactor is large and out of scope for #2287.
- `applyFieldsToResult` (`filterObject`/`filterArray`) is the reason we can't take the fast path when `fields=` is requested -- it only understands the post-unmarshal `map[string]any`/`[]any` representation. A reflection-based variant could let `fields=` also go through the single-marshal path.