### PR TITLE
fix(engine): bridge file_conventions glob to source-pattern entities via property

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -203,6 +203,19 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	seenEntities := make(map[string]bool)
 
 	for _, cs := range sets {
+		// Precompute all file_convention globs that match this file (for this
+		// ruleset). This is evaluated once per (ruleset, file) pair — O(conventions)
+		// — and reused for every source-pattern entity emitted below, so there is
+		// no per-entity re-scan. The result is the comma-joined glob string used to
+		// annotate source-pattern entities (bridge for issue #2383).
+		var matchedConventionGlobs []string
+		for _, fc := range cs.fileConventions {
+			if fc.matchesFile(file.Path) {
+				matchedConventionGlobs = append(matchedConventionGlobs, fc.glob)
+			}
+		}
+		conventionAnnotation := strings.Join(matchedConventionGlobs, ",")
+
 		// Extract entities from source patterns.
 		// Issue #1413 — use FindAllStringSubmatchIndex so we have byte offsets
 		// for computing StartLine. Also derives QualifiedName for Python entities.
@@ -245,6 +258,19 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 					}
 				}
 
+				props := map[string]string{
+					"framework":    sp.framework,
+					"pattern_type": "yaml_driven",
+				}
+				// Bridge #2383: when a file_convention glob also matches this file,
+				// annotate the source-pattern entity so queries can find "all entities
+				// from convention Y" or "entities identified by both rule X and convention Y".
+				// Convention-derived entities (pattern_type=file_convention) already
+				// encode their origin; this annotation is for source-pattern entities only.
+				if conventionAnnotation != "" {
+					props["file_convention"] = conventionAnnotation
+				}
+
 				entity := types.EntityRecord{
 					Name:          name,
 					QualifiedName: qn,
@@ -252,10 +278,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 					SourceFile:    file.Path,
 					Language:      file.Language,
 					StartLine:     startLine,
-					Properties: map[string]string{
-						"framework":    sp.framework,
-						"pattern_type": "yaml_driven",
-					},
+					Properties:    props,
 					EnrichmentRequired: isComplexEntity(sp.entityType),
 					EnrichmentStatus:   types.StatusPending,
 					QualityScore:       0.5,

--- a/internal/engine/file_conventions_test.go
+++ b/internal/engine/file_conventions_test.go
@@ -284,6 +284,146 @@ func TestDetector_FileConvention_PatternType(t *testing.T) {
 // Integration: django.yaml embedded rules load and contain Migration convention
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Integration: bridge #2383 — file_convention property on source-pattern entities
+// ---------------------------------------------------------------------------
+
+// bridgeConventionYAML defines a rule set with BOTH a file_convention (class_name)
+// and source_patterns — the combination that #2383 targets.
+const bridgeConventionYAML = `
+file_conventions:
+  - glob: "*/migrations/0*.py"
+    entity_type: Migration
+    name_from: class_name
+source_patterns:
+  - pattern: "class (\\w+Migration)\\b"
+    entity_type: Migration
+    name_group: 1
+relationship_rules: []
+`
+
+// bridgeTwoConventionsYAML exercises the multi-convention comma-join path.
+const bridgeTwoConventionsYAML = `
+file_conventions:
+  - glob: "*/migrations/0*.py"
+    entity_type: Migration
+    name_from: class_name
+  - glob: "*/migrations/*.py"
+    entity_type: Migration
+    name_from: class_name
+source_patterns:
+  - pattern: "class (\\w+Migration)\\b"
+    entity_type: Migration
+    name_group: 1
+relationship_rules: []
+`
+
+// TestDetector_Bridge_FileConvention_AnnotatesSourcePatternEntities verifies that
+// a source-pattern entity emitted for a file that ALSO matches a file_convention
+// glob (name_from=class_name) carries Properties["file_convention"] = <glob>.
+func TestDetector_Bridge_FileConvention_AnnotatesSourcePatternEntities(t *testing.T) {
+	fsys := fstest.MapFS{
+		"rules/python/frameworks/test_bridge.yaml": &fstest.MapFile{
+			Data: []byte(bridgeConventionYAML),
+		},
+	}
+	rules, err := LoadAllRulesFromFS(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFS: %v", err)
+	}
+
+	det := New(rules)
+	ctx := context.Background()
+
+	t.Run("matching file: source-pattern entity carries file_convention property", func(t *testing.T) {
+		result, err := det.Detect(ctx, extractor.FileInput{
+			Path:     "core/migrations/0042_add_device.py",
+			Language: "python",
+			Content:  []byte("class AddDeviceMigration(Migration):\n    pass\n"),
+		})
+		if err != nil {
+			t.Fatalf("Detect: %v", err)
+		}
+
+		found := false
+		for _, e := range result.Entities {
+			if e.Kind == "Migration" && e.Properties["pattern_type"] == "yaml_driven" {
+				found = true
+				got := e.Properties["file_convention"]
+				if got != "*/migrations/0*.py" {
+					t.Errorf("file_convention property: want %q, got %q", "*/migrations/0*.py", got)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("no yaml_driven Migration entity found; entities: %+v", result.Entities)
+		}
+	})
+
+	t.Run("non-matching file: source-pattern entities have no file_convention property", func(t *testing.T) {
+		result, err := det.Detect(ctx, extractor.FileInput{
+			Path:     "core/models.py",
+			Language: "python",
+			Content:  []byte("class UserMigration(Migration):\n    pass\n"),
+		})
+		if err != nil {
+			t.Fatalf("Detect: %v", err)
+		}
+
+		for _, e := range result.Entities {
+			if e.Properties["pattern_type"] == "yaml_driven" {
+				if v, ok := e.Properties["file_convention"]; ok {
+					t.Errorf("unexpected file_convention=%q on entity from non-matching file: %+v", v, e)
+				}
+			}
+		}
+	})
+}
+
+// TestDetector_Bridge_MultipleConventions_CommaJoined verifies that when a file
+// matches multiple file_convention globs, the file_convention property on source-
+// pattern entities is a comma-joined string of all matched globs.
+func TestDetector_Bridge_MultipleConventions_CommaJoined(t *testing.T) {
+	fsys := fstest.MapFS{
+		"rules/python/frameworks/test_bridge_multi.yaml": &fstest.MapFile{
+			Data: []byte(bridgeTwoConventionsYAML),
+		},
+	}
+	rules, err := LoadAllRulesFromFS(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFS: %v", err)
+	}
+
+	det := New(rules)
+	ctx := context.Background()
+
+	result, err := det.Detect(ctx, extractor.FileInput{
+		Path:     "app/migrations/0001_initial.py",
+		Language: "python",
+		Content:  []byte("class InitialMigration(Migration):\n    pass\n"),
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	for _, e := range result.Entities {
+		if e.Kind == "Migration" && e.Properties["pattern_type"] == "yaml_driven" {
+			got := e.Properties["file_convention"]
+			// Both globs match; expect comma-joined in definition order.
+			want := "*/migrations/0*.py,*/migrations/*.py"
+			if got != want {
+				t.Errorf("file_convention (multi): want %q, got %q", want, got)
+			}
+			return
+		}
+	}
+	t.Fatalf("no yaml_driven Migration entity found; entities: %+v", result.Entities)
+}
+
+// ---------------------------------------------------------------------------
+// Integration: django.yaml embedded rules load and contain Migration convention
+// ---------------------------------------------------------------------------
+
 // TestDjangoYAML_HasMigrationConvention verifies that the embedded
 // django.yaml actually contains the Migration file_convention with the
 // correct glob/entity_type/name_from — confirming the YAML fields are


### PR DESCRIPTION
## Summary

- Closes #2383
- PR #2382 (#2348) wired YAML `file_conventions` dispatch but `name_from=class_name` (used on 9 of 11 entries in `django.yaml`) was informational only — the detector made no link between source-pattern entities and the convention glob that also matched the file.
- Sets `Properties["file_convention"] = <glob>` on source-pattern entities when a file_convention glob matches the same file. Convention-derived entities already carry `pattern_type=file_convention`; this annotation bridges source-pattern entities only.
- Multiple matching globs are comma-joined: `"*/migrations/0*.py,*/migrations/*.py"`.

## Dispatch site changed

`internal/engine/detector.go` — inside the `for _, cs := range sets` loop, before the source-pattern sub-loop. Precomputes `matchedConventionGlobs []string` once per (ruleset, file) pair in O(conventions), then annotates each emitted source-pattern entity.

## Test plan

- [x] `TestDetector_Bridge_FileConvention_AnnotatesSourcePatternEntities/matching_file` — file matching `*/migrations/0*.py` AND triggering source-pattern → class entity carries `Properties["file_convention"] = "*/migrations/0*.py"`
- [x] `TestDetector_Bridge_FileConvention_AnnotatesSourcePatternEntities/non-matching_file` — file not matching any convention → no `file_convention` property on source-pattern entities
- [x] `TestDetector_Bridge_MultipleConventions_CommaJoined` — file matching two globs → `file_convention` is comma-joined in definition order
- [x] All pre-existing `internal/engine/...` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)