### PR TITLE
fix(graph): persist Language field through indexer pipeline + load-time sanity check

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1321,7 +1321,77 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		}
 	}
 
+	// Issue #2341 — sanity-check: warn when entities with a recognized source
+	// extension have an empty Language tag. A non-zero count here means the
+	// indexer pipeline dropped or never set the Language field for these files,
+	// which would cause language-filtered queries (archigraph_find --language)
+	// to silently skip them. This is non-fatal; the graph is still usable.
+	warnEmptyLanguageEntities(doc)
+
 	return doc, nil
+}
+
+// knownLanguageExtensions maps source-file suffixes (including the dot) to the
+// language tag they imply. Used by warnEmptyLanguageEntities to distinguish
+// entities whose Language should be known from truly extension-less ones
+// (e.g. synthetic ext:* placeholders).
+var knownLanguageExtensions = map[string]string{
+	".go":    "go",
+	".py":    "python",
+	".ts":    "typescript",
+	".tsx":   "typescript",
+	".js":    "javascript",
+	".jsx":   "javascript",
+	".java":  "java",
+	".rb":    "ruby",
+	".rs":    "rust",
+	".php":   "php",
+	".cs":    "csharp",
+	".cpp":   "cpp",
+	".cc":    "cpp",
+	".cxx":   "cpp",
+	".c":     "c",
+	".h":     "c",
+	".hpp":   "cpp",
+	".kt":    "kotlin",
+	".swift": "swift",
+	".scala": "scala",
+	".tf":    "hcl",
+	".hcl":   "hcl",
+	".yaml":  "yaml",
+	".yml":   "yaml",
+}
+
+// warnEmptyLanguageEntities logs a warning to stderr when entities with a
+// recognized source-file extension have an empty Language tag. Issue #2341 —
+// prevents the bug from silently recurring after a future regression.
+func warnEmptyLanguageEntities(doc *graph.Document) {
+	type bad struct{ kind, name, src string }
+	var bads []bad
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		if e.Language != "" || e.SourceFile == "" {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(e.SourceFile))
+		if _, known := knownLanguageExtensions[ext]; known {
+			bads = append(bads, bad{e.Kind, e.Name, e.SourceFile})
+		}
+	}
+	if len(bads) == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"archigraph: WARNING: %d entities have a recognized source extension but Language=\"\" "+
+			"— language-filtered queries will silently skip them (issue #2341). "+
+			"First 5 examples:\n", len(bads))
+	limit := 5
+	if len(bads) < limit {
+		limit = len(bads)
+	}
+	for _, b := range bads[:limit] {
+		fmt.Fprintf(os.Stderr, "  kind=%s name=%s src=%s\n", b.kind, b.name, b.src)
+	}
 }
 
 // verbose reports whether the indexer should emit the per-extractor

--- a/cmd/archigraph/index_test.go
+++ b/cmd/archigraph/index_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/classifier"
 	"github.com/cajasmota/archigraph/internal/engine"
 	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
 	"github.com/cajasmota/archigraph/internal/resolve"
 	"github.com/cajasmota/archigraph/internal/treesitter"
 	"github.com/cajasmota/archigraph/internal/types"
@@ -881,5 +882,135 @@ func TestModuleCoverage_AllEntitiesTagged(t *testing.T) {
 					tc.name, len(modules), total)
 			}
 		})
