### PR TITLE
refactor(engine): extract shared Django field-index helper

### DIFF
--- a/internal/engine/field_index.go
+++ b/internal/engine/field_index.go
@@ -1,0 +1,86 @@
+// Shared Django model field-index helper (issue #2295).
+//
+// BuildFieldIndex is extracted from the inline indexDjangoModelFields
+// function that was defined solely in orm_field_edges.go. Any engine
+// pass that needs a "<Model>.<field>" presence index for a Django source
+// file should call BuildFieldIndex rather than re-implement the regex
+// scan. The key format — `<Model>.<field>` — is byte-identical to the
+// Name the Python extractor emits at python/extractor.go:1411-1412, so
+// consumers that see both pipelines can match by name without further
+// normalisation.
+//
+// Refs #2295.
+package engine
+
+import "regexp"
+
+// djangoClassDeclRe locates Django model class declarations:
+//
+//	class <Name>(... Model ...):
+//
+// The base class list is matched loosely (any parenthesised group that
+// contains "Model") so subclasses of project-local abstract bases
+// (e.g. `class User(TimestampedModel):` where TimestampedModel itself
+// inherits from models.Model) are still recognised. False positives
+// (a plain class whose parens contain the word "Model" but is not
+// actually a Django model) are inert: their fields just won't be the
+// target of any ORM filter_keys so no spurious edges are emitted.
+var djangoClassDeclRe = regexp.MustCompile(
+	`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*Model[^)]*)\)\s*:`,
+)
+
+// djangoFieldDeclRe locates field declarations inside a model body:
+//
+//	    <name> = models.<SomethingField>(...)
+//	    <name> = <CustomField>(...)
+//
+// We accept either the `models.` namespace (stdlib Django fields) or a
+// bare `<Capitalised>Field(` call (project-local custom field classes,
+// django-money MoneyField, etc.). The leading indentation is required
+// so top-level assignments at module scope (e.g. `User = get_user_model()`)
+// are NOT treated as field declarations.
+var djangoFieldDeclRe = regexp.MustCompile(
+	`(?m)^[ \t]+([a-z_][a-zA-Z0-9_]*)\s*=\s*(?:models\.[A-Z]\w*|[A-Z]\w*?Field)\s*\(`,
+)
+
+// BuildFieldIndex scans src for Django model class bodies and returns
+// the set of "<Model>.<field>" names discovered, mirroring the Name
+// convention the Python extractor uses at python/extractor.go:1411.
+//
+// Strategy: locate each `class X(... Model ...):` header, then scan
+// forward to the next class declaration (or EOF) and harvest every
+// indented `<name> = models.…Field(…)` or `<name> = <Custom>Field(…)`
+// assignment as a field of the enclosing class.
+//
+// The returned map is a presence set — values are always true. A nil /
+// empty map is returned for source files that contain no recognisable
+// Django model definitions.
+func BuildFieldIndex(src string) map[string]bool {
+	out := map[string]bool{}
+	classMatches := djangoClassDeclRe.FindAllStringSubmatchIndex(src, -1)
+	if len(classMatches) == 0 {
+		return out
+	}
+	for i, m := range classMatches {
+		className := src[m[2]:m[3]]
+		// Body extends from the end of the matched header to the start
+		// of the next class declaration (or EOF for the last class).
+		bodyStart := m[1]
+		bodyEnd := len(src)
+		if i+1 < len(classMatches) {
+			bodyEnd = classMatches[i+1][0]
+		}
+		body := src[bodyStart:bodyEnd]
+		for _, fm := range djangoFieldDeclRe.FindAllStringSubmatch(body, -1) {
+			if len(fm) < 2 {
+				continue
+			}
+			fieldName := fm[1]
+			if fieldName == "" {
+				continue
+			}
+			out[className+"."+fieldName] = true
+		}
+	}
+	return out
+}

