### PR TITLE
fix(extractor): add TagEntitiesLanguage helper parallel to TagRelationshipsLanguage

### DIFF
--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -131,6 +131,41 @@ func FileEntity(file FileInput) types.EntityRecord {
 	}
 }
 
+// TagEntitiesLanguage stamps Language = lang and Properties["language"] = lang
+// on every entity in records. It is the symmetric counterpart of
+// TagRelationshipsLanguage for entities (issue #2371).
+//
+// Both fields are set so that consumers that read EntityRecord.Language and
+// consumers that consult Properties["language"] (e.g. the resolver's
+// per-language dynamic-pattern dispatch — the tunnel introduced in PR #2365)
+// see a consistent value.
+//
+// Entities that already carry a non-empty Language are left untouched so that
+// explicit per-extractor overrides (e.g. a dialect variant) are preserved.
+// Properties maps are allocated lazily. No-op when lang is empty.
+func TagEntitiesLanguage(records []types.EntityRecord, lang string) {
+	if lang == "" {
+		return
+	}
+	for i := range records {
+		e := &records[i]
+		// If the entity already carries an explicit language assignment, leave
+		// both Language and Properties["language"] untouched so per-extractor
+		// dialect overrides are preserved.
+		if e.Language != "" {
+			continue
+		}
+		e.Language = lang
+		if e.Properties == nil {
+			e.Properties = map[string]string{"language": lang}
+			continue
+		}
+		if _, ok := e.Properties["language"]; !ok {
+			e.Properties["language"] = lang
+		}
+	}
+}
+
 // TagStandaloneRelationshipsLanguage is TagRelationshipsLanguage for a slice
 // of standalone (pass-2) relationships rather than entity-embedded ones.
 func TagStandaloneRelationshipsLanguage(rels []types.RelationshipRecord, lang string) {

--- a/internal/extractor/tag_entities_language_test.go
+++ b/internal/extractor/tag_entities_language_test.go
@@ -1,0 +1,96 @@
+package extractor
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// TestTagEntitiesLanguage verifies the parallel-to-TagRelationshipsLanguage
+// helper introduced in issue #2371.
+func TestTagEntitiesLanguage(t *testing.T) {
+	t.Run("sets Language and Properties language on each entity", func(t *testing.T) {
+		records := []types.EntityRecord{
+			{Name: "A", Kind: "SCOPE.Operation", SourceFile: "a.py"},
+			{Name: "B", Kind: "SCOPE.Operation", SourceFile: "b.py"},
+		}
+		TagEntitiesLanguage(records, "python")
+		for _, r := range records {
+			if r.Language != "python" {
+				t.Errorf("entity %q: Language = %q, want %q", r.Name, r.Language, "python")
+			}
+			if got := r.Properties["language"]; got != "python" {
+				t.Errorf("entity %q: Properties[language] = %q, want %q", r.Name, got, "python")
+			}
+		}
+	})
+
+	t.Run("no-op when entity already has non-empty Language", func(t *testing.T) {
+		records := []types.EntityRecord{
+			{Name: "A", Kind: "SCOPE.Operation", SourceFile: "a.py", Language: "go"},
+		}
+		TagEntitiesLanguage(records, "python")
+		if records[0].Language != "go" {
+			t.Errorf("Language should be preserved: got %q, want %q", records[0].Language, "go")
+		}
+		// When Language is already set, Properties must remain nil (entire entity is skipped).
+		if records[0].Properties != nil {
+			t.Errorf("Properties should remain nil when Language is already set, got %v", records[0].Properties)
+		}
+	})
+
+	t.Run("no-op when lang is empty string", func(t *testing.T) {
+		records := []types.EntityRecord{
+			{Name: "A", Kind: "SCOPE.Operation", SourceFile: "a.py"},
+		}
+		TagEntitiesLanguage(records, "")
+		if records[0].Language != "" {
+			t.Errorf("Language should remain empty, got %q", records[0].Language)
+		}
+		if records[0].Properties != nil {
+			t.Errorf("Properties should remain nil, got %v", records[0].Properties)
+		}
+	})
+
+	t.Run("empty input slice is a no-op", func(t *testing.T) {
+		// Should not panic.
+		TagEntitiesLanguage(nil, "python")
+		TagEntitiesLanguage([]types.EntityRecord{}, "python")
+	})
+
+	t.Run("allocates Properties map lazily", func(t *testing.T) {
+		records := []types.EntityRecord{
+			{Name: "A", Kind: "SCOPE.Operation", SourceFile: "a.py"},
+		}
+		if records[0].Properties != nil {
+			t.Fatal("precondition: Properties must be nil before tagging")
+		}
+		TagEntitiesLanguage(records, "rust")
+		if records[0].Properties == nil {
+			t.Fatal("Properties should be allocated after tagging")
+		}
+		if got := records[0].Properties["language"]; got != "rust" {
+			t.Errorf("Properties[language] = %q, want %q", got, "rust")
+		}
+	})
+
+	t.Run("preserves existing Properties language override", func(t *testing.T) {
+		records := []types.EntityRecord{
+			{
+				Name:       "A",
+				Kind:       "SCOPE.Operation",
+				SourceFile: "a.py",
+				Properties: map[string]string{"language": "dialect-python"},
+			},
+		}
+		TagEntitiesLanguage(records, "python")
+		// Language field was empty, so it gets set.
+		if records[0].Language != "python" {
+			t.Errorf("Language = %q, want python", records[0].Language)
+		}
+		// Existing Properties["language"] must be preserved.
+		if got := records[0].Properties["language"]; got != "dialect-python" {
+			t.Errorf("Properties[language] = %q, want dialect-python", got)
+		}
+	})
+}

--- a/internal/extractors/clojure/clojure.go
+++ b/internal/extractors/clojure/clojure.go
@@ -112,6 +112,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractClojure(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "clojure")
+	extractor.TagEntitiesLanguage(out, "clojure")
 	return out, nil
 }
 

