### PR TITLE
chore(daemon): JSON-lines mcp_rpc log mode + document no-rotation contract

### DIFF
--- a/internal/daemon/mcp_rpc.go
+++ b/internal/daemon/mcp_rpc.go
@@ -23,11 +23,64 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/perf"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
+
+// ── JSON-lines log constants (issue #2299) ────────────────────────────────────
+//
+// EnvDaemonLogJSON is the environment variable that switches [mcp-rpc] log
+// lines from human-readable text to JSON-lines. Set to "1" or "true" to
+// enable; unset or any other value keeps the default human-readable format.
+//
+//	ARCHIGRAPH_DAEMON_LOG_JSON=1  →  {"event":"mcp_rpc","tool":"…","elapsed_ms":…,"repo":"…","ts":"…"}
+const EnvDaemonLogJSON = "ARCHIGRAPH_DAEMON_LOG_JSON"
+
+// Log event and field-name constants for the mcp_rpc JSON-lines format.
+// Centralised here so future consumers (log shippers, tests, dashboards)
+// do not re-derive the strings independently.
+const (
+	// LogEventMCPRPC is the "event" field value for every mcp_rpc log line.
+	LogEventMCPRPC = "mcp_rpc"
+
+	// LogFieldPhase is the JSON key for the dispatch phase ("received" or "done").
+	LogFieldPhase = "phase"
+
+	// LogFieldTool is the JSON key for the tool name.
+	LogFieldTool = "tool"
+
+	// LogFieldElapsedMS is the JSON key for elapsed wall-clock time in ms.
+	LogFieldElapsedMS = "elapsed_ms"
+
+	// LogFieldRepo is the JSON key for the caller's repo / CWD label.
+	LogFieldRepo = "repo"
+
+	// LogFieldTS is the JSON key for the RFC3339 timestamp.
+	LogFieldTS = "ts"
+)
+
+// mcpRPCLogEntry is the structured payload for a single JSON-lines log line.
+// Phase is "received" on the pre-dispatch line and "done" on the post-dispatch
+// line. ElapsedMS is 0 on the "received" line and the actual wall-clock time
+// on the "done" line.
+type mcpRPCLogEntry struct {
+	Event     string `json:"event"`
+	Phase     string `json:"phase"`
+	Tool      string `json:"tool"`
+	ElapsedMS int64  `json:"elapsed_ms"`
+	Repo      string `json:"repo"`
+	TS        string `json:"ts"`
+}
+
+// daemonLogJSON reports whether the JSON-lines mode is active.
+func daemonLogJSON() bool {
+	v := strings.TrimSpace(os.Getenv(EnvDaemonLogJSON))
+	return v == "1" || strings.EqualFold(v, "true")
+}
 
 // ── Injected function types ───────────────────────────────────────────────────
 
@@ -181,7 +234,18 @@ func (s *Service) MCPToolCall(args *MCPToolCallArgs, reply *MCPToolCallReply) er
 		repoLabel = "(cwd not provided)"
 	}
 	if s.logger != nil {
-		s.logger.Printf("[mcp-rpc] tool=%s received repo=%s", args.Name, repoLabel)
+		if daemonLogJSON() {
+			b, _ := json.Marshal(mcpRPCLogEntry{
+				Event: LogEventMCPRPC,
+				Phase: "received",
+				Tool:  args.Name,
+				Repo:  repoLabel,
+				TS:    time.Now().UTC().Format(time.RFC3339),
+			})
+			s.logger.Printf("%s", string(b))
+		} else {
+			s.logger.Printf("[mcp-rpc] tool=%s received repo=%s", args.Name, repoLabel)
+		}
 	}
 
 	start := time.Now()
