### PR TITLE
refactor(engine): rename isGitWorkTree→isGitRoot, stamp module on synthetic File entities, add subdirectory test

### DIFF
--- a/internal/engine/commit_coupling_edges.go
+++ b/internal/engine/commit_coupling_edges.go
@@ -92,6 +92,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/module"
 )
 
 // KindCommitCoupled is the relationship kind emitted by this pass.
@@ -197,9 +198,9 @@ func ApplyCommitCoupling(doc *graph.Document, repoPath string, cfg CommitCouplin
 	// Detect git working tree. The check uses `git rev-parse` rather than
 	// stat-ing .git because submodules and git-worktrees use a .git file
 	// (pointing at the real gitdir) instead of a directory.
-	if !isGitWorkTree(repoPath) {
+	if !isGitRoot(repoPath) {
 		stats.Skipped = true
-		stats.SkipReason = "not a git working tree"
+		stats.SkipReason = "not a git root"
 		return stats
 	}
 
@@ -260,17 +261,23 @@ func ApplyCommitCoupling(doc *graph.Document, repoPath string, cfg CommitCouplin
 			continue
 		}
 		existingEntities[fid] = true
+		props := map[string]string{
+			"path":      f,
+			"repo":      doc.Repo,
+			"synthetic": "true",
+			"source":    "commit-coupling",
+		}
+		// Issue #2354 — stamp "module" on every synthetic File entity so these
+		// late-appended nodes satisfy the module-coverage invariant checked by
+		// TestModuleCoverage_AllEntitiesTagged. We pass nil for the MarkerSet;
+		// module.Derive's depth-N fallback is sufficient for file-path rollup.
+		props = module.EnsureModule(props, f, nil)
 		doc.Entities = append(doc.Entities, graph.Entity{
 			ID:         fid,
 			Name:       f,
 			Kind:       KindFile,
 			SourceFile: f,
-			Properties: map[string]string{
-				"path":      f,
-				"repo":      doc.Repo,
-				"synthetic": "true",
-				"source":    "commit-coupling",
-			},
+			Properties: props,
 		})
 		stats.FileEntities++
 	}
@@ -331,7 +338,8 @@ func withDefaults(cfg CommitCouplingConfig) CommitCouplingConfig {
 	return cfg
 }
 
-// isGitWorkTree reports whether repoPath is the root of a git working tree.
+// isGitRoot reports whether repoPath is the root of a git working tree (i.e.
+// the path returned by `git rev-parse --show-toplevel`).
 //
 // Two conditions must both hold:
 //  1. repoPath is inside a git working tree (rev-parse --is-inside-work-tree).
@@ -344,7 +352,7 @@ func withDefaults(cfg CommitCouplingConfig) CommitCouplingConfig {
 // 1000+ commit history from the wrong repo would flood the document with
 // synthetic File entities for every file that has EVER appeared in the parent
 // repo — none of which belong to the indexed fixture. See issue #2334.
-func isGitWorkTree(repoPath string) bool {
+func isGitRoot(repoPath string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -365,7 +373,17 @@ func isGitWorkTree(repoPath string) bool {
 		return false
 	}
 	toplevel := filepath.Clean(strings.TrimSpace(string(topOut)))
-	return filepath.Clean(repoPath) == toplevel
+	// Resolve symlinks on both sides before comparing: on macOS /var is a
+	// symlink to /private/var, so filepath.Clean alone can produce a mismatch
+	// when repoPath was obtained from os.MkdirTemp / t.TempDir. EvalSymlinks
+	// is best-effort; fall back to the cleaned path if it fails.
+	if resolved, err2 := filepath.EvalSymlinks(repoPath); err2 == nil {
+		repoPath = resolved
+	}
+	if resolved, err2 := filepath.EvalSymlinks(toplevel); err2 == nil {
+		toplevel = resolved
+	}
+	return filepath.Clean(repoPath) == filepath.Clean(toplevel)
 }
 
 // commitRecord is one scanned commit's set of files.

--- a/internal/engine/commit_coupling_edges_test.go
+++ b/internal/engine/commit_coupling_edges_test.go
@@ -386,3 +386,100 @@ func TestApplyCommitCoupling_RespectsMinSupport(t *testing.T) {
 		t.Errorf("MinSupport=2 with 3 co-changes must emit 3 edges, got %d", stats2.CoupledEdges)
 	}
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// #2355 / #2356 — isGitRoot + subdirectory failure mode
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestIsGitRoot_SubdirReturnsFalse is the regression test for issue #2351.
+// It creates a real git repo, then verifies:
+//   - isGitRoot(root) == true (the root is the git root)
+//   - isGitRoot(subdir) == false (a subdirectory is NOT the git root)
+//   - ApplyCommitCoupling called with the subdirectory is skipped and emits
+//     no synthetic entities (no cross-contamination from the parent repo).
+func TestIsGitRoot_SubdirReturnsFalse(t *testing.T) {
+	if !gitAvailable(t) {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	makeFixtureRepo(t, root, [][]string{
+		{"a.go", "b.go"},
+		{"a.go", "b.go"},
+		{"a.go", "b.go"},
+		{"a.go", "b.go"},
+		{"a.go", "b.go"},
+	})
+
+	// Root must be recognised as the git root.
+	if !isGitRoot(root) {
+		t.Fatalf("isGitRoot(%q) = false, want true", root)
+	}
+
+	// Create a subdirectory inside the repo.
+	subdir := filepath.Join(root, "subpkg")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+
+	// The subdirectory must NOT be the git root.
+	if isGitRoot(subdir) {
+		t.Fatalf("isGitRoot(%q) = true, want false (subdir is not git root)", subdir)
+	}
+
+	// ApplyCommitCoupling with the subdirectory path must skip entirely and
+	// emit no synthetic entities — the bug that PR #2351 fixed.
+	doc := &graph.Document{Repo: "test"}
+	stats := ApplyCommitCoupling(doc, subdir, DefaultCommitCouplingConfig())
+	if !stats.Skipped {
+		t.Errorf("ApplyCommitCoupling(subdir) should be skipped, got Skipped=false")
+	}
+	if len(doc.Entities) != 0 {
+		t.Errorf("ApplyCommitCoupling(subdir) must not emit entities, got %d", len(doc.Entities))
+	}
+	if len(doc.Relationships) != 0 {
+		t.Errorf("ApplyCommitCoupling(subdir) must not emit relationships, got %d", len(doc.Relationships))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// #2354 — synthetic File entities must have module property stamped
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestApplyCommitCoupling_FileEntitiesHaveModuleProperty verifies that every
+// synthetic File entity emitted by ApplyCommitCoupling carries a non-empty
+// Properties["module"] value. This is the defense-in-depth fix for issue #2354:
+// File entities are appended after the main module-tagging pass in the indexer,
+// so they must stamp themselves.
+func TestApplyCommitCoupling_FileEntitiesHaveModuleProperty(t *testing.T) {
+	if !gitAvailable(t) {
+		t.Skip("git not available")
+	}
+	// Use nested paths so the module rollup produces a non-trivial label.
+	files := []string{"pkg/server/handler.go", "pkg/server/middleware.go", "pkg/client/client.go"}
+	commits := [][]string{
+		files, files, files, files, files, // 5 commits → support=5, above default threshold
+	}
+
+	dir := t.TempDir()
+	makeFixtureRepo(t, dir, commits)
+
+	doc := &graph.Document{Repo: "fixture"}
+	stats := ApplyCommitCoupling(doc, dir, DefaultCommitCouplingConfig())
+	if stats.Skipped {
+		t.Fatalf("expected pass to run, got skipped: %s", stats.SkipReason)
+	}
+	if stats.FileEntities == 0 {
+		t.Fatal("expected synthetic File entities to be emitted")
+	}
+
+	for _, e := range doc.Entities {
+		if e.Kind != KindFile {
+			continue
+		}
+		m := e.Properties["module"]
+		if m == "" {
+			t.Errorf("synthetic File entity %q (path=%q) has empty Properties[\"module\"]",
+				e.ID, e.Properties["path"])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **#2355** Rename `isGitWorkTree` → `isGitRoot` in `internal/engine/commit_coupling_edges.go`. The function verifies the path equals `git rev-parse --show-toplevel`, making "isGitRoot" the accurate name.
- **#2354** Stamp `Properties["module"]` on every synthetic `File` entity created by `ApplyCommitCoupling` via `module.EnsureModule(props, sourceFile, nil)`. These entities are appended after the main module-tagging loop in the indexer, so they must self-stamp. Passing `nil` for `MarkerSet` uses `module.Derive`'s depth-N fallback, which is sufficient for file-path rollup.
- **#2356** Add `TestIsGitRoot_SubdirReturnsFalse` — creates a temp git repo, asserts `isGitRoot(root)==true` and `isGitRoot(subdir)==false`, then verifies `ApplyCommitCoupling` skips and emits no entities when given the subdirectory (regression test for the bug PR #2351 fixed). Add `TestApplyCommitCoupling_FileEntitiesHaveModuleProperty` asserting every emitted File entity has a non-empty `module` key. Also fix a latent symlink comparison bug on macOS (calls `filepath.EvalSymlinks` on both sides before comparing).

Closes #2354
Closes #2355
Closes #2356

## Test plan

- [ ] `go build ./...` green
- [ ] `go test ./internal/engine/...` green (all prior tests + 2 new tests)
- [ ] `go test ./cmd/archigraph/...` green
- [ ] `TestModuleCoverage_AllEntitiesTagged` still passes
- [ ] `TestIsGitRoot_SubdirReturnsFalse` — new, asserts subdir returns false and no entities emitted
- [ ] `TestApplyCommitCoupling_FileEntitiesHaveModuleProperty` — new, asserts module key is non-empty on every File entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)