### PR TITLE
refactor(extractor): wire ExtractorConfig through TryIncremental + retire daemon/sched env-var

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon/watch"
 	"github.com/cajasmota/archigraph/internal/dashboard"
 	"github.com/cajasmota/archigraph/internal/docgen"
+	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/extractors"
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/jobs"
@@ -46,6 +47,13 @@ import (
 // per-module rows with file counters instead of a generic bar (#1531). It is
 // created once in runDaemon before the RPC + dashboard servers start.
 var daemonProgressBroker = progress.NewBroker()
+
+// daemonExtractorCfg is the ExtractorConfig built once at daemon startup from
+// the process environment (issue #2397). It is the single source of truth for
+// feature toggles such as ARCHIGRAPH_INCREMENTAL_REINDEX so that the scheduler
+// and TryIncremental consult IsIncrementalEnabled() instead of re-reading env
+// vars directly. Populated by runDaemon before the scheduler is wired.
+var daemonExtractorCfg extractor.ExtractorConfig
 
 // defaultDashboardPort is the default TCP port for the embedded dashboard.
 const defaultDashboardPort = 47274
@@ -279,6 +287,11 @@ func runDaemon(argv []string) error {
 		}
 	}
 
+	// Issue #2397: build the ExtractorConfig once at daemon startup from the
+	// process environment so downstream paths (scheduler, TryIncremental) can
+	// consult IsIncrementalEnabled() rather than re-reading env vars directly.
+	daemonExtractorCfg = extractor.ConfigFromEnv()
+
 	cfg := daemon.Config{
 		Layout:       layout,
 		Logger:       logger,
@@ -296,6 +309,8 @@ func runDaemon(argv []string) error {
 		SchedulerLinks:       daemonSchedulerLinks,
 		SchedulerAlgo:        daemonSchedulerAlgo,
 		SchedulerIncremental: daemonSchedulerIncremental,
+		// Single source of truth for the incremental toggle (issue #2397).
+		ExtractorConfig: &daemonExtractorCfg,
 
 		MaxRSSBudgetMB:      maxRSSBudget,
 		RSSHistoryPath:      filepath.Join(filepath.Dir(layout.PIDPath), "repo-rss-history.json"),
@@ -508,7 +523,7 @@ func daemonSchedulerIncremental(_ context.Context, repoPath string, ref string) 
 	if stateDir == "" {
 		stateDir = daemon.StateDirForRepo(repoPath)
 	}
-	res := extractors.TryIncremental(context.Background(), repoPath, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repoPath, stateDir, nil, &daemonExtractorCfg)
 	if res.Done {
 		invalidateAfterIndex(repoPath)
 		tierAfterIndex(repoPath, ref)

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -46,6 +46,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
 )
 
 // IndexFn re-indexes a single repo at a specific git ref. The scheduler
@@ -175,9 +177,9 @@ type Config struct {
 	Clone CloneFn
 
 	// Incremental, when non-nil, is attempted before IndexFn when the
-	// ARCHIGRAPH_INCREMENTAL_REINDEX=1 env var is set (S3 of epic #2149,
-	// issue #2153). It performs a surgical file-level graph patch that is
-	// ~25× faster than a full reindex for single-file edits.
+	// incremental reindex path is enabled (S3 of epic #2149, issue #2153).
+	// It performs a surgical file-level graph patch that is ~25× faster
+	// than a full reindex for single-file edits.
 	//
 	// The function returns (done=true) when the incremental patch succeeded
 	// and the full IndexFn should be skipped. It returns (done=false) on any
@@ -187,6 +189,17 @@ type Config struct {
 	// Default (nil): incremental path is never tried; behaviour is identical
 	// to before this field was added.
 	Incremental IncrementalFn
+
+	// ExtractorConfig, when non-nil, is consulted by the scheduler to
+	// determine whether the incremental reindex path is active (issue #2397).
+	// IsIncrementalEnabled() on this config replaces the private
+	// incrementalEnabled() helper that read ARCHIGRAPH_INCREMENTAL_REINDEX
+	// directly, establishing a single source of truth.
+	//
+	// When nil the scheduler falls back to env-var reads via a nil-safe
+	// ExtractorConfig.IsIncrementalEnabled() call, preserving backward
+	// compatibility for callers that have not yet been migrated.
+	ExtractorConfig *extractor.ExtractorConfig
 }
 
 // deadManTimeout is how long the scheduler waits with a non-empty pending
@@ -674,13 +687,18 @@ func (s *Scheduler) runIndex(tok jobToken) {
 
 	// S3: attempt incremental file-level reindex before the full index or
 	// clone-from-parent path. Only tried when the Incremental callback is
-	// configured AND the opt-in env var is set.
+	// configured AND the incremental toggle is active.
+	//
+	// Issue #2397: consult s.cfg.ExtractorConfig.IsIncrementalEnabled()
+	// (single source of truth) instead of the private incrementalEnabled()
+	// helper that read ARCHIGRAPH_INCREMENTAL_REINDEX directly. The nil-
+	// receiver method falls through to the env-var for backward compat.
 	//
 	// On success (res.Done=true) we skip both clone and full reindex.
 	// On fallback (res.Done=false) we log the reason and fall through normally.
 	var err error
 	incrementalDone := false
-	if s.cfg.Incremental != nil && incrementalEnabled() {
+	if s.cfg.Incremental != nil && s.cfg.ExtractorConfig.IsIncrementalEnabled() {
 		res := s.cfg.Incremental(context.Background(), repoPath, tok.ref)
 		if res.Done {
 			incrementalDone = true
@@ -1034,14 +1052,6 @@ func formatMB(mb int64) string {
 		return "0MB"
 	}
 	return itoa(mb) + "MB"
-}
-
-// incrementalEnabled reports whether the S3 incremental reindex path is
-// active. Reads ARCHIGRAPH_INCREMENTAL_REINDEX once per call. Default is
-// false so behaviour is unchanged for existing installations.
-func incrementalEnabled() bool {
-	v := os.Getenv("ARCHIGRAPH_INCREMENTAL_REINDEX")
-	return v == "1" || v == "true"
 }
 
 func itoa(n int64) string {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon/sched"
 	"github.com/cajasmota/archigraph/internal/daemon/transport"
 	"github.com/cajasmota/archigraph/internal/daemon/watch"
+	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/gitmeta"
 )
 
@@ -47,9 +48,16 @@ type Config struct {
 
 	// SchedulerIncremental, when non-nil, is wired as the S3 incremental
 	// file-level reindex hook (issue #2153). It is attempted before
-	// SchedulerIndex when ARCHIGRAPH_INCREMENTAL_REINDEX=1 is set. When nil
+	// SchedulerIndex when the incremental toggle is active. When nil
 	// the incremental path is never tried (default: full reindex always).
 	SchedulerIncremental func(ctx context.Context, repo string, ref string) sched.IncrementalResult
+
+	// ExtractorConfig, when non-nil, is passed to the scheduler so it can
+	// consult IsIncrementalEnabled() instead of reading
+	// ARCHIGRAPH_INCREMENTAL_REINDEX from the process env directly (issue
+	// #2397). When nil the scheduler falls back to the env-var path, which
+	// preserves backward compatibility.
+	ExtractorConfig *extractor.ExtractorConfig
 
 	// MaxRSSBudgetMB caps the total predicted RSS of concurrently
 	// running index jobs. 0 disables admission control (legacy
@@ -267,6 +275,10 @@ func Run(ctx context.Context, cfg Config) error {
 			// S3 incremental file-level reindex (issue #2153). When nil
 			// the scheduler falls through to full reindex on every tick.
 			Incremental: cfg.SchedulerIncremental,
+			// Issue #2397: single source of truth for the incremental toggle.
+			// The scheduler calls ExtractorConfig.IsIncrementalEnabled()
+			// rather than reading the env var directly.
+			ExtractorConfig: cfg.ExtractorConfig,
 		})
 		if cfg.MaxRSSBudgetMB > 0 {
 			logger.Info("scheduler: RSS-budget admission control enabled", "budget_mb", cfg.MaxRSSBudgetMB, "history", cfg.RSSHistoryPath)

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -151,6 +151,8 @@ func StampFile(absPath string) (FileStamp, error) {
 // TryIncremental attempts a file-level incremental reindex for repoPath.
 // stateDir is the on-disk directory where graph.fb and file-index.json live.
 // logger may be nil (falls back to stderr).
+// cfg is optional (nil-safe): when non-nil its IncrementalMaxFiles value
+// overrides the env-var / gitmeta heuristic for the trigger limit (issue #2396).
 //
 // The call flow:
 //  1. Load the diff manifest; detect changed files.
@@ -163,7 +165,7 @@ func StampFile(absPath string) (FileStamp, error) {
 //     targeting newly extracted entities.
 //  8. Merge new entities/rels into the document, sort, write graph.fb atomically.
 //  9. Update the diff manifest.
-func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.Logger) Result {
+func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.Logger, cfg *extractor.ExtractorConfig) Result {
 	t0 := time.Now()
 	if logger == nil {
 		logger = log.New(os.Stderr, "incremental: ", log.LstdFlags)
@@ -221,9 +223,9 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	totalChanged := len(changedFiles) + len(deletedFiles)
 
 	// --- Step 2: trigger limit (#2170 raised limits + main-branch hot-path) ---
-	// Issue #2320: TryIncremental does not (yet) receive an ExtractorConfig;
-	// pass nil so effectiveLimit falls through to the env-var / gitmeta path.
-	limit := effectiveLimit(absRepo, nil)
+	// Issue #2396: cfg is now threaded through from the caller so programmatic
+	// config overrides the env-var / gitmeta path when non-nil.
+	limit := effectiveLimit(absRepo, cfg)
 	if totalChanged > limit {
 		return fallback(t0, fmt.Sprintf("too-many-changed files=%d limit=%d",
 			totalChanged, limit))

--- a/internal/extractors/incremental_test.go
+++ b/internal/extractors/incremental_test.go
@@ -194,7 +194,7 @@ func TestIncremental_WhitespaceOnlyEdit_Skipped(t *testing.T) {
 	// The AST hash should differ (content changed) but function body unchanged.
 	// For this test we verify that TryIncremental completes successfully and
 	// the graph still contains "Hello".
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Errorf("TryIncremental: unexpected fallback: %s", res.FallbackReason)
 	}
@@ -235,7 +235,7 @@ func TestIncremental_SingleFileEdit_FunctionBodyChange(t *testing.T) {
 	writeFile(t, repo, "svc/service.go", "package svc\n\nfunc NewFunc() {}\n")
 
 	t0 := time.Now()
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	dur := time.Since(t0)
 
 	if !res.Done {
@@ -290,7 +290,7 @@ func TestIncremental_AddNewFile_EntitiesAppear(t *testing.T) {
 	// Add a new file with a new entity.
 	writeFile(t, repo, "new_handler.go", "package main\n\nfunc NewHandler() {}\n")
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Fatalf("TryIncremental: unexpected fallback: %s", res.FallbackReason)
 	}
@@ -347,7 +347,7 @@ func TestIncremental_DeleteFile_EntitiesDisappear(t *testing.T) {
 	// Delete b.go.
 	deleteFile(t, repo, "b.go")
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Fatalf("TryIncremental: unexpected fallback: %s", res.FallbackReason)
 	}
@@ -401,7 +401,7 @@ func TestIncremental_TooManyChangedFiles_Fallback(t *testing.T) {
 	m := diff.LoadManifest(t.TempDir()) // empty manifest from an unrelated temp dir
 	_ = diff.SaveManifest(stateDir, repo, m)
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if res.Done {
 		t.Error("TryIncremental should fall back when > 20 files changed (default feature-branch limit)")
 	}
@@ -433,7 +433,7 @@ func TestIncremental_EnvOverrideLimit(t *testing.T) {
 	// so it should succeed — but with env override set to 5 it should fallback.
 	t.Setenv("ARCHIGRAPH_INCREMENTAL_MAX_FILES", "5")
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if res.Done {
 		t.Error("TryIncremental should fall back when files exceed ARCHIGRAPH_INCREMENTAL_MAX_FILES=5")
 	}
@@ -464,7 +464,7 @@ func TestIncremental_MainBranchHotPath_30Files(t *testing.T) {
 	// (same as mainBranchIncrementalFiles).
 	t.Setenv("ARCHIGRAPH_INCREMENTAL_MAX_FILES", "50")
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Errorf("TryIncremental should succeed on 30-file batch when limit is 50 (main-branch hot-path), fallback=%s", res.FallbackReason)
 	}
@@ -492,7 +492,7 @@ func TestIncremental_FeatureBranch_50Files_Fallback(t *testing.T) {
 
 	// Default limit (no env override). repo is a bare temp dir, not a git repo,
 	// so IsDefaultBranch returns false → limit = defaultIncrementalFiles (20).
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if res.Done {
 		t.Error("TryIncremental should fall back on 50-file feature-branch batch (limit=20)")
 	}
@@ -538,7 +538,7 @@ func TestIncremental_SignatureChange_InboundCallersRewired(t *testing.T) {
 	// Mutate Foo's signature: rename parameter (arity unchanged but signature text differs).
 	writeFile(t, repo, "pkg/foo.go", "package pkg\n\nfunc Foo(count int) error { return nil }\n")
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Fatalf("TryIncremental: signature change should not trigger fallback, got: %s", res.FallbackReason)
 	}
@@ -602,7 +602,7 @@ func TestIncremental_ManifestCorruption_FallsBackToFull(t *testing.T) {
 	// fresh empty manifest on corruption, so all files appear "changed". Since
 	// the graph exists, the incremental pass should succeed (treating main.go as
 	// new/changed and re-extracting it) — not panic or error out.
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	// The result may be Done=true (treated as new file) or Done=false (fallback
 	// for other reasons). What matters is that it does NOT panic.
 	t.Logf("manifest corruption recovery: done=%v fallback=%s took=%s",
@@ -633,14 +633,14 @@ func TestIncremental_ManifestGC_DeletedEntryRemoved(t *testing.T) {
 	deleteFile(t, repo, "todelete.go")
 
 	// First incremental pass: should detect deletion, prune entity, update manifest.
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Fatalf("first incremental (deletion): unexpected fallback: %s", res.FallbackReason)
 	}
 
 	// Second incremental pass: todelete.go should NOT appear as a "changed" file
 	// (the manifest GC should have removed its entry on the first pass).
-	res2 := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res2 := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res2.Done {
 		t.Fatalf("second incremental (after GC): unexpected fallback: %s", res2.FallbackReason)
 	}
@@ -660,7 +660,7 @@ func TestIncremental_NoExistingGraph_Fallback(t *testing.T) {
 
 	writeFile(t, repo, "main.go", "package main\n\nfunc Main() {}\n")
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if res.Done {
 		t.Error("TryIncremental should fall back when no existing graph is present")
 	}
@@ -684,7 +684,7 @@ func TestIncremental_NoChanges_DoneWithoutWork(t *testing.T) {
 	seedManifest(t, repo, stateDir)
 
 	// No mutation — manifest is up to date.
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Fatalf("TryIncremental: unexpected fallback when no files changed: %s", res.FallbackReason)
 	}
@@ -724,7 +724,7 @@ func TestIncremental_GoldenSemanticEquivalence(t *testing.T) {
 	seedManifest(t, repo, stateDir)
 
 	// Sanity: incremental on unchanged repo should preserve both entities.
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Fatalf("phase-1 baseline: unexpected fallback: %s", res.FallbackReason)
 	}
@@ -736,7 +736,7 @@ func TestIncremental_GoldenSemanticEquivalence(t *testing.T) {
 	// Phase 2: remove Beta, add Gamma.
 	writeFile(t, repo, "core.go", "package core\n\nfunc Alpha() {}\n\nfunc Gamma() {}\n")
 
-	res = extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res = extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Fatalf("phase-2 mutation: unexpected fallback: %s", res.FallbackReason)
 	}
@@ -826,7 +826,7 @@ func TestIncrementalResult_FallbackPreservesReason(t *testing.T) {
 
 	writeFile(t, repo, "x.go", "package p\n")
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if res.Done {
 		t.Error("should fail back when no graph.fb exists")
 	}
@@ -902,7 +902,7 @@ func TestIncremental_Performance_SingleFileEdit(t *testing.T) {
 	writeFile(t, repo, "svc/svc0.go", "package svc\n\nfunc Func0Updated() {}\nfunc Helper0Updated() {}\n")
 
 	t0 := time.Now()
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	dur := time.Since(t0)
 
 	if !res.Done {
@@ -934,7 +934,7 @@ func TestIncremental_GraphFBReadableAfterWrite(t *testing.T) {
 	// Edit the file.
 	writeFile(t, repo, "pkg.go", "package p\n\nfunc Foo() {}\n\nfunc Bar() {}\n")
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Fatalf("TryIncremental failed: %s", res.FallbackReason)
 	}
@@ -969,13 +969,13 @@ func TestIncremental_ManifestUpdatedAfterSuccess(t *testing.T) {
 	// Change the file.
 	writeFile(t, repo, "app.go", "package app\n\nfunc Start() {}\n\nfunc Stop() {}\n")
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res.Done {
 		t.Fatalf("TryIncremental failed: %s", res.FallbackReason)
 	}
 
 	// Run incremental again immediately — no changes since last stamp.
-	res2 := extractors.TryIncremental(context.Background(), repo, stateDir, nil)
+	res2 := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 	if !res2.Done {
 		t.Fatalf("second TryIncremental failed: %s", res2.FallbackReason)
 	}
@@ -1122,5 +1122,109 @@ func TestIncrementalConfig_EffectiveMaxFiles_NilConfig_EnvUnset(t *testing.T) {
 	var cfg *extractor.ExtractorConfig
 	if got := cfg.EffectiveIncrementalMaxFiles(); got != 0 {
 		t.Errorf("nil Config + unset env: expected 0 (auto); got %d", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #2396 — TryIncremental respects injected ExtractorConfig
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestTryIncremental_InjectedConfig_MaxFilesOverride verifies that TryIncremental
+// honours the trigger-limit set in an injected ExtractorConfig rather than
+// always falling through to the env-var / gitmeta path.
+//
+// Concretely: set IncrementalMaxFiles=1 in Config (env var unset) and change
+// two files in the repo. The incremental path should fall back with
+// "too-many-changed" because 2 > 1, even though the env-var-based default
+// would allow up to 20 files.
+func TestTryIncremental_InjectedConfig_MaxFilesOverride(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_INCREMENTAL_MAX_FILES", "") // ensure env var is unset
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	// Two source files — both will be "changed" relative to the manifest.
+	writeFile(t, repo, "a.go", "package p\n\nfunc Alpha() {}\n")
+	writeFile(t, repo, "b.go", "package p\n\nfunc Beta() {}\n")
+
+	entities := []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "Alpha", "a.go"),
+			Name: "Alpha", Kind: "SCOPE.Operation", SourceFile: "a.go", Language: "go"},
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "Beta", "b.go"),
+			Name: "Beta", Kind: "SCOPE.Operation", SourceFile: "b.go", Language: "go"},
+	}
+	buildMinimalGraph(t, stateDir, entities, nil)
+	seedManifest(t, repo, stateDir)
+
+	// Mutate both files so the diff detects 2 changed files.
+	writeFile(t, repo, "a.go", "package p\n\nfunc Alpha() { /* changed */ }\n")
+	writeFile(t, repo, "b.go", "package p\n\nfunc Beta() { /* changed */ }\n")
+
+	// Inject a config with a very low limit (1). With 2 changed files the
+	// incremental path must fall back.
+	cfg := &extractor.ExtractorConfig{
+		IncrementalReindex:    true,
+		IncrementalReindexSet: true,
+		IncrementalMaxFiles:   1, // Config channel: limit = 1
+	}
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, cfg)
+	if res.Done {
+		t.Errorf("TryIncremental should have fallen back (2 files > limit 1), but Done=true")
+	}
+	if res.FallbackReason == "" {
+		t.Error("FallbackReason should be set when falling back on too-many-changed")
+	}
+}
+
+// TestTryIncremental_InjectedConfig_MaxFilesPermitsChange verifies the positive
+// case: injected config with a generous limit allows the incremental path to
+// succeed even though the env-var path would use the default lower limit.
+func TestTryIncremental_InjectedConfig_MaxFilesPermitsChange(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_INCREMENTAL_MAX_FILES", "") // ensure env var is unset
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	writeFile(t, repo, "svc.go", "package p\n\nfunc Svc() {}\n")
+
+	entities := []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "Svc", "svc.go"),
+			Name: "Svc", Kind: "SCOPE.Operation", SourceFile: "svc.go", Language: "go"},
+	}
+	buildMinimalGraph(t, stateDir, entities, nil)
+	seedManifest(t, repo, stateDir)
+
+	// Rename the function — one file changed.
+	writeFile(t, repo, "svc.go", "package p\n\nfunc SvcV2() {}\n")
+
+	// Inject a config with IncrementalReindex explicitly enabled and a generous
+	// limit so the path definitely runs (env var is unset).
+	cfg := &extractor.ExtractorConfig{
+		IncrementalReindex:    true,
+		IncrementalReindexSet: true,
+		IncrementalMaxFiles:   100,
+	}
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, cfg)
+	if !res.Done {
+		t.Fatalf("TryIncremental should have succeeded with injected config (limit=100, 1 file changed), got fallback: %s", res.FallbackReason)
+	}
+
+	// Correctness: Svc removed, SvcV2 present.
+	names := loadGraphEntityNames(t, stateDir)
+	for _, n := range names {
+		if n == "Svc" {
+			t.Errorf("Old entity 'Svc' should have been removed after incremental, names=%v", names)
+		}
+	}
+	found := false
+	for _, n := range names {
+		if n == "SvcV2" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("New entity 'SvcV2' should appear after incremental reindex, names=%v", names)
 	}
 }


### PR DESCRIPTION
## Summary

- **#2396**: Updated `TryIncremental` signature to accept `*ExtractorConfig` parameter (5th arg, nil-safe). The `cfg` is now threaded into `effectiveLimit()` replacing the hardcoded `nil` that forced env-var/gitmeta fallback on every call.
- **#2397**: Deleted the private `incrementalEnabled()` function in `internal/daemon/sched/scheduler.go` that read `ARCHIGRAPH_INCREMENTAL_REINDEX` directly. Replaced the call site with `s.cfg.ExtractorConfig.IsIncrementalEnabled()`. Added `ExtractorConfig *extractor.ExtractorConfig` field to `sched.Config`. The daemon startup (`runDaemon`) calls `extractor.ConfigFromEnv()` once and threads the result through `daemon.Config` → `sched.Config`.

Closes #2396
Closes #2397

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go test ./internal/extractors/... ./internal/daemon/sched/...` — all green (21 test cases in `incremental_test.go`, plus sched suite)
- [ ] Two new tests added: `TestTryIncremental_InjectedConfig_MaxFilesOverride` (fallback when cfg limit < changed files) and `TestTryIncremental_InjectedConfig_MaxFilesPermitsChange` (success with generous limit)
- [ ] `grep -rn "ARCHIGRAPH_INCREMENTAL_REINDEX" internal/daemon/ --include="*.go" | grep -v "_test.go"` — only comments, no `os.Getenv` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)