--- a/internal/engine/field_index_test.go
+++ b/internal/engine/field_index_test.go
@@ -1,0 +1,192 @@
+// Tests for BuildFieldIndex (field_index.go, issue #2295).
+//
+// Coverage:
+//
+//	(a) scalar fields (CharField, IntegerField, BooleanField, etc.)
+//	(b) FK / relation fields (ForeignKey, OneToOneField, ManyToManyField)
+//	(c) custom / project-local field classes (MoneyField, etc.)
+//	(d) multiple model classes in one file — fields stay on correct model
+//	(e) abstract base class (no "models.Model" in parent, but "Model" present)
+//	(f) module-scope assignments are NOT treated as fields
+//	(g) empty / non-Django source returns empty map
+//
+// These tests exercise BuildFieldIndex in isolation — no detector pipeline
+// needed. The integration tests in orm_field_edges_test.go cover the call
+// site wiring through the full Detect path.
+package engine
+
+import (
+	"testing"
+)
+
+// (a) Scalar fields — basic smoke test.
+func TestBuildFieldIndex_ScalarFields(t *testing.T) {
+	src := `from django.db import models
+
+class User(models.Model):
+    cognito_id = models.CharField(max_length=64)
+    email = models.EmailField(unique=True)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+`
+	idx := BuildFieldIndex(src)
+	wantFields := []string{
+		"User.cognito_id",
+		"User.email",
+		"User.is_active",
+		"User.created_at",
+	}
+	for _, f := range wantFields {
+		if !idx[f] {
+			t.Errorf("BuildFieldIndex missing expected field %q; got index: %v", f, idx)
+		}
+	}
+	if len(idx) != len(wantFields) {
+		t.Errorf("BuildFieldIndex returned %d entries, want %d; index: %v", len(idx), len(wantFields), idx)
+	}
+}
+
+// (b) FK / relation fields — ForeignKey, OneToOneField, ManyToManyField.
+func TestBuildFieldIndex_FKFields(t *testing.T) {
+	src := `from django.db import models
+
+class Article(models.Model):
+    author = models.ForeignKey("User", on_delete=models.CASCADE)
+    reviewer = models.OneToOneField("User", on_delete=models.SET_NULL, null=True)
+    tags = models.ManyToManyField("Tag", blank=True)
+    title = models.CharField(max_length=200)
+`
+	idx := BuildFieldIndex(src)
+	wantFields := []string{
+		"Article.author",
+		"Article.reviewer",
+		"Article.tags",
+		"Article.title",
+	}
+	for _, f := range wantFields {
+		if !idx[f] {
+			t.Errorf("BuildFieldIndex missing FK/relation field %q; got: %v", f, idx)
+		}
+	}
+	if len(idx) != len(wantFields) {
+		t.Errorf("BuildFieldIndex returned %d entries, want %d; index: %v", len(idx), len(wantFields), idx)
+	}
+}
+
+// (c) Custom / project-local field classes (e.g. django-money MoneyField,
+// phonenumber PhoneNumberField, etc.).
+func TestBuildFieldIndex_CustomFields(t *testing.T) {
+	src := `from django.db import models
+from djmoney.models.fields import MoneyField
+
+class Invoice(models.Model):
+    amount = MoneyField(max_digits=14, decimal_places=2)
+    notes = models.TextField(blank=True)
+`
+	idx := BuildFieldIndex(src)
+	if !idx["Invoice.amount"] {
+		t.Errorf("BuildFieldIndex should recognise custom MoneyField; got: %v", idx)
+	}
+	if !idx["Invoice.notes"] {
+		t.Errorf("BuildFieldIndex missing Invoice.notes; got: %v", idx)
+	}
+}
+
+// (d) Multiple model classes — fields stay on their own model, no cross-
+// contamination.
+func TestBuildFieldIndex_MultipleModels(t *testing.T) {
+	src := `from django.db import models
+
+class User(models.Model):
+    email = models.EmailField()
+    name = models.CharField(max_length=100)
+
+class Post(models.Model):
+    title = models.CharField(max_length=200)
+    body = models.TextField()
+    author = models.ForeignKey("User", on_delete=models.CASCADE)
+`
+	idx := BuildFieldIndex(src)
+	userFields := []string{"User.email", "User.name"}
+	postFields := []string{"Post.title", "Post.body", "Post.author"}
+
+	for _, f := range userFields {
+		if !idx[f] {
+			t.Errorf("missing User field %q; got: %v", f, idx)
+		}
+	}
+	for _, f := range postFields {
+		if !idx[f] {
+			t.Errorf("missing Post field %q; got: %v", f, idx)
+		}
+	}
+	// Cross-contamination: Post fields must not appear under User and vice versa.
+	if idx["User.title"] {
+		t.Errorf("User.title should not exist (it belongs to Post); got: %v", idx)
+	}
+	if idx["Post.email"] {
+		t.Errorf("Post.email should not exist (it belongs to User); got: %v", idx)
+	}
+}
+
+// (e) Abstract base class — still indexed if parent name contains "Model".
+func TestBuildFieldIndex_AbstractBaseClass(t *testing.T) {
+	src := `from django.db import models
+
+class TimestampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+
+class Widget(TimestampedModel):
+    label = models.CharField(max_length=50)
+`
+	idx := BuildFieldIndex(src)
+	if !idx["TimestampedModel.created_at"] {
+		t.Errorf("BuildFieldIndex missing TimestampedModel.created_at; got: %v", idx)
+	}
+	if !idx["TimestampedModel.updated_at"] {
+		t.Errorf("BuildFieldIndex missing TimestampedModel.updated_at; got: %v", idx)
+	}
+	if !idx["Widget.label"] {
+		t.Errorf("BuildFieldIndex missing Widget.label; got: %v", idx)
+	}
+}
+
+// (f) Module-scope assignments (not inside a class body) must NOT be indexed.
+func TestBuildFieldIndex_ModuleScopeAssignmentsSkipped(t *testing.T) {
+	src := `from django.db import models
+
+# Module-scope helper — must NOT be indexed as a field.
+User = get_user_model()
+
+class Profile(models.Model):
+    bio = models.TextField(blank=True)
+`
+	idx := BuildFieldIndex(src)
+	// "User" at module scope looks like a module-level assignment, not a
+	// field declaration, because it lacks leading indentation.
+	if idx["Profile.User"] || idx["User.User"] {
+		t.Errorf("module-scope assignment was incorrectly indexed as a field; got: %v", idx)
+	}
+	if !idx["Profile.bio"] {
+		t.Errorf("BuildFieldIndex missing Profile.bio; got: %v", idx)
+	}
+}
+
+// (g) Non-Django / empty source returns an empty map without panicking.
+func TestBuildFieldIndex_EmptyOrNonDjango(t *testing.T) {
+	cases := []string{
+		"",
+		"def helper(): pass\n",
+		"class Foo:\n    x = 1\n",
+	}
+	for _, src := range cases {
+		idx := BuildFieldIndex(src)
+		if len(idx) != 0 {
+			t.Errorf("BuildFieldIndex(%q) = %v, want empty map", src, idx)
+		}
+	}
+}

