### PR TITLE
refactor(mcp): PaginationOpts.FromRequest builder internalizes format resolution

### DIFF
--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -319,18 +319,32 @@ type PaginationOpts struct {
 	Method       string
 }
 
-// paginationOptsFromReq extracts the standard pagination and filter arguments
-// from an MCP CallToolRequest into a PaginationOpts. The verbose flag is passed
-// separately because callers may have already resolved format="terse"|"full"
-// precedence before calling this function.
-func paginationOptsFromReq(req mcpapi.CallToolRequest, verbose bool, pathContains, method string) PaginationOpts {
+// Format returns the canonical format label ("full" or "terse") for this opts.
+func (o PaginationOpts) Format() string { return formatLabel(o.Verbose) }
+
+// FromRequest builds a fully-populated PaginationOpts from an MCP
+// CallToolRequest. Format-precedence resolution is internalised here so callers
+// need not thread verbose/pathContains/method as explicit params:
+//
+//   - format="full"  → Verbose=true  (takes precedence over verbose bool)
+//   - format="terse" → Verbose=false (takes precedence over verbose bool)
+//   - format unset   → Verbose=argBool(req,"verbose",false)
+//   - path_contains and method are read and normalised (lower/upper) here.
+func (PaginationOpts) FromRequest(req mcpapi.CallToolRequest) PaginationOpts {
+	format := strings.ToLower(argString(req, "format", ""))
+	verbose := argBool(req, "verbose", false)
+	if format == "full" {
+		verbose = true
+	} else if format == "terse" {
+		verbose = false
+	}
 	return PaginationOpts{
 		Offset:       argInt(req, "offset", 0),
 		Limit:        argInt(req, "limit", 20),
 		TokenBudget:  argInt(req, "token_budget", 800),
 		Verbose:      verbose,
-		PathContains: pathContains,
-		Method:       method,
+		PathContains: strings.ToLower(argString(req, "path_contains", "")),
+		Method:       strings.ToUpper(argString(req, "method", "")),
 	}
 }
 
@@ -443,18 +457,11 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 		return errRes, nil
 	}
 	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
-	pathContains := strings.ToLower(argString(req, "path_contains", ""))
-	method := strings.ToUpper(argString(req, "method", ""))
+	pOpts := PaginationOpts{}.FromRequest(req)
+	pathContains := pOpts.PathContains
+	method := pOpts.Method
+	verbose := pOpts.Verbose
 	orphanOnly := argBool(req, "orphan_only", false)
-	// format="terse"|"full" is the preferred control; verbose=bool kept for
-	// backward compatibility. format takes precedence when set explicitly.
-	format := strings.ToLower(argString(req, "format", ""))
-	verbose := argBool(req, "verbose", false)
-	if format == "full" {
-		verbose = true
-	} else if format == "terse" {
-		verbose = false
-	}
 
 	// #2292: orphan_only=true filters to endpoint definitions with no inbound
 	// client-call edges. In this graph the edge kind from a call-site to its
@@ -530,8 +537,7 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 	total := len(out)
 
 	// #2315: use respondPaginated helper (token budget + page + cap).
-	// #2344: build PaginationOpts from req — keeps respondPaginated decoupled from MCP.
-	pOpts := paginationOptsFromReq(req, verbose, pathContains, method)
+	// #2360: pOpts already built via PaginationOpts{}.FromRequest(req) above.
 	out, env, truncationNote := respondPaginated(pOpts, out, total)
 
 	resp := map[string]any{
@@ -729,16 +735,11 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 		return errRes, nil
 	}
 	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	pOpts := PaginationOpts{}.FromRequest(req)
 	orphanOnly := argBool(req, "orphan_only", false)
-	pathContains := strings.ToLower(argString(req, "path_contains", ""))
-	method := strings.ToUpper(argString(req, "method", ""))
-	format := strings.ToLower(argString(req, "format", ""))
-	verbose := argBool(req, "verbose", false)
-	if format == "full" {
-		verbose = true
-	} else if format == "terse" {
-		verbose = false
-	}
+	pathContains := pOpts.PathContains
+	method := pOpts.Method
+	verbose := pOpts.Verbose
 
 	// #2336: use shared endpointResolution helper.
 	// orphanOnly=false → linkedTargets not populated (not needed for call handler).
@@ -864,8 +865,7 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 	total := len(out)
 
 	// #2315: use respondPaginated helper (token budget + page + cap).
-	// #2344: build PaginationOpts from req — keeps respondPaginated decoupled from MCP.
-	pOpts := paginationOptsFromReq(req, verbose, pathContains, method)
+	// #2360: pOpts already built via PaginationOpts{}.FromRequest(req) above.
 	out, env, truncationNote := respondPaginated(pOpts, out, total)
 
 	// #2311: mirror the #2288/#2309 fix — terse mode (default) emits lines

