### PR TITLE
refactor(daemon): complete slog migration — drop loggerLegacy bridge (#2388)

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -264,11 +265,10 @@ func runDaemon(argv []string) error {
 		return fmt.Errorf("open log %s: %w", layout.LogPath, err)
 	}
 	defer logFile.Close()
-	logger := log.New(io.MultiWriter(os.Stderr, logFile), "archigraph-daemon: ",
-		log.LstdFlags|log.Lmicroseconds)
+	logger := buildDaemonSlogLogger(io.MultiWriter(os.Stderr, logFile))
 	// ADR-0016 flip-day (#808): log the active graph format mode so users
 	// can confirm the daemon is running in the expected configuration.
-	logger.Printf("graph format: fb-default (json-fallback enabled) — graph.fb written on every index; --skip-json opt-in drops graph.json")
+	logger.Info("graph format: fb-default (json-fallback enabled) — graph.fb written on every index; --skip-json opt-in drops graph.json")
 
 	// Resolve dashboard port: env var > default. A future
 	// ~/.config/archigraph/daemon.toml can add more overrides.
@@ -477,7 +477,7 @@ func daemonSchedulerIndex(ctx context.Context, repoPath string, ref string) erro
 	var err error
 	if sched.SubprocessIndexEnabled() {
 		// S5 path: fork-exec `archigraph index-internal` for memory isolation.
-		err = sched.RunSubprocessIndex(ctx, repoPath, ref, []string{"graph-algo"}, log.Default())
+		err = sched.RunSubprocessIndex(ctx, repoPath, ref, []string{"graph-algo"}, slog.Default())
 	} else {
 		// In-process path (legacy default, enabled on existing installs).
 		// ADR-0016 flip-day (#808): graph.fb is always written by default now.
@@ -1026,8 +1026,8 @@ func daemonPatternGroupDirs() map[string]string {
 //
 // This function lives in cmd/archigraph (not internal/daemon) to avoid the
 // import cycle: internal/dashboard already imports internal/daemon.
-func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Context, bind string, port int, logger *log.Logger) error {
-	return func(ctx context.Context, bind string, port int, logger *log.Logger) error {
+func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Context, bind string, port int, logger *slog.Logger) error {
+	return func(ctx context.Context, bind string, port int, logger *slog.Logger) error {
 		addr := net.JoinHostPort(bind, strconv.Itoa(port))
 		l, err := net.Listen("tcp", addr)
 		if err != nil {
@@ -1104,8 +1104,18 @@ func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Contex
 
 		srv.UseListener(l)
 		if logger != nil {
-			logger.Printf("dashboard ready http://%s/", addr)
+			logger.Info("dashboard ready", "url", "http://"+addr+"/")
 		}
 		return srv.Serve(ctx)
 	}
+}
+
+// buildDaemonSlogLogger constructs a *slog.Logger for the daemon process.
+// Handler selection follows ARCHIGRAPH_DAEMON_LOG_JSON (same as daemon.buildSlogLogger).
+func buildDaemonSlogLogger(w io.Writer) *slog.Logger {
+	v := strings.TrimSpace(os.Getenv("ARCHIGRAPH_DAEMON_LOG_JSON"))
+	if v == "1" || strings.EqualFold(v, "true") {
+		return slog.New(slog.NewJSONHandler(w, nil))
+	}
+	return slog.New(slog.NewTextHandler(w, nil))
 }

--- a/cmd/archigraph/daemon_tier.go
+++ b/cmd/archigraph/daemon_tier.go
@@ -48,7 +48,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -81,7 +81,7 @@ var daemonSchedulerEnqueue func(repoPath string)
 //
 // P0.3 (#2141): injects the real system memory size into TTLConfig so
 // the pressure-eviction threshold is computed against physical RAM.
-func startDaemonTierManager(ctx context.Context, logger *log.Logger) {
+func startDaemonTierManager(ctx context.Context, logger *slog.Logger) {
 	ttl := tier.EnvTTLConfig()
 
 	// P0.3: populate SystemMemoryBytes from the process package so the
@@ -91,7 +91,9 @@ func startDaemonTierManager(ctx context.Context, logger *log.Logger) {
 		ttl.SystemMemoryBytes = uint64(sysMB) * 1024 * 1024
 	}
 
-	daemonTierMgr = tier.NewManager(ctx, ttl, tierEvictCallback, tierReloadCallback, tierDiskEvictCallback, logger)
+	// tier.NewManager still accepts *log.Logger; bridge via slog.NewLogLogger.
+	tierLog := slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
+	daemonTierMgr = tier.NewManager(ctx, ttl, tierEvictCallback, tierReloadCallback, tierDiskEvictCallback, tierLog)
 
 	// Wire the MCP graph-cache access hook so every GetForRepoRef call
 	// updates lastAccessedAt in the tier manager without extra call-sites.
@@ -114,13 +116,13 @@ func startDaemonTierManager(ctx context.Context, logger *log.Logger) {
 // state directory. Any ref directory that contains a graph.fb is registered.
 // If no refs/ dir exists, the _unknown sentinel is skipped (it would be
 // refused by GetForRepoRef anyway).
-func registerKnownGroupsCold(logger *log.Logger) {
+func registerKnownGroupsCold(logger *slog.Logger) {
 	if daemonTierMgr == nil {
 		return
 	}
 	groups, err := registry.Groups()
 	if err != nil {
-		logger.Printf("tier: lazy-hydration: registry.Groups: %v (skipping cold-register)", err)
+		logger.Warn("tier: lazy-hydration: registry.Groups failed (skipping cold-register)", "err", err)
 		return
 	}
 
@@ -165,7 +167,7 @@ func registerKnownGroupsCold(logger *log.Logger) {
 		}
 	}
 	if registered > 0 {
-		logger.Printf("tier: S1 lazy-hydration: cold-registered %d slot(s) from registry (no graph.fb opened)", registered)
+		logger.Info("tier: S1 lazy-hydration: cold-registered slots from registry (no graph.fb opened)", "count", registered)
 	}
 }
 
@@ -177,7 +179,7 @@ func registerKnownGroupsCold(logger *log.Logger) {
 // subscriptions. The first MCP query for a group calls SubscribeGroupWatcher
 // which lazily subscribes that group's repos. This means the watcher manager
 // starts with an empty slots map and a zero subscription count.
-func onWatcherReady(w *watch.Watcher, logger *log.Logger) {
+func onWatcherReady(w *watch.Watcher, logger *slog.Logger) {
 	mgr := watch.NewDefaultManager(w, logger)
 	daemonWatcherMgr = mgr
 
@@ -187,7 +189,7 @@ func onWatcherReady(w *watch.Watcher, logger *log.Logger) {
 
 	if daemonTierMgr != nil {
 		daemonTierMgr.SetWatcherHook(mgr)
-		logger.Printf("tier: watcher pause/resume hook wired (M2 lazy-subscribe — 0 subscriptions at boot)")
+		logger.Info("tier: watcher pause/resume hook wired (M2 lazy-subscribe — 0 subscriptions at boot)")
 	}
 }
 

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -39,7 +39,7 @@ package sched
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"runtime"
 	"sort"
@@ -134,7 +134,7 @@ type Config struct {
 	Links         LinksFn
 	Algorithms    AlgoFn
 	GroupsForRepo GroupsForRepoFn
-	Logger        *log.Logger
+	Logger        *slog.Logger
 
 	// BudgetMB caps the total predicted RSS of concurrently running
 	// index jobs (megabytes). 0 disables admission control entirely
@@ -211,7 +211,7 @@ type enqueueRequest struct {
 //   - an RSS-budget ledger that gates dispatch.
 type Scheduler struct {
 	cfg    Config
-	logger *log.Logger
+	logger *slog.Logger
 	enq    chan enqueueRequest // public enqueue input → dedup → pending queue
 	jobs   chan jobToken       // admitted jobs handed to workers
 	wake   chan struct{}       // poked when a worker frees budget
@@ -305,7 +305,7 @@ func New(cfg Config) *Scheduler {
 		cfg.AlgoDebounce = 30 * time.Second
 	}
 	if cfg.Logger == nil {
-		cfg.Logger = log.New(os.Stderr, "sched: ", log.LstdFlags)
+		cfg.Logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "sched")
 	}
 	algoCap := resolveAlgoCap(cfg.AlgoCap)
 	return &Scheduler{
@@ -527,8 +527,8 @@ func (s *Scheduler) checkDeadMan() {
 	s.deadManAt = time.Time{} // reset clock; the job is now admitted
 	s.logEventLocked("admit_deadman", repo,
 		"force-admitted after "+stuckFor.String()+" with no progress; predicted="+formatMB(smallestMB))
-	s.logger.Printf("sched: dead-man: force-admitting %s (predicted=%dMB) after queue stuck %s",
-		repo, smallestMB, stuckFor)
+	s.logger.Info("sched: dead-man: force-admitting",
+		"repo", repo, "predicted_mb", smallestMB, "stuck_for", stuckFor)
 
 	tok := jobToken{repoPath: repo, ref: ref, predictedMB: smallestMB}
 	// Dispatch asynchronously so we don't hold the lock while blocking on
@@ -645,8 +645,7 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	s.logEvent("index_start", repoPath, "predicted="+formatMB(tok.predictedMB)+" ref="+tok.ref)
 	// Observability: log goroutine identity + ref so concurrent-indexer
 	// regressions are diagnosable without a pprof trace (#2141).
-	s.logger.Printf("indexer: starting repo=%s ref=%s goroutine_id=%d",
-		repoPath, tok.ref, goroutineID())
+	s.logger.Info("indexer: starting", "repo", repoPath, "ref", tok.ref, "goroutine_id", goroutineID())
 
 	// Spawn RSS sampler so we capture the peak the daemon hit during
 	// this job. Records into history on completion.
@@ -690,8 +689,7 @@ func (s *Scheduler) runIndex(tok jobToken) {
 		} else {
 			s.logEvent("incremental_fallback", repoPath,
 				"reason="+res.FallbackReason)
-			s.logger.Printf("sched: incremental fallback repo=%s reason=%s",
-				repoPath, res.FallbackReason)
+			s.logger.Info("sched: incremental fallback", "repo", repoPath, "reason", res.FallbackReason)
 		}
 	}
 
@@ -747,15 +745,14 @@ func (s *Scheduler) runIndex(tok jobToken) {
 
 	if err != nil {
 		s.logEvent("index_err", repoPath, err.Error())
-		s.logger.Printf("sched: index %s failed: %v (took %s)", repoPath, err, time.Since(t0))
+		s.logger.Error("sched: index failed", "repo", repoPath, "err", err, "took", time.Since(t0))
 		return
 	}
 	dur := time.Since(t0).Truncate(time.Millisecond)
 	allocDiff := observedPeakMB - tok.predictedMB
 	s.logEvent("index_ok", repoPath,
 		dur.String()+" peak="+formatMB(observedPeakMB))
-	s.logger.Printf("indexer: completed repo=%s took=%s peak_heap=%dMB alloc_diff=%dMB",
-		repoPath, dur, observedPeakMB, allocDiff)
+	s.logger.Info("indexer: completed", "repo", repoPath, "took", dur, "peak_heap_mb", observedPeakMB, "alloc_diff_mb", allocDiff)
 
 	// Schedule downstream passes.
 	s.scheduleAlgo(repoPath)
@@ -794,7 +791,7 @@ func (s *Scheduler) runLinks(group string) {
 	err := s.cfg.Links(context.Background(), group)
 	if err != nil {
 		s.logEvent("links_err", "", group+": "+err.Error())
-		s.logger.Printf("sched: links %s failed: %v", group, err)
+		s.logger.Error("sched: links failed", "group", group, "err", err)
 		return
 	}
 	s.logEvent("links_ok", "", group+" "+time.Since(t0).Truncate(time.Millisecond).String())
@@ -867,7 +864,7 @@ func (s *Scheduler) runAlgo(ctx context.Context, repoPath string) {
 	// / #2140 hyp-2). The acquire is interruptible via ctx so a cancellation
 	// (new write arrives for this repo) doesn't block forever.
 	cap := cap(s.algoSem)
-	s.logger.Printf("algo-pass: starting repo=%s cap=%d goroutines", repoPath, cap)
+	s.logger.Info("algo-pass: starting", "repo", repoPath, "cap", cap)
 	select {
 	case s.algoSem <- struct{}{}:
 		// acquired
@@ -888,7 +885,7 @@ func (s *Scheduler) runAlgo(ctx context.Context, repoPath string) {
 			return
 		}
 		s.logEvent("algo_err", repoPath, err.Error())
-		s.logger.Printf("sched: algo %s failed: %v", repoPath, err)
+		s.logger.Error("sched: algo failed", "repo", repoPath, "err", err)
 		return
 	}
 	s.mu.Lock()

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -57,7 +57,7 @@ type ipcEvent struct {
 //	repoPath   — absolute path of the repository
 //	ref        — git ref captured at enqueue time (may be "")
 //	skipPasses — pass names forwarded via --skip-pass
-//	logger     — daemon's log.Logger for structured event lines
+//	logger     — daemon's slog.Logger for structured event lines
 //
 // The child's stderr is copied line-by-line to logger (prefixed with the
 // repo basename) so the daemon log file includes child extractor output
@@ -66,7 +66,7 @@ type ipcEvent struct {
 // Cancellation: ctx.Done() sends SIGTERM to the child. The child is
 // expected to exit on SIGTERM; if it does not, the parent waits and the
 // context timeout (if any) will eventually unblock the caller.
-func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []string, logger *log.Logger) error {
+func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []string, logger *slog.Logger) error {
 	binary, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("subprocess-indexer: resolve binary: %w", err)
@@ -104,7 +104,7 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 
 	pid := cmd.Process.Pid
 	if logger != nil {
-		logger.Printf("subprocess-indexer: started pid=%d repo=%s ref=%s", pid, repoPath, ref)
+		logger.Info("subprocess-indexer: started", "pid", pid, "repo", repoPath, "ref", ref)
 	}
 
 	// Drain child stderr in a goroutine — each line forwarded to the daemon
@@ -116,7 +116,7 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 		sc := bufio.NewScanner(stderrPipe)
 		for sc.Scan() {
 			if logger != nil {
-				logger.Printf("[child pid=%d] %s", pid, sc.Text())
+				logger.Info("[child]", "pid", pid, "line", sc.Text())
 			}
 		}
 	}()
@@ -134,7 +134,7 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 			}
 			lastEvent = ev
 			if logger != nil {
-				logger.Printf("subprocess-indexer: event=%s repo=%s ref=%s", ev.Event, ev.Repo, ev.Ref)
+				logger.Info("subprocess-indexer: event", "event", ev.Event, "repo", ev.Repo, "ref", ev.Ref)
 			}
 		}
 	}()
@@ -146,9 +146,9 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 
 	if logger != nil {
 		if waitErr != nil {
-			logger.Printf("subprocess-indexer: pid=%d exited with error: %v", pid, waitErr)
+			logger.Error("subprocess-indexer: exited with error", "pid", pid, "err", waitErr)
 		} else {
-			logger.Printf("subprocess-indexer: pid=%d completed successfully", pid)
+			logger.Info("subprocess-indexer: completed successfully", "pid", pid)
 		}
 	}
 

--- a/internal/daemon/sched/subprocess_runner_test.go
+++ b/internal/daemon/sched/subprocess_runner_test.go
@@ -2,7 +2,7 @@ package sched
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -62,7 +62,7 @@ func TestRunSubprocessIndexMissingBinary(t *testing.T) {
 	// Point to a directory that looks like a binary but is not — on Linux/macOS
 	// exec will return "permission denied" or "not a file". We just want a
 	// non-zero exit.
-	err := RunSubprocessIndex(ctx, tmpDir, "", nil, log.New(os.Stderr, "test: ", 0))
+	err := RunSubprocessIndex(ctx, tmpDir, "", nil, slog.Default())
 	// Any error is correct here — non-existent binary OR index failure on tmpDir.
 	if err == nil {
 		t.Fatal("expected an error for non-repo tmpDir but got nil")

--- a/internal/daemon/selfdefense.go
+++ b/internal/daemon/selfdefense.go
@@ -19,7 +19,7 @@ package daemon
 import (
 	"bytes"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
@@ -51,15 +51,15 @@ func isTmpPath(path string) bool {
 // running, the function returns a descriptive error and the caller must exit.
 //
 // logger may be nil; a default stderr logger will be used.
-func SelfDefenseCheck(logger *log.Logger) error {
+func SelfDefenseCheck(logger *slog.Logger) error {
 	if logger == nil {
-		logger = log.New(os.Stderr, "archigraph-daemon: ", log.LstdFlags)
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "selfdefense")
 	}
 
 	self, err := os.Executable()
 	if err != nil {
 		// Can't determine our own path — skip check rather than blocking startup.
-		logger.Printf("selfdefense: os.Executable() failed: %v (skipping check)", err)
+		logger.Warn("selfdefense: os.Executable() failed (skipping check)", "err", err)
 		return nil
 	}
 
@@ -90,9 +90,9 @@ func SelfDefenseCheck(logger *log.Logger) error {
 //
 // Both conditions must hold to avoid killing legitimate short-lived binaries
 // that happen to live under /tmp.
-func StartCPUWatchdog(inflightCounter *int64, logger *log.Logger) {
+func StartCPUWatchdog(inflightCounter *int64, logger *slog.Logger) {
 	if logger == nil {
-		logger = log.New(os.Stderr, "archigraph-daemon: ", log.LstdFlags)
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "selfdefense")
 	}
 
 	self, err := os.Executable()
@@ -171,14 +171,13 @@ func findCanonicalDaemon() (pid int, exe string) {
 //   - daemon enters hot-loop at ~1000% CPU
 //   - no inflight RPC work
 //   - watchdog self-terminates within ~5 minutes
-func cpuWatchdog(inflight *int64, logger *log.Logger) {
+func cpuWatchdog(inflight *int64, logger *slog.Logger) {
 	const (
 		pollInterval    = 60 * time.Second
 		cpuThresholdPct = 500.0
 		sustainedTicks  = 5 // 5 × 60s = 5 minutes
 	)
-	logger.Printf("selfdefense: CPU watchdog started (threshold=%.0f%% for %d ticks)",
-		cpuThresholdPct, sustainedTicks)
+	logger.Info("selfdefense: CPU watchdog started", "threshold_pct", cpuThresholdPct, "sustained_ticks", sustainedTicks)
 
 	hotTicks := 0
 	ticker := time.NewTicker(pollInterval)
@@ -193,18 +192,17 @@ func cpuWatchdog(inflight *int64, logger *log.Logger) {
 		pct := selfCPUPercent()
 		if pct > cpuThresholdPct {
 			hotTicks++
-			logger.Printf("selfdefense: hot-loop suspected (cpu=%.1f%% inflight=0 ticks=%d/%d)",
-				pct, hotTicks, sustainedTicks)
+			logger.Warn("selfdefense: hot-loop suspected", "cpu_pct", pct, "inflight", 0, "ticks", hotTicks, "max_ticks", sustainedTicks)
 			if hotTicks >= sustainedTicks {
 				// Dump a goroutine profile to stderr before exiting so the operator
 				// can inspect what was spinning. This is Layer 2 of the diagnostic.
 				dumpGoroutineProfile(logger)
-				logger.Printf("selfdefense: self-detecting hot-loop (cpu=%.1f%%), exiting", pct)
+				logger.Error("selfdefense: self-detecting hot-loop, exiting", "cpu_pct", pct)
 				os.Exit(0)
 			}
 		} else {
 			if hotTicks > 0 {
-				logger.Printf("selfdefense: CPU normalised (%.1f%%), resetting counter", pct)
+				logger.Info("selfdefense: CPU normalised, resetting counter", "cpu_pct", pct)
 			}
 			hotTicks = 0
 		}
@@ -224,23 +222,23 @@ func selfCPUPercent() float64 {
 // dumpGoroutineProfile writes a goroutine stack dump (for diagnosing the hot
 // function) to a temporary file and logs the path. Also logs a brief in-memory
 // summary to logger. This is the Layer 2 pprof integration mentioned in #857.
-func dumpGoroutineProfile(logger *log.Logger) {
+func dumpGoroutineProfile(logger *slog.Logger) {
 	var buf bytes.Buffer
 	p := pprof.Lookup("goroutine")
 	if p == nil {
 		return
 	}
 	if err := p.WriteTo(&buf, 1); err != nil {
-		logger.Printf("selfdefense: goroutine dump failed: %v", err)
+		logger.Error("selfdefense: goroutine dump failed", "err", err)
 		return
 	}
 
 	f, err := os.CreateTemp("", "archigraph-hotloop-*.pprof.txt")
 	if err != nil {
-		logger.Printf("selfdefense: goroutine dump (inline):\n%s", buf.String())
+		logger.Info("selfdefense: goroutine dump (inline)", "dump", buf.String())
 		return
 	}
 	_, _ = f.Write(buf.Bytes())
 	_ = f.Close()
-	logger.Printf("selfdefense: goroutine dump written to %s", f.Name())
+	logger.Info("selfdefense: goroutine dump written", "path", f.Name())
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"net"
 	"net/rpc"
@@ -31,12 +30,9 @@ type Config struct {
 	Index        IndexFunc        // injected from cmd/archigraph
 	Rebuild      RebuildFunc      // injected from cmd/archigraph
 	QualityAudit QualityAuditFunc // injected from cmd/archigraph (Phase E)
-	// Logger is the legacy *log.Logger forwarded to sub-packages (sched,
-	// watch) that still accept *log.Logger. Daemon-internal log output uses
-	// a *slog.Logger constructed from this writer in Run. When nil, Run
-	// constructs a default stderr *log.Logger for the sub-packages and a
-	// corresponding slog.Logger for its own use.
-	Logger *log.Logger
+	// Logger is the *slog.Logger used by daemon-internal code and all sub-packages.
+	// When nil, Run constructs a default stderr slog.Logger.
+	Logger *slog.Logger
 
 	// Phase B optional wiring. When all four are non-nil the daemon
 	// starts the fsnotify watcher + scheduler and registers every
@@ -95,7 +91,7 @@ type Config struct {
 	//
 	// The hook receives the bind address and port to listen on, and the
 	// daemon logger. It should block until ctx is done.
-	DashboardServe func(ctx context.Context, bind string, port int, logger *log.Logger) error
+	DashboardServe func(ctx context.Context, bind string, port int, logger *slog.Logger) error
 
 	// DashboardPort is the TCP port for the embedded dashboard HTTP server
 	// (#929/#931). When 0 the dashboard is disabled. Default production
@@ -165,17 +161,14 @@ type Config struct {
 // daemon's entire public surface — cmd/archigraph just imports daemon
 // and calls Run.
 func Run(ctx context.Context, cfg Config) error {
-	// loggerLegacy is forwarded to sub-packages (sched, watch, selfdefense)
-	// that still accept *log.Logger. It is separate from slogger below.
-	loggerLegacy := cfg.Logger
-	if loggerLegacy == nil {
-		loggerLegacy = log.New(os.Stderr, "archigraph-daemon: ", log.LstdFlags|log.Lmicroseconds)
+	// slogger is the structured logger used by the daemon itself (Run + Service)
+	// and all sub-packages. Handler selection is based on ARCHIGRAPH_DAEMON_LOG_JSON
+	// at startup — this encodes the choice in the handler so call sites never check
+	// the env var.
+	slogger := cfg.Logger
+	if slogger == nil {
+		slogger = buildSlogLogger(os.Stderr)
 	}
-
-	// slogger is the structured logger used by the daemon itself (Run + Service).
-	// Handler selection is based on ARCHIGRAPH_DAEMON_LOG_JSON at startup —
-	// this encodes the choice in the handler so call sites never check the env var.
-	slogger := buildSlogLogger(loggerLegacy.Writer())
 	// Keep a short alias for readability in the long Run body below.
 	logger := slogger
 
@@ -183,7 +176,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// is already running and this binary lives under /tmp. This prevents the
 	// hot-loop runaway observed on 2026-05-20 where agent-spawned daemons were
 	// adopted by launchd after the agent exited and spun at ~1000% CPU.
-	if err := SelfDefenseCheck(loggerLegacy); err != nil {
+	if err := SelfDefenseCheck(logger); err != nil {
 		return err
 	}
 
@@ -249,7 +242,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// Layer 2 self-defense: start CPU watchdog for ephemeral /tmp daemons.
 	// The watchdog passes the service's real inFlight counter so it can
 	// distinguish hot-loops (no work) from legitimate sustained indexing.
-	StartCPUWatchdog(&svc.inFlight, loggerLegacy)
+	StartCPUWatchdog(&svc.inFlight, logger)
 
 	// Phase B — bring up the scheduler + watcher when the caller
 	// supplied the four hooks. They are optional so tests can exercise
@@ -261,7 +254,7 @@ func Run(ctx context.Context, cfg Config) error {
 			Links:         cfg.SchedulerLinks,
 			Algorithms:    cfg.SchedulerAlgo,
 			GroupsForRepo: cfg.GroupsForRepo,
-			Logger:        loggerLegacy,
+			Logger:        logger,
 			BudgetMB:      cfg.MaxRSSBudgetMB,
 			Predict:       sched.PredictRSS,
 			History:       history,
@@ -288,7 +281,7 @@ func Run(ctx context.Context, cfg Config) error {
 				logger.Info("watcher: bulk trigger — enqueuing full reindex", "repo", repo)
 			}
 			scheduler.Enqueue(repo)
-		}, loggerLegacy)
+		}, logger)
 		if werr != nil {
 			logger.Warn("watcher: disabled", "err", werr)
 		} else {
@@ -314,7 +307,7 @@ func Run(ctx context.Context, cfg Config) error {
 					cfg.BranchSwitchSink(ev.RepoPath, ev.OldRef)
 				}
 				scheduler.EnqueueRef(ev.RepoPath, ev.NewRef)
-			}, loggerLegacy)
+			}, logger)
 			headPoller.Start()
 			defer headPoller.Stop()
 
@@ -380,7 +373,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// .previous-* backups every 24 h. Opt-in: nil = disabled (--no-auto-cleanup).
 	if cfg.DocgenSweep != nil {
 		sweepCfg := *cfg.DocgenSweep
-		sweepCfg.Logger = loggerLegacy
+		sweepCfg.Logger = logger
 		sweepStop := make(chan struct{})
 		StartDocgenSweeper(sweepCfg, sweepStop)
 		defer close(sweepStop)
@@ -403,7 +396,7 @@ func Run(ctx context.Context, cfg Config) error {
 		dashCtx, dashCancel := context.WithCancel(ctx)
 		defer dashCancel()
 		go func() {
-			if err := cfg.DashboardServe(dashCtx, bind, cfg.DashboardPort, loggerLegacy); err != nil {
+			if err := cfg.DashboardServe(dashCtx, bind, cfg.DashboardPort, logger); err != nil {
 				logger.Error("dashboard", "err", err)
 			}
 		}()
@@ -599,10 +592,9 @@ func buildPatternDecayJob(groupDirs func() map[string]string, logger *slog.Logge
 //     with log shippers)
 //   - anything else → slog.NewTextHandler (human-readable logfmt)
 //
-// The writer w is inherited from the caller's *log.Logger so both the legacy
-// bridge and the slog logger share the same output sink. Handler selection at
-// construction time eliminates the prefix-corruption failure mode that required
-// the startup guard removed in #2375 — slog cannot be misconfigured this way.
+// Handler selection at construction time eliminates the prefix-corruption
+// failure mode that required the startup guard removed in #2375 — slog cannot
+// be misconfigured this way.
 func buildSlogLogger(w io.Writer) *slog.Logger {
 	v := strings.TrimSpace(os.Getenv(EnvDaemonLogJSON))
 	if v == "1" || strings.EqualFold(v, "true") {

--- a/internal/daemon/sweeper.go
+++ b/internal/daemon/sweeper.go
@@ -13,7 +13,8 @@ package daemon
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
+	"os"
 	"time"
 )
 
@@ -30,8 +31,8 @@ type DocgenSweeperConfig struct {
 	// Interval between sweeps. Default (zero value): 24 hours.
 	Interval time.Duration
 
-	// Logger is used for sweep diagnostics. When nil, log.Default() is used.
-	Logger *log.Logger
+	// Logger is used for sweep diagnostics. When nil, a default stderr slog.Logger is used.
+	Logger *slog.Logger
 }
 
 // StartDocgenSweeper launches the background docgen cleanup goroutine and
@@ -49,7 +50,7 @@ func StartDocgenSweeper(cfg DocgenSweeperConfig, stopCh <-chan struct{}) {
 	}
 	logger := cfg.Logger
 	if logger == nil {
-		logger = log.Default()
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "sweeper")
 	}
 
 	go runDocgenSweeper(interval, cfg.CleanupFn, logger, stopCh)
@@ -57,7 +58,7 @@ func StartDocgenSweeper(cfg DocgenSweeperConfig, stopCh <-chan struct{}) {
 
 // runDocgenSweeper is the goroutine body. It performs an initial sweep on
 // entry (after a short startup delay) and then sweeps on a ticker.
-func runDocgenSweeper(interval time.Duration, cleanupFn func() (int, int64, error), logger *log.Logger, stopCh <-chan struct{}) {
+func runDocgenSweeper(interval time.Duration, cleanupFn func() (int, int64, error), logger *slog.Logger, stopCh <-chan struct{}) {
 	// Short startup delay so the daemon socket is live before we do I/O.
 	startupDelay := 30 * time.Second
 	select {
@@ -69,10 +70,10 @@ func runDocgenSweeper(interval time.Duration, cleanupFn func() (int, int64, erro
 	sweep := func() {
 		n, freed, err := cleanupFn()
 		if err != nil {
-			logger.Printf("docgen sweeper: cleanup error: %v", err)
+			logger.Error("docgen sweeper: cleanup error", "err", err)
 			return
 		}
-		logger.Printf("docgen sweeper: removed %d item(s), freed %s", n, sweeperHumanBytes(freed))
+		logger.Info("docgen sweeper: removed items", "count", n, "freed", sweeperHumanBytes(freed))
 	}
 
 	// Initial sweep.

--- a/internal/daemon/watch/githead_poller.go
+++ b/internal/daemon/watch/githead_poller.go
@@ -46,7 +46,7 @@
 package watch
 
 import (
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -139,7 +139,7 @@ type commonDirGroup struct {
 type GitHeadPoller struct {
 	interval time.Duration
 	sink     BranchSwitchSink
-	logger   *log.Logger
+	logger   *slog.Logger
 
 	mu          sync.Mutex
 	groups      map[string]*commonDirGroup // key: absolute common-dir path
@@ -157,12 +157,12 @@ const defaultPollInterval = 2 * time.Second
 
 // NewGitHeadPoller constructs a poller. interval=0 uses the default (2 s).
 // sink must be non-nil. logger may be nil.
-func NewGitHeadPoller(interval time.Duration, sink BranchSwitchSink, logger *log.Logger) *GitHeadPoller {
+func NewGitHeadPoller(interval time.Duration, sink BranchSwitchSink, logger *slog.Logger) *GitHeadPoller {
 	if interval <= 0 {
 		interval = defaultPollInterval
 	}
 	if logger == nil {
-		logger = log.New(os.Stderr, "githead-poller: ", log.LstdFlags)
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "githead-poller")
 	}
 	return &GitHeadPoller{
 		interval:    interval,
@@ -369,7 +369,7 @@ func (p *GitHeadPoller) loop() {
 // smallDiffThreshold+1 to bound memory).
 //
 // If either SHA is empty or the git command fails, ReindexUnknown is returned.
-func classifyRefChange(repoPath, oldSHA, newSHA string, logger *log.Logger) (ReindexHint, []string) {
+func classifyRefChange(repoPath, oldSHA, newSHA string, logger *slog.Logger) (ReindexHint, []string) {
 	if oldSHA == "" || newSHA == "" {
 		return ReindexUnknown, nil
 	}
@@ -385,7 +385,7 @@ func classifyRefChange(repoPath, oldSHA, newSHA string, logger *log.Logger) (Rei
 	cmd.Dir = repoPath
 	out, err := cmd.Output()
 	if err != nil {
-		logger.Printf("classifyRefChange: git diff failed in %s: %v", repoPath, err)
+		logger.Warn("classifyRefChange: git diff failed", "repo", repoPath, "err", err)
 		return ReindexUnknown, nil
 	}
 
@@ -529,13 +529,14 @@ func (p *GitHeadPoller) poll() {
 			ev.ChangedFiles = changedFiles
 
 			if hint == ReindexNone {
-				p.logger.Printf("ref-change: %s %s..%s no-source-changes — skipping reindex",
-					repoPath, s.prev.SHA, current.SHA)
+				p.logger.Info("ref-change: no-source-changes — skipping reindex",
+					"repo", repoPath, "old_sha", s.prev.SHA, "new_sha", current.SHA)
 				continue
 			}
 
-			p.logger.Printf("branch-switch detected: %s %s@%s -> %s@%s hint=%d changed_files=%d",
-				repoPath, ev.OldRef, ev.OldSHA, ev.NewRef, ev.NewSHA, hint, len(changedFiles))
+			p.logger.Info("branch-switch detected",
+				"repo", repoPath, "old_ref", ev.OldRef, "old_sha", ev.OldSHA,
+				"new_ref", ev.NewRef, "new_sha", ev.NewSHA, "hint", hint, "changed_files", len(changedFiles))
 			p.sink(ev)
 		}
 	}

--- a/internal/daemon/watch/manager.go
+++ b/internal/daemon/watch/manager.go
@@ -32,7 +32,7 @@
 package watch
 
 import (
-	"log"
+	"log/slog"
 	"os"
 	"sync"
 	"time"
@@ -67,7 +67,7 @@ type slotState struct {
 // It is goroutine-safe.
 type DefaultManager struct {
 	watcher *Watcher
-	logger  *log.Logger
+	logger  *slog.Logger
 
 	mu sync.Mutex
 	// slots maps "repoPath\x00ref" → slotState
@@ -83,9 +83,9 @@ type DefaultManager struct {
 
 // NewDefaultManager creates a DefaultManager backed by w.
 // logger may be nil.
-func NewDefaultManager(w *Watcher, logger *log.Logger) *DefaultManager {
+func NewDefaultManager(w *Watcher, logger *slog.Logger) *DefaultManager {
 	if logger == nil {
-		logger = log.New(os.Stderr, "watch-mgr: ", log.LstdFlags)
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "watch-mgr")
 	}
 	return &DefaultManager{
 		watcher:   w,
@@ -165,7 +165,7 @@ func (m *DefaultManager) SubscribeGroup(groupName string, repoPaths []string) in
 	for _, rp := range toSubscribe {
 		n, err := m.watcher.AddRepo(rp)
 		if err != nil {
-			m.logger.Printf("watcher-mgr: SubscribeGroup %s repo=%s AddRepo err=%v", groupName, rp, err)
+			m.logger.Error("watcher-mgr: SubscribeGroup AddRepo failed", "group", groupName, "repo", rp, "err", err)
 			// Decrement on failure so the next call retries.
 			m.mu.Lock()
 			m.refCounts[rp]--
@@ -173,7 +173,7 @@ func (m *DefaultManager) SubscribeGroup(groupName string, repoPaths []string) in
 			m.mu.Unlock()
 			continue
 		}
-		m.logger.Printf("watcher-mgr: SubscribeGroup %s repo=%s dirs=%d (lazy subscribe)", groupName, rp, n)
+		m.logger.Info("watcher-mgr: SubscribeGroup lazy subscribe", "group", groupName, "repo", rp, "dirs", n)
 		added += n
 	}
 	return added
@@ -235,11 +235,10 @@ func (m *DefaultManager) Pause(repoPath, ref string) {
 
 	if removeRepo {
 		m.watcher.RemoveRepo(repoPath)
-		m.logger.Printf("watcher-mgr: paused repo=%s ref=%s — fsnotify unsubscribed (elapsed %s)",
-			repoPath, ref, time.Since(start).Round(time.Microsecond))
+		m.logger.Info("watcher-mgr: paused — fsnotify unsubscribed",
+			"repo", repoPath, "ref", ref, "elapsed", time.Since(start).Round(time.Microsecond))
 	} else {
-		m.logger.Printf("watcher-mgr: paused ref=%s repo=%s — other refs still active",
-			ref, repoPath)
+		m.logger.Info("watcher-mgr: paused — other refs still active", "ref", ref, "repo", repoPath)
 	}
 }
 
@@ -276,16 +275,15 @@ func (m *DefaultManager) Resume(repoPath, ref string) time.Duration {
 		n, err := m.watcher.AddRepo(repoPath)
 		elapsed := time.Since(start)
 		if err != nil {
-			m.logger.Printf("watcher-mgr: resume repo=%s ref=%s AddRepo err=%v (elapsed %s)",
-				repoPath, ref, err, elapsed.Round(time.Microsecond))
+			m.logger.Error("watcher-mgr: resume AddRepo failed",
+				"repo", repoPath, "ref", ref, "err", err, "elapsed", elapsed.Round(time.Microsecond))
 		} else {
-			m.logger.Printf("watcher-mgr: resumed repo=%s ref=%s dirs=%d (elapsed %s)",
-				repoPath, ref, n, elapsed.Round(time.Microsecond))
+			m.logger.Info("watcher-mgr: resumed",
+				"repo", repoPath, "ref", ref, "dirs", n, "elapsed", elapsed.Round(time.Microsecond))
 		}
 		return elapsed
 	}
-	m.logger.Printf("watcher-mgr: resumed ref=%s repo=%s — subscription already active",
-		ref, repoPath)
+	m.logger.Info("watcher-mgr: resumed — subscription already active", "ref", ref, "repo", repoPath)
 	return time.Since(start)
 }
 

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -3,7 +3,7 @@ package watch
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -99,7 +99,7 @@ func (c *Config) heartbeatInterval() time.Duration {
 // because the volume of mutations is low (handful of repos, lifecycle
 // is registration/deregistration, not per-event).
 type Watcher struct {
-	logger    *log.Logger
+	logger    *slog.Logger
 	cfg       Config
 	sink      EventSink
 	extraSkip map[string]struct{}
@@ -142,17 +142,17 @@ type repoState struct {
 // Deprecated convenience: callers that pass only a debounce duration should
 // migrate to NewWatcherConfig. This overload is kept for back-compat with
 // existing call sites in server.go.
-func NewWatcher(debounce time.Duration, sink EventSink, logger *log.Logger) (*Watcher, error) {
+func NewWatcher(debounce time.Duration, sink EventSink, logger *slog.Logger) (*Watcher, error) {
 	return NewWatcherConfig(Config{Debounce: debounce}, sink, logger)
 }
 
 // NewWatcherConfig constructs a Watcher with the full Config surface.
-func NewWatcherConfig(cfg Config, sink EventSink, logger *log.Logger) (*Watcher, error) {
+func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher, error) {
 	if sink == nil {
 		return nil, errors.New("watch: sink is required")
 	}
 	if logger == nil {
-		logger = log.New(os.Stderr, "watch: ", log.LstdFlags)
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "watch")
 	}
 	fw, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -211,7 +211,7 @@ func (w *Watcher) AddRepo(repoPath string) (int, error) {
 	if err != nil {
 		return added, err
 	}
-	w.logger.Printf("watcher: registered repo=%s dirs=%d debounce=%s", abs, added, w.cfg.debounce())
+	w.logger.Info("watcher: registered", "repo", abs, "dirs", added, "debounce", w.cfg.debounce())
 	return added, nil
 }
 
@@ -243,13 +243,13 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 			if relErr == nil {
 				relPath = filepath.ToSlash(relPath)
 				if skip, reason := ShouldSkipDirGitignore(abs, p, relPath); skip {
-					w.logger.Printf("watcher: skip %s (%s)", p, reason)
+					w.logger.Info("watcher: skip", "path", p, "reason", reason)
 					return filepath.SkipDir
 				}
 			}
 		}
 		if err := w.fs.Add(p); err != nil {
-			w.logger.Printf("watcher: add %s: %v", p, err)
+			w.logger.Warn("watcher: add failed", "path", p, "err", err)
 			return nil
 		}
 		w.mu.Lock()
@@ -345,7 +345,7 @@ func (w *Watcher) ForceRescan() {
 	}
 	w.mu.Unlock()
 	for _, p := range paths {
-		w.logger.Printf("watcher: force-rescan repo=%s", p)
+		w.logger.Info("watcher: force-rescan", "repo", p)
 		w.sink(p, true)
 	}
 }
@@ -382,13 +382,13 @@ func (w *Watcher) heartbeat() {
 			// still healthy — nothing to do
 		case <-w.restartCh:
 			// loop goroutine detected unexpected channel closure.
-			w.logger.Printf("watcher: fsnotify closed unexpectedly — restarting")
+			w.logger.Warn("watcher: fsnotify closed unexpectedly — restarting")
 			atomic.AddUint64(&w.droppedReplay, 1)
 
 			// Recreate fsnotify.
 			fw, err := fsnotify.NewWatcher()
 			if err != nil {
-				w.logger.Printf("watcher: restart failed: %v", err)
+				w.logger.Error("watcher: restart failed", "err", err)
 				continue
 			}
 			w.mu.Lock()
@@ -404,9 +404,9 @@ func (w *Watcher) heartbeat() {
 			// Re-subscribe.
 			for _, abs := range repos {
 				if n, err := w.subscribeRepo(abs); err != nil {
-					w.logger.Printf("watcher: restart re-subscribe %s: %v", abs, err)
+					w.logger.Error("watcher: restart re-subscribe failed", "repo", abs, "err", err)
 				} else {
-					w.logger.Printf("watcher: restart re-subscribed repo=%s dirs=%d", abs, n)
+					w.logger.Info("watcher: restart re-subscribed", "repo", abs, "dirs", n)
 				}
 			}
 
@@ -465,7 +465,7 @@ func (w *Watcher) loop() {
 				return
 			}
 			if err != nil {
-				w.logger.Printf("watcher: error: %v", err)
+				w.logger.Error("watcher: error", "err", err)
 			}
 		case <-w.stopCh:
 			// Stop() was called while we were blocked waiting; drain
@@ -596,7 +596,7 @@ func (w *Watcher) recordAndArm(repo string) {
 		}
 		rs.pending = false
 		repoPath := repo
-		w.logger.Printf("watcher: bulk-detect repo=%s events_in_window=%d → full reindex", repoPath, rs.bulkCount)
+		w.logger.Info("watcher: bulk-detect", "repo", repoPath, "events_in_window", rs.bulkCount)
 		go w.sink(repoPath, true)
 		return
 	}


### PR DESCRIPTION
## Summary

- Migrates all 6 `*log.Logger` sub-package call sites in `internal/daemon` to `*slog.Logger`, completing the migration started in #2387 (#2375)
- Deletes the `loggerLegacy *log.Logger` bridge variable from `internal/daemon/server.go`
- Updates `cmd/archigraph/daemon.go` and `daemon_tier.go` to match the new `*slog.Logger` signatures (minimal: only signature and Printf→Info/Warn/Error conversions); `daemon_tier.go` bridges to `tier.NewManager` (out of scope) via `slog.NewLogLogger`
- All `logger.Printf(...)` calls converted to structured `logger.Info/Warn/Error(...)` with key-value pairs

Closes #2388

## Files changed

| File | Change |
|---|---|
| `internal/daemon/sched/scheduler.go` | Config.Logger and Scheduler.logger → *slog.Logger; 7 Printf → structured |
| `internal/daemon/sched/subprocess_runner.go` | logger param → *slog.Logger; 5 Printf → structured |
| `internal/daemon/sched/subprocess_runner_test.go` | log.New → slog.Default() |
| `internal/daemon/watch/watcher.go` | Watcher.logger, NewWatcher, NewWatcherConfig → *slog.Logger; 10 Printf → structured |
| `internal/daemon/watch/githead_poller.go` | GitHeadPoller.logger, NewGitHeadPoller, classifyRefChange → *slog.Logger; 3 Printf → structured |
| `internal/daemon/watch/manager.go` | DefaultManager.logger, NewDefaultManager → *slog.Logger; 6 Printf → structured |
| `internal/daemon/selfdefense.go` | SelfDefenseCheck, StartCPUWatchdog, cpuWatchdog, dumpGoroutineProfile → *slog.Logger; 7 Printf → structured |
| `internal/daemon/sweeper.go` | DocgenSweeperConfig.Logger, runDocgenSweeper → *slog.Logger; 2 Printf → structured |
| `internal/daemon/server.go` | Removed loggerLegacy bridge; Config.Logger → *slog.Logger; DashboardServe hook → *slog.Logger |
| `cmd/archigraph/daemon.go` | logger → buildDaemonSlogLogger(…); DashboardServe closure → *slog.Logger |
| `cmd/archigraph/daemon_tier.go` | startDaemonTierManager, registerKnownGroupsCold, onWatcherReady → *slog.Logger |

## Test plan

- [x] `go build ./...` green
- [x] `go test ./internal/daemon/...` — all 15 packages pass
- [x] `git grep -nE "\*log\.Logger\b" internal/daemon/` → zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)