### PR TITLE
refactor(mcp): consolidate test-server helper + standardize *LoadedRepo signatures

### DIFF
--- a/internal/mcp/adjacency_scans_2285_test.go
+++ b/internal/mcp/adjacency_scans_2285_test.go
@@ -39,7 +39,7 @@ func TestPerf2285_FindCompactEmitsEdgesBetweenVisibleNodes(t *testing.T) {
 			{FromID: "b", ToID: "orphan", Kind: "CALLS"},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"group":   "test",
@@ -96,7 +96,7 @@ func TestPerf2285_AgentResolvedEdgesUsesAdjacency(t *testing.T) {
 			}},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "src"}
 	res, err := srv.handleGetNode(context.Background(), req)
@@ -150,7 +150,7 @@ func TestPerf2285_AgentResolvedEdgesEmptyWhenNoAgentEdges(t *testing.T) {
 			{FromID: "src", ToID: "dst", Kind: "CALLS"}, // no Properties
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "src"}
 	res, _ := srv.handleGetNode(context.Background(), req)

--- a/internal/mcp/auth_coverage_test.go
+++ b/internal/mcp/auth_coverage_test.go
@@ -167,7 +167,7 @@ func endpointsByID(t *testing.T, out map[string]any) map[string]map[string]any {
 // ---------------------------------------------------------------------------
 
 func TestAuthCoverage_CallSitesExcluded(t *testing.T) {
-	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
 	if _, found := eps["ep_call_site"]; found {
@@ -176,7 +176,7 @@ func TestAuthCoverage_CallSitesExcluded(t *testing.T) {
 }
 
 func TestAuthCoverage_FileLevel_HasAuth(t *testing.T) {
-	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
 
@@ -193,7 +193,7 @@ func TestAuthCoverage_FileLevel_HasAuth(t *testing.T) {
 }
 
 func TestAuthCoverage_PropertyLevel_HasAuth(t *testing.T) {
-	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
 
@@ -210,7 +210,7 @@ func TestAuthCoverage_PropertyLevel_HasAuth(t *testing.T) {
 }
 
 func TestAuthCoverage_Public_SeverityWarn(t *testing.T) {
-	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
 
@@ -227,7 +227,7 @@ func TestAuthCoverage_Public_SeverityWarn(t *testing.T) {
 }
 
 func TestAuthCoverage_DeleteWithIDOR_SeverityError(t *testing.T) {
-	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
 
@@ -250,7 +250,7 @@ func TestAuthCoverage_DeleteWithIDOR_SeverityError(t *testing.T) {
 }
 
 func TestAuthCoverage_PaymentEndpoint_SeverityError(t *testing.T) {
-	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
 
@@ -267,7 +267,7 @@ func TestAuthCoverage_PaymentEndpoint_SeverityError(t *testing.T) {
 }
 
 func TestAuthCoverage_OnlyMissing(t *testing.T) {
-	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{
 		"group":        "test",
 		"only_missing": true,
@@ -289,7 +289,7 @@ func TestAuthCoverage_OnlyMissing(t *testing.T) {
 }
 
 func TestAuthCoverage_RepoSummary(t *testing.T) {
-	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 
 	summaries, ok := out["repo_summaries"].([]any)
@@ -367,7 +367,7 @@ func TestAuthCoverage_DefaultDeny(t *testing.T) {
 			},
 		},
 	}
-	s := newTestServerWithDoc(t, doc)
+	s := newTestServer(t, doc)
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 
 	summaries, _ := out["repo_summaries"].([]any)
@@ -399,7 +399,7 @@ func TestAuthCoverage_TaggedAS(t *testing.T) {
 			{ID: "rel1", FromID: "ep1", ToID: "auth1", Kind: "TAGGED_AS"},
 		},
 	}
-	s := newTestServerWithDoc(t, doc)
+	s := newTestServer(t, doc)
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
 	ep, ok := eps["ep1"]
@@ -458,7 +458,7 @@ func TestAuthCoverage_IDORRiskDetection(t *testing.T) {
 
 func TestAuthCoverage_SeverityOrdering(t *testing.T) {
 	// Errors must appear before warns, warns before infos.
-	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps, _ := out["endpoints"].([]any)
 

--- a/internal/mcp/cleanup_group_a_test.go
+++ b/internal/mcp/cleanup_group_a_test.go
@@ -215,7 +215,7 @@ func TestHandleFindPathsSyntheticEdgesRelIdx(t *testing.T) {
 			{FromID: "src", ToID: "dst", Kind: "CALLS"},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"group": "test",
@@ -302,7 +302,7 @@ func TestNoSessionMetaInNonWhoamiHandlers(t *testing.T) {
 			{FromID: "fn_a", ToID: "fn_b", Kind: "CALLS"},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// Each entry: handler func + args to call it with.
 	type tc struct {

--- a/internal/mcp/clusters_cap_2289_test.go
+++ b/internal/mcp/clusters_cap_2289_test.go
@@ -28,7 +28,7 @@ func Test_handleListCommunities_DefaultCaps_2289(t *testing.T) {
 			{ID: 4, Size: 20, Modularity: 0.6, TopEntities: []string{"p", "q", "r", "s"}},
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{"r": doc})
+	srv := newTestServer(t, doc)
 	text := callEndpointToolText(t, srv.handleListCommunities, map[string]any{
 		"group": "test",
 	})
@@ -69,7 +69,7 @@ func Test_handleListCommunities_OverrideCaps_2289(t *testing.T) {
 			{ID: 2, Size: 5, Modularity: 0.3, TopEntities: []string{"x", "y"}},
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{"r": doc})
+	srv := newTestServer(t, doc)
 	text := callEndpointToolText(t, srv.handleListCommunities, map[string]any{
 		"group":              "test",
 		"top_entities_limit": -1,
@@ -99,7 +99,7 @@ func Test_handleListCommunities_ExplicitLimitHigherThanLen_2289(t *testing.T) {
 			{ID: 1, Size: 100, Modularity: 0.5, TopEntities: []string{"a", "b"}},
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{"r": doc})
+	srv := newTestServer(t, doc)
 	text := callEndpointToolText(t, srv.handleListCommunities, map[string]any{
 		"group":              "test",
 		"top_entities_limit": 10,
@@ -130,7 +130,7 @@ func Test_handleListCommunities_SortBySize_2319(t *testing.T) {
 			{ID: 3, Size: 30, Modularity: 0.4, TopEntities: []string{"d", "e", "f"}},
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{"r": doc})
+	srv := newTestServer(t, doc)
 	text := callEndpointToolText(t, srv.handleListCommunities, map[string]any{
 		"group":              "test",
 		"min_size":           20,  // filters out id=1 (size 10)

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -469,7 +469,7 @@ func (s *Server) handleFlowDetail(_ context.Context, req mcpapi.CallToolRequest)
 		if procEnt == nil {
 			continue
 		}
-		steps := buildProcessSteps(r.Doc, procEnt, r.ByID, r.Repo)
+		steps := buildProcessSteps(r, procEnt)
 		// Collect SIDE_EFFECT_OF edges attached to any step in this process.
 		stepSet := map[string]bool{}
 		for _, st := range steps {

--- a/internal/mcp/dashboard_tools_test.go
+++ b/internal/mcp/dashboard_tools_test.go
@@ -9,47 +9,6 @@ import (
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-// newTestServerWithDoc builds a minimal Server with one group ("test") and
-// one repo ("repo1") loaded from the supplied Document.
-func newTestServerWithDoc(t *testing.T, doc *graph.Document) *Server {
-	t.Helper()
-	reg := &Registry{Groups: map[string]RegistryGroup{
-		"test": {
-			Repos: map[string]RegistryRepo{
-				"repo1": {Path: t.TempDir()},
-			},
-		},
-	}}
-	st := NewState(reg)
-	// Inject the document directly rather than loading from disk.
-	st.mu.Lock()
-	byID := make(map[string]*graph.Entity, len(doc.Entities))
-	for i := range doc.Entities {
-		byID[doc.Entities[i].ID] = &doc.Entities[i]
-	}
-	st.groups["test"] = &LoadedGroup{
-		Name: "test",
-		Repos: map[string]*LoadedRepo{
-			"repo1": {
-				Repo:       "repo1",
-				Doc:        doc,
-				LabelIndex: BuildLabelIndex(doc),
-				BM25:       BuildBM25(doc),
-				Adjacency:  buildAdjacency(doc, "repo1"),
-				CallsAdj:   buildCallsAdjacency(doc),
-				ByID:       byID,
-			},
-		},
-	}
-	st.mu.Unlock()
-	srv := &Server{State: st, Tel: NewTelemetry(0)}
-	return srv
-}
-
 // callDashboardTool invokes a handler directly and decodes the JSON result.
 func callDashboardTool(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) map[string]any {
 	t.Helper()
@@ -95,7 +54,7 @@ func TestHandleTopologyOrphanPublishers(t *testing.T) {
 		{ID: "r2", FromID: "svc", ToID: "t2", Kind: "PUBLISHES_TO"},
 		{ID: "r3", FromID: "svc", ToID: "t2", Kind: "SUBSCRIBES_TO"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleTopologyOrphanPublishers, map[string]any{"group": "test"})
 
 	count := int(out["count"].(float64))
@@ -124,7 +83,7 @@ func TestHandleTopologyOrphanSubscribers(t *testing.T) {
 		{ID: "r2", FromID: "svc", ToID: "t1", Kind: "SUBSCRIBES_TO"},
 		{ID: "r3", FromID: "svc", ToID: "t2", Kind: "SUBSCRIBES_TO"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleTopologyOrphanSubscribers, map[string]any{"group": "test"})
 	count := int(out["count"].(float64))
 	if count != 1 {
@@ -151,7 +110,7 @@ func TestHandleTopologyTopicDetail(t *testing.T) {
 		{ID: "r1", FromID: "pub", ToID: "t1", Kind: "PUBLISHES_TO"},
 		{ID: "r2", FromID: "sub", ToID: "t1", Kind: "SUBSCRIBES_TO"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleTopologyTopicDetail, map[string]any{
 		"group":    "test",
 		"topic_id": "t1",
@@ -170,7 +129,7 @@ func TestHandleTopologyTopicDetail(t *testing.T) {
 }
 
 func TestHandleTopologyTopicDetail_NotFound(t *testing.T) {
-	srv := newTestServerWithDoc(t, minDoc(nil, nil))
+	srv := newTestServer(t, minDoc(nil, nil))
 	out := callDashboardTool(t, srv.handleTopologyTopicDetail, map[string]any{
 		"group":    "test",
 		"topic_id": "nonexistent",
@@ -197,7 +156,7 @@ func TestTopicDetail_PrefixedIDRoundtrip(t *testing.T) {
 		{ID: "r1", FromID: "pub", ToID: "t1", Kind: "PUBLISHES_TO"},
 		{ID: "r2", FromID: "sub", ToID: "t1", Kind: "SUBSCRIBES_TO"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 
 	// Simulate what search_entities returns: prefixedID(r.Repo, e.ID) = "repo1::t1".
 	prefixedTopicID := prefixedID("repo1", "t1")
@@ -234,7 +193,7 @@ func TestTopicDetail_NameLookupRoundtrip(t *testing.T) {
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "pub", ToID: "t1", Kind: "PUBLISHES_TO"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 
 	// Pass the topic name directly — LabelIndex.Lookup must bridge the gap.
 	out := callDashboardTool(t, srv.handleTopologyTopicDetail, map[string]any{
@@ -265,9 +224,7 @@ func TestTopicDetail_RepoAliasRoundtrip(t *testing.T) {
 	}
 	// Register under the slug key — repo1 path-basename is "payments_service"
 	// (underscore variant).  buildRepoAliasMap must alias both forms.
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{
-		"payments-service": docA,
-	})
+	srv := newTestServer(t, docA)
 
 	// search_entities would emit "payments-service::t1" (canonical slug prefix).
 	// topic_detail must resolve this even if an internal alias is involved.
@@ -334,7 +291,7 @@ func TestSearchEntities_SchemaFieldFold(t *testing.T) {
 			StartLine: 40,
 		},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	srv := newTestServer(t, minDoc(entities, nil))
 
 	// Default: only the parent class + the operation should appear; fields suppressed.
 	out := callDashboardTool(t, srv.handleSearchEntities, map[string]any{
@@ -375,7 +332,7 @@ func TestSearchEntities_TopicKindAlias(t *testing.T) {
 		{ID: "q3", Name: "order.placed", Kind: "Topic"},
 		{ID: "x1", Name: "PaymentService", Kind: "Class"}, // must not match
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	srv := newTestServer(t, minDoc(entities, nil))
 
 	out := callDashboardTool(t, srv.handleSearchEntities, map[string]any{
 		"group":       "test",
@@ -412,7 +369,7 @@ func TestHandleFlowDeadEnds(t *testing.T) {
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "fn1", ToID: "fn2", Kind: "CALLS"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleFlowDeadEnds, map[string]any{"group": "test"})
 	count := int(out["count"].(float64))
 	if count != 1 {
@@ -435,7 +392,7 @@ func TestHandleFlowTruncated(t *testing.T) {
 			"step_count": "5",
 		}},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	srv := newTestServer(t, minDoc(entities, nil))
 	out := callDashboardTool(t, srv.handleFlowTruncated, map[string]any{"group": "test"})
 	count := int(out["count"].(float64))
 	if count != 1 {
@@ -468,7 +425,7 @@ func TestHandleFlowDetail(t *testing.T) {
 		{ID: "r2", FromID: "p1", ToID: "fn2", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "1"}},
 		{ID: "r3", FromID: "fx1", ToID: "fn2", Kind: "SIDE_EFFECT_OF"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleFlowDetail, map[string]any{
 		"group":      "test",
 		"process_id": "p1",
@@ -492,7 +449,7 @@ func TestHandleFlowDetail(t *testing.T) {
 
 func TestHandleDiagnostics(t *testing.T) {
 	entities := []graph.Entity{{ID: "e1", Name: "Foo", Kind: "Function"}}
-	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	srv := newTestServer(t, minDoc(entities, nil))
 	out := callDashboardTool(t, srv.handleDiagnostics, map[string]any{"group": "test"})
 	if out["group"] != "test" {
 		t.Errorf("expected group=test, got %v", out["group"])
@@ -522,7 +479,7 @@ func TestHandleQualityOrphans(t *testing.T) {
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "e1", ToID: "e1", Kind: "CALLS"}, // self loop — e1 is connected
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleQualityOrphans, map[string]any{"group": "test"})
 	count := int(out["count"].(float64))
 	if count != 1 {
@@ -545,7 +502,7 @@ func TestHandleSearchEntities(t *testing.T) {
 		{ID: "e2", Name: "PaymentRepository", Kind: "Class", SourceFile: "repo.go"},
 		{ID: "e3", Name: "UserService", Kind: "Class", SourceFile: "user.go"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	srv := newTestServer(t, minDoc(entities, nil))
 	out := callDashboardTool(t, srv.handleSearchEntities, map[string]any{
 		"group": "test",
 		"query": "Payment",
@@ -561,7 +518,7 @@ func TestHandleSearchEntities_KindFilter(t *testing.T) {
 		{ID: "e1", Name: "processPayment", Kind: "Function"},
 		{ID: "e2", Name: "PaymentService", Kind: "Class"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	srv := newTestServer(t, minDoc(entities, nil))
 	out := callDashboardTool(t, srv.handleSearchEntities, map[string]any{
 		"group":       "test",
 		"query":       "payment",
@@ -587,7 +544,7 @@ func TestHandleFindPaths(t *testing.T) {
 		{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"},
 		{ID: "r2", FromID: "b", ToID: "c", Kind: "CALLS"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleFindPaths, map[string]any{
 		"group": "test",
 		"from":  "a",
@@ -607,7 +564,7 @@ func TestHandleFindPaths_NoPath(t *testing.T) {
 		{ID: "a", Name: "A", Kind: "Function"},
 		{ID: "b", Name: "B", Kind: "Function"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	srv := newTestServer(t, minDoc(entities, nil))
 	out := callDashboardTool(t, srv.handleFindPaths, map[string]any{
 		"group": "test",
 		"from":  "a",
@@ -652,7 +609,7 @@ func TestHandleTopology_OrphanPublishers(t *testing.T) {
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "svc", ToID: "t1", Kind: "PUBLISHES_TO"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleTopology, map[string]any{
 		"group":  "test",
 		"action": "orphan_publishers",
@@ -670,7 +627,7 @@ func TestHandleTopology_OrphanSubscribers(t *testing.T) {
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "svc", ToID: "t2", Kind: "SUBSCRIBES_TO"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleTopology, map[string]any{
 		"group":  "test",
 		"action": "orphan_subscribers",
@@ -688,7 +645,7 @@ func TestHandleTopology_TopicDetail(t *testing.T) {
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "pub", ToID: "t1", Kind: "PUBLISHES_TO"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 	out := callDashboardTool(t, srv.handleTopology, map[string]any{
 		"group":    "test",
 		"action":   "topic_detail",
@@ -700,7 +657,7 @@ func TestHandleTopology_TopicDetail(t *testing.T) {
 }
 
 func TestHandleTopology_UnknownAction(t *testing.T) {
-	srv := newTestServerWithDoc(t, minDoc(nil, nil))
+	srv := newTestServer(t, minDoc(nil, nil))
 	req := newReq(map[string]any{"group": "test", "action": "bogus"})
 	res, err := srv.handleTopology(ctxBg(), req)
 	if err != nil {
@@ -716,7 +673,7 @@ func TestHandleTopology_UnknownAction(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHandleFlows_DeadEnds(t *testing.T) {
-	srv := newTestServerWithDoc(t, minDoc(nil, nil))
+	srv := newTestServer(t, minDoc(nil, nil))
 	out := callDashboardTool(t, srv.handleFlows, map[string]any{
 		"group":  "test",
 		"action": "dead_ends",
@@ -727,7 +684,7 @@ func TestHandleFlows_DeadEnds(t *testing.T) {
 }
 
 func TestHandleFlows_Truncated(t *testing.T) {
-	srv := newTestServerWithDoc(t, minDoc(nil, nil))
+	srv := newTestServer(t, minDoc(nil, nil))
 	out := callDashboardTool(t, srv.handleFlows, map[string]any{
 		"group":  "test",
 		"action": "truncated",
@@ -738,7 +695,7 @@ func TestHandleFlows_Truncated(t *testing.T) {
 }
 
 func TestHandleFlows_Detail_NotFound(t *testing.T) {
-	srv := newTestServerWithDoc(t, minDoc(nil, nil))
+	srv := newTestServer(t, minDoc(nil, nil))
 	out := callDashboardTool(t, srv.handleFlows, map[string]any{
 		"group":      "test",
 		"action":     "detail",
@@ -750,7 +707,7 @@ func TestHandleFlows_Detail_NotFound(t *testing.T) {
 }
 
 func TestHandleFlows_UnknownAction(t *testing.T) {
-	srv := newTestServerWithDoc(t, minDoc(nil, nil))
+	srv := newTestServer(t, minDoc(nil, nil))
 	req := newReq(map[string]any{"group": "test", "action": "bogus"})
 	res, err := srv.handleFlows(ctxBg(), req)
 	if err != nil {
@@ -770,7 +727,7 @@ func TestHandleGraphPatterns_List(t *testing.T) {
 		{ID: "p1", Name: "RepositoryPattern", Kind: "SCOPE.Pattern",
 			Properties: map[string]string{"status": "active", "confidence": "0.9"}},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	srv := newTestServer(t, minDoc(entities, nil))
 	out := callDashboardTool(t, srv.handleGraphPatterns, map[string]any{
 		"group":  "test",
 		"action": "list",
@@ -788,7 +745,7 @@ func TestHandleGraphPatterns_Get(t *testing.T) {
 	entities := []graph.Entity{
 		{ID: "p1", Name: "RepositoryPattern", Kind: "SCOPE.Pattern"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	srv := newTestServer(t, minDoc(entities, nil))
 	out := callDashboardTool(t, srv.handleGraphPatterns, map[string]any{
 		"group":      "test",
 		"action":     "get",
@@ -800,7 +757,7 @@ func TestHandleGraphPatterns_Get(t *testing.T) {
 }
 
 func TestHandleGraphPatterns_UnknownAction(t *testing.T) {
-	srv := newTestServerWithDoc(t, minDoc(nil, nil))
+	srv := newTestServer(t, minDoc(nil, nil))
 	req := newReq(map[string]any{"group": "test", "action": "bogus"})
 	res, err := srv.handleGraphPatterns(ctxBg(), req)
 	if err != nil {

--- a/internal/mcp/endpoint_tools_test.go
+++ b/internal/mcp/endpoint_tools_test.go
@@ -70,7 +70,7 @@ func buildEndpointDoc() *graph.Document {
 
 func newEndpointServer(t *testing.T) *Server {
 	t.Helper()
-	return newTestServerWithDoc(t, buildEndpointDoc())
+	return newTestServer(t, buildEndpointDoc())
 }
 
 func callEndpointTool(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) map[string]any {
@@ -365,7 +365,7 @@ func TestEndpointDefinitions_OrphanOnly_NoOrphansReturnsEmpty(t *testing.T) {
 	doc.Relationships = append(doc.Relationships, graph.Relationship{
 		FromID: "fn_other", ToID: "ep_legacy", Kind: "FETCHES",
 	})
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
 		"group":       "test",
@@ -395,7 +395,7 @@ func TestEndpointDefinitions_OrphanOnly_IgnoresNonFetchesInbound(t *testing.T) {
 	doc.Relationships = []graph.Relationship{
 		{FromID: "fn_other", ToID: "ep_def", Kind: "CONTAINS"},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
 		"group":       "test",
@@ -600,7 +600,7 @@ func TestEndpointStats_MigratedTrueWhenNoLegacy(t *testing.T) {
 			{ID: "c1", Kind: "http_endpoint_call", Name: "fetchA"},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	res := callEndpointTool(t, srv.handleEndpointStats, map[string]any{"group": "test"})
 	migrated, ok := res["migrated"].(bool)
 	if !ok {
@@ -645,7 +645,7 @@ func TestQualityOrphans_LegacyKindFilterExpands(t *testing.T) {
 			{ID: "isolated_call", Kind: "http_endpoint_call", Name: "fetchIsolated"},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	res := callDashboardTool(t, srv.handleQualityOrphans, map[string]any{
 		"group":       "test",
 		"kind_filter": "http_endpoint",
@@ -834,7 +834,7 @@ func buildLargeEndpointDoc(n int) *graph.Document {
 // TestEndpointDefaultLimit_Definitions verifies that without an explicit
 // limit=N, handleEndpointDefinitions returns at most 20 items (#1738).
 func TestEndpointDefaultLimit_Definitions(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildLargeEndpointDoc(30))
+	srv := newTestServer(t, buildLargeEndpointDoc(30))
 	// #2288: terse-default response omits `definitions`; use `lines` for the
 	// rendered count assertion, plus a parallel full-mode call to assert the
 	// struct-array slice is also capped.
@@ -853,7 +853,7 @@ func TestEndpointDefaultLimit_Definitions(t *testing.T) {
 // TestEndpointTokenBudget_Definitions verifies that a tight token_budget caps
 // the definitions slice and adds a truncation_note (#1738).
 func TestEndpointTokenBudget_Definitions(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildLargeEndpointDoc(30))
+	srv := newTestServer(t, buildLargeEndpointDoc(30))
 	// Pass a very tight budget (50 tokens = 200 bytes) — forces truncation.
 	out := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
 		"group":        "test",
@@ -957,7 +957,7 @@ func TestEndpointDefinitions_TriplePathDedupe(t *testing.T) {
 			},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
 		"group":  "test",
 		"format": "full",
@@ -1019,7 +1019,7 @@ func TestEndpointDefinitions_PathContainsFilterBeforeLimit(t *testing.T) {
 		ID: "ep_prop_2", Kind: "http_endpoint_definition",
 		Properties: map[string]string{"verb": "POST", "path": "/api/v1/proposals/create"},
 	})
-	srv := newTestServerWithDoc(t, &graph.Document{Entities: entities})
+	srv := newTestServer(t, &graph.Document{Entities: entities})
 
 	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
 		"group":         "test",
@@ -1049,7 +1049,7 @@ func TestEndpointDefinitions_MethodFilterBeforeLimit(t *testing.T) {
 		{ID: "ep3", Kind: "http_endpoint_definition", Properties: map[string]string{"verb": "GET", "path": "/c"}},
 		{ID: "ep4", Kind: "http_endpoint_definition", Properties: map[string]string{"verb": "DELETE", "path": "/d"}},
 	}
-	srv := newTestServerWithDoc(t, &graph.Document{Entities: entities})
+	srv := newTestServer(t, &graph.Document{Entities: entities})
 
 	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{
 		"group":  "test",

--- a/internal/mcp/field_elision_test.go
+++ b/internal/mcp/field_elision_test.go
@@ -95,7 +95,7 @@ func buildElisionDoc() *graph.Document {
 
 func newElisionServer(t *testing.T) *Server {
 	t.Helper()
-	return newTestServerWithDoc(t, buildElisionDoc())
+	return newTestServer(t, buildElisionDoc())
 }
 
 func callToolArgs(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) map[string]any {

--- a/internal/mcp/find_paths_1690_test.go
+++ b/internal/mcp/find_paths_1690_test.go
@@ -43,10 +43,7 @@ func TestFindPaths_1690_RepoPrefixAlias(t *testing.T) {
 			{ID: "handler_fn", Name: "InspectionViewSet.create_deficiency", Kind: "Function", SourceFile: "views.py"},
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{
-		"core-mobile": docMobile,
-		"upvate-core": docCore,
-	})
+	srv := newTestServer(t, docMobile, docCore)
 	lg := srv.State.Group("test")
 	// The links emitter wrote the upvate-core side as `upvate_core::handler_fn`
 	// (path-basename with underscores) — this MUST still resolve.
@@ -107,10 +104,7 @@ func TestFindPaths_1690_ReverseImplementsAcrossRepo(t *testing.T) {
 			{ID: "r2", FromID: "handler_fn", ToID: "ep_def", Kind: "IMPLEMENTS"},
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{
-		"core-mobile": docMobile,
-		"upvate-core": docCore,
-	})
+	srv := newTestServer(t, docMobile, docCore)
 	lg := srv.State.Group("test")
 	lg.Links = []CrossRepoLink{
 		{
@@ -152,7 +146,7 @@ func TestFindPaths_1690_NoPathStillNoPath(t *testing.T) {
 			{ID: "b", Name: "B", Kind: "Function"}, // unconnected
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{"solo": doc})
+	srv := newTestServer(t, doc)
 	res := callEndpointTool(t, srv.handleFindPaths, map[string]any{
 		"group": "test",
 		"from":  "solo::a",

--- a/internal/mcp/find_ranking_1747_test.go
+++ b/internal/mcp/find_ranking_1747_test.go
@@ -43,7 +43,7 @@ func buildNoisyFindDoc() *graph.Document {
 // count with the default cutoff is strictly fewer than with min_score=0.
 func TestMinScore_DefaultCutsNoiseTail(t *testing.T) {
 	doc := buildNoisyFindDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// With default min_score (0.15): expect fewer hits than unfiltered.
 	resFiltered := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
@@ -84,7 +84,7 @@ func TestMinScore_DefaultCutsNoiseTail(t *testing.T) {
 // cutoff and returns every matched entity, including the noisy tail.
 func TestMinScore_ZeroDisablesCutoff(t *testing.T) {
 	doc := buildNoisyFindDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
 		"group":     "test",

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -112,7 +112,7 @@ func buildDeadCodeDoc() *graph.Document {
 // (mergeNeighbors) consumes this without ever parsing wire bytes.
 func TestFindCallersStructured_NoWireBytes(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{"entity_id": "ent-b"}
@@ -177,7 +177,7 @@ func TestMergeNeighbors_NoParse(t *testing.T) {
 
 func TestFindCallers_DirectCaller(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncB has 1 direct caller: FuncA.
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
@@ -203,7 +203,7 @@ func TestFindCallers_DirectCaller(t *testing.T) {
 
 func TestFindCallers_Transitive(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncC has 1 direct caller (FuncB) and 1 transitive caller (FuncA at depth 2).
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
@@ -222,7 +222,7 @@ func TestFindCallers_Transitive(t *testing.T) {
 
 func TestFindCallers_NotFound(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	errMsg := callFlowToolError(t, srv.handleFindCallers, map[string]any{
 		"entity_id": "no-such-entity",
 	})
@@ -233,7 +233,7 @@ func TestFindCallers_NotFound(t *testing.T) {
 
 func TestFindCallers_NoCallers(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncA has no callers.
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
@@ -250,7 +250,7 @@ func TestFindCallers_NoCallers(t *testing.T) {
 // callers, the response carries the explicit no-edge signal (#1618).
 func TestFindCallers_NoEdgeSignal(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
 		"entity_id": "ent-a",
@@ -275,7 +275,7 @@ func TestFindCallers_NoEdgeSignal(t *testing.T) {
 // present when callers are found (#1618 regression guard).
 func TestFindCallers_WithCallersNoSignal(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncB has 1 caller (FuncA) — result field must NOT be set.
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
@@ -307,7 +307,7 @@ func TestFindCallers_ExcludesContainsEdges(t *testing.T) {
 			{FromID: "caller-fn", ToID: "hook-fn", Kind: "CALLS"},
 		},
 	)
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
 		"entity_id": "hook-fn",
@@ -358,7 +358,7 @@ func TestFindCallers_FileEntityReferencesSource(t *testing.T) {
 			{FromID: "admin-file", ToID: "contract-model", Kind: "REFERENCES"},
 		},
 	)
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
 		"entity_id": "contract-model",
@@ -399,7 +399,7 @@ func TestFindCallers_FileEntityImportsSource(t *testing.T) {
 			{FromID: "viewset-file", ToID: "has-permission", Kind: "IMPORTS"},
 		},
 	)
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
 		"entity_id": "has-permission",
@@ -446,7 +446,7 @@ func TestFindCallers_ModuleInitReExports(t *testing.T) {
 			{FromID: "init-module", ToID: "celery-module", Kind: "IMPORTS"},
 		},
 	)
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
 		"entity_id": "celery-module",
@@ -514,7 +514,7 @@ func TestFindCallers_ChecklistAdminPyPostFinalize(t *testing.T) {
 			{FromID: "register-call", ToID: "checklist-model", Kind: "CALLS"},
 		},
 	)
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
 		"entity_id": "checklist-model",
@@ -558,7 +558,7 @@ func TestFindCallers_NilByIDSyntheticFileCaller(t *testing.T) {
 			{FromID: "raw/path/admin.py", ToID: "target-model", Kind: "REFERENCES"},
 		},
 	)
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
 		"entity_id": "target-model",
 		"depth":     float64(1),
@@ -580,7 +580,7 @@ func TestFindCallers_NilByIDSyntheticFileCaller(t *testing.T) {
 
 func TestFindCallees_Direct(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncA calls FuncB directly.
 	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
@@ -602,7 +602,7 @@ func TestFindCallees_Direct(t *testing.T) {
 
 func TestFindCallees_Transitive(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncA calls FuncB (hop 1) and transitively FuncC (hop 2).
 	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
@@ -617,7 +617,7 @@ func TestFindCallees_Transitive(t *testing.T) {
 
 func TestFindCallees_LeafReturnsEmpty(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncC is a leaf — no outbound edges.
 	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
@@ -634,7 +634,7 @@ func TestFindCallees_LeafReturnsEmpty(t *testing.T) {
 // callees, the response carries the explicit no-edge signal (#1618).
 func TestFindCallees_NoEdgeSignal(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncC is a leaf — no outbound edges.
 	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
@@ -660,7 +660,7 @@ func TestFindCallees_NoEdgeSignal(t *testing.T) {
 // present when callees are found (#1618 regression guard).
 func TestFindCallees_WithCalleesNoSignal(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncA calls FuncB — result field must NOT be set.
 	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
@@ -678,7 +678,7 @@ func TestFindCallees_WithCalleesNoSignal(t *testing.T) {
 
 func TestImpactRadius_RootChanges(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// Changing FuncB affects FuncA (its caller).
 	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
@@ -709,7 +709,7 @@ func TestImpactRadius_RootChanges(t *testing.T) {
 
 func TestImpactRadius_RootHasNoUpstreamImpact(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncA is the root of the chain (no inbound callers), so changing it
 	// affects nobody above it. impact_radius walks inbound, so count = 0.
@@ -729,7 +729,7 @@ func TestImpactRadius_RootHasNoUpstreamImpact(t *testing.T) {
 
 func TestSubgraph_FormatMarkdown_ContainsStructure(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	text := callFlowToolText(t, srv.handleSubgraph, map[string]any{
 		"entity_id": "ent-b",
@@ -750,7 +750,7 @@ func TestSubgraph_FormatMarkdown_ContainsStructure(t *testing.T) {
 
 func TestSubgraph_FormatMarkdown_RootNoCallers(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	text := callFlowToolText(t, srv.handleSubgraph, map[string]any{
 		"entity_id": "ent-a",
@@ -776,7 +776,7 @@ func TestSubgraph_FormatRaw_DefaultsToRaw(t *testing.T) {
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "root", ToID: "child", Kind: "CALLS"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 
 	// No format= → default is "raw".
 	out := callFlowTool(t, srv.handleSubgraph, map[string]any{
@@ -808,7 +808,7 @@ func TestSubgraph_FormatRaw_GraphCounts(t *testing.T) {
 		{ID: "r1", FromID: "root", ToID: "child", Kind: "CALLS"},
 		{ID: "r2", FromID: "child", ToID: "grandchild", Kind: "CALLS"},
 	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	srv := newTestServer(t, minDoc(entities, rels))
 
 	// depth=2 from root should reach root+child+grandchild (3 nodes, 2 edges).
 	unified := callFlowTool(t, srv.handleSubgraph, map[string]any{
@@ -832,7 +832,7 @@ func TestSubgraph_FormatRaw_GraphCounts(t *testing.T) {
 // returns a summary containing the target entity name.
 func TestSubgraph_FormatMarkdown_ContainsEntityName(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	text := callFlowToolText(t, srv.handleSubgraph, map[string]any{
 		"entity_id": "ent-b",
@@ -847,7 +847,7 @@ func TestSubgraph_FormatMarkdown_ContainsEntityName(t *testing.T) {
 // TestSubgraph_InvalidFormat verifies a helpful error is returned for unknown format.
 func TestSubgraph_InvalidFormat(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
@@ -870,7 +870,7 @@ func TestSubgraph_InvalidFormat(t *testing.T) {
 
 func TestFindDeadCode_IsolatedEntity(t *testing.T) {
 	doc := buildDeadCodeDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	out := callFlowTool(t, srv.handleFindDeadCode, map[string]any{})
 	dead, ok := out["dead_code"].([]any)
@@ -900,7 +900,7 @@ func TestFindDeadCode_IsolatedEntity(t *testing.T) {
 
 func TestFindDeadCode_KindFilter(t *testing.T) {
 	doc := buildDeadCodeDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// Filter to "Class" — no entities match, expect empty.
 	out := callFlowTool(t, srv.handleFindDeadCode, map[string]any{
@@ -914,7 +914,7 @@ func TestFindDeadCode_KindFilter(t *testing.T) {
 
 func TestFindDeadCode_StdlibExcluded(t *testing.T) {
 	doc := buildDeadCodeDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	out := callFlowTool(t, srv.handleFindDeadCode, map[string]any{})
 	dead := out["dead_code"].([]any)
@@ -972,7 +972,7 @@ func buildPublicAPIDeadCodeDoc() *graph.Document {
 }
 
 func TestFindDeadCode_PrecisionOnPublicAPI(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildPublicAPIDeadCodeDoc())
+	srv := newTestServer(t, buildPublicAPIDeadCodeDoc())
 	out := callFlowTool(t, srv.handleFindDeadCode, map[string]any{})
 	dead := out["dead_code"].([]any)
 
@@ -1000,7 +1000,7 @@ func TestFindDeadCode_PrecisionOnPublicAPI(t *testing.T) {
 }
 
 func TestFindDeadCode_ImportedNotFlagged(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildPublicAPIDeadCodeDoc())
+	srv := newTestServer(t, buildPublicAPIDeadCodeDoc())
 	out := callFlowTool(t, srv.handleFindDeadCode, map[string]any{})
 	for _, item := range out["dead_code"].([]any) {
 		if item.(map[string]any)["name"] == "verifyToken" {
@@ -1057,7 +1057,7 @@ func buildIsolatedDoc() *graph.Document {
 // no-edge signal when the entity is found but has zero neighbours (#1618).
 func TestExpand_NoEdgeSignal(t *testing.T) {
 	doc := buildIsolatedDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	out := callFlowTool(t, srv.handleGetNeighbors, map[string]any{
 		"node": "iso-1",
@@ -1086,7 +1086,7 @@ func TestExpand_NoEdgeSignal(t *testing.T) {
 // when the entity has neighbours (#1618 regression guard).
 func TestExpand_WithEdgesNoSignal(t *testing.T) {
 	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// FuncA has an outbound edge to FuncB — no no-edge signal expected.
 	// handleGetNeighbors returns a flat array for the non-empty case, which
@@ -1150,7 +1150,7 @@ func build25CalleeDoc() *graph.Document {
 // TestFindCallers_TokenBudgetEnforced verifies that a very tight token_budget
 // caps the callers slice and produces a truncation_note (#1738).
 func TestFindCallers_TokenBudgetEnforced(t *testing.T) {
-	srv := newTestServerWithDoc(t, build25CallerDoc())
+	srv := newTestServer(t, build25CallerDoc())
 	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
 		"entity_id":    "target",
 		"depth":        float64(1),
@@ -1169,7 +1169,7 @@ func TestFindCallers_TokenBudgetEnforced(t *testing.T) {
 
 // TestFindCallees_TokenBudgetEnforced verifies the same for callees.
 func TestFindCallees_TokenBudgetEnforced(t *testing.T) {
-	srv := newTestServerWithDoc(t, build25CalleeDoc())
+	srv := newTestServer(t, build25CalleeDoc())
 	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
 		"entity_id":    "root",
 		"depth":        float64(1),
@@ -1204,7 +1204,7 @@ func TestExpand_TokenBudgetEnforced(t *testing.T) {
 		rels = append(rels, graph.Relationship{FromID: "root", ToID: lid, Kind: "CALLS"})
 	}
 	doc := minDoc(entities, rels)
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{

--- a/internal/mcp/get_source_timeout_test.go
+++ b/internal/mcp/get_source_timeout_test.go
@@ -66,7 +66,7 @@ func TestGetSource_ReturnsWindowedSnippet(t *testing.T) {
 			{ID: "foo", Name: "Foo", Kind: "Function", SourceFile: "sample.go", StartLine: 3, EndLine: 5},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	// Repoint the test repo at our temp dir.
 	srv.State.groups["test"].Repos["repo1"].Path = dir
 
@@ -120,7 +120,7 @@ func TestGetSource_TimesOutOnStuckOpen(t *testing.T) {
 			{ID: "stuck", Name: "Stuck", Kind: "Function", SourceFile: "stuck.fifo", StartLine: 1, EndLine: 1},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	srv.State.groups["test"].Repos["repo1"].Path = dir
 
 	// 500ms ceiling — the handler must return well within this budget.

--- a/internal/mcp/ids_in_locate_test.go
+++ b/internal/mcp/ids_in_locate_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // buildLocateDoc returns a minimal document suitable for testing all locate
-// tools. The repo name used by newTestServerWithDoc is "repo1".
+// tools. The repo name used by newTestServer is "repo1" (doc.Repo is unset).
 func buildLocateDoc() *graph.Document {
 	return &graph.Document{
 		Entities: []graph.Entity{
@@ -177,7 +177,7 @@ func TestIDsInLocate_Find_TOONRowContainsID(t *testing.T) {
 // TestIDsInLocate_Find_JSONPathIncludesID verifies that the JSON-mode
 // archigraph_find response (full=true) includes "id" in each match row.
 func TestIDsInLocate_Find_JSONPathIncludesID(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildLocateDoc())
+	srv := newTestServer(t, buildLocateDoc())
 	res := callToolArgs(t, srv.handleQueryGraph, map[string]any{
 		"group":    "test",
 		"question": "AlphaFunc",
@@ -207,7 +207,7 @@ func TestIDsInLocate_Find_JSONPathIncludesID(t *testing.T) {
 // TestIDsInLocate_Expand_NeighborRowsIncludeID verifies that each neighbor
 // row in the expand result carries a prefixed ADR-0009 "id".
 func TestIDsInLocate_Expand_NeighborRowsIncludeID(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildLocateDoc())
+	srv := newTestServer(t, buildLocateDoc())
 	// fn_beta has an outbound edge to fn_alpha so we'll get neighbors.
 	raw := callHandlerText(t, srv.handleGetNeighbors, map[string]any{
 		"group": "test",
@@ -243,7 +243,7 @@ func TestIDsInLocate_Expand_NeighborRowsIncludeID(t *testing.T) {
 // archigraph_traces action=get carries a prefixed "id" field alongside the
 // existing "node_id" (kept for backward compatibility).
 func TestIDsInLocate_TracesGet_StepsIncludeID(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildLocateDoc())
+	srv := newTestServer(t, buildLocateDoc())
 	res := callToolArgs(t, srv.handleTracesGet, map[string]any{
 		"group":      "test",
 		"process_id": "proc_locate",
@@ -278,7 +278,7 @@ func TestIDsInLocate_TracesGet_StepsIncludeID(t *testing.T) {
 // TestIDsInLocate_TracesFollow_StepsIncludeID verifies that each step in
 // archigraph_traces action=follow carries a prefixed "id" field.
 func TestIDsInLocate_TracesFollow_StepsIncludeID(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildLocateDoc())
+	srv := newTestServer(t, buildLocateDoc())
 	res := callToolArgs(t, srv.handleTracesFollow, map[string]any{
 		"group":          "test",
 		"entry_point_id": "fn_beta",
@@ -314,7 +314,7 @@ func TestIDsInLocate_TracesFollow_StepsIncludeID(t *testing.T) {
 // TestIDsInLocate_FindCallers_NarrowIncludesID verifies that each caller row
 // includes a prefixed "id" in the narrow (verbose=false) default mode.
 func TestIDsInLocate_FindCallers_NarrowIncludesID(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildLocateDoc())
+	srv := newTestServer(t, buildLocateDoc())
 	res := callToolArgs(t, srv.handleFindCallers, map[string]any{
 		"group":     "test",
 		"entity_id": "fn_alpha",
@@ -342,7 +342,7 @@ func TestIDsInLocate_FindCallers_NarrowIncludesID(t *testing.T) {
 // TestIDsInLocate_FindCallees_NarrowIncludesID verifies that each callee row
 // includes a prefixed "id" in the narrow (verbose=false) default mode.
 func TestIDsInLocate_FindCallees_NarrowIncludesID(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildLocateDoc())
+	srv := newTestServer(t, buildLocateDoc())
 	res := callToolArgs(t, srv.handleFindCallees, map[string]any{
 		"group":     "test",
 		"entity_id": "fn_alpha",
@@ -392,21 +392,20 @@ func TestIDsInLocate_Find_MultiRepo_TOONHasIDs(t *testing.T) {
 
 	// Two repos, each with a uniquely named entity so BM25 can score them.
 	docA := &graph.Document{
+		Repo: "repo-a",
 		Entities: []graph.Entity{
 			{ID: "fn_widget", Name: "WidgetHandler", Kind: "SCOPE.Function",
 				QualifiedName: "pkg.WidgetHandler", SourceFile: "src/widget.go", StartLine: 10},
 		},
 	}
 	docB := &graph.Document{
+		Repo: "repo-b",
 		Entities: []graph.Entity{
 			{ID: "fn_widget_b", Name: "WidgetProcessor", Kind: "SCOPE.Function",
 				QualifiedName: "pkg.WidgetProcessor", SourceFile: "src/proc.go", StartLine: 20},
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{
-		"repo-a": docA,
-		"repo-b": docB,
-	})
+	srv := newTestServer(t, docA, docB)
 
 	raw := callHandlerText(t, srv.handleQueryGraph, map[string]any{
 		"group":    "test",
@@ -446,21 +445,20 @@ func TestIDsInLocate_Find_MultiRepo_MarkdownFallback(t *testing.T) {
 	t.Setenv("MCP_FIND_FORMAT", "markdown")
 
 	docA := &graph.Document{
+		Repo: "repo-c",
 		Entities: []graph.Entity{
 			{ID: "fn_gadget", Name: "GadgetHandler", Kind: "SCOPE.Function",
 				QualifiedName: "pkg.GadgetHandler", SourceFile: "src/gadget.go", StartLine: 5},
 		},
 	}
 	docB := &graph.Document{
+		Repo: "repo-d",
 		Entities: []graph.Entity{
 			{ID: "fn_gadget_b", Name: "GadgetProcessor", Kind: "SCOPE.Function",
 				QualifiedName: "pkg.GadgetProcessor", SourceFile: "src/gp.go", StartLine: 7},
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{
-		"repo-c": docA,
-		"repo-d": docB,
-	})
+	srv := newTestServer(t, docA, docB)
 
 	raw := callHandlerText(t, srv.handleQueryGraph, map[string]any{
 		"group":    "test",
@@ -479,7 +477,7 @@ func TestIDsInLocate_Find_MultiRepo_MarkdownFallback(t *testing.T) {
 // TestIDsInLocate_VerboseModePreservesID verifies that verbose=true does not
 // remove the id field — it only adds extra fields on top of the narrow set.
 func TestIDsInLocate_VerboseModePreservesID(t *testing.T) {
-	srv := newTestServerWithDoc(t, buildLocateDoc())
+	srv := newTestServer(t, buildLocateDoc())
 
 	// find_callers verbose.
 	res := callToolArgs(t, srv.handleFindCallers, map[string]any{

--- a/internal/mcp/testhelpers_test.go
+++ b/internal/mcp/testhelpers_test.go
@@ -1,0 +1,78 @@
+package mcp
+
+// testhelpers_test.go — shared server-construction helpers for internal/mcp tests.
+//
+// Introduced in #2306 to unify the near-duplicate newTestServerWithDoc
+// (dashboard_tools_test.go) and newTestServerWithDocs (ux_1650_test.go).
+// The two originals had subtly different Registry plumbing; this single
+// variadic helper handles both the single-doc and multi-doc cases.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// newTestServer builds a minimal Server with one group ("test") loaded from
+// the supplied documents.
+//
+// Repo naming: each doc is keyed by its doc.Repo field.  When doc.Repo is
+// empty the repo is auto-named "repo1", "repo2", … in the order the docs are
+// provided.  Callers that need a specific repo name (e.g. cross-repo tests
+// that check prefixed IDs) must set doc.Repo before calling this helper.
+//
+// Single-doc shorthand:
+//
+//	srv := newTestServer(t, doc)   // repo name = doc.Repo or "repo1"
+//
+// Multi-doc (cross-repo tests):
+//
+//	frontend.Repo = "frontend"
+//	backend.Repo  = "backend"
+//	srv := newTestServer(t, frontend, backend)
+func newTestServer(t *testing.T, docs ...*graph.Document) *Server {
+	t.Helper()
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{}},
+	}}
+
+	// Assign repo names: prefer doc.Repo; fall back to "repo<N>".
+	type namedDoc struct {
+		name string
+		doc  *graph.Document
+	}
+	named := make([]namedDoc, 0, len(docs))
+	for i, doc := range docs {
+		name := doc.Repo
+		if name == "" {
+			name = fmt.Sprintf("repo%d", i+1)
+		}
+		named = append(named, namedDoc{name, doc})
+		reg.Groups["test"].Repos[name] = RegistryRepo{Path: t.TempDir()}
+	}
+
+	st := NewState(reg)
+	st.mu.Lock()
+	lg := &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{}}
+	for _, nd := range named {
+		doc := nd.doc
+		byID := make(map[string]*graph.Entity, len(doc.Entities))
+		for i := range doc.Entities {
+			byID[doc.Entities[i].ID] = &doc.Entities[i]
+		}
+		lg.Repos[nd.name] = &LoadedRepo{
+			Repo:       nd.name,
+			Doc:        doc,
+			LabelIndex: BuildLabelIndex(doc),
+			BM25:       BuildBM25(doc),
+			Adjacency:  buildAdjacency(doc, nd.name),
+			CallsAdj:   buildCallsAdjacency(doc),
+			ByID:       byID,
+		}
+	}
+	st.groups["test"] = lg
+	st.mu.Unlock()
+	return &Server{State: st, Tel: NewTelemetry(0)}
+}

--- a/internal/mcp/traces.go
+++ b/internal/mcp/traces.go
@@ -202,7 +202,7 @@ func (s *Server) handleTracesGet(_ context.Context, req mcpapi.CallToolRequest) 
 			// name/file/line/repo from the correct companion repo instead of being
 			// emitted as bare {id, node_id, step_index} stubs.
 			xrLookup := buildGroupCrossRepoLookup(lg, r.Repo)
-			steps := buildProcessStepsWithCrossRepo(r.Doc, e, r.ByID, r.Repo, xrLookup, verbose)
+			steps := buildProcessStepsWithCrossRepo(r, e, xrLookup, verbose)
 			return jsonResult(map[string]any{
 				"process_id":  prefixedID(r.Repo, e.ID),
 				"repo":        r.Repo,
@@ -367,19 +367,25 @@ func buildGroupCrossRepoLookup(lg *LoadedGroup, seedRepo string) crossRepoLookup
 // archigraph_inspect round-trip (#1744). node_id (local ID) is preserved for
 // backward compatibility.
 //
-// crossRepo, when non-nil, is consulted for step entity IDs not found in byID.
+// crossRepo, when non-nil, is consulted for step entity IDs not found in r.ByID.
 // This is the cross-repo companion lookup needed to enrich bridge steps in
 // flows that extend across repo boundaries (#1905). When crossRepo is nil the
 // function behaves identically to the single-repo path.
-func buildProcessSteps(doc *graph.Document, proc *graph.Entity, byID map[string]*graph.Entity, repo string, verbose ...bool) []map[string]any {
-	return buildProcessStepsWithCrossRepo(doc, proc, byID, repo, nil, verbose...)
+//
+// Migrated from (doc *graph.Document, proc *graph.Entity, byID map[string]*graph.Entity,
+// repo string) to *LoadedRepo in #2307 — all callers already hold a *LoadedRepo.
+func buildProcessSteps(r *LoadedRepo, proc *graph.Entity, verbose ...bool) []map[string]any {
+	return buildProcessStepsWithCrossRepo(r, proc, nil, verbose...)
 }
 
 // buildProcessStepsWithCrossRepo is the cross-repo-aware variant of
 // buildProcessSteps (#1905). Pass a non-nil crossRepo to resolve bridge step
 // entities that live in companion repos.
-func buildProcessStepsWithCrossRepo(doc *graph.Document, proc *graph.Entity, byID map[string]*graph.Entity, repo string, crossRepo crossRepoLookup, verbose ...bool) []map[string]any {
+func buildProcessStepsWithCrossRepo(r *LoadedRepo, proc *graph.Entity, crossRepo crossRepoLookup, verbose ...bool) []map[string]any {
 	wantVerbose := len(verbose) > 0 && verbose[0]
+	doc := r.Doc
+	repo := r.Repo
+	byID := r.ByID
 	if byID == nil {
 		// Defensive fallback: callers should always pass a cached map (#1656),
 		// but synthesize on the fly if absent so tests that pass nil still work.
@@ -391,16 +397,16 @@ func buildProcessStepsWithCrossRepo(doc *graph.Document, proc *graph.Entity, byI
 	}
 	var ordered []indexed
 	for i := range doc.Relationships {
-		r := &doc.Relationships[i]
-		if r.Kind != stepInProcessEdge || r.FromID != proc.ID {
+		rel := &doc.Relationships[i]
+		if rel.Kind != stepInProcessEdge || rel.FromID != proc.ID {
 			continue
 		}
 		idxStr := ""
-		if r.Properties != nil {
-			idxStr = r.Properties["step_index"]
+		if rel.Properties != nil {
+			idxStr = rel.Properties["step_index"]
 		}
 		n, _ := strconv.Atoi(idxStr)
-		ordered = append(ordered, indexed{n, r.ToID})
+		ordered = append(ordered, indexed{n, rel.ToID})
 	}
 	if len(ordered) == 0 {
 		// Fallback to the chain property if the edges weren't emitted.

--- a/internal/mcp/traces_test.go
+++ b/internal/mcp/traces_test.go
@@ -202,7 +202,7 @@ func build20ProcessDoc() *graph.Document {
 // TestTracesList_DefaultLimit10 verifies that without an explicit limit,
 // the list returns at most 10 items (#1738 default reduction from 25).
 func TestTracesList_DefaultLimit10(t *testing.T) {
-	srv := newTestServerWithDoc(t, build20ProcessDoc())
+	srv := newTestServer(t, build20ProcessDoc())
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"action":    "list",
@@ -226,7 +226,7 @@ func TestTracesList_DefaultLimit10(t *testing.T) {
 // TestTracesList_TokenBudgetEnforced verifies that a tight token_budget
 // caps the list and adds a truncation_note (#1738).
 func TestTracesList_TokenBudgetEnforced(t *testing.T) {
-	srv := newTestServerWithDoc(t, build20ProcessDoc())
+	srv := newTestServer(t, build20ProcessDoc())
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"action":       "list",
@@ -310,10 +310,7 @@ func buildCrossRepoFlowFixture() (frontend, backend *graph.Document) {
 // and its id carries the companion repo prefix — not the seed repo prefix.
 func TestTracesGet_BridgeStepMetadata_1905(t *testing.T) {
 	frontend, backend := buildCrossRepoFlowFixture()
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{
-		"frontend": frontend,
-		"backend":  backend,
-	})
+	srv := newTestServer(t, frontend, backend)
 
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = map[string]any{

--- a/internal/mcp/ux_1650_test.go
+++ b/internal/mcp/ux_1650_test.go
@@ -32,7 +32,7 @@ func TestUX1650_FlowToolsReturnIDs(t *testing.T) {
 			{FromID: "b", ToID: "c", Kind: "CALLS"},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	res := callEndpointTool(t, srv.handleFindCallers, map[string]any{"group": "test", "entity_id": "b"})
 	callers := getSlice(t, res, "callers")
 	if len(callers) == 0 {
@@ -65,7 +65,7 @@ func TestUX1650_GetSourceAcceptsLabelWithClarifier(t *testing.T) {
 			{ID: "h2", Name: "handler", QualifiedName: "b.handler", Kind: "Function", SourceFile: "b.go", StartLine: 20, EndLine: 22},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// label is ambiguous → clarifier.
 	res := callEndpointTool(t, srv.handleGetNodeSource, map[string]any{"group": "test", "node_id": "handler"})
@@ -119,7 +119,7 @@ func TestUX1650_EndpointsFilterAndTerse(t *testing.T) {
 		Properties: map[string]string{"verb": "GET", "path": "/api/v1/proposals/get_counts"},
 	})
 	doc := &graph.Document{Entities: ents}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 
 	// path_contains="proposal" → 1 line, not 5,780.
 	// #2288: terse default omits `definitions` — assert `count` and `lines`
@@ -167,7 +167,7 @@ func TestUX1650_EndpointStatsCrossRepoLinks(t *testing.T) {
 			{FromID: "caller", ToID: "ext_unknown", Kind: "FETCHES"},
 		},
 	}
-	srv := newTestServerWithDoc(t, doc)
+	srv := newTestServer(t, doc)
 	// Inject a cross-repo link covering the caller.
 	lg := srv.State.Group("test")
 	if lg == nil {
@@ -192,19 +192,18 @@ func TestUX1650_EndpointStatsCrossRepoLinks(t *testing.T) {
 func TestUX1650_FindPathsCrossRepo(t *testing.T) {
 	// Build a multi-repo group: repoA (mobile) and repoB (backend).
 	docA := &graph.Document{
+		Repo: "repoA",
 		Entities: []graph.Entity{
 			{ID: "mobile_call", Name: "useProposalCounts", Kind: "Function", SourceFile: "App.jsx"},
 		},
 	}
 	docB := &graph.Document{
+		Repo: "repoB",
 		Entities: []graph.Entity{
 			{ID: "backend_handler", Name: "get_counts", Kind: "Function", SourceFile: "views.py"},
 		},
 	}
-	srv := newTestServerWithDocs(t, map[string]*graph.Document{
-		"repoA": docA,
-		"repoB": docB,
-	})
+	srv := newTestServer(t, docA, docB)
 	lg := srv.State.Group("test")
 	lg.Links = []CrossRepoLink{
 		{
@@ -234,7 +233,7 @@ func TestUX1650_FindPathsCrossRepo(t *testing.T) {
 // We exercise wrap directly because the handler-level tests in this file
 // call the handlers without the wrap middleware.
 func TestUX1650_WrapInjectsElapsedMS(t *testing.T) {
-	srv := newTestServerWithDoc(t, &graph.Document{
+	srv := newTestServer(t, &graph.Document{
 		Entities: []graph.Entity{{ID: "x", Name: "x", Kind: "Function"}},
 	})
 	wrapped := srv.wrap("test_tool", srv.handleWhoami)
@@ -256,7 +255,7 @@ func TestUX1650_WrapInjectsElapsedMS(t *testing.T) {
 // scenario_h — #1687: error responses also carry elapsed_ms so callers can
 // measure latency even when the tool returns a validation or lookup error.
 func TestUX1687_WrapInjectsElapsedMSOnError(t *testing.T) {
-	srv := newTestServerWithDoc(t, &graph.Document{
+	srv := newTestServer(t, &graph.Document{
 		Entities: []graph.Entity{{ID: "x", Name: "x", Kind: "Function"}},
 	})
 	// handleFindCallers requires entity_id; call with the wrong key so it
@@ -281,37 +280,6 @@ func TestUX1687_WrapInjectsElapsedMSOnError(t *testing.T) {
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
-
-func newTestServerWithDocs(t *testing.T, docs map[string]*graph.Document) *Server {
-	t.Helper()
-	reg := &Registry{Groups: map[string]RegistryGroup{
-		"test": {Repos: map[string]RegistryRepo{}},
-	}}
-	for name := range docs {
-		reg.Groups["test"].Repos[name] = RegistryRepo{Path: t.TempDir()}
-	}
-	st := NewState(reg)
-	st.mu.Lock()
-	lg := &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{}}
-	for name, doc := range docs {
-		byID := make(map[string]*graph.Entity, len(doc.Entities))
-		for i := range doc.Entities {
-			byID[doc.Entities[i].ID] = &doc.Entities[i]
-		}
-		lg.Repos[name] = &LoadedRepo{
-			Repo:       name,
-			Doc:        doc,
-			LabelIndex: BuildLabelIndex(doc),
-			BM25:       BuildBM25(doc),
-			Adjacency:  buildAdjacency(doc, name),
-			CallsAdj:   buildCallsAdjacency(doc),
-			ByID:       byID,
-		}
-	}
-	st.groups["test"] = lg
-	st.mu.Unlock()
-	return &Server{State: st, Tel: NewTelemetry(0)}
-}
 
 func callEndpointToolText(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) string {
 	t.Helper()


### PR DESCRIPTION
## Summary

- **#2306**: Unified `newTestServerWithDoc` (`dashboard_tools_test.go`) and `newTestServerWithDocs` (`ux_1650_test.go`) — near-duplicates with subtly different Registry plumbing — into a single variadic `newTestServer(docs ...*graph.Document)` in `internal/mcp/testhelpers_test.go`. Repo name is taken from `doc.Repo`; auto-assigned `"repo1"`, `"repo2"`, … when unset. Migrated all 12 multi-doc call sites, setting `doc.Repo` on the few fixtures that did not yet carry it.
- **#2307**: Audited helpers in `internal/mcp/` for the older `*graph.Document + repo string` convention; migrated `buildProcessSteps` and `buildProcessStepsWithCrossRepo` to `*LoadedRepo` (both callers already held the struct in scope). `buildAdjacency(doc, repo)` and `followCallsBFS(doc, …)` left unchanged — construction primitives where `*LoadedRepo` does not yet exist or the decomposed params are structurally required.

Behavior-neutral refactor; 426 tests pass before and after.

Closes #2306
Closes #2307

## Test plan

- [x] `go build ./...` green
- [x] `go test ./internal/mcp/... -count=1` — 426 PASS, 0 FAIL (unchanged from baseline)
- [x] No behavior changes — pure rename/consolidation + signature tightening

🤖 Generated with [Claude Code](https://claude.com/claude-code)