+	}
+}
+
+// TestLanguageTagPersistsAfterFBRoundtrip is the integration-level regression
+// for issue #2341. It indexes a Python fixture, writes graph.fb, reads it back,
+// and asserts that every entity sourced from a .py file has Language="python".
+//
+// Before the fix, buildEntity in fbwriter never serialized Language and the
+// load.go workaround (restore from Properties["language"]) had nothing to read,
+// so all entities came back with Language="" and archigraph_find --language
+// python silently returned nothing.
+func TestLanguageTagPersistsAfterFBRoundtrip(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/crossfile_python", "crossfile_python", nil)
+
+	// Quick sanity: the fixture must produce at least one Python entity.
+	totalPy := 0
+	for _, e := range doc.Entities {
+		if strings.HasSuffix(e.SourceFile, ".py") {
+			totalPy++
+		}
+	}
+	if totalPy == 0 {
+		t.Fatal("fixture produced no .py entities at all — nothing to verify")
+	}
+
+	// Write to graph.fb via the fbwriter, then reload via LoadGraphFromDir
+	// (the FB path). We import fbwriter transitively through the main package
+	// so use the graph-package shim: WriteAtomic (JSON) is NOT sufficient here
+	// because the bug only manifests on the FB path. Instead sort the doc and
+	// call fbwriter.WriteAtomic to write graph.fb, then LoadGraphFromDir which
+	// prefers graph.fb over graph.json when both are present.
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	sortDocumentForEmission(doc)
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("fbwriter.WriteAtomic: %v", err)
+	}
+	reloaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+
+	// Assert: every entity with a .py source file must have Language="python"
+	// after the roundtrip.
+	missing := 0
+	for _, e := range reloaded.Entities {
+		if strings.HasSuffix(e.SourceFile, ".py") && e.Language != "python" {
+			missing++
+			t.Logf("entity missing Language: id=%s name=%s kind=%s src=%s lang=%q",
+				e.ID, e.Name, e.Kind, e.SourceFile, e.Language)
+		}
+	}
+	if missing > 0 {
+		t.Errorf("%d/%d .py entities have Language=\"\" after graph.fb roundtrip (issue #2341)",
+			missing, totalPy)
+	}
+}
+
+// TestWarnEmptyLanguageEntities verifies that warnEmptyLanguageEntities emits
+// a warning to stderr when entities with a recognized source extension have
+// Language="". This is the buildDocument sanity-check required by issue #2341.
+func TestWarnEmptyLanguageEntities(t *testing.T) {
+	// Build a tiny document: one .py entity without Language (should warn),
+	// one .py entity WITH Language (no warn), one synthetic entity with no
+	// SourceFile (no warn).
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "a", Name: "bad_view", Kind: "class", SourceFile: "views.py", Language: ""},
+			{ID: "b", Name: "good_view", Kind: "class", SourceFile: "models.py", Language: "python"},
+			{ID: "c", Name: "ext:requests", Kind: "external", SourceFile: ""},
+		},
+	}
+
+	// Redirect stderr to capture the warning.
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	warnEmptyLanguageEntities(doc)
+
+	w.Close()
+	os.Stderr = origStderr
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if !strings.Contains(output, "#2341") {
+		t.Errorf("expected warning mentioning #2341, got: %q", output)
+	}
+	if !strings.Contains(output, "bad_view") || !strings.Contains(output, "views.py") {
+		t.Errorf("expected warning to name the offending entity, got: %q", output)
+	}
+	// The good entity (Language="python") must NOT appear in the warning.
+	if strings.Contains(output, "good_view") {
+		t.Errorf("warning should not mention entity with Language set, got: %q", output)
+	}
+}
+
+// TestWarnEmptyLanguageEntities_NoBadEntities verifies that no warning is
+// emitted when all entities with recognized extensions already have Language set.
+func TestWarnEmptyLanguageEntities_NoBadEntities(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "a", Name: "views", Kind: "class", SourceFile: "views.py", Language: "python"},
+			{ID: "b", Name: "handler", Kind: "function", SourceFile: "main.go", Language: "go"},
+		},
+	}
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	warnEmptyLanguageEntities(doc)
+
+	w.Close()
+	os.Stderr = origStderr
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if output != "" {
+		t.Errorf("expected no warning when all Language fields set, got: %q", output)
 	}
 }

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -81,7 +81,26 @@ func buildEntity(b *flatbuffers.Builder, e *graph.Entity) flatbuffers.UOffsetT {
 	nameOff := b.CreateString(e.Name)
 	srcOff := b.CreateString(e.SourceFile)
 
-	propsVec := buildPropertyVector(b, e.Properties)
+	// Issue #2341 — persist Language via Properties["language"] so that the
+	// load.go reader's workaround (fbEntityToGraphEntity restores Language from
+	// props["language"]) can recover it on read. The FlatBuffers schema has no
+	// top-level language slot, so we inject the value into the props map before
+	// building the property vector. We work on a shallow copy of the map to
+	// avoid mutating the caller's entity struct.
+	props := e.Properties
+	if e.Language != "" {
+		if _, alreadySet := props["language"]; !alreadySet {
+			// Shallow-copy only when we need to add the key so the common
+			// "extractor already stamped it" path stays zero-alloc.
+			copied := make(map[string]string, len(props)+1)
+			for k, v := range props {
+				copied[k] = v
+			}
+			copied["language"] = e.Language
+			props = copied
+		}
+	}
+	propsVec := buildPropertyVector(b, props)
 
 	// PH8 (#2100): embedding_ref — only create string offset when non-empty
 	// to preserve bytewise identity for pre-PH8 graphs.

--- a/internal/graph/fbwriter/writer_test.go
+++ b/internal/graph/fbwriter/writer_test.go
@@ -267,6 +267,91 @@ func TestRoundtripCoverageStatus(t *testing.T) {
 	}
 }
 
