### PR TITLE
fix(mcp): sort clusters by size before applying limits

### DIFF
--- a/internal/mcp/clusters_cap_2289_test.go
+++ b/internal/mcp/clusters_cap_2289_test.go
@@ -115,3 +115,47 @@ func Test_handleListCommunities_ExplicitLimitHigherThanLen_2289(t *testing.T) {
 		t.Errorf("limit=10 with 2 entities should return 2, got %v", top)
 	}
 }
+
+// Test_handleListCommunities_SortBySize_2319 verifies that communities are
+// sorted by size in descending order before applying min_size and top_entities_limit.
+// This ensures the cap applies to the largest communities, not an arbitrary subset.
+// Issue #2319: without sorting, top_entities_limit=3 would pick 3 communities in
+// iteration order rather than the 3 largest.
+func Test_handleListCommunities_SortBySize_2319(t *testing.T) {
+	doc := &graph.Document{
+		Communities: []graph.CommunityResult{
+			// Provided in unsorted order (sizes 10, 50, 30)
+			{ID: 1, Size: 10, Modularity: 0.5, TopEntities: []string{"a"}},
+			{ID: 2, Size: 50, Modularity: 0.6, TopEntities: []string{"b", "c"}},
+			{ID: 3, Size: 30, Modularity: 0.4, TopEntities: []string{"d", "e", "f"}},
+		},
+	}
+	srv := newTestServerWithDocs(t, map[string]*graph.Document{"r": doc})
+	text := callEndpointToolText(t, srv.handleListCommunities, map[string]any{
+		"group":              "test",
+		"min_size":           20,  // filters out id=1 (size 10)
+		"top_entities_limit": 3,   // default; not a limit on count but per-community
+	})
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(text), &got); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, text)
+	}
+	// Should keep ids 2 (50) and 3 (30), filtered in size descending order.
+	if len(got) != 2 {
+		t.Fatalf("want 2 communities (sizes 50 and 30 >= min_size 20), got %d: %+v", len(got), got)
+	}
+	// First result should be the largest (id=2, size 50)
+	if got[0]["id"].(float64) != 2 {
+		t.Errorf("first community should be id=2 (size 50), got id=%v", got[0]["id"])
+	}
+	if got[0]["size"].(float64) != 50 {
+		t.Errorf("first community size should be 50, got %v", got[0]["size"])
+	}
+	// Second result should be id=3 (size 30)
+	if got[1]["id"].(float64) != 3 {
+		t.Errorf("second community should be id=3 (size 30), got id=%v", got[1]["id"])
+	}
+	if got[1]["size"].(float64) != 30 {
+		t.Errorf("second community size should be 30, got %v", got[1]["size"])
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1227,6 +1227,11 @@ func (s *Server) handleListCommunities(ctx context.Context, req mcpapi.CallToolR
 		if r.Doc == nil {
 			continue
 		}
+		// Sort communities by size descending so top_entities_limit applies to the
+		// largest communities (issue #2319). This ensures deterministic results.
+		sort.SliceStable(r.Doc.Communities, func(i, j int) bool {
+			return r.Doc.Communities[i].Size > r.Doc.Communities[j].Size
+		})
 		for _, c := range r.Doc.Communities {
 			if c.Size < minSize {
 				continue


### PR DESCRIPTION
## Summary
- Adds explicit sort by size (descending) before applying `min_size` filter and `top_entities_limit` cap
- Ensures deterministic results — always returns largest N communities meeting criteria
- Fixes arbitrary iteration-order selection introduced in PR #2310

## Test plan
- [x] All existing tests pass (2289 series)
- [x] New test added: `Test_handleListCommunities_SortBySize_2319` validates sort order
- [x] `go build ./...` passes
- [x] `go test ./internal/mcp/...` passes (all tests)

Closes #2319