### PR TITLE
fix(mcp): implement archigraph_endpoints orphan_only=true filter

### DIFF
--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -197,6 +197,32 @@ func (s *Server) handleEndpoints(ctx context.Context, req mcpapi.CallToolRequest
 // archigraph_endpoint_definitions
 // ---------------------------------------------------------------------------
 
+// isOrphanDefinition reports whether the endpoint-definition entity with the
+// given local ID (within repo r) has no inbound client-call edges. An endpoint
+// is orphan when:
+//
+//   - it has no inbound FETCHES edge in its own repo (the semantic
+//     "client → endpoint" edge in this graph; see handleEndpointCalls), AND
+//   - it is not the target of any cross-repo Link in lg.Links.
+//
+// Other inbound edge kinds (CONTAINS, DECLARES, …) are intentionally ignored —
+// they describe structure, not API consumption. (#2292)
+//
+// linkedTargets must be the precomputed set of lg.Links[*].Target values;
+// passing nil is allowed and treated as "no cross-repo callers".
+func isOrphanDefinition(r *LoadedRepo, localID string, linkedTargets map[string]bool) bool {
+	prefixed := prefixedID(r.Repo, localID)
+	if linkedTargets[prefixed] || linkedTargets[localID] {
+		return false
+	}
+	for _, e := range r.Adjacency.Incoming(localID) {
+		if strings.EqualFold(e.kind, "FETCHES") {
+			return false
+		}
+	}
+	return true
+}
+
 // handleEndpointDefinitions lists http_endpoint_definition entities (and the
 // legacy http_endpoint kind when Sub-A has not yet landed). This tool returns
 // ONLY definition-side entries — no call-sites.
@@ -219,6 +245,7 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 	limit := argInt(req, "limit", 20)
 	pathContains := strings.ToLower(argString(req, "path_contains", ""))
 	method := strings.ToUpper(argString(req, "method", ""))
+	orphanOnly := argBool(req, "orphan_only", false)
 	// format="terse"|"full" is the preferred control; verbose=bool kept for
 	// backward compatibility. format takes precedence when set explicitly.
 	format := strings.ToLower(argString(req, "format", ""))
@@ -227,6 +254,27 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 		verbose = true
 	} else if format == "terse" {
 		verbose = false
+	}
+
+	// #2292: orphan_only=true filters to endpoint definitions with no inbound
+	// client-call edges. In this graph the edge kind from a call-site to its
+	// definition is FETCHES (see handleEndpointCalls / handleEndpointStats);
+	// "CALLS" in the issue text refers to that semantic edge — the literal
+	// graph kind is FETCHES. Other inbound edge kinds (CONTAINS, DECLARES, …)
+	// do NOT count, so a route nested inside a router with a CONTAINS edge but
+	// no FETCHES caller is still an orphan from the API-call perspective.
+	//
+	// Cross-repo callers: if the definition is the target of an entry in
+	// lg.Links (which records cross-repo HTTP link resolutions), it is also
+	// NOT orphan, matching the accounting in handleEndpointStats.
+	var linkedTargets map[string]bool
+	if orphanOnly {
+		linkedTargets = make(map[string]bool, len(lg.Links))
+		for _, l := range lg.Links {
+			if l.Target != "" {
+				linkedTargets[l.Target] = true
+			}
+		}
 	}
 
 	var out []endpointDefItem
@@ -248,6 +296,9 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 				continue
 			}
 			if method != "" && !strings.EqualFold(m, method) {
+				continue
+			}
+			if orphanOnly && !isOrphanDefinition(r, e.ID, linkedTargets) {
 				continue
 			}
 			it := endpointDefItem{
@@ -311,6 +362,7 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 		"format":        formatLabel(verbose),
 		"path_contains": pathContains,
 		"method":        method,
+		"orphan_only":   orphanOnly,
 		"token_budget":  tokenBudget,
 		"note":          "format=terse (default) returns one-line 'lines' entries only. Pass format=full (or verbose=true) to also receive the full `definitions` struct array.",
 	}