+// TestRoundtripLanguage verifies that Entity.Language survives a write→read
+// cycle through graph.fb (issue #2341). Before the fix, Language was never
+// serialized into the FlatBuffer so every entity read back with Language="".
+func TestRoundtripLanguage(t *testing.T) {
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		Repo:        "fixture-language",
+		Entities: []graph.Entity{
+			// Entity with Language set but NOT in Properties — the common case
+			// produced by extractors that set entity.Language directly.
+			{ID: "ent0000000000000a", Name: "MyView", Kind: "class",
+				SourceFile: "views.py", Language: "python"},
+			// Entity with Language already mirrored in Properties (extractor
+			// overrides must be preserved, not doubled).
+			{ID: "ent0000000000000b", Name: "handler", Kind: "function",
+				SourceFile: "main.go", Language: "go",
+				Properties: map[string]string{"language": "go", "module": "cmd/main"}},
+			// Entity with no Language and no recognized extension (synthetic).
+			// Must round-trip with Language="" (no spurious tag injected).
+			{ID: "ent0000000000000c", Name: "ext:requests", Kind: "external",
+				SourceFile: ""},
+		},
+	}
+	doc.Stats.Entities = len(doc.Entities)
+
+	out := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(out, doc); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := graph.LoadGraphFromDir(filepath.Dir(out))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	byID := make(map[string]*graph.Entity, len(got.Entities))
+	for i := range got.Entities {
+		e := &got.Entities[i]
+		byID[e.ID] = e
+	}
+
+	// entity a: Language="python" must survive the roundtrip.
+	ea := byID["ent0000000000000a"]
+	if ea == nil {
+		t.Fatal("entity a not found after roundtrip")
+	}
+	if ea.Language != "python" {
+		t.Errorf("entity a Language: got %q want %q", ea.Language, "python")
+	}
+	// Properties["language"] must also be set so MCP query handlers that read
+	// props directly (not the top-level field) see the value.
+	if ea.Properties["language"] != "python" {
+		t.Errorf("entity a Properties[language]: got %q want %q",
+			ea.Properties["language"], "python")
+	}
+
+	// entity b: Language="go" already in Properties — must not be duplicated
+	// or overwritten.
+	eb := byID["ent0000000000000b"]
+	if eb == nil {
+		t.Fatal("entity b not found after roundtrip")
+	}
+	if eb.Language != "go" {
+		t.Errorf("entity b Language: got %q want %q", eb.Language, "go")
+	}
+	if eb.Properties["language"] != "go" {
+		t.Errorf("entity b Properties[language]: got %q want %q",
+			eb.Properties["language"], "go")
+	}
+	// Other properties must be preserved.
+	if eb.Properties["module"] != "cmd/main" {
+		t.Errorf("entity b Properties[module]: got %q want %q",
+			eb.Properties["module"], "cmd/main")
+	}
+
+	// entity c: no Language, no source file — must read back with Language="".
+	ec := byID["ent0000000000000c"]
+	if ec == nil {
+		t.Fatal("entity c not found after roundtrip")
+	}
+	if ec.Language != "" {
+		t.Errorf("entity c Language: got %q want empty", ec.Language)
+	}
+}
+
 // TestRoundtripNoAlgoData verifies a graph written with NO community data
 // (the --skip-pass=graph-algo case) reads back with zero communities, nil
 // AlgorithmStats, and un-annotated entities (#1620 — old-file compatibility).


### PR DESCRIPTION
## Summary

- **Root cause (b) confirmed:** `buildEntity()` in `internal/graph/fbwriter/writer.go` never serialized `Entity.Language`. The FlatBuffers schema has no `language` field on the `Entity` table, so the value was silently dropped on every write. The existing `load.go` workaround (restore Language from `Properties["language"]`) could never fire because `Properties["language"]` was only stamped on *relationships* — never on entity records.
- **Fix:** In `buildEntity`, inject `Language` into a shallow copy of the entity's `Properties["language"]` map before building the property vector. This makes the existing `load.go` workaround work correctly on every read.
- **Sanity check added:** `warnEmptyLanguageEntities()` is called after `buildDocument` and logs a WARNING to stderr when entities with a recognized source extension (`.py`, `.go`, `.ts`, etc.) have `Language=""`, preventing silent recurrence.

## Test plan

- [x] `TestRoundtripLanguage` (fbwriter) — entity with `Language="python"` written via `WriteAtomic`, read back via `LoadGraphFromDir`; asserts `Language` and `Properties["language"]` both survive the roundtrip
- [x] `TestLanguageTagPersistsAfterFBRoundtrip` (cmd/archigraph integration) — indexes the `crossfile_python` fixture, writes `graph.fb`, reloads, asserts every `.py` entity has `Language="python"`
- [x] `TestWarnEmptyLanguageEntities` — asserts the sanity-check emits a warning mentioning `#2341` and the offending entity when Language is blank
- [x] `TestWarnEmptyLanguageEntities_NoBadEntities` — asserts no warning emitted when all language fields are set
- [x] All existing `fbwriter` and `cmd/archigraph` tests pass without regression

Closes #2341

🤖 Generated with [Claude Code](https://claude.com/claude-code)