### PR TITLE
cleanup(bench): pflag flags + sub-command table + strconv.Itoa

### DIFF
--- a/cmd/archigraph/bench_capture.go
+++ b/cmd/archigraph/bench_capture.go
@@ -13,7 +13,6 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -23,6 +22,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/pflag"
 )
 
 // defaultDaemonLog is the default daemon log path used when --log is not given.
@@ -57,10 +58,10 @@ type BenchCaptureOutput struct {
 	McpRPCPerTool      map[string]*ToolRPCStats `json:"mcp_rpc_per_tool"`
 }
 
-// runBenchCapture is the entry-point for `archigraph bench-capture rpc`.
+// runBenchCaptureRPC is the entry-point for `archigraph bench-capture rpc`.
 // argv is everything after "bench-capture rpc".
-func runBenchCapture(argv []string) error {
-	fs := flag.NewFlagSet("bench-capture rpc", flag.ContinueOnError)
+func runBenchCaptureRPC(argv []string) error {
+	fs := pflag.NewFlagSet("bench-capture rpc", pflag.ContinueOnError)
 	logPath := fs.String("log", defaultDaemonLog, "path to daemon log file")
 	startOff := fs.Int64("start-offset", 0, "byte offset to start reading from (inclusive)")
 	endOff := fs.Int64("end-offset", -1, "byte offset to stop reading at (exclusive); -1 = EOF")
@@ -201,17 +202,25 @@ func parseBenchCapture(data []byte) BenchCaptureOutput {
 	return out
 }
 
+// benchCaptureSubcommands maps subverb names to their handler functions.
+// Adding a new verb (e.g., "tokens") is a simple map entry addition.
+var benchCaptureSubcommands = map[string]func([]string) error{
+	"rpc": runBenchCaptureRPC,
+}
+
 // runBenchCaptureDispatch handles `archigraph bench-capture <subverb> [flags]`.
-// Currently only "rpc" is supported; this wrapper makes it easy to add
-// further subverbs (e.g., "tokens") without changing the top-level dispatch.
+// It looks up the subverb in the subcommand table and delegates.
 func runBenchCaptureDispatch(argv []string) error {
 	if len(argv) == 0 {
 		return fmt.Errorf("usage: archigraph bench-capture <subverb> [flags]\n  subverbs: rpc")
 	}
-	switch argv[0] {
-	case "rpc":
-		return runBenchCapture(argv[1:])
-	default:
-		return fmt.Errorf("unknown bench-capture subverb %q; supported: rpc", argv[0])
+	handler, ok := benchCaptureSubcommands[argv[0]]
+	if !ok {
+		var supported []string
+		for k := range benchCaptureSubcommands {
+			supported = append(supported, k)
+		}
+		return fmt.Errorf("unknown bench-capture subverb %q; supported: %v", argv[0], supported)
 	}
+	return handler(argv[1:])
 }

--- a/cmd/archigraph/bench_capture_test.go
+++ b/cmd/archigraph/bench_capture_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -167,7 +168,7 @@ func TestParseBenchCapture_PercentileKnownFixture(t *testing.T) {
 	// p99 = sorted[ceil(10*0.99)-1] = sorted[ceil(9.9)-1] = sorted[10-1] = sorted[9] = 10.
 	var lines []string
 	for i := 1; i <= 10; i++ {
-		lines = append(lines, "x [mcp-rpc] tool=t elapsed="+intStr(i)+"ms repo=/r")
+		lines = append(lines, "x [mcp-rpc] tool=t elapsed="+strconv.Itoa(i)+"ms repo=/r")
 	}
 	lines = append(lines, "")
 	out := parseBenchCapture([]byte(strings.Join(lines, "\n")))
@@ -287,21 +288,19 @@ func TestRunBenchCapture_MissingFile(t *testing.T) {
 	}
 }
 
-// intStr is a helper used in test fixtures to avoid importing strconv.
-func intStr(n int) string {
-	return strings.TrimLeft(strings.Repeat("0", 10)+itoa(n), "0")
-}
+// TestBenchCaptureRPCHelp verifies that the rpc subcommand is properly registered
+// in the subcommand table and will respond to help requests via cobra/CLI layer.
+func TestBenchCaptureRPCHelp(t *testing.T) {
+	// Verify the subcommand table exists and that "rpc" is registered.
+	// The actual help rendering is tested at the cobra/CLI layer in internal/cli.
+	if _, ok := benchCaptureSubcommands["rpc"]; !ok {
+		t.Fatal("rpc subcommand not registered in benchCaptureSubcommands")
+	}
 
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
+	// Verify all subcommands have a handler function
+	for name, handler := range benchCaptureSubcommands {
+		if handler == nil {
+			t.Errorf("subcommand %q has nil handler", name)
+		}
 	}
-	var buf [20]byte
-	pos := len(buf)
-	for n > 0 {
-		pos--
-		buf[pos] = byte('0' + n%10)
-		n /= 10
-	}
-	return string(buf[pos:])
 }

--- a/internal/cli/bench_capture.go
+++ b/internal/cli/bench_capture.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -14,17 +15,63 @@ import (
 //
 // Surface: `archigraph bench-capture rpc [--log <path>] [--start-offset N] [--end-offset N]`
 //
-// Closes #2298.
+// Closes #2298, #2362, #2363.
 func newBenchCaptureCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:                "bench-capture",
-		Short:              "Capture daemon-log RPC metrics into JSON (bench skill helper)",
-		DisableFlagParsing: true,
-		RunE: func(_ *cobra.Command, args []string) error {
+	cmd := &cobra.Command{
+		Use:   "bench-capture",
+		Short: "Capture daemon-log RPC metrics into JSON (bench skill helper)",
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if activeHooks.RunBenchCapture == nil {
 				return errors.New("bench-capture handler not wired")
 			}
 			return activeHooks.RunBenchCapture(args)
 		},
 	}
+
+	// Add subcommands for rpc
+	cmd.AddCommand(newBenchCaptureRPCCmd())
+
+	return cmd
+}
+
+// newBenchCaptureRPCCmd returns the cobra command for `archigraph bench-capture rpc`.
+func newBenchCaptureRPCCmd() *cobra.Command {
+	var (
+		logPath   string
+		startOff  int64
+		endOff    int64
+	)
+
+	cmd := &cobra.Command{
+		Use:   "rpc",
+		Short: "Capture RPC metrics from daemon log",
+		Long: `Reads a daemon log slice between two byte offsets, parses every
+[mcp-rpc] tool=<X> elapsed=<N>ms line, aggregates counts + handler durations,
+and emits JSON to stdout.
+
+Flags:
+  --log <path>           path to daemon log file (default: ~/.archigraph/logs/daemon.log)
+  --start-offset <N>     byte offset to start reading from (inclusive, default: 0)
+  --end-offset <N>       byte offset to stop reading at (exclusive, default: -1 for EOF)`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if activeHooks.RunBenchCapture == nil {
+				return errors.New("bench-capture handler not wired")
+			}
+			// Construct argv for the handler: ["rpc", "--log", logPath, "--start-offset", ...]
+			argv := []string{"rpc", "--log", logPath, "--start-offset", formatInt64(startOff), "--end-offset", formatInt64(endOff)}
+			return activeHooks.RunBenchCapture(argv)
+		},
+	}
+
+	cmd.Flags().StringVar(&logPath, "log", "~/.archigraph/logs/daemon.log", "path to daemon log file")
+	cmd.Flags().Int64Var(&startOff, "start-offset", 0, "byte offset to start reading from (inclusive)")
+	cmd.Flags().Int64Var(&endOff, "end-offset", -1, "byte offset to stop reading at (exclusive); -1 = EOF")
+
+	return cmd
+}
+
+// formatInt64 converts an int64 to a string for flag passing.
+func formatInt64(n int64) string {
+	return strconv.FormatInt(n, 10)
 }


### PR DESCRIPTION
## Summary

Three related bench-capture polish items:
- **#2361**: Replace `intStr`/`itoa` helpers with `strconv.Itoa` (removes 18 LOC of custom code)
- **#2362**: Migrate `DisableFlagParsing: true` to declared pflag flags; `--help` now renders automatically
- **#2363**: Refactor `runBenchCaptureDispatch` to use a sub-command table for cleaner dispatch; adding new verbs becomes a single map entry

## Files Changed

- `cmd/archigraph/bench_capture.go`: +9 LOC (imports pflag, renames runBenchCapture → runBenchCaptureRPC, adds benchCaptureSubcommands map, refactors dispatch)
- `cmd/archigraph/bench_capture_test.go`: -1 LOC (replaces intStr/itoa with strconv.Itoa, adds TestBenchCaptureRPCHelp)
- `internal/cli/bench_capture.go`: +47 LOC (removes DisableFlagParsing, adds newBenchCaptureRPCCmd with declared Flags)

## Test Results

- All 10 existing bench-capture tests pass
- New TestBenchCaptureRPCHelp verifies sub-command registration
- `--help` output confirms flags are now discoverable
- `go build ./...` clean
- `go test ./cmd/archigraph -run BenchCapture` all pass

## Sample Help Output

\`\`\`
$ archigraph bench-capture rpc --help
...
Flags:
      --end-offset int     byte offset to stop reading at (exclusive); -1 = EOF (default -1)
  -h, --help               help for rpc
      --log string         path to daemon log file (default "~/.archigraph/logs/daemon.log")
      --start-offset int   byte offset to start reading from (inclusive)
\`\`\`

## Tech Debt Surfaced

None observed. Code is cleaner after refactor.

---
Generated with Claude Code