### PR TITLE
fix(daemon): warn when log.Logger has flags set under JSON-line mode

### DIFF
--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -183,9 +183,31 @@ type Service struct {
 // per-call logging (tool=name elapsed=X repo=Y).
 // maxConcurrentGroups controls how many groups may be rebuilt in parallel
 // (0 or 1 → serial; ≥2 → worker pool). Added in #1276.
+//
+// JSON-lines mode (ARCHIGRAPH_DAEMON_LOG_JSON=1, added in PR #2350):
+// When this env var is set, every log line is emitted as a JSON object so
+// structured log shippers can parse it. For this to produce valid JSON the
+// underlying logger MUST be created with log.New(w, "", 0) — no prefix and
+// no flags. If the logger has any flags set (e.g. log.LstdFlags adds a
+// timestamp prefix), log lines will look like:
+//
+//	2026/05/27 12:00:00 {"event":"mcp_rpc",...}
+//
+// which is NOT valid JSON and will cause log shippers to silently discard
+// the entry. newService warns to stderr at startup if it detects this
+// misconfiguration. Long-term: migrate to log/slog (tracked as follow-up).
 func newService(idx IndexFunc, rb RebuildFunc, qa QualityAuditFunc, socketPath string, stopReq chan<- struct{}, logger *log.Logger, maxConcurrentGroups int) *Service {
 	if maxConcurrentGroups < 1 {
 		maxConcurrentGroups = 1
+	}
+	// Guard: warn at startup if JSON-lines mode is active but the logger has
+	// flags set. Flags like log.LstdFlags prepend a timestamp to every line,
+	// making the JSON output invalid. The check is cheap and non-fatal — the
+	// daemon continues to run, but operators are alerted immediately rather
+	// than discovering parse failures in their log shipper.
+	if logger != nil && daemonLogJSON() && logger.Flags() != 0 {
+		logger.Printf("WARN: %s=1 but log.Logger has flags=%d — JSON lines may be prefixed with timestamps and unparseable by log shippers; recreate the logger with log.New(w, \"\", 0)",
+			EnvDaemonLogJSON, logger.Flags())
 	}
 	return &Service{
 		startedAt:           time.Now(),

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -1,12 +1,104 @@
 package daemon
 
 import (
+	"bytes"
+	"log"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/daemon/sched"
 )
+
+// TestNewService_JSONMode_WarnsFlaggedLogger verifies that newService emits a
+// warning to stderr when ARCHIGRAPH_DAEMON_LOG_JSON=1 is active and the
+// supplied log.Logger has non-zero flags (issue #2353). A flagged logger
+// prepends a timestamp prefix, making JSON output invalid.
+func TestNewService_JSONMode_WarnsFlaggedLogger(t *testing.T) {
+	t.Setenv(EnvDaemonLogJSON, "1")
+
+	var buf bytes.Buffer
+	// log.LstdFlags = Ldate | Ltime — the default flags that break JSON output.
+	logger := log.New(&buf, "", log.LstdFlags)
+
+	newService(
+		func(proto.IndexArgs) (string, string, error) { return "", "", nil },
+		func(proto.RebuildArgs) ([]string, string, error) { return []string{}, "", nil },
+		func(proto.QualityAuditRequest) (proto.QualityAuditReply, error) {
+			return proto.QualityAuditReply{}, nil
+		},
+		"/tmp/test.sock",
+		make(chan struct{}),
+		logger,
+		1,
+	)
+
+	out := buf.String()
+	if !strings.Contains(out, "WARN:") {
+		t.Errorf("expected WARN in log output when logger has flags under JSON mode, got: %q", out)
+	}
+	if !strings.Contains(out, EnvDaemonLogJSON) {
+		t.Errorf("expected env var name %q in warning, got: %q", EnvDaemonLogJSON, out)
+	}
+	if !strings.Contains(out, "flags=") {
+		t.Errorf("expected flags= value in warning, got: %q", out)
+	}
+}
+
+// TestNewService_JSONMode_NoWarnZeroFlags verifies that newService does NOT
+// emit a warning when JSON mode is active and the logger has flags=0 (the
+// correct configuration for JSON-lines output).
+func TestNewService_JSONMode_NoWarnZeroFlags(t *testing.T) {
+	t.Setenv(EnvDaemonLogJSON, "1")
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0) // flags=0: safe for JSON output
+
+	newService(
+		func(proto.IndexArgs) (string, string, error) { return "", "", nil },
+		func(proto.RebuildArgs) ([]string, string, error) { return []string{}, "", nil },
+		func(proto.QualityAuditRequest) (proto.QualityAuditReply, error) {
+			return proto.QualityAuditReply{}, nil
+		},
+		"/tmp/test.sock",
+		make(chan struct{}),
+		logger,
+		1,
+	)
+
+	out := buf.String()
+	if strings.Contains(out, "WARN:") {
+		t.Errorf("unexpected WARN in log output when logger has flags=0 under JSON mode, got: %q", out)
+	}
+}
+
+// TestNewService_TextMode_NoWarnFlaggedLogger verifies that the flagged-logger
+// warning is NOT emitted when JSON mode is disabled, even if the logger has
+// non-zero flags (flags only corrupt output in JSON-lines mode).
+func TestNewService_TextMode_NoWarnFlaggedLogger(t *testing.T) {
+	t.Setenv(EnvDaemonLogJSON, "") // JSON mode off
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", log.LstdFlags)
+
+	newService(
+		func(proto.IndexArgs) (string, string, error) { return "", "", nil },
+		func(proto.RebuildArgs) ([]string, string, error) { return []string{}, "", nil },
+		func(proto.QualityAuditRequest) (proto.QualityAuditReply, error) {
+			return proto.QualityAuditReply{}, nil
+		},
+		"/tmp/test.sock",
+		make(chan struct{}),
+		logger,
+		1,
+	)
+
+	out := buf.String()
+	if strings.Contains(out, "WARN:") {
+		t.Errorf("unexpected WARN in log output in text mode with flagged logger, got: %q", out)
+	}
+}
 
 // TestStatusRSSReportsActualMemory verifies that Status.RSSUsedMB
 // reports the actual daemon memory (in MB) from runtime.MemStats,


### PR DESCRIPTION
## Summary

- `ARCHIGRAPH_DAEMON_LOG_JSON=1` (PR #2350) emits structured JSON lines via `s.logger.Printf`. If the `log.Logger` was constructed with non-zero flags (e.g. `log.LstdFlags`), a timestamp prefix is prepended, producing `2026/05/27 12:00:00 {...}` — invalid JSON that log shippers silently discard.
- This PR adds a startup guard in `newService`: when JSON mode is active and `logger.Flags() != 0`, a `WARN:` line is written immediately so misconfiguration is caught at daemon start, not discovered later in the shipper.
- A comment block at the `newService` site documents the `log.New(w, "", 0)` requirement for JSON-lines mode.

## Changes (internal/daemon/ only)

- **service.go**: added warning guard in `newService` + doc comment block.
- **service_test.go**: three new tests — warns when flagged+JSON, silent when flags=0+JSON, silent when flagged+text mode.

## Test plan

- [ ] `go test ./internal/daemon/ -run TestNewService_JSONMode_WarnsFlaggedLogger` — PASS, warning emitted
- [ ] `go test ./internal/daemon/ -run TestNewService_JSONMode_NoWarnZeroFlags` — PASS, no warning
- [ ] `go test ./internal/daemon/ -run TestNewService_TextMode_NoWarnFlaggedLogger` — PASS, no warning
- [ ] `go test ./internal/daemon/` — all existing tests still pass

Closes #2353. Long-term slog migration tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)