--- a/internal/extractors/cpp/extractor.go
+++ b/internal/extractors/cpp/extractor.go
@@ -138,6 +138,7 @@ func (e *CppExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 	)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(records, lang)
+	extractor.TagEntitiesLanguage(records, lang)
 	return records, nil
 }
 

--- a/internal/extractors/crystal/extractor.go
+++ b/internal/extractors/crystal/extractor.go
@@ -120,6 +120,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractCrystal(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "crystal")
+	extractor.TagEntitiesLanguage(out, "crystal")
 	return out, nil
 }
 

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -71,6 +71,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	walk(root, file, "", nil, imports, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "csharp")
+	extractor.TagEntitiesLanguage(entities, "csharp")
 	return entities, nil
 }
 

--- a/internal/extractors/css/css.go
+++ b/internal/extractors/css/css.go
@@ -76,11 +76,13 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 			lang = "sass"
 		}
 		extractor.TagRelationshipsLanguage(entities, lang)
+		extractor.TagEntitiesLanguage(entities, lang)
 		return entities, nil
 	case ".less":
 		var entities []types.EntityRecord
 		ExtractLess(ctx, file, &entities)
 		extractor.TagRelationshipsLanguage(entities, "less")
+		extractor.TagEntitiesLanguage(entities, "less")
 		return entities, nil
 	default:
 		// Plain CSS: tree-sitter parse required.
@@ -91,6 +93,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		root := file.Tree.RootNode()
 		extractCSS(root, file, &entities)
 		extractor.TagRelationshipsLanguage(entities, "css")
+		extractor.TagEntitiesLanguage(entities, "css")
 		return entities, nil
 	}
 }

