### PR TITLE
chore(extractor-js): gate const_destructure emit behind ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -29,6 +29,7 @@ package javascript
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -40,6 +41,30 @@ import (
 	extreg "github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// emitDestructureDetailEnv is the env var that opts const_destructure /
+// const_destructure_call subtype emission back on.
+//
+// Issue #2338: on the UpVate bench corpus the JS/TS extractor produced
+// ~2,633 SCOPE.Component/const_destructure entities and ~1,294
+// SCOPE.Operation/const_destructure_call entities (~4,000 total, ~20% of
+// the graph) whose consumer landscape was not fully verified. Binding
+// entities are still emitted in default-off mode with subtype "const" or
+// "function" (same as other const declarations) so per-binding resolution
+// continues to work. What is lost is the specific destructure-pattern
+// label; set this flag to "1" or "true" to restore it.
+//
+// Accepted truthy values: "1", "true" (case-sensitive). Anything else,
+// including unset, leaves destructure-detail emission disabled.
+const emitDestructureDetailEnv = "ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL"
+
+// emitDestructureDetailEnabled reports whether const_destructure /
+// const_destructure_call subtypes should be emitted. Reads the env var on
+// every call — cheap, and lets tests toggle via t.Setenv without restarting.
+func emitDestructureDetailEnabled() bool {
+	v := os.Getenv(emitDestructureDetailEnv)
+	return v == "1" || v == "true"
+}
 
 // New returns a new JSExtractor. Use this in tests or explicit registrations.
 func New() *JSExtractor {
@@ -1384,6 +1409,16 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 		kind = "SCOPE.Operation"
 		subtype = "const_destructure_call"
 		sigPrefix = "const"
+	}
+	// Issue #2338 — gate destructure-detail subtypes behind the env var.
+	// Default-off: use the plain "const" subtype (same as other const
+	// declarations) so the binding entities are still emitted and the
+	// resolver can bind same-file REFERENCES / CALLS edges, but the
+	// const_destructure / const_destructure_call label is not stamped
+	// and the entity count stays low. The kind (Component vs Operation)
+	// is preserved so mutation-hook callables remain SCOPE.Operation.
+	if !emitDestructureDetailEnabled() {
+		subtype = "const"
 	}
 
 	var walk func(p *sitter.Node, arrayIdx int)

--- a/internal/extractors/javascript/issue2338_const_destructure_gate_test.go
+++ b/internal/extractors/javascript/issue2338_const_destructure_gate_test.go
@@ -1,0 +1,254 @@
+// Package javascript — unit tests for issue #2338: gate const_destructure /
+// const_destructure_call subtype emission behind ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL.
+//
+// Three invariants are tested:
+//
+//  1. Default-off: 0 entities with subtype const_destructure or const_destructure_call.
+//  2. Opt-in (ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL=1): entities ARE emitted with
+//     those subtypes.
+//  3. Bindings-always: individual bindings (data, isLoading, createFoo, …) are
+//     emitted regardless of the flag — the non-negotiable correctness invariant
+//     that keeps the resolver working.
+//
+// Fixture summary for multiDestructureSrc (default-off probe results):
+//
+//	useFooQuery()  object-pattern  → opLift=false  → SCOPE.Component/const
+//	useCreateFoo() object-pattern  → opLift=true   → SCOPE.Operation/const
+//	useState(0)    array-pattern   → opLift=true (state hook) → SCOPE.Operation/const
+//	                               setCount stays state_setter regardless of flag
+package javascript_test
+
+import (
+	"testing"
+)
+
+// multiDestructureSrc exercises three destructure shapes.
+// useState is treated as a mutation-style hook (opLift=true) by the extractor,
+// so count / setCount are both SCOPE.Operation.
+const multiDestructureSrc = `
+const { data, isLoading, error } = useFooQuery();
+const { mutate: createFoo, isError } = useCreateFoo();
+const [count, setCount] = useState(0);
+`
+
+// ---------------------------------------------------------------------------
+// 1. Default-off: no const_destructure* subtypes
+// ---------------------------------------------------------------------------
+
+// TestDestructureGate_DefaultOff verifies that with ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL
+// unset, no entity has subtype "const_destructure" or "const_destructure_call".
+func TestDestructureGate_DefaultOff(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL", "")
+
+	src := []byte(multiDestructureSrc)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	for _, e := range entities {
+		if e.Subtype == "const_destructure" || e.Subtype == "const_destructure_call" {
+			t.Errorf("default-off: entity %q has forbidden subtype %q; ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL must be set to emit these",
+				e.Name, e.Subtype)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Opt-in: const_destructure* subtypes ARE emitted
+// ---------------------------------------------------------------------------
+
+// TestDestructureGate_OptIn verifies that with ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL=1
+// at least one entity with subtype const_destructure or const_destructure_call
+// is emitted.
+func TestDestructureGate_OptIn(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL", "1")
+
+	src := []byte(multiDestructureSrc)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	found := false
+	for _, e := range entities {
+		if e.Subtype == "const_destructure" || e.Subtype == "const_destructure_call" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("opt-in: expected at least one const_destructure* entity; none found. entities: %v", entityNames(entities))
+	}
+}
+
+// TestDestructureGate_OptIn_TrueValue verifies "true" is also accepted as
+// a truthy flag value (mirrors the ARCHIGRAPH_MARKDOWN_EMIT_HEADINGS pattern).
+func TestDestructureGate_OptIn_TrueValue(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL", "true")
+
+	src := []byte(multiDestructureSrc)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	found := false
+	for _, e := range entities {
+		if e.Subtype == "const_destructure" || e.Subtype == "const_destructure_call" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("opt-in (true): expected const_destructure* entities; none found. entities: %v", entityNames(entities))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Bindings always preserved (correctness invariant)
+// ---------------------------------------------------------------------------
+
+// TestDestructureGate_BindingsAlways_DefaultOff asserts that the individual
+// binding entities (data, isLoading, error, createFoo, count, setCount) are
+// still emitted in default-off mode. The subtype changes (to "const" or
+// "state_setter") but the entities themselves must exist so the resolver can
+// bind same-file REFERENCES / CALLS edges.
+func TestDestructureGate_BindingsAlways_DefaultOff(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL", "")
+
+	src := []byte(multiDestructureSrc)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	// data, isLoading, error — from useFooQuery() (opLift=false → Component).
+	for _, name := range []string{"data", "isLoading", "error"} {
+		e := findByName(entities, name)
+		if e == nil {
+			t.Errorf("bindings-always: entity %q not found in default-off mode; names: %v",
+				name, entityNames(entities))
+			continue
+		}
+		if e.Kind != "SCOPE.Component" {
+			t.Errorf("bindings-always: %q Kind=%q, want SCOPE.Component", name, e.Kind)
+		}
+	}
+
+	// createFoo, isError — from useCreateFoo() (opLift=true → Operation).
+	for _, name := range []string{"createFoo", "isError"} {
+		e := findByName(entities, name)
+		if e == nil {
+			t.Errorf("bindings-always: entity %q not found in default-off mode; names: %v",
+				name, entityNames(entities))
+			continue
+		}
+		if e.Kind != "SCOPE.Operation" {
+			t.Errorf("bindings-always: %q Kind=%q, want SCOPE.Operation (mutation-hook kind must not degrade)", name, e.Kind)
+		}
+	}
+
+	// count, setCount — from useState(0) which is also opLift=true (state hooks
+	// are mutation-style), so both become SCOPE.Operation.
+	for _, name := range []string{"count", "setCount"} {
+		e := findByName(entities, name)
+		if e == nil {
+			t.Errorf("bindings-always: entity %q not found in default-off mode; names: %v",
+				name, entityNames(entities))
+		}
+	}
+}
+
+// TestDestructureGate_BindingsAlways_OptIn asserts that with the flag on the
+// same bindings are present and carry the expected const_destructure* subtypes.
+func TestDestructureGate_BindingsAlways_OptIn(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL", "1")
+
+	src := []byte(multiDestructureSrc)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	// Plain-hook bindings → const_destructure.
+	for _, name := range []string{"data", "isLoading", "error"} {
+		e := findByName(entities, name)
+		if e == nil {
+			t.Errorf("opt-in: entity %q not found; names: %v", name, entityNames(entities))
+			continue
+		}
+		if e.Subtype != "const_destructure" {
+			t.Errorf("opt-in: %q Subtype=%q, want const_destructure", name, e.Subtype)
+		}
+	}
+
+	// Mutation-hook bindings → const_destructure_call.
+	for _, name := range []string{"createFoo", "isError"} {
+		e := findByName(entities, name)
+		if e == nil {
+			t.Errorf("opt-in: entity %q not found; names: %v", name, entityNames(entities))
+			continue
+		}
+		if e.Subtype != "const_destructure_call" {
+			t.Errorf("opt-in: %q Subtype=%q, want const_destructure_call", name, e.Subtype)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. Kind preservation for mutation-hook bindings (correctness guard)
+// ---------------------------------------------------------------------------
+
+// TestDestructureGate_MutationHookOp_DefaultOff verifies that a mutation-hook
+// binding stays SCOPE.Operation in default-off mode. The kind must not degrade
+// to SCOPE.Component; only the subtype label is suppressed.
+func TestDestructureGate_MutationHookOp_DefaultOff(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL", "")
+
+	src := []byte(`const { mutate: createFoo } = useCreateFoo();`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	e := findByName(entities, "createFoo")
+	if e == nil {
+		t.Fatalf("createFoo not found; names: %v", entityNames(entities))
+	}
+	if e.Kind != "SCOPE.Operation" {
+		t.Errorf("createFoo default-off: Kind=%q, want SCOPE.Operation (mutation-hook kind must not degrade)", e.Kind)
+	}
+	if e.Subtype == "const_destructure_call" {
+		t.Errorf("createFoo default-off: Subtype=%q, must not be const_destructure_call when flag is off", e.Subtype)
+	}
+}
+
+// TestDestructureGate_MutationHookOp_OptIn verifies the same binding gets
+// the const_destructure_call subtype when the flag is on.
+func TestDestructureGate_MutationHookOp_OptIn(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL", "1")
+
+	src := []byte(`const { mutate: createFoo } = useCreateFoo();`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	e := findByName(entities, "createFoo")
+	if e == nil {
+		t.Fatalf("createFoo not found; names: %v", entityNames(entities))
+	}
+	if e.Kind != "SCOPE.Operation" {
+		t.Errorf("createFoo opt-in: Kind=%q, want SCOPE.Operation", e.Kind)
+	}
+	if e.Subtype != "const_destructure_call" {
+		t.Errorf("createFoo opt-in: Subtype=%q, want const_destructure_call", e.Subtype)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. TypeScript variant — gate applies equally to TS files
+// ---------------------------------------------------------------------------
+
+// TestDestructureGate_TypeScript_DefaultOff verifies default-off behavior
+// when the TypeScript grammar is used.
+func TestDestructureGate_TypeScript_DefaultOff(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL", "")
+
+	src := []byte(`const { data, isLoading }: QueryResult = useQuery<Data>("key");`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	for _, e := range entities {
+		if e.Subtype == "const_destructure" || e.Subtype == "const_destructure_call" {
+			t.Errorf("typescript default-off: entity %q has forbidden subtype %q", e.Name, e.Subtype)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2338

## Summary

- Gates `const_destructure` / `const_destructure_call` subtype emission behind `ARCHIGRAPH_EMIT_DESTRUCTURE_DETAIL=1` (default off), following the conservative-prune policy established 2026-05-27
- Default-off preserves all binding entities with subtype `"const"` (same as other const declarations), so per-binding visibility and resolver correctness are unchanged
- The kind (`SCOPE.Component` vs `SCOPE.Operation`) is preserved in default-off mode — mutation-hook callables remain `SCOPE.Operation`

## Consumer audit

Full `git grep` output across `internal/` (post-commit, includes new comments from this PR):

**`git grep -n "const_destructure" internal/`**

```
internal/extractors/javascript/extractor.go — comment + emit sites (this PR)
internal/extractors/javascript/references.go:408 — comment explaining why SCOPE.Component bindings stay orphaned without REFERENCES edges; not a code-level consumer
internal/extractors/javascript/references_test.go:478,482,593 — comments in test docstrings; not consumers
internal/mcp/denoise_test.go:120,124,133,137,146 — test fixtures for local_scope classification; denoise.go classifies via local_scope=true property, NOT by subtype name
internal/quality/audit/heuristics_test.go:19 — test fixture for ClassifyOrphan; heuristics.go matches via strings.Contains(lst, "const") — generic prefix that catches "const" subtype too
```

**`git grep -n "const_destructure_call" internal/`**

```
internal/extractors/javascript/extractor.go — emit site + comments (this PR)
```

**Classification of every match outside emit sites:**

| File:line | Classification |
|---|---|
| `references.go:408` | comment — documents why SCOPE.Component is not CALLS-bindable |
| `references_test.go:478,482,593` | comment — in test function docstrings |
| `denoise_test.go:120–146` | test fixture — denoise.go keys on `local_scope=true` property, not subtype name |
| `heuristics_test.go:19` | test fixture — heuristics.go uses `strings.Contains(lst, "const")` which matches the fallback `"const"` subtype too |

**No actual consumers** — no production code path walks the graph specifically looking for `const_destructure` or `const_destructure_call` subtype values. The two near-consumers (denoise + heuristics) use patterns that remain correct with the default `"const"` subtype.

## What we lose with the flag off

1. **Per-pattern destructure identification** — the `const_destructure` / `const_destructure_call` subtype label is suppressed. The binding entities still exist (e.g. `data`, `isLoading`, `createFoo`) but are indistinguishable from ordinary `const` declarations by subtype alone. Workaround: the surrounding call site's CALLS edge to `useFooQuery` / `useCreateFoo` provides the contextual link.
2. **Mutation-hook callable classification in subtype** — `createFoo` from `const { mutate: createFoo } = useCreateFoo()` gets subtype `"const"` instead of `"const_destructure_call"`. Its kind remains `SCOPE.Operation`, so CALLS resolution still works. Only the `_call` label is lost.
3. **State-hook value classification** — `count` from `const [count, setCount] = useState(0)` gets subtype `"const"` instead of `"const_destructure_call"`. `setCount` retains `"state_setter"` because that branch uses a hardcoded override inside `emitDestructuredEntities`.

## Files modified

- `internal/extractors/javascript/extractor.go` — added `os` import, `emitDestructureDetailEnv` constant, `emitDestructureDetailEnabled()` function, gate in `emitDestructuredEntities`
- `internal/extractors/javascript/issue2338_const_destructure_gate_test.go` — **new** fixture test (8 test functions)

## Test approach

8 new tests in `issue2338_const_destructure_gate_test.go`:
- `TestDestructureGate_DefaultOff` — 0 `const_destructure*` entities when flag unset
- `TestDestructureGate_OptIn` — entities present when flag = `"1"`
- `TestDestructureGate_OptIn_TrueValue` — entities present when flag = `"true"`
- `TestDestructureGate_BindingsAlways_DefaultOff` — binding entities present as `SCOPE.Component` (plain hook) and `SCOPE.Operation` (mutation hook) in default-off mode
- `TestDestructureGate_BindingsAlways_OptIn` — binding entities present with correct subtypes in opt-in mode
- `TestDestructureGate_MutationHookOp_DefaultOff` — mutation-hook kind stays `SCOPE.Operation` in default-off
- `TestDestructureGate_MutationHookOp_OptIn` — mutation-hook binding gets `const_destructure_call` in opt-in
- `TestDestructureGate_TypeScript_DefaultOff` — gate applies equally to TS grammar

All pass. `go build ./...` and `go test ./internal/extractors/...` clean.

## CI note

No `ci:full` — extractor flag gate; default minimal CI.