### PR TITLE
chore(indexer): drop error_handling:try_catch:<line> pattern nodes

### DIFF
--- a/internal/extractors/java/errorpattern.go
+++ b/internal/extractors/java/errorpattern.go
@@ -1,88 +1,26 @@
 // Error-handling pattern extraction for Java source files.
 //
-// This file implements a secondary extraction pass that emits one
-// SCOPE.Pattern EntityRecord per `try { ... } catch (...) { ... }`
-// occurrence. It runs AFTER the base entity extraction in
-// Extractor.Extract and never aborts the primary walker — a failure
-// here is logged at warn level and partial results are returned
-//.
+// HISTORY: this pass used to emit one SCOPE.Pattern EntityRecord per
+// `try { ... } catch (...) { ... }` (and try-with-resources)
+// occurrence, with Name "error_handling:try_catch:N". Issue #2282
+// dropped the emit — see internal/extractors/python/errorpattern.go for
+// the full rationale (per-line try nodes were ~5.5% of the UpVate
+// graph and had no consumer).
 //
-// Entity shape (parity with Python / Go / JS):
-//
-//	Kind       = "SCOPE.Pattern"
-//	Name       = "error_handling:try_catch:N"  (N = 1-based line number)
-//	SourceFile = absolute path of the source file
-//	StartLine  = line number of the try statement (EndLine matches)
-//	Language   = "java"
-//	Metadata   = {"pattern_type": "error_handling"}
-//
-// Detection rule:
-//
-//	AST node type: try_statement (matches both try/catch and
-//	               try-with-resources, since tree-sitter-java exposes
-//	               them as try_statement and try_with_resources_statement
-//	               respectively). We treat both as error-handling blocks.
-//
-// We match on node.Type() string so a grammar upgrade that renames
-// the node does not silently turn the pass into a no-op — a rename
-// would be caught by the test suite (not here).
+// The function is preserved as a no-op so the calling extractor in
+// java.go doesn't need to be rewired.
 
 package java
 
 import (
-	"fmt"
-	"log"
-
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// extractErrorHandlingPatterns walks the AST iteratively and returns one
-// EntityRecord per try_statement or try_with_resources_statement node
-// found. Safe against panics — a recover at the top converts them into
-// a warn-level log, preserving any records already collected.
+// extractErrorHandlingPatterns is intentionally a no-op since #2282.
 func extractErrorHandlingPatterns(root *sitter.Node, filePath string) []types.EntityRecord {
-	if root == nil {
-		return nil
-	}
-
-	var records []types.EntityRecord
-	defer func() {
-		if r := recover(); r != nil {
-			log.Printf("[java extractor] WARNING: error-pattern pass panicked on %s: %v — returning partial results", filePath, r)
-		}
-	}()
-
-	stack := []*sitter.Node{root}
-	for len(stack) > 0 {
-		n := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-		if n == nil {
-			continue
-		}
-		t := n.Type()
-		if t == "try_statement" || t == "try_with_resources_statement" {
-			line := int(n.StartPoint().Row) + 1
-			records = append(records, types.EntityRecord{
-				Name:       fmt.Sprintf("error_handling:try_catch:%d", line),
-				Kind:       "SCOPE.Pattern",
-				SourceFile: filePath,
-				StartLine:  line,
-				EndLine:    line,
-				Language:   "java",
-				Metadata: map[string]interface{}{
-					"pattern_type": "error_handling",
-				},
-				QualityScore:       1.0,
-				EnrichmentRequired: false,
-			})
-		}
-		count := int(n.ChildCount())
-		for i := 0; i < count; i++ {
-			stack = append(stack, n.Child(i))
-		}
-	}
-
-	return records
+	_ = root
+	_ = filePath
+	return nil
 }

--- a/internal/extractors/java/errorpattern_test.go
+++ b/internal/extractors/java/errorpattern_test.go
@@ -2,7 +2,6 @@ package java_test
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -31,23 +30,15 @@ func extractJava(t *testing.T, src string) []types.EntityRecord {
 	return recs
 }
 
-// errorPatternsJava filters records to SCOPE.Pattern entities.
-func errorPatternsJava(t *testing.T, src string) []types.EntityRecord {
-	t.Helper()
-	var out []types.EntityRecord
-	for _, r := range extractJava(t, src) {
-		if r.Kind == "SCOPE.Pattern" {
-			out = append(out, r)
-		}
-	}
-	return out
-}
-
-// TestErrorPatternJava_SingleTryCatch verifies one try/catch emits one
-// SCOPE.Pattern entity with the correct key and line number.
-func TestErrorPatternJava_SingleTryCatch(t *testing.T) {
+// TestErrorPatternJava_NoTryCatchEmit verifies issue #2282 — the Java
+// extractor must no longer emit per-line `error_handling:try_catch:N`
+// SCOPE.Pattern entities. Exercises plain try/catch and try-with-resources.
+func TestErrorPatternJava_NoTryCatchEmit(t *testing.T) {
 	src := `
 package com.example;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
 
 public class Foo {
     public void load() {
@@ -58,265 +49,20 @@ public class Foo {
         }
     }
 
-    private void doWork() {}
-}
-`
-	patterns := errorPatternsJava(t, src)
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 error pattern, got %d", len(patterns))
-	}
-	p := patterns[0]
-	if p.Kind != "SCOPE.Pattern" {
-		t.Errorf("Kind = %q, want %q", p.Kind, "SCOPE.Pattern")
-	}
-	if !strings.HasPrefix(p.Name, "error_handling:try_catch:") {
-		t.Errorf("Name = %q, missing error_handling:try_catch: prefix", p.Name)
-	}
-	if p.Language != "java" {
-		t.Errorf("Language = %q, want %q", p.Language, "java")
-	}
-	pt, _ := p.Metadata["pattern_type"].(string)
-	if pt != "error_handling" {
-		t.Errorf("metadata.pattern_type = %q, want %q", pt, "error_handling")
-	}
-	if p.StartLine == 0 || p.EndLine == 0 {
-		t.Errorf("StartLine/EndLine must be non-zero, got %d/%d", p.StartLine, p.EndLine)
-	}
-	if p.StartLine != p.EndLine {
-		t.Errorf("StartLine (%d) must equal EndLine (%d)", p.StartLine, p.EndLine)
-	}
-}
-
-// TestErrorPatternJava_MultipleTryCatch verifies each try/catch block
-// produces its own entity.
-func TestErrorPatternJava_MultipleTryCatch(t *testing.T) {
-	src := `
-package com.example;
-
-public class Foo {
-    public void a() {
-        try { x(); } catch (Exception e) {}
-        try { y(); } catch (Exception e) {}
-        try { z(); } catch (Exception e) {}
-    }
-    private void x() {}
-    private void y() {}
-    private void z() {}
-}
-`
-	patterns := errorPatternsJava(t, src)
-	if len(patterns) != 3 {
-		t.Fatalf("expected 3 patterns, got %d", len(patterns))
-	}
-	seen := make(map[string]bool, len(patterns))
-	for _, p := range patterns {
-		if seen[p.Name] {
-			t.Errorf("duplicate Name %q", p.Name)
-		}
-		seen[p.Name] = true
-	}
-}
-
-// TestErrorPatternJava_TryFinallyNoCatch verifies a try-finally block
-// without a catch clause is still captured.
-func TestErrorPatternJava_TryFinallyNoCatch(t *testing.T) {
-	src := `
-package com.example;
-
-public class Foo {
-    public void a() {
-        try {
-            doWork();
-        } finally {
-            cleanup();
+    public void withResources() throws Exception {
+        try (BufferedReader r = new BufferedReader(new FileReader("x"))) {
+            r.readLine();
+        } catch (Exception e) {
+            throw e;
         }
     }
-    private void doWork() {}
-    private void cleanup() {}
-}
-`
-	patterns := errorPatternsJava(t, src)
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 pattern for try/finally, got %d", len(patterns))
-	}
-}
 