--- a/internal/extractors/dart/dart.go
+++ b/internal/extractors/dart/dart.go
@@ -114,6 +114,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	out := extractDart(string(file.Content), file.Path)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(out, "dart")
+	extractor.TagEntitiesLanguage(out, "dart")
 	return out, nil
 }
 

--- a/internal/extractors/dockerfile/dockerfile.go
+++ b/internal/extractors/dockerfile/dockerfile.go
@@ -75,7 +75,12 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	entity, stageCount := buildDockerfileEntity(tree.RootNode(), file)
 
 	// Issue #384 — language tag for resolver dynamic-pattern dispatch.
-	extractor.TagRelationshipsLanguage([]types.EntityRecord{entity}, "dockerfile")
+	// Issue #2371 — entity language tag via named slice so both entity and
+	// relationship language fields are stamped on the actual entity value.
+	entities := []types.EntityRecord{entity}
+	extractor.TagRelationshipsLanguage(entities, "dockerfile")
+	extractor.TagEntitiesLanguage(entities, "dockerfile")
+	entity = entities[0]
 
 	span.SetAttributes(
 		attribute.Int("file_line_count", lineCount),

--- a/internal/extractors/elixir/elixir.go
+++ b/internal/extractors/elixir/elixir.go
@@ -67,6 +67,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	walkNode(file.Tree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "elixir")
+	extractor.TagEntitiesLanguage(entities, "elixir")
 	return entities, nil
 }
 

--- a/internal/extractors/elm/extractor.go
+++ b/internal/extractors/elm/extractor.go
@@ -118,6 +118,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractElm(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "elm")
+	extractor.TagEntitiesLanguage(out, "elm")
 	return out, nil
 }
 

--- a/internal/extractors/erlang/extractor.go
+++ b/internal/extractors/erlang/extractor.go
@@ -122,6 +122,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractErlang(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "erlang")
+	extractor.TagEntitiesLanguage(out, "erlang")
 	return out, nil
 }
 

--- a/internal/extractors/fish/fish.go
+++ b/internal/extractors/fish/fish.go
@@ -190,6 +190,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "fish")
+	extractor.TagEntitiesLanguage(entities, "fish")
 	return entities, nil
 }
 

--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -121,6 +121,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractFSharp(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "fsharp")
+	extractor.TagEntitiesLanguage(out, "fsharp")
 	return out, nil
 }
 

--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -213,6 +213,7 @@ func (g *GoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]
 	// Issue #90 — stamp Properties["language"]="go" so the resolver's
 	// per-language dynamic-pattern dispatch picks the Go catalog.
 	extractor.TagRelationshipsLanguage(records, "go")
+	extractor.TagEntitiesLanguage(records, "go")
 
 	return records, nil
 }

--- a/internal/extractors/graphql/graphql.go
+++ b/internal/extractors/graphql/graphql.go
@@ -96,6 +96,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	entities := extractGraphQL(string(file.Content), file.Path)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "graphql")
+	extractor.TagEntitiesLanguage(entities, "graphql")
 	return entities, nil
 }
 

--- a/internal/extractors/groovy/groovy.go
+++ b/internal/extractors/groovy/groovy.go
@@ -64,6 +64,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	walkGroovy(root, file, imports, &entities)
 	// Issue #90 — tag every relationship with language="groovy".
 	extractor.TagRelationshipsLanguage(entities, "groovy")
+	extractor.TagEntitiesLanguage(entities, "groovy")
 	return entities, nil
 }
 

--- a/internal/extractors/haskell/extractor.go
+++ b/internal/extractors/haskell/extractor.go
@@ -134,6 +134,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractHaskell(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "haskell")
+	extractor.TagEntitiesLanguage(out, "haskell")
 	return out, nil
 }
 

--- a/internal/extractors/idris/extractor.go
+++ b/internal/extractors/idris/extractor.go
@@ -125,6 +125,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractIdris(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "idris")
+	extractor.TagEntitiesLanguage(out, "idris")
 	return out, nil
 }
 

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -152,6 +152,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// Issue #90 — tag every embedded relationship with language="java" so
 	// the resolver routes to the JVM dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "java")