--- a/internal/mcp/endpoint_tools_test.go
+++ b/internal/mcp/endpoint_tools_test.go
@@ -1115,6 +1115,108 @@ func TestDedupeEndpointProperties(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// #2360: PaginationOpts.FromRequest builder tests
+// ---------------------------------------------------------------------------
+
+// makeReq builds a CallToolRequest with the given arguments for builder tests.
+func makeReq(args map[string]any) mcpapi.CallToolRequest {
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	return req
+}
+
+// TestPaginationOptsFromRequest_FormatFull verifies that format="full" sets
+// Verbose=true regardless of the verbose bool param.
+func TestPaginationOptsFromRequest_FormatFull(t *testing.T) {
+	opts := PaginationOpts{}.FromRequest(makeReq(map[string]any{"format": "full", "verbose": false}))
+	if !opts.Verbose {
+		t.Error("format=full should set Verbose=true")
+	}
+	if opts.Format() != "full" {
+		t.Errorf("Format() should return %q, got %q", "full", opts.Format())
+	}
+}
+
+// TestPaginationOptsFromRequest_FormatTerse verifies that format="terse" sets
+// Verbose=false regardless of the verbose bool param.
+func TestPaginationOptsFromRequest_FormatTerse(t *testing.T) {
+	opts := PaginationOpts{}.FromRequest(makeReq(map[string]any{"format": "terse", "verbose": true}))
+	if opts.Verbose {
+		t.Error("format=terse should set Verbose=false even when verbose=true")
+	}
+}
+
+// TestPaginationOptsFromRequest_DefaultVerboseFalse verifies that when format
+// is absent, Verbose defaults to false.
+func TestPaginationOptsFromRequest_DefaultVerboseFalse(t *testing.T) {
+	opts := PaginationOpts{}.FromRequest(makeReq(map[string]any{}))
+	if opts.Verbose {
+		t.Error("default (no format, no verbose) should set Verbose=false")
+	}
+}
+
+// TestPaginationOptsFromRequest_VerboseTrueFallback verifies that when format
+// is absent but verbose=true, Verbose is true.
+func TestPaginationOptsFromRequest_VerboseTrueFallback(t *testing.T) {
+	opts := PaginationOpts{}.FromRequest(makeReq(map[string]any{"verbose": true}))
+	if !opts.Verbose {
+		t.Error("verbose=true with no format should set Verbose=true")
+	}
+}
+
+// TestPaginationOptsFromRequest_PathContainsNormalised verifies that
+// path_contains is lower-cased by the builder.
+func TestPaginationOptsFromRequest_PathContainsNormalised(t *testing.T) {
+	opts := PaginationOpts{}.FromRequest(makeReq(map[string]any{"path_contains": "Users"}))
+	if opts.PathContains != "users" {
+		t.Errorf("PathContains should be lower-cased, got %q", opts.PathContains)
+	}
+}
+
+// TestPaginationOptsFromRequest_MethodNormalised verifies that method is
+// upper-cased by the builder.
+func TestPaginationOptsFromRequest_MethodNormalised(t *testing.T) {
+	opts := PaginationOpts{}.FromRequest(makeReq(map[string]any{"method": "post"}))
+	if opts.Method != "POST" {
+		t.Errorf("Method should be upper-cased, got %q", opts.Method)
+	}
+}
+
+// TestPaginationOptsFromRequest_PaginationDefaults verifies default offset,
+// limit, and token_budget values when absent from the request.
+func TestPaginationOptsFromRequest_PaginationDefaults(t *testing.T) {
+	opts := PaginationOpts{}.FromRequest(makeReq(map[string]any{}))
+	if opts.Offset != 0 {
+		t.Errorf("default Offset: want 0, got %d", opts.Offset)
+	}
+	if opts.Limit != 20 {
+		t.Errorf("default Limit: want 20, got %d", opts.Limit)
+	}
+	if opts.TokenBudget != 800 {
+		t.Errorf("default TokenBudget: want 800, got %d", opts.TokenBudget)
+	}
+}
+
+// TestPaginationOptsFromRequest_ExplicitPagination verifies that explicit
+// offset/limit/token_budget values are respected.
+func TestPaginationOptsFromRequest_ExplicitPagination(t *testing.T) {
+	opts := PaginationOpts{}.FromRequest(makeReq(map[string]any{
+		"offset":       float64(10),
+		"limit":        float64(5),
+		"token_budget": float64(200),
+	}))
+	if opts.Offset != 10 {
+		t.Errorf("Offset: want 10, got %d", opts.Offset)
+	}
+	if opts.Limit != 5 {
+		t.Errorf("Limit: want 5, got %d", opts.Limit)
+	}
+	if opts.TokenBudget != 200 {
+		t.Errorf("TokenBudget: want 200, got %d", opts.TokenBudget)
+	}
+}
+
 // TestDedupeEndpointProperties_NilAndEmpty verifies edge cases.
 func TestDedupeEndpointProperties_NilAndEmpty(t *testing.T) {
 	if got := dedupeEndpointProperties(nil); got != nil {


### PR DESCRIPTION
## Summary

- Adds `(PaginationOpts) FromRequest(req mcpapi.CallToolRequest) PaginationOpts` builder method that internalizes format-precedence resolution (`format=full|terse` → `Verbose`) and reads `path_contains`/`method` from the request directly
- Adds `(PaginationOpts) Format() string` convenience method wrapping `formatLabel`
- Replaces `paginationOptsFromReq(req, verbose, pathContains, method)` call sites in `handleEndpointDefinitions` and `handleEndpointCalls` with `PaginationOpts{}.FromRequest(req)`; the local format-resolution blocks in each handler are deleted
- Deletes `paginationOptsFromReq` (the old thread-explicit-params helper)

Closes #2360

## Test plan

- [ ] `go build ./...` green
- [ ] `go test ./internal/mcp/...` green (22.9s, all existing tests pass)
- [ ] 8 new focused builder tests added: `format=full` sets `Verbose=true`; `format=terse` overrides `verbose=true`; default → `Verbose=false`; `verbose=true` fallback; `path_contains` lower-cased; `method` upper-cased; default pagination values; explicit pagination values

🤖 Generated with [Claude Code](https://claude.com/claude-code)