--- a/internal/engine/orm_field_edges.go
+++ b/internal/engine/orm_field_edges.go
@@ -91,14 +91,15 @@ func applyORMFieldEdges(
 	// detector (Pass 2.5) — the entities slice handed to this pass
 	// contains only Pass 2.5 output, so the field entities are NOT
 	// visible here. We therefore reconstruct the field index from the
-	// source content directly using a coarse `class … :` + indented
-	// `<name> = models.<Type>(` scan that matches the extractor's
-	// convention closely enough for Phase A (Django ORM).
+	// source content directly using BuildFieldIndex (field_index.go),
+	// which uses a coarse `class … :` + indented `<name> = models.<Type>(`
+	// scan that matches the extractor's convention closely enough for
+	// Phase A (Django ORM).
 	//
 	// The resulting key `<Model>.<field>` is byte-identical to the Name
 	// the Python extractor emits, so consumers that DO see both can
 	// match by name without further normalisation.
-	fieldIdx := indexDjangoModelFields(string(content))
+	fieldIdx := BuildFieldIndex(string(content))
 	if len(fieldIdx) == 0 {
 		// Defensive fallback: some files may have field entities visible
 		// in `entities` (e.g. when a future pass forwards them). Honour
@@ -315,73 +316,6 @@ func ormFieldEdgeKindForVerb(verb string) string {
 		return ormWritesFieldKind
 	}
 	return ""
-}
-
-// djangoClassDeclRe locates Django model class declarations:
-//
-//	class <Name>(... models.Model ...):
-//
-// The base class list is matched loosely (any parenthesised group that
-// contains "Model") so subclasses of project-local abstract bases
-// (e.g. `class User(TimestampedModel):` where TimestampedModel itself
-// inherits from models.Model) are still recognised. False positives
-// (a plain class whose parens contain the word "Model" but is not
-// actually a Django model) are inert: their fields just won't be the
-// target of any ORM filter_keys so no spurious edges are emitted.
-var djangoClassDeclRe = regexp.MustCompile(
-	`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*Model[^)]*)\)\s*:`,
-)
-
-// djangoFieldDeclRe locates field declarations inside a model body:
-//
-//	    <name> = models.<SomethingField>(...)
-//	    <name> = <CustomField>(...)
-//
-// We accept either the `models.` namespace (stdlib Django fields) or a
-// bare `<Capitalised>Field(` call (project-local custom field classes,
-// django-money MoneyField, etc.). The leading indentation is required
-// so top-level assignments at module scope (e.g. `User = get_user_model()`)
-// are NOT treated as field declarations.
-var djangoFieldDeclRe = regexp.MustCompile(
-	`(?m)^[ \t]+([a-z_][a-zA-Z0-9_]*)\s*=\s*(?:models\.[A-Z]\w*|[A-Z]\w*?Field)\s*\(`,
-)
-
-// indexDjangoModelFields scans `src` for Django model class bodies and
-// returns the set of `<Model>.<field>` names discovered, mirroring the
-// Name convention the Python extractor uses at python/extractor.go:1411.
-//
-// Strategy: locate each `class X(... Model ...):` header, then scan
-// forward to the next class declaration (or EOF) and harvest every
-// indented `<name> = models.…Field(…)` or `<name> = <Custom>Field(…)`
-// assignment as a field of the enclosing class.
-func indexDjangoModelFields(src string) map[string]bool {
-	out := map[string]bool{}
-	classMatches := djangoClassDeclRe.FindAllStringSubmatchIndex(src, -1)
-	if len(classMatches) == 0 {
-		return out
-	}
-	for i, m := range classMatches {
-		className := src[m[2]:m[3]]
-		// Body extends from the end of the matched header to the start
-		// of the next class declaration (or EOF for the last class).
-		bodyStart := m[1]
-		bodyEnd := len(src)
-		if i+1 < len(classMatches) {
-			bodyEnd = classMatches[i+1][0]
-		}
-		body := src[bodyStart:bodyEnd]
-		for _, fm := range djangoFieldDeclRe.FindAllStringSubmatch(body, -1) {
-			if len(fm) < 2 {
-				continue
-			}
-			fieldName := fm[1]
-			if fieldName == "" {
-				continue
-			}
-			out[className+"."+fieldName] = true
-		}
-	}
-	return out
 }
 
 // stripDjangoLookup strips Django lookup suffixes and relation


### PR DESCRIPTION
## Summary

- Extracts `indexDjangoModelFields` and its two regexes from `orm_field_edges.go` into a new `internal/engine/field_index.go` file as the exported `BuildFieldIndex(src string) map[string]bool` helper
- `orm_field_edges.go` calls `BuildFieldIndex` at its single call site; file shrinks by 67 lines (418 → 351)
- Adds `internal/engine/field_index_test.go` with 7 focused unit tests for the helper in isolation

Closes #2295

## Test plan

- [ ] `go build ./...` — green (verified locally)
- [ ] `go test ./internal/engine/...` — green: 7 new `TestBuildFieldIndex_*` tests + 6 existing `TestORMFieldEdges_*` integration tests all pass
- [ ] `BuildFieldIndex` covers: scalar fields, FK/relation fields, custom field classes (MoneyField), multiple models per file, abstract base classes, module-scope assignment exclusion, empty/non-Django source

## Tech debt surfaced

**Option (b) — Pass 1 → Pass 2.5 plumbing — is NOT trivial.**

The comment preserved at `orm_field_edges.go:87-100` spells out why: Pass 1 (Python extractor) and Pass 2.5 (YAML detector + engine passes) run in separate pipeline stages and the `entities` slice passed to engine passes contains only Pass 2.5 output. To forward Pass 1 `SCOPE.Schema(subtype=field)` entities into Pass 2.5 would require threading them through `DetectResult` → `applyORMFieldEdges` contract, which touches `detector.go`, the extractor pipeline, and the test harness. The existing defensive fallback in `applyORMFieldEdges` (lines 106-119) already scans `entities` for any field entities that happen to appear — so when option (b) is eventually plumbed, `BuildFieldIndex` and the fallback can be unified at that boundary rather than requiring a rewrite. This is a deliberate deferral, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)