+	extractor.TagEntitiesLanguage(entities, "java")
 	return entities, nil
 }
 

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -277,6 +277,7 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 	// "typescript") on every embedded relationship so the resolver routes
 	// to the right per-language dynamic-pattern catalog.
 	extreg.TagRelationshipsLanguage(x.entities, file.Language)
+	extreg.TagEntitiesLanguage(x.entities, file.Language)
 
 	return x.entities, nil
 }

--- a/internal/extractors/just/just.go
+++ b/internal/extractors/just/just.go
@@ -291,6 +291,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "just")
+	extractor.TagEntitiesLanguage(entities, "just")
 	return entities, nil
 }
 

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -84,6 +84,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "kotlin")
+	extractor.TagEntitiesLanguage(entities, "kotlin")
 	return entities, nil
 }
 

--- a/internal/extractors/lisp/extractor.go
+++ b/internal/extractors/lisp/extractor.go
@@ -202,6 +202,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	dialect := dialectFromPath(file.Path)
 	out := extractLisp(string(file.Content), file.Path, dialect)
 	extractor.TagRelationshipsLanguage(out, dialect)
+	extractor.TagEntitiesLanguage(out, dialect)
 	return out, nil
 }
 

--- a/internal/extractors/lua/lua.go
+++ b/internal/extractors/lua/lua.go
@@ -97,6 +97,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "lua")
+	extractor.TagEntitiesLanguage(entities, "lua")
 	return entities, nil
 }
 

--- a/internal/extractors/nim/nim.go
+++ b/internal/extractors/nim/nim.go
@@ -109,6 +109,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractNim(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "nim")
+	extractor.TagEntitiesLanguage(out, "nim")
 	return out, nil
 }
 

--- a/internal/extractors/ocaml/extractor.go
+++ b/internal/extractors/ocaml/extractor.go
@@ -117,6 +117,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractOCaml(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "ocaml")
+	extractor.TagEntitiesLanguage(out, "ocaml")
 	return out, nil
 }
 

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -54,6 +54,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	walk(file.Tree.RootNode(), file, "", &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "php")
+	extractor.TagEntitiesLanguage(entities, "php")
 	return entities, nil
 }
 

--- a/internal/extractors/pony/extractor.go
+++ b/internal/extractors/pony/extractor.go
@@ -128,6 +128,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractPony(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "pony")
+	extractor.TagEntitiesLanguage(out, "pony")
 	return out, nil
 }
 

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -143,6 +143,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 			attribute.Bool("django_migration_pruned", true),
 		)
 		extractor.TagRelationshipsLanguage(entities, "python")
+		extractor.TagEntitiesLanguage(entities, "python")
 		return entities, nil
 	}
 
@@ -450,6 +451,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// picks the python catalog instead of falling back to the cross-language
 	// one. Existing tags are preserved.
 	extractor.TagRelationshipsLanguage(entities, "python")
+	extractor.TagEntitiesLanguage(entities, "python")
 	return entities, nil
 }
 