@@ -190,7 +254,19 @@ func (s *Service) MCPToolCall(args *MCPToolCallArgs, reply *MCPToolCallReply) er
 
 	// Debug log: tool=name elapsed=Xms repo=Y (from CWD when available)
 	if s.logger != nil {
-		s.logger.Printf("[mcp-rpc] tool=%s elapsed=%dms repo=%s", args.Name, elapsed.Milliseconds(), repoLabel)
+		if daemonLogJSON() {
+			b, _ := json.Marshal(mcpRPCLogEntry{
+				Event:     LogEventMCPRPC,
+				Phase:     "done",
+				Tool:      args.Name,
+				ElapsedMS: elapsed.Milliseconds(),
+				Repo:      repoLabel,
+				TS:        time.Now().UTC().Format(time.RFC3339),
+			})
+			s.logger.Printf("%s", string(b))
+		} else {
+			s.logger.Printf("[mcp-rpc] tool=%s elapsed=%dms repo=%s", args.Name, elapsed.Milliseconds(), repoLabel)
+		}
 	}
 
 	if err != nil {

--- a/internal/daemon/mcp_rpc_test.go
+++ b/internal/daemon/mcp_rpc_test.go
@@ -1,9 +1,13 @@
 package daemon
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
+	"strings"
 	"testing"
+	"time"
 )
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -269,5 +273,142 @@ func TestMCPToolList_SentinelReturned(t *testing.T) {
 	}
 	if reply.Tools[0].Name != "archigraph_status" {
 		t.Errorf("unexpected sentinel name: %q", reply.Tools[0].Name)
+	}
+}
+
+// ── JSON-lines log mode tests (issue #2299) ───────────────────────────────────
+
+// testServiceWithLogger returns a Service wired with a buf-backed logger.
+func testServiceWithLogger(callTool MCPCallToolFunc) (*Service, *bytes.Buffer) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0) // no prefix/flags so output is deterministic
+	svc := &Service{
+		mcpCallTool: callTool,
+		progress:    make(map[string]*rebuildSession),
+		logger:      logger,
+	}
+	return svc, &buf
+}
+
+// TestMCPToolCall_DefaultLog_TextFormat verifies that with ARCHIGRAPH_DAEMON_LOG_JSON
+// unset the log output is the human-readable "[mcp-rpc] tool=… elapsed=…ms repo=…" text.
+func TestMCPToolCall_DefaultLog_TextFormat(t *testing.T) {
+	t.Setenv(EnvDaemonLogJSON, "") // ensure JSON mode is off
+
+	svc, buf := testServiceWithLogger(func(name string, _ map[string]any, _ string) (MCPCallResult, error) {
+		return MCPCallResult{Content: []map[string]any{{"type": "text", "text": "ok"}}}, nil
+	})
+
+	var reply MCPToolCallReply
+	if err := svc.MCPToolCall(&MCPToolCallArgs{Name: "archigraph_find", CWD: "/repo/myproject"}, &reply); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "[mcp-rpc]") {
+		t.Errorf("expected [mcp-rpc] prefix in text log, got: %q", out)
+	}
+	if !strings.Contains(out, "tool=archigraph_find") {
+		t.Errorf("expected tool= field in text log, got: %q", out)
+	}
+	if !strings.Contains(out, "elapsed=") {
+		t.Errorf("expected elapsed= field in text log, got: %q", out)
+	}
+	// Must NOT be valid JSON on the elapsed line (the received line has no elapsed).
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "elapsed=") {
+			var m map[string]any
+			if json.Unmarshal([]byte(line), &m) == nil {
+				t.Errorf("text mode line looks like JSON: %q", line)
+			}
+		}
+	}
+}
+
+// TestMCPToolCall_JSONLog_ParseableJSON verifies that with ARCHIGRAPH_DAEMON_LOG_JSON=1
+// every log line is valid JSON containing the expected fields.
+func TestMCPToolCall_JSONLog_ParseableJSON(t *testing.T) {
+	t.Setenv(EnvDaemonLogJSON, "1")
+
+	svc, buf := testServiceWithLogger(func(name string, _ map[string]any, _ string) (MCPCallResult, error) {
+		return MCPCallResult{Content: []map[string]any{{"type": "text", "text": "ok"}}}, nil
+	})
+
+	const wantTool = "archigraph_find"
+	const wantRepo = "/repo/myproject"
+	var reply MCPToolCallReply
+	if err := svc.MCPToolCall(&MCPToolCallArgs{Name: wantTool, CWD: wantRepo}, &reply); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := strings.TrimSpace(buf.String())
+	lines := strings.Split(out, "\n")
+	// Expect at least two lines: "received" and the elapsed completion line.
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 log lines, got %d: %q", len(lines), out)
+	}
+
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Errorf("line %d is not valid JSON: %v — raw: %q", i, err, line)
+			continue
+		}
+		if entry[LogFieldTool] != wantTool {
+			t.Errorf("line %d: tool=%q, want %q", i, entry[LogFieldTool], wantTool)
+		}
+		if entry[LogFieldRepo] != wantRepo {
+			t.Errorf("line %d: repo=%q, want %q", i, entry[LogFieldRepo], wantRepo)
+		}
+		if entry["event"] != LogEventMCPRPC {
+			t.Errorf("line %d: event=%q, want %q", i, entry["event"], LogEventMCPRPC)
+		}
+		if _, ok := entry[LogFieldTS]; !ok {
+			t.Errorf("line %d: missing %q field", i, LogFieldTS)
+		}
+		// Validate ts is parseable RFC3339.
+		if ts, _ := entry[LogFieldTS].(string); ts != "" {
+			if _, err := time.Parse(time.RFC3339, ts); err != nil {
+				t.Errorf("line %d: ts %q is not RFC3339: %v", i, ts, err)
+			}
+		}
+	}
+
+	// The second (completion) line must have elapsed_ms >= 0.
+	var lastEntry map[string]any
+	_ = json.Unmarshal([]byte(strings.TrimSpace(lines[len(lines)-1])), &lastEntry)
+	if _, ok := lastEntry[LogFieldElapsedMS]; !ok {
+		t.Errorf("completion line missing %q field", LogFieldElapsedMS)
+	}
+}
+
+// TestMCPToolCall_JSONLog_TrueVariant verifies ARCHIGRAPH_DAEMON_LOG_JSON=true
+// also activates JSON-lines mode.
+func TestMCPToolCall_JSONLog_TrueVariant(t *testing.T) {
+	t.Setenv(EnvDaemonLogJSON, "true")
+
+	svc, buf := testServiceWithLogger(func(_ string, _ map[string]any, _ string) (MCPCallResult, error) {
+		return MCPCallResult{Content: []map[string]any{{"type": "text", "text": "ok"}}}, nil
+	})
+
+	var reply MCPToolCallReply
+	if err := svc.MCPToolCall(&MCPToolCallArgs{Name: "archigraph_stats"}, &reply); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Errorf("expected JSON line, got: %q (%v)", line, err)
+		}
 	}
 }