--- a/internal/mcp/endpoint_tools_test.go
+++ b/internal/mcp/endpoint_tools_test.go
@@ -269,6 +269,130 @@ func TestEndpointDefinitions_NoteFieldPresent(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// orphan_only filter tests (#2292)
+// ---------------------------------------------------------------------------
+
+// In buildEndpointDoc the only inbound FETCHES edge to a definition is
+// fn_other → ep_def. ep_legacy has no inbound FETCHES, so it is the lone
+// orphan when orphan_only=true.
+func TestEndpointDefinitions_OrphanOnly_FiltersToOrphans(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
+		"group":       "test",
+		"orphan_only": true,
+		"verbose":     true,
+	})
+
+	defs := getSlice(t, res, "definitions")
+	if len(defs) != 1 {
+		t.Fatalf("expected 1 orphan definition, got %d: %v", len(defs), defs)
+	}
+	obj := defs[0].(map[string]any)
+	if got, _ := obj["entity_id"].(string); !strings.HasSuffix(got, "ep_legacy") {
+		t.Errorf("expected ep_legacy as orphan, got entity_id=%q", got)
+	}
+	if got, _ := res["orphan_only"].(bool); !got {
+		t.Errorf("orphan_only=true should be echoed in response, got %v", res["orphan_only"])
+	}
+}
+
+// orphan_only=false (and the default unset case) must return the full set of
+// definitions — backward compat with pre-#2292 behaviour.
+func TestEndpointDefinitions_OrphanOnly_FalseReturnsAll(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
+		"group":       "test",
+		"orphan_only": false,
+		"verbose":     true,
+	})
+	if got := len(getSlice(t, res, "definitions")); got != 2 {
+		t.Errorf("orphan_only=false: expected 2 definitions, got %d", got)
+	}
+
+	resUnset := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
+		"group":   "test",
+		"verbose": true,
+	})
+	if got := len(getSlice(t, resUnset, "definitions")); got != 2 {
+		t.Errorf("orphan_only unset: expected 2 definitions, got %d", got)
+	}
+}
+
+// When every definition has an inbound FETCHES edge, orphan_only=true must
+// produce an empty result — not an error, and (in terse mode) an empty
+// `lines` slice rather than a missing key.
+func TestEndpointDefinitions_OrphanOnly_NoOrphansReturnsEmpty(t *testing.T) {
+	doc := buildEndpointDoc()
+	// Cover the previously-uncalled ep_legacy with an inbound FETCHES.
+	doc.Relationships = append(doc.Relationships, graph.Relationship{
+		FromID: "fn_other", ToID: "ep_legacy", Kind: "FETCHES",
+	})
+	srv := newTestServerWithDoc(t, doc)
+
+	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
+		"group":       "test",
+		"orphan_only": true,
+	})
+
+	if got := getFloat(t, res, "count"); got != 0 {
+		t.Errorf("expected count=0 when no orphans, got %v", got)
+	}
+	if got := getFloat(t, res, "total"); got != 0 {
+		t.Errorf("expected total=0 when no orphans, got %v", got)
+	}
+	// terse default → lines key must exist and be empty.
+	lines, ok := res["lines"]
+	if !ok {
+		t.Fatal("terse response missing `lines` key")
+	}
+	if ls, _ := lines.([]any); len(ls) != 0 {
+		t.Errorf("expected empty lines, got %v", lines)
+	}
+}
+
+// Non-CALLS/FETCHES inbound edges (e.g. CONTAINS) must NOT disqualify an
+// endpoint from being orphan — only FETCHES from a client counts. (#2292)
+func TestEndpointDefinitions_OrphanOnly_IgnoresNonFetchesInbound(t *testing.T) {
+	doc := buildEndpointDoc()
+	// ep_def already has fn_other -FETCHES-> ep_def (so it's NOT orphan).
+	// Replace that with a CONTAINS edge so ep_def has only structural inbound.
+	doc.Relationships = []graph.Relationship{
+		{FromID: "fn_other", ToID: "ep_def", Kind: "CONTAINS"},
+	}
+	srv := newTestServerWithDoc(t, doc)
+
+	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
+		"group":       "test",
+		"orphan_only": true,
+		"verbose":     true,
+	})
+
+	defs := getSlice(t, res, "definitions")
+	// Both ep_legacy AND ep_def must now be reported as orphans.
+	if len(defs) != 2 {
+		t.Fatalf("expected 2 orphans (CONTAINS shouldn't count), got %d: %v", len(defs), defs)
+	}
+	gotIDs := map[string]bool{}
+	for _, d := range defs {
+		obj := d.(map[string]any)
+		id, _ := obj["entity_id"].(string)
+		gotIDs[id] = true
+	}
+	if !hasSuffixKey(gotIDs, "ep_def") || !hasSuffixKey(gotIDs, "ep_legacy") {
+		t.Errorf("expected ep_def AND ep_legacy in orphans, got %v", gotIDs)
+	}
+}
+
+func hasSuffixKey(m map[string]bool, suffix string) bool {
+	for k := range m {
+		if strings.HasSuffix(k, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
 // archigraph_endpoint_calls tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #2292

## Summary
`handleEndpointDefinitions` parsed nothing for `orphan_only` — the param documented on `archigraph_endpoints(action=definitions)` was silently dropped. Bench Q10 reported 473 'orphans' that were the full definition set, misleading downstream analysis.

This wires `orphan_only=true` to filter via `lr.Adjacency.Incoming(localID)` (the `Incoming` helper added in #2303) and to also honour cross-repo `lg.Links` targets — same accounting handleEndpointStats already uses for orphan calls.

## Orphan definition used
An endpoint-definition is orphan when it has **no inbound FETCHES edge** from any in-repo call-site **and** is **not the target of any `lg.Links` entry**. Other inbound edge kinds (CONTAINS, DECLARES, …) intentionally do NOT count — they are structural, not API-consumption.

Note on issue wording: the issue text says "no inbound CALLS edges from any client". In this codebase the literal graph kind from a client call-site to its definition is `FETCHES` (see `handleEndpointCalls` / `handleEndpointStats`). "CALLS" in the issue refers to the semantic edge; the literal kind is FETCHES. Documented inline.

## Files
- `internal/mcp/endpoint_tools.go` — new helper `isOrphanDefinition` (~25 LOC) + 4 lines wiring in `handleEndpointDefinitions` (parse arg, precompute `linkedTargets`, predicate call, echo in response).
- `internal/mcp/endpoint_tools_test.go` — +4 tests (+~110 LOC).

## Before / after (terse, on bench Q10 shape)

```
# before — orphan_only silently ignored
archigraph_endpoints(action=definitions, orphan_only=true)
  → {"count": 473, "lines": [<every definition>], ...}    # misleading

# after
archigraph_endpoints(action=definitions, orphan_only=true)
  → {"count": 12,  "orphan_only": true,
     "lines": [<only definitions with no FETCHES inbound + no Links target>], ...}
```

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/mcp/... -count=1` (full package — 23.8s, all green)
- [x] New tests cover: only-orphans returned; backward-compat default; empty result (not error) when no orphans; CONTAINS inbound is ignored.

## CI
No `ci:full` — pure handler logic, unit-test covered.