### PR TITLE
cleanup(mcp): remove dead adjacency.edge.repo field

### DIFF
--- a/internal/mcp/traversal.go
+++ b/internal/mcp/traversal.go
@@ -24,7 +24,6 @@ type edge struct {
 	target string
 	kind   string
 	weight float64
-	repo   string
 	relIdx int
 }
 
@@ -60,8 +59,8 @@ func buildAdjacency(doc *graph.Document, repo string) *adjacency {
 	for i := range doc.Relationships {
 		r := &doc.Relationships[i]
 		w := 1.0
-		a.out[r.FromID] = append(a.out[r.FromID], edge{target: r.ToID, kind: r.Kind, weight: w, repo: repo, relIdx: i})
-		a.in[r.ToID] = append(a.in[r.ToID], edge{target: r.FromID, kind: r.Kind, weight: w, repo: repo, relIdx: i})
+		a.out[r.FromID] = append(a.out[r.FromID], edge{target: r.ToID, kind: r.Kind, weight: w, relIdx: i})
+		a.in[r.ToID] = append(a.in[r.ToID], edge{target: r.FromID, kind: r.Kind, weight: w, relIdx: i})
 	}
 	return a
 }


### PR DESCRIPTION
## Summary
- Removes unused `repo` field from `edge` struct in `internal/mcp/traversal.go`
- Eliminates assignments that were set but never read (confirmed dead code per #2303)
- Tests pass, go vet clean

## Verification
- `go build ./...` passes
- `go test ./internal/mcp/... -count=1` passes (all tests pass)
- `go vet ./internal/mcp/...` passes
- No reads of `edge.repo` found in production or test code

**no `ci:full` — dead-code removal.**

Closes #2308