--- a/internal/extractors/python/tag_entities_language_integration_test.go
+++ b/internal/extractors/python/tag_entities_language_integration_test.go
@@ -1,0 +1,72 @@
+package python_test
+
+// Integration test for issue #2371: verify that TagEntitiesLanguage is called
+// by the python extractor so all returned entities have Language="python".
+// Before the fix, Language="" was emitted on entities (PR #2365 / issue #2341
+// root cause).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/python"
+)
+
+func TestIssue2371_AllEntitiesHaveLanguage_Python(t *testing.T) {
+	src := `
+class MyView:
+    def get(self, request):
+        return None
+
+def helper():
+    pass
+`
+	recs := extractPy(t, src, "myapp/views.py")
+	if len(recs) == 0 {
+		t.Fatal("expected at least one entity from extraction")
+	}
+	for _, r := range recs {
+		if r.Language != "python" {
+			t.Errorf("entity %q (kind=%s, src=%s): Language=%q, want %q",
+				r.Name, r.Kind, r.SourceFile, r.Language, "python")
+		}
+		if r.Properties != nil {
+			if got := r.Properties["language"]; got != "" && got != "python" {
+				t.Errorf("entity %q: Properties[language]=%q, want python or empty", r.Name, got)
+			}
+		}
+	}
+}
+
+// TestIssue2371_AllEntitiesHaveLanguage_Django verifies the Django-specific
+// path through the python extractor also stamps Language on entities.
+func TestIssue2371_AllEntitiesHaveLanguage_DjangoModel(t *testing.T) {
+	src := `
+from django.db import models
+
+class Article(models.Model):
+    title = models.CharField(max_length=200)
+    body = models.TextField()
+`
+	tree := parse(t, []byte(src))
+	ext, ok := extractor.Get("python")
+	if !ok {
+		t.Fatal("python extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "blog/models.py",
+		Content:  []byte(src),
+		Language: "python",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	for _, r := range recs {
+		if r.Language != "python" {
+			t.Errorf("entity %q (kind=%s): Language=%q, want python",
+				r.Name, r.Kind, r.Language)
+		}
+	}
+}

--- a/internal/extractors/reasonml/extractor.go
+++ b/internal/extractors/reasonml/extractor.go
@@ -102,6 +102,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractReasonML(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "reasonml")
+	extractor.TagEntitiesLanguage(out, "reasonml")
 	return out, nil
 }
 

--- a/internal/extractors/rescript/extractor.go
+++ b/internal/extractors/rescript/extractor.go
@@ -125,6 +125,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractReScript(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "rescript")
+	extractor.TagEntitiesLanguage(out, "rescript")
 	return out, nil
 }
 

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -46,6 +46,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// Issue #90 — tag every embedded relationship with the source language
 	// so the resolver picks the Ruby dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "ruby")
+	extractor.TagEntitiesLanguage(entities, "ruby")
 	return entities, nil
 }
 

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -47,6 +47,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	walk(file.Tree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "rust")
+	extractor.TagEntitiesLanguage(entities, "rust")
 	return entities, nil
 }
 

--- a/internal/extractors/scala/scala.go
+++ b/internal/extractors/scala/scala.go
@@ -76,6 +76,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	walkNode(file.Tree.RootNode(), file, nil, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "scala")
+	extractor.TagEntitiesLanguage(entities, "scala")
 	return entities, nil
 }
 

--- a/internal/extractors/shell/shell.go
+++ b/internal/extractors/shell/shell.go
@@ -86,6 +86,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "shell")
+	extractor.TagEntitiesLanguage(entities, "shell")
 	return entities, nil
 }
 

--- a/internal/extractors/sml/extractor.go
+++ b/internal/extractors/sml/extractor.go
@@ -136,6 +136,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractSML(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "sml")
+	extractor.TagEntitiesLanguage(out, "sml")
 	return out, nil
 }
 

--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -111,6 +111,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractSolidity(string(file.Content), file.Path)
 	extractor.TagRelationshipsLanguage(out, "solidity")
+	extractor.TagEntitiesLanguage(out, "solidity")
 	return out, nil
 }
 

--- a/internal/extractors/swift/package.go
+++ b/internal/extractors/swift/package.go
@@ -58,6 +58,7 @@ func (p *PackageExtractor) Extract(_ context.Context, file extractor.FileInput) 
 	src := string(file.Content)
 	targets := extractTargets(src, file.Path)
 	extractor.TagRelationshipsLanguage(targets, "swift_package")
+	extractor.TagEntitiesLanguage(targets, "swift_package")
 	return targets, nil
 }
 

