### PR TITLE
fix(install): Windows path-separator handling in ClaudeSkillsDirForConfig + test

### DIFF
--- a/internal/install/skilllink/skilllink_test.go
+++ b/internal/install/skilllink/skilllink_test.go
@@ -8,6 +8,11 @@ import (
 	"testing"
 )
 
+// toSlash is a test-local helper that normalises a path to forward slashes so
+// that TestClaudeSkillsDirForConfig can use hard-coded Unix-style want strings
+// on all platforms (including Windows, where filepath.Join returns backslashes).
+func toSlash(p string) string { return filepath.ToSlash(p) }
+
 func TestDiscoverSkillsDir(t *testing.T) {
 	dir := t.TempDir()
 
@@ -126,7 +131,10 @@ func TestClaudeSkillsDirForConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ClaudeSkillsDirForConfig(tt.in)
-			if got != tt.want {
+			// Normalise to forward slashes before comparing so the test passes
+			// on Windows (where filepath.Join returns backslash-separated paths)
+			// while still exercising the correct derivation logic on all platforms.
+			if toSlash(got) != tt.want {
 				t.Errorf("ClaudeSkillsDirForConfig(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Summary

- `ClaudeSkillsDirForConfig` uses `filepath.Join` which correctly returns OS-native separators (backslashes on Windows) — this is intentional because the output is passed to `os.MkdirAll`, `os.Symlink`, etc.
- `TestClaudeSkillsDirForConfig` compared the raw output directly against hard-coded Unix-style `want` strings (e.g. `"/home/u/.claude/skills"`), causing 5 subtests to fail on Windows where the output is `"\\home\\u\\.claude\\skills"`.
- **Option B chosen**: normalize `got` in the test via `filepath.ToSlash` before comparing. The production function's contract (OS-native paths) is preserved for callers doing real filesystem work on Windows.

## Files modified

- `internal/install/skilllink/skilllink_test.go` only:
  - Added test-local `toSlash()` helper wrapping `filepath.ToSlash`
  - Changed the `TestClaudeSkillsDirForConfig` assertion from `got != tt.want` to `toSlash(got) != tt.want`

## Test result (macOS, local)

```
--- PASS: TestClaudeSkillsDirForConfig (0.00s)
    --- PASS: .../primary_config_in_HOME
    --- PASS: .../sidecar_config_inside_.claude-personal_dir
    --- PASS: .../sidecar_config_inside_.claude-extra_dir
    --- PASS: .../config_in_a_non-Claude_parent_dir
    --- PASS: .../hypothetical_flat_sidecar_(~/.claude-personal.json)
    --- PASS: .../no_.json_suffix_→_empty_string
    --- PASS: .../empty_string_→_empty_string
ok  github.com/cajasmota/archigraph/internal/install/skilllink  0.990s
```

## CI note

`ci:full` label set — this is a Windows platform-sensitive fix; Windows CI runs to verify the fix resolves the 5 failing subtests on Windows.

This unblocks PRs #2275, #2276, and #2277 which were all failing Windows CI on this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)