--- a/internal/daemon/paths.go
+++ b/internal/daemon/paths.go
@@ -66,6 +66,15 @@ func layoutFromRoot(root, socketPath string) Layout {
 		socketDir = filepath.Dir(socketPath)
 	}
 	logDir := filepath.Join(root, "logs")
+	// No-rotation contract (issue #2300):
+	// daemon.log grows monotonically by design. The bench harness
+	// (skills/archigraph-graph-quality/prompts/03-with-mcp-run.md) uses
+	// byte offsets into daemon.log and assumes the file is append-only and
+	// never truncated or renamed. If log rotation is ever added, the bench
+	// skill will need a sidecar offset-translation strategy to remain
+	// correct. Operators who need bounded log sizes should use an external
+	// tool (logrotate, newsyslog) with copytruncate semantics, and must
+	// update the bench skill accordingly.
 	return Layout{
 		Root:       root,
 		SocketDir:  socketDir,

--- a/internal/daemon/paths_unix.go
+++ b/internal/daemon/paths_unix.go
@@ -72,6 +72,7 @@ func DefaultLayout() (Layout, error) {
 		return Layout{}, err
 	}
 	root = filepath.Join(home, ".archigraph")
+	// See no-rotation contract in layoutFromRoot (paths.go).
 	return Layout{
 		Root:       root,
 		SocketDir:  filepath.Dir(socketPath),

--- a/internal/daemon/paths_windows.go
+++ b/internal/daemon/paths_windows.go
@@ -41,6 +41,7 @@ func DefaultLayout() (Layout, error) {
 	}
 
 	logDir := filepath.Join(root, "logs")
+	// See no-rotation contract in layoutFromRoot (paths.go).
 	return Layout{
 		Root:       root,
 		SocketDir:  "", // named pipes have no filesystem directory


### PR DESCRIPTION
## Summary

- **#2299** — Add `ARCHIGRAPH_DAEMON_LOG_JSON` env var (`1` or `true`) that switches `[mcp-rpc]` log lines from human-readable text to JSON-lines format. Default is off (text) so `tail -f daemon.log` is unchanged for operators. Each JSON line emits `event`, `phase` (`received`/`done`), `tool`, `elapsed_ms`, `repo`, and `ts` (RFC3339). Field-name and event-name constants are exported from `mcp_rpc.go` so log shippers and dashboards can reference them without re-deriving magic strings.
- **#2300** — Document the no-rotation contract in `paths.go` (`layoutFromRoot`) with cross-reference comments in `paths_unix.go` and `paths_windows.go`. `daemon.log` grows monotonically by design; the graph-quality bench skill uses byte offsets and assumes append-only semantics. Rotation is NOT implemented — no existing config infrastructure implies it is expected, and the correct future path (copytruncate + offset-translation sidecar in the bench skill) is noted in the comment.

Closes #2299
Closes #2300

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/daemon/...` passes (all packages green)
- [ ] `TestMCPToolCall_DefaultLog_TextFormat` — text mode produces `[mcp-rpc]` lines, not JSON
- [ ] `TestMCPToolCall_JSONLog_ParseableJSON` — `ARCHIGRAPH_DAEMON_LOG_JSON=1` emits valid JSON with `event`, `phase`, `tool`, `elapsed_ms`, `repo`, `ts`
- [ ] `TestMCPToolCall_JSONLog_TrueVariant` — `ARCHIGRAPH_DAEMON_LOG_JSON=true` also activates JSON mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)