-// TestErrorPatternJava_TryWithResources verifies a try-with-resources
-// block produces a pattern entity.
-func TestErrorPatternJava_TryWithResources(t *testing.T) {
-	src := `
-package com.example;
-
-import java.io.*;
-
-public class Foo {
-    public void a() throws IOException {
-        try (BufferedReader br = new BufferedReader(new FileReader("x"))) {
-            br.readLine();
-        }
-    }
-}
-`
-	patterns := errorPatternsJava(t, src)
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 pattern for try-with-resources, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternJava_NestedTry verifies nested try/catch blocks are
-// each captured separately.
-func TestErrorPatternJava_NestedTry(t *testing.T) {
-	src := `
-package com.example;
-
-public class Foo {
-    public void a() {
-        try {
-            try {
-                x();
-            } catch (RuntimeException e) {}
-        } catch (Exception e) {}
-    }
-    private void x() {}
-}
-`
-	patterns := errorPatternsJava(t, src)
-	if len(patterns) != 2 {
-		t.Fatalf("expected 2 patterns for nested try, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternJava_NoTry verifies files without try blocks produce
-// no pattern records.
-func TestErrorPatternJava_NoTry(t *testing.T) {
-	src := `
-package com.example;
-
-public class Foo {
-    public void a() {
-        System.out.println("hi");
-    }
-}
-`
-	patterns := errorPatternsJava(t, src)
-	if len(patterns) != 0 {
-		t.Fatalf("expected 0 patterns, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternJava_EmptyFile verifies empty content produces no
-// patterns (no crash on nil tree).
-func TestErrorPatternJava_EmptyFile(t *testing.T) {
-	ext, ok := extractor.Get("java")
-	if !ok {
-		t.Fatal("java extractor not registered")
-	}
-	recs, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path:     "empty.java",
-		Content:  []byte(""),
-		Language: "java",
-		Tree:     nil,
-	})
-	if err != nil {
-		t.Fatalf("Extract: %v", err)
-	}
-	var count int
-	for _, r := range recs {
-		if r.Kind == "SCOPE.Pattern" {
-			count++
-		}
-	}
-	if count != 0 {
-		t.Fatalf("expected 0 patterns for empty file, got %d", count)
-	}
-}
-
-// TestErrorPatternJava_PreservesBaseExtraction verifies class + method
-// records still come through after the secondary pass is added.
-func TestErrorPatternJava_PreservesBaseExtraction(t *testing.T) {
-	src := `
-package com.example;
-
-public class Worker {
-    public void run() {
-        try {
-            doWork();
-        } catch (Exception e) {}
-    }
     private void doWork() {}
 }
 `
-	recs := extractJava(t, src)
-	var hasClass, hasMethod, hasPattern bool
-	for _, r := range recs {
-		if r.Kind == "SCOPE.Component" && r.Name == "Worker" {
-			hasClass = true
+	for _, r := range extractJava(t, src) {
+		if r.Kind == "SCOPE.Pattern" && strings.HasPrefix(r.Name, "error_handling:try_catch:") {
+			t.Errorf("regression: %q emitted; #2282 dropped per-line try_catch entities", r.Name)
 		}
-		if r.Kind == "SCOPE.Operation" && r.Name == "Worker.run" {
-			hasMethod = true
-		}
-		if r.Kind == "SCOPE.Pattern" {
-			hasPattern = true
-		}
-	}
-	if !hasClass {
-		t.Error("base class extraction missing")
-	}
-	if !hasMethod {
-		t.Error("base method extraction missing")
-	}
-	if !hasPattern {
-		t.Error("error handling pattern missing")
-	}
-}
-
-// TestErrorPatternJava_UniqueNames verifies multi-pattern output has
-// no duplicate Name values.
-func TestErrorPatternJava_UniqueNames(t *testing.T) {
-	src := `
-package com.example;
-
-public class Foo {
-    public void a() {
-        try { x(); } catch (Exception e) {}
-        try { x(); } catch (Exception e) {}
-    }
-    private void x() {}
-}
-`
-	patterns := errorPatternsJava(t, src)
-	seen := make(map[string]bool, len(patterns))
-	for _, p := range patterns {
-		if seen[p.Name] {
-			t.Errorf("duplicate Name %q", p.Name)
-		}
-		seen[p.Name] = true
-	}
-}
-
-// TestErrorPatternJava_NamePreservesLine verifies the Name line suffix
-// matches the StartLine value exactly (catches stringification bugs).
-func TestErrorPatternJava_NamePreservesLine(t *testing.T) {
-	src := `
-package com.example;
-
-public class Foo {
-    public void a() {
-        int x = 1;
-        try {
-            doWork();
-        } catch (Exception e) {}
-    }
-    private void doWork() {}
-}
-`
-	patterns := errorPatternsJava(t, src)
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 pattern, got %d", len(patterns))
-	}
-	p := patterns[0]
-	wantName := fmt.Sprintf("error_handling:try_catch:%d", p.StartLine)
-	if p.Name != wantName {
-		t.Errorf("Name = %q, want %q", p.Name, wantName)
 	}
 }

--- a/internal/extractors/javascript/errorpattern.go
+++ b/internal/extractors/javascript/errorpattern.go
@@ -1,96 +1,28 @@
 // Error-handling pattern extraction for JavaScript and TypeScript source
 // files.
 //
-// This file implements a secondary extraction pass that emits one
-// SCOPE.Pattern EntityRecord per `try { ... } catch (...) { ... }`
-// occurrence. It runs AFTER the base entity extraction in
-// JSExtractor.Extract and never aborts the primary walker — a failure
-// here is logged at warn level and partial results are returned
-//. The pass handles both "javascript" and
-// "typescript" languages: the language field is carried from
-// FileInput and written back into each emitted record so downstream
-// consumers can tell them apart.
+// HISTORY: this pass used to emit one SCOPE.Pattern EntityRecord per
+// `try { ... } catch (...) { ... }` occurrence, with Name
+// "error_handling:try_catch:N". Issue #2282 dropped the emit — see
+// internal/extractors/python/errorpattern.go for the full rationale
+// (per-line try nodes were ~5.5% of the UpVate graph and had no
+// consumer).
 //
-// Entity shape (parity with Python / Go / Java):
-//
-//	Kind       = "SCOPE.Pattern"
-//	Name       = "error_handling:try_catch:N"  (N = 1-based line number)
-//	SourceFile = absolute path of the source file
-//	StartLine  = line number of the try statement (EndLine matches)
-//	Language   = "javascript" or "typescript"
-//	Metadata   = {"pattern_type": "error_handling"}
-//
-// Detection rule:
-//
-//	AST node type: try_statement
-//
-// tree-sitter-javascript and tree-sitter-typescript both expose try/catch
-// blocks as a "try_statement" node regardless of whether they have a
-// catch clause, a finally clause, or both. Each occurrence of `try`
-// produces one entity.
+// The function is preserved as a no-op so the calling extractor in
+// extractor.go doesn't need to be rewired.
 
 package javascript
 
 import (
-	"fmt"
-	"log"
-
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// extractErrorHandlingPatterns walks the AST iteratively and returns one
-// EntityRecord per try_statement found. Safe against panics — a recover
-// at the top converts them into a warn-level log, preserving any
-// records already collected.
-//
-// language is either "javascript" or "typescript" — written into each
-// emitted record's Language field so downstream consumers can tell
-// them apart without having to look at the file extension.
+// extractErrorHandlingPatterns is intentionally a no-op since #2282.
 func extractErrorHandlingPatterns(root *sitter.Node, filePath, language string) []types.EntityRecord {
-	if root == nil {
-		return nil
-	}
-
-	var records []types.EntityRecord
-	defer func() {
-		if r := recover(); r != nil {
-			log.Printf("[javascript extractor] WARNING: error-pattern pass panicked on %s: %v — returning partial results", filePath, r)
-		}
-	}()
-
-	stack := []*sitter.Node{root}
-	for len(stack) > 0 {
-		n := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-		if n == nil {
-			continue
-		}
-		if n.Type() == "try_statement" {
-			line := int(n.StartPoint().Row) + 1
-			e := types.EntityRecord{
-				Name:       fmt.Sprintf("error_handling:try_catch:%d", line),
-				Kind:       "SCOPE.Pattern",
-				SourceFile: filePath,
-				StartLine:  line,
-				EndLine:    line,
-				Language:   language,
-				Metadata: map[string]interface{}{
-					"pattern_type": "error_handling",
-				},
-				QualityScore:       1.0,
-				EnrichmentStatus:   types.StatusPending,
-				EnrichmentRequired: false,
-			}
-			e.ID = e.ComputeID()
-			records = append(records, e)
-		}
-		count := int(n.ChildCount())
-		for i := 0; i < count; i++ {
-			stack = append(stack, n.Child(i))
-		}
-	}
-
-	return records
+	_ = root
+	_ = filePath
+	_ = language
+	return nil
 }

--- a/internal/extractors/javascript/errorpattern_test.go
+++ b/internal/extractors/javascript/errorpattern_test.go
@@ -19,246 +19,25 @@ func extractAll(t *testing.T, src, language string) []types.EntityRecord {
 	return extract(t, content, language, tree)
 }
 
-// errorPatternsJS filters records to SCOPE.Pattern entities.
-func errorPatternsJS(t *testing.T, src, language string) []types.EntityRecord {
-	t.Helper()
-	var out []types.EntityRecord
-	for _, r := range extractAll(t, src, language) {
-		if r.Kind == "SCOPE.Pattern" {
-			out = append(out, r)
-		}
-	}
-	return out
-}
-
-// TestErrorPatternJS_SingleTryCatch verifies a basic JS try/catch emits
-// one SCOPE.Pattern entity with the correct Name and line.
-func TestErrorPatternJS_SingleTryCatch(t *testing.T) {
-	src := `function load() {
+// TestErrorPatternJS_NoTryCatchEmit verifies issue #2282 — the JS/TS
+// extractor must no longer emit per-line `error_handling:try_catch:N`
+// SCOPE.Pattern entities. Covers both grammars and nested try/finally.
+func TestErrorPatternJS_NoTryCatchEmit(t *testing.T) {
+	for _, lang := range []string{"javascript", "typescript"} {
+		t.Run(lang, func(t *testing.T) {
+			src := `function load() {
   try {
     doWork();
   } catch (e) {
-    console.error(e);
+    try { cleanup(); } finally { reset(); }
   }
 }
 `
-	patterns := errorPatternsJS(t, src, "javascript")
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 error pattern, got %d", len(patterns))
-	}
-	p := patterns[0]
-	if p.Kind != "SCOPE.Pattern" {
-		t.Errorf("Kind = %q, want SCOPE.Pattern", p.Kind)
-	}
-	if p.Name != "error_handling:try_catch:2" {
-		t.Errorf("Name = %q, want error_handling:try_catch:2", p.Name)
-	}
-	if p.StartLine != 2 {
-		t.Errorf("StartLine = %d, want 2", p.StartLine)
-	}
-	if p.EndLine != 2 {
-		t.Errorf("EndLine = %d, want 2", p.EndLine)
-	}
-	if p.Language != "javascript" {
-		t.Errorf("Language = %q, want javascript", p.Language)
-	}
-	pt, _ := p.Metadata["pattern_type"].(string)
-	if pt != "error_handling" {
-		t.Errorf("metadata.pattern_type = %q, want error_handling", pt)
-	}
-	if p.ID == "" {
-		t.Error("ID must be computed for JS pattern records")
-	}
-}
-
-// TestErrorPatternJS_MultipleTryCatch verifies each try block has its
-// own entity keyed by its own line.
-func TestErrorPatternJS_MultipleTryCatch(t *testing.T) {
-	src := `function a() {
-  try { x(); } catch (e) {}
-  try { y(); } catch (e) {}
-}
-`
-	patterns := errorPatternsJS(t, src, "javascript")
-	if len(patterns) != 2 {
-		t.Fatalf("expected 2 patterns, got %d", len(patterns))
-	}
-	seen := make(map[string]bool, len(patterns))
-	for _, p := range patterns {
-		if seen[p.Name] {
-			t.Errorf("duplicate Name %q", p.Name)
-		}
-		seen[p.Name] = true
-	}
-}
-
-// TestErrorPatternJS_TryFinallyNoCatch verifies try-finally without a
-// catch clause is still captured (matches Go/Python/Java behaviour).
-func TestErrorPatternJS_TryFinallyNoCatch(t *testing.T) {
-	src := `function a() {
-  try {
-    doWork();
-  } finally {
-    cleanup();
-  }
-}
-`
-	patterns := errorPatternsJS(t, src, "javascript")
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 pattern for try/finally, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternJS_NestedTry verifies nested try/catch blocks each
-// produce a separate entity.
-func TestErrorPatternJS_NestedTry(t *testing.T) {
-	src := `function a() {
-  try {
-    try {
-      x();
-    } catch (e) {}
-  } catch (e) {}
-}
-`
-	patterns := errorPatternsJS(t, src, "javascript")
-	if len(patterns) != 2 {
-		t.Fatalf("expected 2 patterns for nested try, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternJS_ClassMethod verifies try blocks inside class
-// methods are captured — the secondary walker scans the whole tree.
-func TestErrorPatternJS_ClassMethod(t *testing.T) {
-	src := `class Foo {
-  bar() {
-    try {
-      x();
-    } catch (e) {}
-  }
-}
-`
-	patterns := errorPatternsJS(t, src, "javascript")
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 pattern, got %d", len(patterns))
-	}
-	if patterns[0].StartLine != 3 {
-		t.Errorf("StartLine = %d, want 3", patterns[0].StartLine)
-	}
-}
-
-// TestErrorPatternJS_NoTry verifies files without try blocks produce
-// no pattern records.
-func TestErrorPatternJS_NoTry(t *testing.T) {
-	src := `function a() { return 1; }
-`
-	patterns := errorPatternsJS(t, src, "javascript")
-	if len(patterns) != 0 {
-		t.Fatalf("expected 0 patterns, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternJS_EmptyFile verifies empty content produces no
-// patterns (the extractor short-circuits on len==0).
-func TestErrorPatternJS_EmptyFile(t *testing.T) {
-	patterns := errorPatternsJS(t, "", "javascript")
-	if len(patterns) != 0 {
-		t.Fatalf("expected 0 patterns for empty file, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternJS_TypeScriptLanguage verifies a TS try/catch emits
-// a pattern whose Language field is "typescript", not "javascript".
-func TestErrorPatternJS_TypeScriptLanguage(t *testing.T) {
-	src := `function load(): void {
-  try {
-    doWork();
-  } catch (e: unknown) {
-    console.error(e);
-  }
-}
-`
-	patterns := errorPatternsJS(t, src, "typescript")
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 pattern, got %d", len(patterns))
-	}
-	if patterns[0].Language != "typescript" {
-		t.Errorf("Language = %q, want typescript", patterns[0].Language)
-	}
-	if !strings.HasPrefix(patterns[0].Name, "error_handling:try_catch:") {
-		t.Errorf("Name = %q missing prefix", patterns[0].Name)
-	}
-}
-
-// TestErrorPatternJS_PreservesBaseExtraction verifies the secondary
-// pass is additive — function / class / import edges must all
-// still be present. Updated for issue #742: import-placeholder entity
-// "bar" is no longer emitted; the IMPORTS edge lives on the file entity.
-func TestErrorPatternJS_PreservesBaseExtraction(t *testing.T) {
-	src := `import { foo } from "bar";
-
-class Worker {
-  run() {
-    try {
-      doWork();
-    } catch (e) {}
-  }
-}
-`
-	recs := extractAll(t, src, "javascript")
-	var hasClass, hasMethod, hasPattern bool
-	// Issue #742: verify IMPORTS edge for "bar" exists on any entity.
-	hasImport := false
-	for _, r := range recs {
-		if r.Kind == "SCOPE.Component" && r.Name == "Worker" {
-			hasClass = true
-		}
-		if r.Kind == "SCOPE.Operation" && r.Name == "run" {
-			hasMethod = true
-		}
-		if r.Kind == "SCOPE.Pattern" {
-			hasPattern = true
-		}
-		// No longer a standalone SCOPE.Component/import entity; check edges.
-		for _, rel := range r.Relationships {
-			if rel.Kind == "IMPORTS" {
-				ip := ""
-				if rel.Properties != nil {
-					ip = rel.Properties["import_path"]
-				}
-				if ip == "" {
-					ip = rel.ToID
-				}
-				if ip == "bar" {
-					hasImport = true
+			for _, r := range extractAll(t, src, lang) {
+				if r.Kind == "SCOPE.Pattern" && strings.HasPrefix(r.Name, "error_handling:try_catch:") {
+					t.Errorf("regression in %s: %q emitted; #2282 dropped per-line try_catch entities", lang, r.Name)
 				}
 			}
-		}
-	}
-	if !hasClass {
-		t.Error("base class extraction missing")
-	}
-	if !hasMethod {
-		t.Error("base method extraction missing")
-	}
-	if !hasImport {
-		t.Error("base import extraction missing")
-	}
-	if !hasPattern {
-		t.Error("error handling pattern missing")
-	}
-}
-
-// TestErrorPatternJS_ArrowFunctionBody verifies try blocks inside an
-// arrow function body are captured (walker scans all nodes).
-func TestErrorPatternJS_ArrowFunctionBody(t *testing.T) {
-	src := `const run = () => {
-  try {
-    doWork();
-  } catch (e) {}
-};
-`
-	patterns := errorPatternsJS(t, src, "javascript")
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 pattern for arrow fn body, got %d", len(patterns))
+		})
 	}
 }

--- a/internal/extractors/python/errorpattern.go
+++ b/internal/extractors/python/errorpattern.go
@@ -1,94 +1,32 @@
 // Error-handling pattern extraction for Python source files.
 //
-// This file implements a secondary extraction pass that emits one
-// SCOPE.Pattern EntityRecord per `try: ... except: ...` occurrence.
-// It runs AFTER the base entity extraction in Extractor.Extract and
-// never aborts the primary walker — a failure here is logged at warn
-// level and partial results are returned.
+// HISTORY: this pass used to emit one SCOPE.Pattern EntityRecord per
+// `try: ... except: ...` occurrence, with Name
+// "error_handling:try_catch:N". On the UpVate bench corpus that produced
+// ~1,077 nodes (~5.5% of the entire graph) with zero query value: no
+// caller asks "show me every try block at line N". Issue #2282 dropped
+// the emit. Pattern-level discovery (clustering, frequency analysis)
+// can be done over the existing kind=SCOPE.Component/SCOPE.Operation
+// nodes when we want it.
 //
-// Entity shape (matches Python indexer parser.py exactly):
-//
-//	Kind       = "SCOPE.Pattern"
-//	Name       = "error_handling:try_catch:N"  (N = 1-based line number)
-//	SourceFile = absolute path of the source file
-//	StartLine  = line number of the try statement (EndLine matches)
-//	Language   = "python"
-//	Metadata   = {"pattern_type": "error_handling"}
-//
-// Detection rule:
-//
-//	AST node type: try_statement
-//
-// tree-sitter-python represents `try/except/finally/else` blocks as a
-// single try_statement node. Every occurrence, whether it has one or
-// many except clauses, is emitted as one entity — matching the Python
-// parser behaviour where one `try` token in the file produces one
-// entity with the try-line number as the key.
+// The function is preserved as a no-op so the per-language extractor.go
+// call sites don't need to be rewired. If we ever want a different
+// pattern shape here (per-function aggregate, per-module roll-up,
+// per-file boolean), it slots in at this seam.
 
 package python
 
 import (
-	"fmt"
-	"log"
-
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// extractErrorHandlingPatterns walks the AST and returns one EntityRecord
-// per try_statement node found. Safe against panics — a recover at the
-// top converts them into a warn-level log, preserving any records
-// already collected.
+// extractErrorHandlingPatterns is intentionally a no-op since #2282.
+// Returns nil so the calling extractor's "entities = append(entities,
+// errorPatterns...)" continues to work without a special case.
 func extractErrorHandlingPatterns(root *sitter.Node, filePath string) []types.EntityRecord {
-	if root == nil {
-		return nil
-	}
-
-	var records []types.EntityRecord
-	defer func() {
-		if r := recover(); r != nil {
-			log.Printf("[python extractor] WARNING: error-pattern pass panicked on %s: %v — returning partial results", filePath, r)
-		}
-	}()
-
-	// Depth-first walk: collect every try_statement node. Iterative to
-	// avoid stack overflow on deeply-nested try/except blocks.
-	stack := []*sitter.Node{root}
-	for len(stack) > 0 {
-		n := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-		if n == nil {
-			continue
-		}
-		if n.Type() == "try_statement" {
-			line := int(n.StartPoint().Row) + 1
-			// Issue #1964 — emit the real end line from the AST node so the
-			// docgen source_window helper can excerpt the full try/except
-			// block instead of clipping at start_line.
-			endLine := int(n.EndPoint().Row) + 1
-			if endLine < line {
-				endLine = line
-			}
-			records = append(records, types.EntityRecord{
-				Name:       fmt.Sprintf("error_handling:try_catch:%d", line),
-				Kind:       "SCOPE.Pattern",
-				SourceFile: filePath,
-				StartLine:  line,
-				EndLine:    endLine,
-				Language:   "python",
-				Metadata: map[string]interface{}{
-					"pattern_type": "error_handling",
-				},
-				QualityScore:       1.0,
-				EnrichmentRequired: false,
-			})
-		}
-		count := int(n.ChildCount())
-		for i := 0; i < count; i++ {
-			stack = append(stack, n.Child(i))
-		}
-	}
-
-	return records
+	_ = root
+	_ = filePath
+	return nil
 }

--- a/internal/extractors/python/errorpattern_test.go
+++ b/internal/extractors/python/errorpattern_test.go
@@ -2,9 +2,6 @@ package python_test
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -33,167 +30,36 @@ func extractPy(t *testing.T, src, path string) []types.EntityRecord {
 	return recs
 }
 
-// errorPatternsPy filters the returned records to SCOPE.Pattern entities.
-func errorPatternsPy(t *testing.T, src, path string) []types.EntityRecord {
-	t.Helper()
-	var out []types.EntityRecord
-	for _, r := range extractPy(t, src, path) {
-		if r.Kind == "SCOPE.Pattern" {
-			out = append(out, r)
-		}
-	}
-	return out
-}
-
-// TestErrorPatternPy_SingleTry verifies a single try/except emits one
-// SCOPE.Pattern entity with the correct Name / line / metadata.
-func TestErrorPatternPy_SingleTry(t *testing.T) {
-	src := `def load():
-    try:
-        do_work()
-    except ValueError:
-        pass
-`
-	patterns := errorPatternsPy(t, src, "test.py")
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 error pattern, got %d", len(patterns))
-	}
-	p := patterns[0]
-	if p.Kind != "SCOPE.Pattern" {
-		t.Errorf("Kind = %q, want %q", p.Kind, "SCOPE.Pattern")
-	}
-	if p.Name != "error_handling:try_catch:2" {
-		t.Errorf("Name = %q, want %q", p.Name, "error_handling:try_catch:2")
-	}
-	if p.StartLine != 2 {
-		t.Errorf("StartLine = %d, want 2", p.StartLine)
-	}
-	// Issue #1964 — end_line is the real AST end line (last line of the
-	// try/except block), not start_line. Source has try on line 2 and
-	// the except clause runs through line 5.
-	if p.EndLine != 5 {
-		t.Errorf("EndLine = %d, want 5 (real AST end, #1964)", p.EndLine)
-	}
-	if p.Language != "python" {
-		t.Errorf("Language = %q, want %q", p.Language, "python")
-	}
-	if p.SourceFile != "test.py" {
-		t.Errorf("SourceFile = %q, want %q", p.SourceFile, "test.py")
-	}
-	pt, _ := p.Metadata["pattern_type"].(string)
-	if pt != "error_handling" {
-		t.Errorf("metadata.pattern_type = %q, want %q", pt, "error_handling")
-	}
-}
-
-// TestErrorPatternPy_MultipleTry verifies separate try blocks each
-// produce their own entity, keyed by their own line.
-func TestErrorPatternPy_MultipleTry(t *testing.T) {
-	src := `def a():
-    try:
-        x()
-    except:
-        pass
-    try:
-        y()
-    except:
-        pass
-`
-	patterns := errorPatternsPy(t, src, "test.py")
-	if len(patterns) != 2 {
-		t.Fatalf("expected 2 error patterns, got %d", len(patterns))
-	}
-	got := make(map[string]bool, len(patterns))
-	for _, p := range patterns {
-		got[p.Name] = true
-	}
-	for _, line := range []int{2, 6} {
-		want := fmt.Sprintf("error_handling:try_catch:%d", line)
-		if !got[want] {
-			t.Errorf("missing expected pattern %q; got %v", want, got)
-		}
-	}
-}
-
-// TestErrorPatternPy_NestedTry verifies nested try/except blocks are
-// each captured separately — not collapsed.
-func TestErrorPatternPy_NestedTry(t *testing.T) {
-	src := `def a():
-    try:
+// TestErrorPatternPy_NoTryCatchEmit verifies issue #2282 — the Python
+// extractor must no longer emit per-line `error_handling:try_catch:N`
+// SCOPE.Pattern entities. A file dense in try/except is exercised so a
+// regression in the secondary pass would surface here.
+func TestErrorPatternPy_NoTryCatchEmit(t *testing.T) {
+	src := `class Worker:
+    def run(self):
         try:
-            x()
+            do_a()
         except ValueError:
             pass
-    except Exception:
-        pass
-`
-	patterns := errorPatternsPy(t, src, "test.py")
-	if len(patterns) != 2 {
-		t.Fatalf("expected 2 patterns for nested try, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternPy_TryFinallyOnly verifies a try block with finally
-// but no except is still captured — `try/finally` is still an error
-// handling pattern.
-func TestErrorPatternPy_TryFinallyOnly(t *testing.T) {
-	src := `def a():
-    try:
-        x()
-    finally:
-        cleanup()
-`
-	patterns := errorPatternsPy(t, src, "test.py")
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 pattern for try/finally, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternPy_ClassMethodContext verifies try blocks inside
-// class methods are captured — the walker recurses into class bodies.
-func TestErrorPatternPy_ClassMethodContext(t *testing.T) {
-	src := `class Foo:
-    def bar(self):
         try:
-            x()
-        except:
-            pass
+            do_b()
+        except Exception:
+            try:
+                cleanup()
+            finally:
+                pass
 `
-	patterns := errorPatternsPy(t, src, "test.py")
-	if len(patterns) != 1 {
-		t.Fatalf("expected 1 pattern in class method, got %d", len(patterns))
-	}
-	if patterns[0].StartLine != 3 {
-		t.Errorf("StartLine = %d, want 3", patterns[0].StartLine)
-	}
-}
-
-// TestErrorPatternPy_NoTry verifies a file with no try blocks produces
-// no pattern records (no false positives).
-func TestErrorPatternPy_NoTry(t *testing.T) {
-	src := `def a():
-    return 1
-
-class Foo:
-    pass
-`
-	patterns := errorPatternsPy(t, src, "test.py")
-	if len(patterns) != 0 {
-		t.Fatalf("expected 0 patterns, got %d", len(patterns))
+	recs := extractPy(t, src, "test.py")
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Pattern" && strings.HasPrefix(r.Name, "error_handling:try_catch:") {
+			t.Errorf("regression: %q emitted; #2282 dropped per-line try_catch entities", r.Name)
+		}
 	}
 }
 
-// TestErrorPatternPy_EmptyFile verifies empty content produces no
-// pattern records.
-func TestErrorPatternPy_EmptyFile(t *testing.T) {
-	patterns := errorPatternsPy(t, "", "empty.py")
-	if len(patterns) != 0 {
-		t.Fatalf("expected 0 patterns for empty file, got %d", len(patterns))
-	}
-}
-
-// TestErrorPatternPy_PreservesBaseExtraction verifies function + class
-// records still come through. The secondary pass must be additive.
+// TestErrorPatternPy_PreservesBaseExtraction guarantees the primary
+// walker (class + method extraction) still works even though the
+// secondary error-handling pass is now a no-op.
 func TestErrorPatternPy_PreservesBaseExtraction(t *testing.T) {
 	src := `class Worker:
     def run(self):
@@ -203,7 +69,7 @@ func TestErrorPatternPy_PreservesBaseExtraction(t *testing.T) {
             pass
 `
 	recs := extractPy(t, src, "test.py")
-	var hasClass, hasMethod, hasPattern bool
+	var hasClass, hasMethod bool
 	for _, r := range recs {
 		if r.Kind == "SCOPE.Component" && r.Name == "Worker" {
 			hasClass = true
@@ -212,79 +78,11 @@ func TestErrorPatternPy_PreservesBaseExtraction(t *testing.T) {
 		if r.Kind == "SCOPE.Operation" && r.Name == "Worker.run" {
 			hasMethod = true
 		}
-		if r.Kind == "SCOPE.Pattern" && strings.HasPrefix(r.Name, "error_handling:try_catch:") {
-			hasPattern = true
-		}
 	}
 	if !hasClass {
 		t.Error("base class extraction missing")
 	}
 	if !hasMethod {
 		t.Error("base method extraction missing")
-	}
-	if !hasPattern {
-		t.Error("error handling pattern missing")
-	}
-}
-
-// TestErrorPatternPy_ComplexityFixture verifies the real complexity.py
-// fixture emits one error_handling:try_catch entity per `try:` node in
-// the file. AC#2 target is 13 per the K-2SO parity comparison,
-// but the committed fixture in this worktree contains a later revision
-// with 11 try blocks; the test enforces parity with the grep-level
-// ground-truth count of the fixture shipped in testdata/ and logs the
-// value for AC review. Any future drop would indicate a walker bug.
-func TestErrorPatternPy_ComplexityFixture(t *testing.T) {
-	// Lower bound: every real `try_statement` in the file must be
-	// emitted. The exact number depends on the complexity.py revision
-	// committed to testdata; see the spec audit in reports/.
-	const minExpected = 11
-	path := filepath.Join("testdata", "complexity.py.fixture")
-	src, err := os.ReadFile(path)
-	if err != nil {
-		t.Skipf("complexity.py.fixture not available: %v", err)
-	}
-	patterns := errorPatternsPy(t, string(src), "complexity.py")
-	if len(patterns) < minExpected {
-		t.Fatalf("complexity fixture: expected at least %d error_handling patterns, got %d", minExpected, len(patterns))
-	}
-	// Every emitted pattern must have a unique line-number key.
-	seen := make(map[string]bool, len(patterns))
-	for _, p := range patterns {
-		if seen[p.Name] {
-			t.Errorf("duplicate Name %q in fixture extraction", p.Name)
-		}
-		seen[p.Name] = true
-	}
-	t.Logf("complexity fixture: emitted %d error_handling patterns (target: 13)", len(patterns))
-}
-
-// TestErrorPatternPy_UniqueNames verifies multi-pattern output has no
-// duplicate Name values — catches off-by-one walker bugs.
-func TestErrorPatternPy_UniqueNames(t *testing.T) {
-	src := `def a():
-    try:
-        x()
-    except:
-        pass
-    try:
-        y()
-    except:
-        pass
-    try:
-        z()
-    except:
-        pass
-`
-	patterns := errorPatternsPy(t, src, "test.py")
-	if len(patterns) != 3 {
-		t.Fatalf("expected 3 patterns, got %d", len(patterns))
-	}
-	seen := make(map[string]bool)
-	for _, p := range patterns {
-		if seen[p.Name] {
-			t.Errorf("duplicate Name %q", p.Name)
-		}
-		seen[p.Name] = true
 	}
 }

--- a/internal/extractors/python/regression_1964_1966_1990_test.go
+++ b/internal/extractors/python/regression_1964_1966_1990_test.go
@@ -247,7 +247,6 @@ def handler():
 	out := extractPy12(t, src, "client_fixture_a/models.py")
 
 	sawConstraint := false
-	sawPattern := false
 	for _, ent := range out {
 		if ent.Language != "python" {
 			t.Errorf("entity %s/%s name=%q has language=%q (want python)",
@@ -256,15 +255,13 @@ def handler():
 		if ent.Kind == "SCOPE.Constraint" {
 			sawConstraint = true
 		}
-		if ent.Kind == "SCOPE.Pattern" {
-			sawPattern = true
-		}
+		// Issue #2282 dropped the SCOPE.Pattern try_catch emit; the
+		// error-handling pass is now a no-op for Python. The sweep
+		// still verifies Language stamping across the remaining passes
+		// (config_module, package_module, imports, constraint).
 	}
 	if !sawConstraint {
 		t.Errorf("fixture did not exercise SCOPE.Constraint (Meta.constraints pass)")
-	}
-	if !sawPattern {
-		t.Errorf("fixture did not exercise SCOPE.Pattern (error-handling pass)")
 	}
 }
 

--- a/internal/patterns/error_handling_detector.go
+++ b/internal/patterns/error_handling_detector.go
@@ -59,14 +59,10 @@ func (e *errorHandlingDetector) Detect(filePath, language, src string) []types.E
 		}
 
 	case "python":
-		// Per-line entities for each `try:` occurrence — matches Python's format.
-		for _, m := range ehPyTryStatementRE.FindAllStringIndex(src, -1) {
-			line := lineOf(src, m[0])
-			name := fmt.Sprintf("error_handling:try_catch:%d", line)
-			results = append(results, makeEntity(filePath,
-				name, "SCOPE.Pattern", "error_handling", language, line,
-				map[string]string{"kind": "error_handling", "pattern": "try_catch"}))
-		}
+		// Issue #2282 — per-line try_catch entities were dropped (no
+		// consumer; ~5.5% of UpVate graph). Python falls through with
+		// no pattern emit here; the language still surfaces real
+		// SCOPE.Component / SCOPE.Operation nodes from the primary pass.
 
 	case "rust":
 		if ehRustMatchRE.MatchString(src) && ehRustOkArmRE.MatchString(src) && ehRustErrArmRE.MatchString(src) {
@@ -104,14 +100,11 @@ func (e *errorHandlingDetector) Detect(filePath, language, src string) []types.E
 		// error_handling pattern entities for them. Suppress to maintain parity.
 
 	default:
-		// Curly-brace try { } — per-line for JS/Java/etc.
-		for _, m := range ehTryStatementRE.FindAllStringIndex(src, -1) {
-			line := lineOf(src, m[0])
-			name := fmt.Sprintf("error_handling:try_catch:%d", line)
-			results = append(results, makeEntity(filePath,
-				name, "SCOPE.Pattern", "error_handling", language, line,
-				map[string]string{"kind": "error_handling", "pattern": "try_catch"}))
-		}
+		// Issue #2282 — per-line `try { ... } catch { ... }` entities
+		// (Java/JS/TS/etc.) were dropped. No graph consumer queries them
+		// at this granularity. The ehTryStatementRE regex is preserved
+		// for AppliesTo() so non-try_catch languages (rust, elixir) keep
+		// flowing through this detector unchanged.
 	}
 
 	return results


### PR DESCRIPTION
Closes #2282

## What

Stops emitting `error_handling:try_catch:<line>` SCOPE.Pattern entities. On the UpVate bench corpus this trimmed 1,077 nodes (~5.5% of the entire graph). No caller queries try blocks at this granularity; pattern discovery at this shape belongs in clustering / frequency-analysis passes, not per-line entity emission.

## Where the emit lived

- `internal/extractors/python/errorpattern.go` — tree-sitter `try_statement` walker
- `internal/extractors/java/errorpattern.go` — `try_statement` + `try_with_resources_statement` walker
- `internal/extractors/javascript/errorpattern.go` — `try_statement` walker (js + ts)
- `internal/patterns/error_handling_detector.go` — regex pass, Python `try:` case and the default curly-brace `try {` branch

Each extractor-side `extractErrorHandlingPatterns` is preserved as a no-op so the call sites in the respective `extractor.go` files don't need rewiring. The regex detector keeps its other branches (`go_error_return`, `panic_recover`, `rust_match_result`, `rust_question_mark`, `elixir_ok_error`) unchanged.

## Consumer migration

No structural consumer was found.

- `internal/mcp/denoise.go` classifies SCOPE.Pattern try_catch as `noisePattern` (a default filter): unchanged, stays as defensive code.
- `internal/links/label_pass.go` already strips trailing `:<digits>` from cross-repo label keys via `lineNumberSuffix`: unchanged.
- `internal/mcp/denoise_test.go` constructs `error_handling:try_catch:N` as test fixtures verifying noise classification: still valid since the classifier remains.

Per-agent isolation guarantee held — no files in `internal/mcp/*.go` were touched.

## Scale impact

UpVate corpus: -1,077 nodes (~5.5% of the graph). Per-repo impact for any try-heavy codebase scales linearly with `count(try blocks)`.

## CI

Default (minimal). Not platform-sensitive.

Refs: `mcp-quality-bench-2026-05-26` over-extraction class.