--- a/internal/extractors/swift/swift.go
+++ b/internal/extractors/swift/swift.go
@@ -66,6 +66,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	walkNode(file.Tree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "swift")
+	extractor.TagEntitiesLanguage(entities, "swift")
 	return entities, nil
 }
 

--- a/internal/extractors/verilog/extractor.go
+++ b/internal/extractors/verilog/extractor.go
@@ -196,6 +196,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractVerilog(string(file.Content), file.Path, lang)
 	extractor.TagRelationshipsLanguage(out, lang)
+	extractor.TagEntitiesLanguage(out, lang)
 	return out, nil
 }
 

--- a/internal/extractors/vhdl/extractor.go
+++ b/internal/extractors/vhdl/extractor.go
@@ -168,6 +168,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	out := extractVHDL(string(file.Content), file.Path, lang)
 	extractor.TagRelationshipsLanguage(out, lang)
+	extractor.TagEntitiesLanguage(out, lang)
 	return out, nil
 }
 

--- a/internal/extractors/vue/extractor.go
+++ b/internal/extractors/vue/extractor.go
@@ -255,6 +255,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (enti
 
 	// --- 5. Tag relationships with language ----------------------------------
 	extractor.TagRelationshipsLanguage(entities, "vue")
+	extractor.TagEntitiesLanguage(entities, "vue")
 
 	return entities, nil
 }

--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -277,6 +277,7 @@ func extractByFlavor(flavor string, root *sitter.Node, file extractor.FileInput)
 	// Issue #386 / #90: stamp Properties["language"]="yaml" on every embedded
 	// relationship so the resolver dispatches the YAML dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "yaml")
+	extractor.TagEntitiesLanguage(entities, "yaml")
 	return entities
 }
 

--- a/internal/extractors/zig/zig.go
+++ b/internal/extractors/zig/zig.go
@@ -106,6 +106,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	out := extractZig(string(file.Content), file.Path)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(out, "zig")
+	extractor.TagEntitiesLanguage(out, "zig")
 	return out, nil
 }
 


### PR DESCRIPTION
## Summary

- Adds `TagEntitiesLanguage(records []types.EntityRecord, lang string)` to `internal/extractor/extractor.go` as a symmetric counterpart to `TagRelationshipsLanguage`
- Wires the new helper at all 46 `TagRelationshipsLanguage` call sites across 44 language extractors — sets both `entity.Language` and `Properties["language"]` on every entity
- Fixes a latent bug in `dockerfile.go` where `TagRelationshipsLanguage` was called with a temporary value-type copy, meaning relationship mutations were discarded

Closes #2371

## What changed

`TagEntitiesLanguage` stamps `Language = lang` AND `Properties["language"] = lang` on each entity. Entities that already carry a non-empty `Language` are skipped (explicit overrides win). Properties maps are allocated lazily. No-op when `lang` is empty.

The `dockerfile` extractor was using `extractor.TagRelationshipsLanguage([]types.EntityRecord{entity}, "dockerfile")` — this passed a throw-away copy, so the real `entity` value was never mutated for relationships. This PR switches to a named slice so both helpers operate on the actual value.

## Test plan

- [ ] New unit test `TestTagEntitiesLanguage` in `internal/extractor/tag_entities_language_test.go` — 6 subtests covering: sets both fields, no-op on already-set Language, no-op on empty lang, empty input, lazy Properties allocation, existing Properties override preserved
- [ ] New integration tests `TestIssue2371_AllEntitiesHaveLanguage_Python` and `TestIssue2371_AllEntitiesHaveLanguage_DjangoModel` in `internal/extractors/python/` — assert all entities have `Language="python"` post-extraction
- [ ] All existing extractor tests pass (`go test ./internal/extractor/... ./internal/extractors/...` — 0 failures)
- [ ] `warnEmptyLanguageEntities` sanity-check tests (`TestWarnEmptyLanguageEntities`, `TestWarnEmptyLanguageEntities_NoBadEntities`) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)