### PR TITLE
Always log foldFileComponentDuplicates observed+folded counts

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -2862,6 +2862,9 @@ func (i *Indexer) foldClassHierarchyShadows(
 
 // foldFileComponentStats reports the result of foldFileComponentDuplicates.
 type foldFileComponentStats struct {
+	// Observed is the number of SCOPE.Component class-like nodes examined as
+	// candidates for folding.
+	Observed int
 	// Folded is the number of SCOPE.Component class-like nodes collapsed into
 	// their co-located SCOPE.Component(subtype="file") sibling.
 	Folded int
@@ -2950,6 +2953,8 @@ func (i *Indexer) foldFileComponentDuplicates(
 		if !ok {
 			continue
 		}
+		// Count this as an observed candidate for folding.
+		stats.Observed++
 		// Anti-over-fold: only absorb if the class entity's name matches
 		// the file stem (case-insensitive). This ensures a class named
 		// "LoginPage" in "LoginPage.tsx" is folded, but a helper class
@@ -3296,11 +3301,9 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	if os.Getenv("ARCHIGRAPH_DISABLE_1727_FILE_FOLD") == "" {
 		var fileStats foldFileComponentStats
 		merged, pass2Rels, fileStats = i.foldFileComponentDuplicates(merged, pass2Rels)
-		if fileStats.Folded > 0 {
-			fmt.Fprintf(os.Stderr,
-				"file-component-fold: folded=%d (edges_repointed=%d)\n",
-				fileStats.Folded, fileStats.EdgesRepointed)
-		}
+		fmt.Fprintf(os.Stderr,
+			"foldFileComponentDuplicates: observed=%d folded=%d (edges_repointed=%d)\n",
+			fileStats.Observed, fileStats.Folded, fileStats.EdgesRepointed)
 	}
 
 	// Pass 3.7 — Bazel resolver overlay (#2183 / M6).


### PR DESCRIPTION
Closes #2340

## Summary
- Always log `foldFileComponentDuplicates: observed=N folded=M` after the pass runs, even when nothing is folded
- Added `Observed` field to `foldFileComponentStats` to track candidates examined
- Changed conditional logging to unconditional, making both "ran but nothing to do" and "didn't run" states visible

## Testing
- `go build ./...` succeeds
- `go test ./cmd/archigraph/...` passes (all tests green)
- Log output confirmed across multiple test cases:
  - When folding occurs: `observed=2 folded=2`
  - When candidates exist but don't match: `observed=2 folded=0`
  - When no candidates: `observed=0 folded=0`