### PR TITLE
perf(ci): conditional race + t.Parallel audit on slow packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,12 +97,25 @@ jobs:
       # can run, masking the current PR's source changes (refs #2253).
       - run: go clean -cache -testcache
 
-      # -timeout 15m: the suite with -race on a loaded CI runner (ubuntu-latest,
-      # macos-latest) can take 8-10 minutes end-to-end. The previous 5m budget
-      # was per-package but the cumulative wall-clock regularly exceeded it once
-      # the extractor and daemon integration tests were added (see #2196). 15m
-      # gives ~50% headroom over the observed worst-case while still catching
-      # real deadlocks well before GitHub's 6-hour job limit.
-      # Original rationale (#1797 / #937) still applies: a hard timeout is
-      # better than the default 10-minute Go-level panic.
-      - run: go test -race -count=1 -timeout 15m ./...
+      # Race detector policy (#2406):
+      #   - push to main → always race (post-merge sanity)
+      #   - release event → always race
+      #   - PR with ci:full label → race (platform-sensitive opt-in)
+      #   - all other CI runs (standard PRs) → no race; saves ~4 min per run
+      #
+      # -timeout 15m: the suite with -race on a loaded CI runner can take
+      # 8-10 min end-to-end. Without -race, 3-4 min is the observed ceiling.
+      # 15m gives headroom for both modes while catching real deadlocks well
+      # before GitHub's 6-hour job limit (refs #1797 / #937 / #2196).
+      - name: Test
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]] || \
+             [[ "${{ github.event_name }}" == "release" ]] || \
+             [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}" == "true" ]]; then
+            echo "Running with -race (main / release / ci:full label)"
+            go test -race -count=1 -timeout 15m ./...
+          else
+            echo "Running without -race (PR fast path)"
+            go test -count=1 -timeout 15m ./...
+          fi

--- a/internal/graph/algorithms_test.go
+++ b/internal/graph/algorithms_test.go
@@ -46,6 +46,7 @@ func itoa(n int) string {
 // should split A,B from C,D. Uses MinSize=1 to disable denoising so the
 // structural community assignment is testable on small fixtures.
 func TestLouvainTwoCommunities(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C", "D")
 	rels := []Relationship{
 		rel("A", "B"), rel("B", "A"),
@@ -72,6 +73,7 @@ func TestLouvainTwoCommunities(t *testing.T) {
 // TestPageRankStarGraph — center connected to 4 leaves; PageRank of center
 // should exceed PageRank of any leaf.
 func TestPageRankStarGraph(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("CENTER", "L1", "L2", "L3", "L4")
 	rels := []Relationship{
 		rel("L1", "CENTER"), rel("L2", "CENTER"),
@@ -88,6 +90,7 @@ func TestPageRankStarGraph(t *testing.T) {
 
 // TestBetweennessPathGraph — 1-2-3-4-5; betweenness peaks at the middle node.
 func TestBetweennessPathGraph(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("1", "2", "3", "4", "5")
 	rels := []Relationship{
 		rel("1", "2"), rel("2", "1"),
@@ -107,6 +110,7 @@ func TestBetweennessPathGraph(t *testing.T) {
 // TestArticulationBridge — two triangles connected via a single bridge node.
 // The bridge node must be flagged as an articulation point.
 func TestArticulationBridge(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A1", "A2", "A3", "BRIDGE", "B1", "B2", "B3")
 	rels := []Relationship{
 		rel("A1", "A2"), rel("A2", "A3"), rel("A3", "A1"),
@@ -124,6 +128,7 @@ func TestArticulationBridge(t *testing.T) {
 // single edge should be flagged as a surprise. Uses MinSize=1 to disable
 // denoising so the cross-community edge detection works on small fixtures.
 func TestSurpriseEdges(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A1", "A2", "A3", "B1", "B2", "B3")
 	rels := []Relationship{
 		rel("A1", "A2"), rel("A2", "A3"), rel("A3", "A1"),
@@ -153,6 +158,7 @@ func TestSurpriseEdges(t *testing.T) {
 // Heavier weights on a path should *reduce* shortest-path use elsewhere.
 // We verify that betweenness is *not* identical when weights change.
 func TestEdgeWeightingAffectsCentrality(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("S", "A", "B", "T")
 	// Two parallel 2-hop routes from S to T: via A or via B.
 	relsLight := []Relationship{
@@ -175,6 +181,7 @@ func TestEdgeWeightingAffectsCentrality(t *testing.T) {
 // TestAlgorithmStatsPopulated — RunAlgorithms must populate every stat field.
 // Uses MinSize=1 so small fixtures (2×3-node communities) are not denoised.
 func TestAlgorithmStatsPopulated(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C", "D", "E", "F")
 	rels := []Relationship{
 		rel("A", "B"), rel("B", "C"), rel("C", "A"),
@@ -231,6 +238,7 @@ func makeLargeGraph(cliqueCount int) ([]Entity, []Relationship) {
 // PageRank scores. This catches float drift that crosses the rounding boundary
 // introduced by non-deterministic map iteration order inside PageRankSparse.
 func TestDeterminism_PageRank(t *testing.T) {
+	t.Parallel()
 	const runs = 10
 	ents, rels := makeLargeGraph(50) // 400 nodes, mimics mid-size real corpus
 
@@ -258,6 +266,7 @@ func TestDeterminism_PageRank(t *testing.T) {
 // values to 4 decimal places (1e-4 tolerance), which is the guarantee
 // established by issue #489 to absorb larger-graph float drift.
 func TestRoundForDeterminism_Precision(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		input float64
 		want  float64
@@ -279,6 +288,7 @@ func TestRoundForDeterminism_Precision(t *testing.T) {
 
 // TestDefaultCommunityOptions — DefaultCommunityOptions must set MinSize=5.
 func TestDefaultCommunityOptions(t *testing.T) {
+	t.Parallel()
 	opts := DefaultCommunityOptions()
 	if opts.MinSize != 5 {
 		t.Errorf("DefaultCommunityOptions().MinSize = %d, want 5", opts.MinSize)
@@ -290,6 +300,7 @@ func TestDefaultCommunityOptions(t *testing.T) {
 // singletons should be assigned community_id=-1 and not appear in
 // Communities. The two large clusters should survive.
 func TestDenoise_SingletonsMergedToUngrouped(t *testing.T) {
+	t.Parallel()
 	// Build two 8-cliques (each node connects to all 7 others) plus 2 singletons.
 	var ids []string
 	var rels []Relationship
@@ -344,6 +355,7 @@ func TestDenoise_SingletonsMergedToUngrouped(t *testing.T) {
 // TestDenoise_MinSizeOne_NoDenoise — with MinSize=1, no communities are dropped
 // even for a graph where every node is isolated.
 func TestDenoise_MinSizeOne_NoDenoise(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C")
 	// No edges: every node is isolated → 3 singleton communities.
 	res := RunAlgorithmsWithOptions(ents, nil, CommunityOptions{MinSize: 1})
@@ -357,6 +369,7 @@ func TestDenoise_MinSizeOne_NoDenoise(t *testing.T) {
 // DefaultCommunityOptions) should produce fewer or equal named communities
 // compared to MinSize=1 on a graph that has small communities.
 func TestDenoise_DefaultOptions_MatchesBehavior(t *testing.T) {
+	t.Parallel()
 	// Ring of 5-node cliques → mix of reasonable communities.
 	ents, rels := makeLargeGraph(4) // 4 cliques × 8 nodes = 32 nodes
 	// Add extra 3 isolated nodes to ensure singletons exist.
@@ -374,6 +387,7 @@ func TestDenoise_DefaultOptions_MatchesBehavior(t *testing.T) {
 // TestDenoise_Determinism — running denoise twice on the same graph must
 // produce byte-identical community assignments.
 func TestDenoise_Determinism(t *testing.T) {
+	t.Parallel()
 	ents, rels := makeLargeGraph(10) // 80 nodes
 	// Add isolated singletons to ensure denoising is exercised.
 	ents = append(ents, makeEntities("X1", "X2", "X3")...)
@@ -399,6 +413,7 @@ func TestDenoise_Determinism(t *testing.T) {
 // panicked with "mat: zero length in matrix dimension") and returns an empty,
 // well-formed AlgorithmResults.
 func TestRunAlgorithmsWithOptions_EmptyDoc(t *testing.T) {
+	t.Parallel()
 	// Must not panic.
 	res := RunAlgorithmsWithOptions(nil, nil, DefaultCommunityOptions())
 

--- a/internal/graph/community_names_test.go
+++ b/internal/graph/community_names_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestTokenize_CamelAndSnake(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		in   string
 		want []string
@@ -28,6 +29,7 @@ func TestTokenize_CamelAndSnake(t *testing.T) {
 }
 
 func TestTokenize_StopwordsAndShort(t *testing.T) {
+	t.Parallel()
 	got := tokenize("a_test_of_the_init_main")
 	// every term is a stopword
 	if len(got) != 0 {
@@ -39,6 +41,7 @@ func TestTokenize_StopwordsAndShort(t *testing.T) {
 // distinguishing term ("order" vs "compliance") should receive distinct
 // auto_names that surface the distinguishing term.
 func TestAssignCommunityNames_DistinguishesOverlappingVocab(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "a1", Name: "OrderService", QualifiedName: "shop.order.OrderService", SourceFile: "shop/order/service.py"},
 		{ID: "a2", Name: "OrderRepository", QualifiedName: "shop.order.OrderRepository", SourceFile: "shop/order/repo.py"},
@@ -79,6 +82,7 @@ func TestAssignCommunityNames_DistinguishesOverlappingVocab(t *testing.T) {
 }
 
 func TestAssignCommunityNames_FallbackOnEmptyTokens(t *testing.T) {
+	t.Parallel()
 	// Entity with only stopword/single-char tokens.
 	entities := []Entity{
 		{ID: "x1", Name: "a", SourceFile: ""},
@@ -92,6 +96,7 @@ func TestAssignCommunityNames_FallbackOnEmptyTokens(t *testing.T) {
 }
 
 func TestAssignCommunityNames_Deterministic(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "a1", Name: "PaymentGateway", QualifiedName: "billing.PaymentGateway", SourceFile: "billing/gateway.go"},
 		{ID: "a2", Name: "PaymentProcessor", QualifiedName: "billing.PaymentProcessor", SourceFile: "billing/processor.go"},
@@ -113,6 +118,7 @@ func TestAssignCommunityNames_Deterministic(t *testing.T) {
 }
 
 func TestAssignCommunityNames_SkipsUnassignedNodes(t *testing.T) {
+	t.Parallel()
 	// commOf=-1 means the entity wasn't placed in any community; it must be
 	// excluded from the corpus so its tokens don't pollute IDF.
 	entities := []Entity{

--- a/internal/graph/coverage_test.go
+++ b/internal/graph/coverage_test.go
@@ -10,6 +10,7 @@ import (
 // ─────────────────────────────────────────────────────────────────────────────
 
 func TestIsTestFile(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		path string
 		want bool
@@ -66,6 +67,7 @@ func makeDoc(entities []Entity, rels []Relationship) *Document {
 
 // TestComputeCoverage_Empty checks that an empty document returns zeroes.
 func TestComputeCoverage_Empty(t *testing.T) {
+	t.Parallel()
 	report := ComputeCoverage(makeDoc(nil, nil))
 	if report.TotalProduction != 0 {
 		t.Errorf("TotalProduction want 0, got %d", report.TotalProduction)
@@ -78,6 +80,7 @@ func TestComputeCoverage_Empty(t *testing.T) {
 // TestComputeCoverage_DirectTESTSEdge verifies that an explicit TESTS edge
 // marks the target entity as covered.
 func TestComputeCoverage_DirectTESTSEdge(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "prod1", Name: "HandleUser", Kind: "Function", SourceFile: "handler.go"},
 		{ID: "test1", Name: "TestHandleUser", Kind: "Function", SourceFile: "handler_test.go"},
@@ -103,6 +106,7 @@ func TestComputeCoverage_DirectTESTSEdge(t *testing.T) {
 // TestComputeCoverage_FiveTESTSEdges verifies that a test calling 5 production
 // entities generates 5 TESTS edges and marks all 5 as covered.
 func TestComputeCoverage_FiveTESTSEdges(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "t1", Name: "TestAll", Kind: "Function", SourceFile: "all_test.go"},
 	}
@@ -140,6 +144,7 @@ func TestComputeCoverage_FiveTESTSEdges(t *testing.T) {
 // TestComputeCoverage_SyntheticFromCALLS verifies the synthetic fallback:
 // a test entity with CALLS edges to production entities gets virtual TESTS edges.
 func TestComputeCoverage_SyntheticFromCALLS(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "t1", Name: "TestFoo", Kind: "Function", SourceFile: "foo_test.go"},
 		{ID: "p1", Name: "Foo", Kind: "Function", SourceFile: "foo.go"},
@@ -165,6 +170,7 @@ func TestComputeCoverage_SyntheticFromCALLS(t *testing.T) {
 // TestComputeCoverage_UntestedFlagged verifies that entities without any
 // TESTS inbound appear in UncoveredEntities.
 func TestComputeCoverage_UntestedFlagged(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "p1", Name: "HandleUser", Kind: "http_endpoint_definition", SourceFile: "handler.go"},
 		{ID: "p2", Name: "ExportedFn", Kind: "Function", SourceFile: "lib.go"},
@@ -189,6 +195,7 @@ func TestComputeCoverage_UntestedFlagged(t *testing.T) {
 
 // TestComputeCoverage_SeverityOrder checks high < medium < low ordering.
 func TestComputeCoverage_SeverityOrder(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "e1", Name: "internalFn", Kind: "Function", SourceFile: "a.go"},
 		{ID: "e2", Name: "ExportedFn", Kind: "Function", SourceFile: "b.go"},
@@ -230,6 +237,7 @@ func containsSeverity(sev []string, target string) bool {
 
 // TestComputeCoverage_ByDirectory checks per-directory aggregation.
 func TestComputeCoverage_ByDirectory(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "p1", Name: "Foo", Kind: "Function", SourceFile: "pkg/foo/foo.go"},
 		{ID: "p2", Name: "Bar", Kind: "Function", SourceFile: "pkg/foo/bar.go"},
@@ -262,6 +270,7 @@ func TestComputeCoverage_ByDirectory(t *testing.T) {
 
 // TestComputeCoverage_ByModule checks per-module aggregation.
 func TestComputeCoverage_ByModule(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "p1", Name: "A", Kind: "Function", SourceFile: "a.go",
 			Properties: map[string]string{"module": "auth"}},
@@ -298,6 +307,7 @@ func TestComputeCoverage_ByModule(t *testing.T) {
 // TestComputeCoverage_HTTPEndpointHighSeverity ensures HTTP endpoints without
 // tests are surfaced with "high" severity.
 func TestComputeCoverage_HTTPEndpointHighSeverity(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "ep1", Name: "POST /users", Kind: "http_endpoint", SourceFile: "routes.go"},
 	}
@@ -317,6 +327,7 @@ func TestComputeCoverage_HTTPEndpointHighSeverity(t *testing.T) {
 // TestComputeEntityCoverage_KnownTested verifies that a production entity with
 // a direct TESTS inbound edge is reported as tested with the covering test ID.
 func TestComputeEntityCoverage_KnownTested(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "prod1", Name: "HandleUser", Kind: "Function", SourceFile: "handler.go"},
 		{ID: "test1", Name: "TestHandleUser", Kind: "Function", SourceFile: "handler_test.go"},
@@ -342,6 +353,7 @@ func TestComputeEntityCoverage_KnownTested(t *testing.T) {
 // TestComputeEntityCoverage_KnownUntested verifies that a production entity
 // with no inbound TESTS edges (and no CALLS fallback) is reported as untested.
 func TestComputeEntityCoverage_KnownUntested(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "prod1", Name: "UntestedFn", Kind: "Function", SourceFile: "lib.go"},
 		{ID: "test1", Name: "TestOther", Kind: "Function", SourceFile: "other_test.go"},
@@ -365,6 +377,7 @@ func TestComputeEntityCoverage_KnownUntested(t *testing.T) {
 // TestComputeEntityCoverage_Unknown verifies that an unknown entity_id returns
 // found=false (triggering "entity not found" in the MCP handler).
 func TestComputeEntityCoverage_Unknown(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "prod1", Name: "HandleUser", Kind: "Function", SourceFile: "handler.go"},
 	}
@@ -380,6 +393,7 @@ func TestComputeEntityCoverage_Unknown(t *testing.T) {
 // TestComputeEntityCoverage_SyntheticCALLS verifies that the synthetic CALLS
 // fallback also works for the per-entity path.
 func TestComputeEntityCoverage_SyntheticCALLS(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "t1", Name: "TestFoo", Kind: "Function", SourceFile: "foo_test.go"},
 		{ID: "p1", Name: "Foo", Kind: "Function", SourceFile: "foo.go"},
@@ -404,6 +418,7 @@ func TestComputeEntityCoverage_SyntheticCALLS(t *testing.T) {
 // compact — the covering_tests slice alone is bounded by the actual test count,
 // not the whole entity list. (Token-budget guard from #1774 spec.)
 func TestComputeEntityCoverage_OutputSize(t *testing.T) {
+	t.Parallel()
 	// Build 100 test entities and 100 production entities; only one covers prod1.
 	entities := []Entity{
 		{ID: "prod1", Name: "TargetFn", Kind: "Function", SourceFile: "target.go"},
@@ -449,6 +464,7 @@ func TestComputeEntityCoverage_OutputSize(t *testing.T) {
 // test files because every Python / Go symbol was counted, including imports,
 // module-level constants, and testmap's SCOPE.Pattern wrapper records.
 func TestComputeCoverage_TotalTestsCountsOnlyCallables(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		// Test file — the actual test function emitted as SCOPE.Operation (counts).
 		{ID: "t1", Name: "test_create_order", Kind: "SCOPE.Operation", SourceFile: "tests/test_orders.py"},

--- a/internal/graph/cycles_test.go
+++ b/internal/graph/cycles_test.go
@@ -16,6 +16,7 @@ func relCalls2(from, to string) Relationship {
 
 // TestFindImportCycles_SimpleCycle — A imports B, B imports A. Must detect one cycle.
 func TestFindImportCycles_SimpleCycle(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B")
 	rels := []Relationship{
 		relImport("A", "B"),
@@ -40,6 +41,7 @@ func TestFindImportCycles_SimpleCycle(t *testing.T) {
 
 // TestFindImportCycles_ThreeNodeCycle — A→B→C→A. Must detect one 3-member cycle.
 func TestFindImportCycles_ThreeNodeCycle(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C")
 	rels := []Relationship{
 		relImport("A", "B"),
@@ -57,6 +59,7 @@ func TestFindImportCycles_ThreeNodeCycle(t *testing.T) {
 
 // TestFindImportCycles_Acyclic — A→B, B→C. No cycles.
 func TestFindImportCycles_Acyclic(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C")
 	rels := []Relationship{
 		relImport("A", "B"),
@@ -70,6 +73,7 @@ func TestFindImportCycles_Acyclic(t *testing.T) {
 
 // TestFindImportCycles_NoImportEdges — Only CALLS edges; cycle detector must ignore them.
 func TestFindImportCycles_NoImportEdges(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B")
 	rels := []Relationship{
 		relCalls2("A", "B"),
@@ -83,6 +87,7 @@ func TestFindImportCycles_NoImportEdges(t *testing.T) {
 
 // TestFindImportCycles_TwoCycles — Two independent 2-cycles.
 func TestFindImportCycles_TwoCycles(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C", "D")
 	rels := []Relationship{
 		relImport("A", "B"),
@@ -98,6 +103,7 @@ func TestFindImportCycles_TwoCycles(t *testing.T) {
 
 // TestFindImportCycles_SortedBySize — larger cycle listed first.
 func TestFindImportCycles_SortedBySize(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C", "D", "E")
 	rels := []Relationship{
 		// 3-cycle: C→D→E→C
@@ -120,6 +126,7 @@ func TestFindImportCycles_SortedBySize(t *testing.T) {
 // TestFindImportCycles_WeakestLink — the entity with the lowest PageRank
 // should be the weakest-link source.
 func TestFindImportCycles_WeakestLink(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C")
 	rels := []Relationship{
 		relImport("A", "B"),
@@ -147,6 +154,7 @@ func TestFindImportCycles_WeakestLink(t *testing.T) {
 // TestFindImportCycles_SuggestedExtraction — the entity with the highest
 // PageRank should be the suggested extraction target.
 func TestFindImportCycles_SuggestedExtraction(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C")
 	rels := []Relationship{
 		relImport("A", "B"),
@@ -169,6 +177,7 @@ func TestFindImportCycles_SuggestedExtraction(t *testing.T) {
 
 // TestFindImportCycles_SelfImport — self-import should not count as a cycle.
 func TestFindImportCycles_SelfImport(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A")
 	rels := []Relationship{
 		relImport("A", "A"),
@@ -182,6 +191,7 @@ func TestFindImportCycles_SelfImport(t *testing.T) {
 // TestFindImportCycles_DanglingEdge — edge referencing an entity not in the
 // entity list should be silently skipped (no panic, no false positive).
 func TestFindImportCycles_DanglingEdge(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B")
 	rels := []Relationship{
 		relImport("A", "B"),
@@ -197,6 +207,7 @@ func TestFindImportCycles_DanglingEdge(t *testing.T) {
 
 // TestFindImportCycles_Empty — empty input must not panic.
 func TestFindImportCycles_Empty(t *testing.T) {
+	t.Parallel()
 	cycles := FindImportCycles(nil, nil, nil)
 	if len(cycles) != 0 {
 		t.Errorf("empty input: expected 0 cycles, got %d", len(cycles))
@@ -206,6 +217,7 @@ func TestFindImportCycles_Empty(t *testing.T) {
 // TestFindImportCycles_Determinism — multiple calls with same input produce
 // identical output (members and edges sorted, cycles in stable order).
 func TestFindImportCycles_Determinism(t *testing.T) {
+	t.Parallel()
 	ents := makeEntities("A", "B", "C", "D", "E", "F")
 	rels := []Relationship{
 		relImport("A", "B"), relImport("B", "C"), relImport("C", "A"),

--- a/internal/graph/diff_test.go
+++ b/internal/graph/diff_test.go
@@ -30,6 +30,7 @@ func diffTestRel(fromID, toID, kind string) Relationship {
 // TestDiffRefs_AddedRemovedModified verifies the three entity change buckets
 // when both graphs have a known delta.
 func TestDiffRefs_AddedRemovedModified(t *testing.T) {
+	t.Parallel()
 	docA := &Document{
 		Entities: []Entity{
 			diffTestEntity("aaa", "Function", "funcA", "pkg/a.go", 10, 20),
@@ -99,6 +100,7 @@ func TestDiffRefs_AddedRemovedModified(t *testing.T) {
 
 // TestDiffRefs_RelationshipSetDiff verifies relationship-level added/removed.
 func TestDiffRefs_RelationshipSetDiff(t *testing.T) {
+	t.Parallel()
 	docA := &Document{
 		Entities: []Entity{
 			diffTestEntity("e1", "Function", "fn1", "a.go", 1, 5),
@@ -149,6 +151,7 @@ func TestDiffRefs_RelationshipSetDiff(t *testing.T) {
 // TestDiffRefs_IdenticalGraphs verifies that two identical graphs produce an
 // empty diff.
 func TestDiffRefs_IdenticalGraphs(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		diffTestEntity("x1", "Function", "fn1", "a.go", 1, 5),
 		diffTestEntity("x2", "Class", "MyClass", "b.go", 1, 100),
@@ -170,6 +173,7 @@ func TestDiffRefs_IdenticalGraphs(t *testing.T) {
 
 // TestDiffRefs_EmptyDocuments verifies that diffing two empty documents is safe.
 func TestDiffRefs_EmptyDocuments(t *testing.T) {
+	t.Parallel()
 	got := DiffDocs(&Document{}, &Document{})
 
 	if got.Summary.EntitiesAdded != 0 {
@@ -187,6 +191,7 @@ func TestDiffRefs_EmptyDocuments(t *testing.T) {
 // TestDiffRefs_SourceWindowChange verifies that changing the line range of
 // an entity (without renaming it) is detected as a source_window modification.
 func TestDiffRefs_SourceWindowChange(t *testing.T) {
+	t.Parallel()
 	docA := &Document{
 		Entities: []Entity{diffTestEntity("zzz", "Function", "fn", "a.go", 1, 10)},
 	}

--- a/internal/graph/load_test.go
+++ b/internal/graph/load_test.go
@@ -52,6 +52,7 @@ func makeTestDoc() *graph.Document {
 // TestLoadGraphFromDir_FBOnly verifies that LoadGraphFromDir loads from
 // graph.fb when only the binary file is present.
 func TestLoadGraphFromDir_FBOnly(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	doc := makeTestDoc()
 
@@ -76,6 +77,7 @@ func TestLoadGraphFromDir_FBOnly(t *testing.T) {
 
 // TestLoadGraphFromDir_JSONOnly verifies the JSON fallback path.
 func TestLoadGraphFromDir_JSONOnly(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	doc := makeTestDoc()
 
@@ -102,6 +104,7 @@ func TestLoadGraphFromDir_JSONOnly(t *testing.T) {
 // TestLoadGraphFromDir_BothPresent verifies that graph.fb is preferred when
 // both files exist.
 func TestLoadGraphFromDir_BothPresent(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	doc := makeTestDoc()
 
@@ -136,6 +139,7 @@ func TestLoadGraphFromDir_BothPresent(t *testing.T) {
 // TestLoadGraphFromDir_NeitherPresent verifies that an error is returned
 // when the directory is empty.
 func TestLoadGraphFromDir_NeitherPresent(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	_, err := graph.LoadGraphFromDir(dir)
 	if err == nil {
@@ -146,6 +150,7 @@ func TestLoadGraphFromDir_NeitherPresent(t *testing.T) {
 // TestLoadGraphFromDir_EntityProperties verifies that Properties on
 // entities are preserved through the FB round-trip.
 func TestLoadGraphFromDir_EntityProperties(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	doc := makeTestDoc()
 	// Add a property that should survive FB serialization.

--- a/internal/graph/module_gds_test.go
+++ b/internal/graph/module_gds_test.go
@@ -35,6 +35,7 @@ func makeModContainer(id, name, repo string) Entity {
 
 // TestRunModuleAlgorithms_EmptyInputs ensures the API never returns nil.
 func TestRunModuleAlgorithms_EmptyInputs(t *testing.T) {
+	t.Parallel()
 	got := RunModuleAlgorithms(nil, nil)
 	if got == nil {
 		t.Fatal("expected non-nil results for empty input")
@@ -47,6 +48,7 @@ func TestRunModuleAlgorithms_EmptyInputs(t *testing.T) {
 // TestAggregation_EntityEdgesCollapseToModules verifies that entity edges in
 // different modules collapse into module edges and intra-module ones are dropped.
 func TestAggregation_EntityEdgesCollapseToModules(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		makeModEntity("e1", "A", "mod_a", "r"),
 		makeModEntity("e2", "B", "mod_a", "r"),
@@ -82,6 +84,7 @@ func TestAggregation_EntityEdgesCollapseToModules(t *testing.T) {
 // DEPENDS_ON edges already exist (post-#1383 documents), they are used and
 // their stored weight is respected.
 func TestAggregation_PrebakedModuleNodes(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		makeModContainer("M_A", "mod_a", "r"),
 		makeModContainer("M_B", "mod_b", "r"),
@@ -110,6 +113,7 @@ func TestAggregation_PrebakedModuleNodes(t *testing.T) {
 // TestExternalBucketDropped — entities without a module label do not get
 // collapsed into the synthetic "_external" bucket as a result.
 func TestExternalBucketDropped(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		makeModContainer("M_EXT", moduleExternal, "r"),
 		makeModContainer("M_A", "mod_a", "r"),
@@ -132,6 +136,7 @@ func TestExternalBucketDropped(t *testing.T) {
 
 // TestSCCDetection_TwoModuleCycle — a 2-module cycle is detected.
 func TestSCCDetection_TwoModuleCycle(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		makeModEntity("a", "A", "mod_a", "r"),
 		makeModEntity("b", "B", "mod_b", "r"),
@@ -167,6 +172,7 @@ func TestSCCDetection_TwoModuleCycle(t *testing.T) {
 
 // TestSCCDetection_NoCycle — a DAG produces no SCC and all SCCOf are -1.
 func TestSCCDetection_NoCycle(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		makeModEntity("a", "A", "mod_a", "r"),
 		makeModEntity("b", "B", "mod_b", "r"),
@@ -189,6 +195,7 @@ func TestSCCDetection_NoCycle(t *testing.T) {
 
 // TestSCCDetection_ThreeModuleCycle — directed triangle a→b→c→a.
 func TestSCCDetection_ThreeModuleCycle(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		makeModEntity("a", "A", "mod_a", "r"),
 		makeModEntity("b", "B", "mod_b", "r"),
@@ -208,6 +215,7 @@ func TestSCCDetection_ThreeModuleCycle(t *testing.T) {
 // TestCentrality_HubHasHighestPageRank — a hub module that everything
 // depends on should sit at the top of the PageRank ranking.
 func TestCentrality_HubHasHighestPageRank(t *testing.T) {
+	t.Parallel()
 	// hub is depended on by all four other modules.
 	entities := []Entity{
 		makeModEntity("h", "H", "hub", "r"),
@@ -240,6 +248,7 @@ func TestCentrality_HubHasHighestPageRank(t *testing.T) {
 // TestCentrality_BottleneckHasHighestBetweenness — a module that sits on
 // every shortest path between two clusters has the highest betweenness.
 func TestCentrality_BottleneckHasHighestBetweenness(t *testing.T) {
+	t.Parallel()
 	// Topology: a → mid → b ; c → mid → d.  mid is the only path.
 	entities := []Entity{
 		makeModEntity("a", "A", "mod_a", "r"),
@@ -265,6 +274,7 @@ func TestCentrality_BottleneckHasHighestBetweenness(t *testing.T) {
 // SCC IDs / member orders / score values. This is a regression guard against
 // gonum's map-iteration noise leaking through (cf. issue #481).
 func TestDeterminism(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		makeModEntity("a", "A", "mod_a", "r"),
 		makeModEntity("b", "B", "mod_b", "r"),

--- a/internal/graph/service_cycles_test.go
+++ b/internal/graph/service_cycles_test.go
@@ -10,6 +10,7 @@ import (
 // back, mediated by no shared entity. The two services must form exactly one
 // SCC of size 2.
 func Test_FindServiceCycles_TwoNodeCycle(t *testing.T) {
+	t.Parallel()
 	links := []ServiceLink{
 		{FromService: "orders", ToService: "payments", Relation: "calls"},
 		{FromService: "payments", ToService: "orders", Relation: "publishes_to"},
@@ -32,6 +33,7 @@ func Test_FindServiceCycles_TwoNodeCycle(t *testing.T) {
 
 // Test_FindServiceCycles_NoCycle ensures a one-way fan-out produces no SCC.
 func Test_FindServiceCycles_NoCycle(t *testing.T) {
+	t.Parallel()
 	links := []ServiceLink{
 		{FromService: "a", ToService: "b", Relation: "calls"},
 		{FromService: "a", ToService: "c", Relation: "calls"},
@@ -46,6 +48,7 @@ func Test_FindServiceCycles_NoCycle(t *testing.T) {
 // `ledger` only consumes payments.settled (payments → ledger) and never calls
 // back. It must NOT join the orders↔payments SCC.
 func Test_FindServiceCycles_OneWaySubscriberNotPulledIn(t *testing.T) {
+	t.Parallel()
 	links := []ServiceLink{
 		{FromService: "orders", ToService: "payments", Relation: "calls"},
 		{FromService: "payments", ToService: "orders", Relation: "publishes_to"},
@@ -69,6 +72,7 @@ func Test_FindServiceCycles_OneWaySubscriberNotPulledIn(t *testing.T) {
 // string_match co-occurrence links cannot fabricate a cycle even when they form
 // a mutual pair.
 func Test_FindServiceCycles_UndirectedRelationsExcluded(t *testing.T) {
+	t.Parallel()
 	links := []ServiceLink{
 		{FromService: "x", ToService: "y", Relation: "shared_label"},
 		{FromService: "y", ToService: "x", Relation: "shared_label"},
@@ -84,6 +88,7 @@ func Test_FindServiceCycles_UndirectedRelationsExcluded(t *testing.T) {
 // (build-time coupling, e.g. two services importing each other's shared lib)
 // do NOT form a runtime service cycle.
 func Test_FindServiceCycles_ImportsExcluded(t *testing.T) {
+	t.Parallel()
 	links := []ServiceLink{
 		{FromService: "p", ToService: "q", Relation: "imports"},
 		{FromService: "q", ToService: "p", Relation: "imports"},
@@ -95,6 +100,7 @@ func Test_FindServiceCycles_ImportsExcluded(t *testing.T) {
 
 // Test_FindServiceCycles_SelfEdgeIgnored confirms a self-loop is not a cycle.
 func Test_FindServiceCycles_SelfEdgeIgnored(t *testing.T) {
+	t.Parallel()
 	links := []ServiceLink{
 		{FromService: "solo", ToService: "solo", Relation: "calls"},
 	}
@@ -105,6 +111,7 @@ func Test_FindServiceCycles_SelfEdgeIgnored(t *testing.T) {
 
 // Test_FindServiceCycles_ThreeNodeCycle covers a larger SCC and edge ordering.
 func Test_FindServiceCycles_ThreeNodeCycle(t *testing.T) {
+	t.Parallel()
 	links := []ServiceLink{
 		{FromService: "a", ToService: "b", Relation: "calls"},
 		{FromService: "b", ToService: "c", Relation: "calls"},

--- a/internal/graph/tests_walkup_test.go
+++ b/internal/graph/tests_walkup_test.go
@@ -39,6 +39,7 @@ func makeWalkUpFixture() *Document {
 // TestDeriveTestsWalkUp_BasicScenario verifies that the canonical
 // test → helper → viewset chain produces a derived TESTS edge.
 func TestDeriveTestsWalkUp_BasicScenario(t *testing.T) {
+	t.Parallel()
 	doc := makeWalkUpFixture()
 	stats := DeriveTestsWalkUp(doc)
 
@@ -76,6 +77,7 @@ func TestDeriveTestsWalkUp_BasicScenario(t *testing.T) {
 // TestDeriveTestsWalkUp_NoDerivedWhenNoCallers verifies that when the TESTS
 // target has no inbound CALLS, no derived edge is emitted.
 func TestDeriveTestsWalkUp_NoDerivedWhenNoCallers(t *testing.T) {
+	t.Parallel()
 	doc := makeDoc(
 		[]Entity{
 			{ID: "fn1", Name: "standalone_fn", Kind: "SCOPE.Operation", SourceFile: "lib.py"},
@@ -99,6 +101,7 @@ func TestDeriveTestsWalkUp_NoDerivedWhenNoCallers(t *testing.T) {
 // TestDeriveTestsWalkUp_HighFanInSkipped verifies that helpers with more than
 // maxCallersPerHelper callers are skipped (wide utility detection).
 func TestDeriveTestsWalkUp_HighFanInSkipped(t *testing.T) {
+	t.Parallel()
 	entities := []Entity{
 		{ID: "helper1", Name: "_util_fn", Kind: "SCOPE.Operation", SourceFile: "utils.py"},
 		{ID: "test1", Name: "test_util", Kind: "SCOPE.Operation", SourceFile: "tests/test_utils.py"},
@@ -132,6 +135,7 @@ func TestDeriveTestsWalkUp_HighFanInSkipped(t *testing.T) {
 // TestDeriveTestsWalkUp_DuplicateSuppressed verifies that if an explicit TESTS
 // edge already exists for the caller, the derived edge is suppressed.
 func TestDeriveTestsWalkUp_DuplicateSuppressed(t *testing.T) {
+	t.Parallel()
 	doc := makeDoc(
 		[]Entity{
 			{ID: "helper1", Name: "_helper", Kind: "SCOPE.Operation", SourceFile: "svc.py"},
@@ -160,6 +164,7 @@ func TestDeriveTestsWalkUp_DuplicateSuppressed(t *testing.T) {
 // reaches the same caller via two different helpers, only one derived edge is
 // emitted (deduplication).
 func TestDeriveTestsWalkUp_MultipleHelpersSharedCaller(t *testing.T) {
+	t.Parallel()
 	doc := makeDoc(
 		[]Entity{
 			{ID: "h1", Name: "_helper_a", Kind: "SCOPE.Operation", SourceFile: "svc.py"},
@@ -188,6 +193,7 @@ func TestDeriveTestsWalkUp_MultipleHelpersSharedCaller(t *testing.T) {
 // TestDeriveTestsWalkUp_TestCallerSkipped verifies that CALLS edges from test
 // entities are not treated as "viewset callers" (only production callers count).
 func TestDeriveTestsWalkUp_TestCallerSkipped(t *testing.T) {
+	t.Parallel()
 	doc := makeDoc(
 		[]Entity{
 			{ID: "h1", Name: "_helper", Kind: "SCOPE.Operation", SourceFile: "svc.py"},
@@ -212,6 +218,7 @@ func TestDeriveTestsWalkUp_TestCallerSkipped(t *testing.T) {
 // checks that the second call adds 0 edges because all callers are already in
 // existingTests via the first derived edge).
 func TestDeriveTestsWalkUp_IDStability(t *testing.T) {
+	t.Parallel()
 	doc := makeWalkUpFixture()
 	s1 := DeriveTestsWalkUp(doc)
 	s2 := DeriveTestsWalkUp(doc)
@@ -227,6 +234,7 @@ func TestDeriveTestsWalkUp_IDStability(t *testing.T) {
 // TestDeriveTestsWalkUp_CoverageIntegration verifies that ComputeCoverage
 // counts the viewset method as covered after DeriveTestsWalkUp runs.
 func TestDeriveTestsWalkUp_CoverageIntegration(t *testing.T) {
+	t.Parallel()
 	doc := makeWalkUpFixture()
 
 	// Before walk-up: only helper1 is covered.

--- a/internal/mcp/auth_coverage_test.go
+++ b/internal/mcp/auth_coverage_test.go
@@ -167,6 +167,7 @@ func endpointsByID(t *testing.T, out map[string]any) map[string]map[string]any {
 // ---------------------------------------------------------------------------
 
 func TestAuthCoverage_CallSitesExcluded(t *testing.T) {
+	t.Parallel()
 	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
@@ -176,6 +177,7 @@ func TestAuthCoverage_CallSitesExcluded(t *testing.T) {
 }
 
 func TestAuthCoverage_FileLevel_HasAuth(t *testing.T) {
+	t.Parallel()
 	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
@@ -193,6 +195,7 @@ func TestAuthCoverage_FileLevel_HasAuth(t *testing.T) {
 }
 
 func TestAuthCoverage_PropertyLevel_HasAuth(t *testing.T) {
+	t.Parallel()
 	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
@@ -210,6 +213,7 @@ func TestAuthCoverage_PropertyLevel_HasAuth(t *testing.T) {
 }
 
 func TestAuthCoverage_Public_SeverityWarn(t *testing.T) {
+	t.Parallel()
 	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
@@ -227,6 +231,7 @@ func TestAuthCoverage_Public_SeverityWarn(t *testing.T) {
 }
 
 func TestAuthCoverage_DeleteWithIDOR_SeverityError(t *testing.T) {
+	t.Parallel()
 	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
@@ -250,6 +255,7 @@ func TestAuthCoverage_DeleteWithIDOR_SeverityError(t *testing.T) {
 }
 
 func TestAuthCoverage_PaymentEndpoint_SeverityError(t *testing.T) {
+	t.Parallel()
 	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 	eps := endpointsByID(t, out)
@@ -267,6 +273,7 @@ func TestAuthCoverage_PaymentEndpoint_SeverityError(t *testing.T) {
 }
 
 func TestAuthCoverage_OnlyMissing(t *testing.T) {
+	t.Parallel()
 	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{
 		"group":        "test",
@@ -289,6 +296,7 @@ func TestAuthCoverage_OnlyMissing(t *testing.T) {
 }
 
 func TestAuthCoverage_RepoSummary(t *testing.T) {
+	t.Parallel()
 	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
 
@@ -330,6 +338,7 @@ func TestAuthCoverage_RepoSummary(t *testing.T) {
 }
 
 func TestAuthCoverage_DefaultDeny(t *testing.T) {
+	t.Parallel()
 	// Build a repo where ≥80% of endpoints are protected.
 	doc := &graph.Document{
 		Entities: []graph.Entity{
@@ -381,6 +390,7 @@ func TestAuthCoverage_DefaultDeny(t *testing.T) {
 }
 
 func TestAuthCoverage_TaggedAS(t *testing.T) {
+	t.Parallel()
 	// Endpoint in a DIFFERENT file than the auth_policy entity, but linked via TAGGED_AS.
 	doc := &graph.Document{
 		Entities: []graph.Entity{
@@ -412,6 +422,7 @@ func TestAuthCoverage_TaggedAS(t *testing.T) {
 }
 
 func TestAuthCoverage_SensitiveTermDetection(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name, path string
 		wantSens   bool
@@ -437,6 +448,7 @@ func TestAuthCoverage_SensitiveTermDetection(t *testing.T) {
 }
 
 func TestAuthCoverage_IDORRiskDetection(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		path string
 		want bool
@@ -457,6 +469,7 @@ func TestAuthCoverage_IDORRiskDetection(t *testing.T) {
 }
 
 func TestAuthCoverage_SeverityOrdering(t *testing.T) {
+	t.Parallel()
 	// Errors must appear before warns, warns before infos.
 	s := newTestServer(t, buildAuthCoverageDoc())
 	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})

--- a/internal/mcp/cycles_tools_test.go
+++ b/internal/mcp/cycles_tools_test.go
@@ -8,6 +8,7 @@ import "testing"
 // surface their direction. The canonical orders↔payments cycle uses
 // relation=calls one way and relation=publishes_to the other.
 func Test_buildServiceCycles_RelationFieldAlias(t *testing.T) {
+	t.Parallel()
 	lg := &LoadedGroup{
 		Name: "g",
 		Links: []CrossRepoLink{
@@ -27,6 +28,7 @@ func Test_buildServiceCycles_RelationFieldAlias(t *testing.T) {
 // Test_buildServiceCycles_SharedLabelExcluded confirms undirected shared_label
 // links cannot fabricate a service cycle even as a mutual pair.
 func Test_buildServiceCycles_SharedLabelExcluded(t *testing.T) {
+	t.Parallel()
 	lg := &LoadedGroup{
 		Links: []CrossRepoLink{
 			{Source: "a::1", Target: "b::2", Relation: "shared_label"},
@@ -41,6 +43,7 @@ func Test_buildServiceCycles_SharedLabelExcluded(t *testing.T) {
 // Test_buildServiceCycles_RepoFilter restricts the service graph to links whose
 // both endpoints fall inside the filter.
 func Test_buildServiceCycles_RepoFilter(t *testing.T) {
+	t.Parallel()
 	lg := &LoadedGroup{
 		Links: []CrossRepoLink{
 			{Source: "orders::a", Target: "payments::b", Relation: "calls"},
@@ -63,6 +66,7 @@ func Test_buildServiceCycles_RepoFilter(t *testing.T) {
 // Test_buildServiceCycles_KindFieldStillWorks verifies the legacy "kind" field
 // (MCP-appended candidates) is still honoured.
 func Test_buildServiceCycles_KindFieldStillWorks(t *testing.T) {
+	t.Parallel()
 	lg := &LoadedGroup{
 		Links: []CrossRepoLink{
 			{Source: "a::1", Target: "b::2", Kind: "calls"},

--- a/internal/mcp/result_helpers_meta_test.go
+++ b/internal/mcp/result_helpers_meta_test.go
@@ -18,6 +18,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestExtractResultText_returnsText(t *testing.T) {
+	t.Parallel()
 	res := makeTextResult(`{"hello":"world"}`)
 	got := extractResultText(t, res)
 	if got != `{"hello":"world"}` {
@@ -26,6 +27,7 @@ func TestExtractResultText_returnsText(t *testing.T) {
 }
 
 func TestExtractResultText_nonJSON(t *testing.T) {
+	t.Parallel()
 	res := makeTextResult("# Markdown heading\nsome text")
 	got := extractResultText(t, res)
 	if got == "" {
@@ -38,6 +40,7 @@ func TestExtractResultText_nonJSON(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestExtractResultJSON_parsesObject(t *testing.T) {
+	t.Parallel()
 	res := makeTextResult(`{"foo":42,"bar":"baz"}`)
 	out := extractResultJSON(t, res)
 	if out["foo"] != float64(42) {
@@ -49,6 +52,7 @@ func TestExtractResultJSON_parsesObject(t *testing.T) {
 }
 
 func TestExtractResultJSON_multipleContent(t *testing.T) {
+	t.Parallel()
 	// Only the first TextContent should be used.
 	res := &mcpapi.CallToolResult{
 		Content: []mcpapi.Content{
@@ -67,12 +71,14 @@ func TestExtractResultJSON_multipleContent(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAssertResultJSON_matchingValue(t *testing.T) {
+	t.Parallel()
 	res := makeTextResult(`{"status":"ok"}`)
 	// Should not fail the sub-test.
 	assertResultJSON(t, res, "status", "ok")
 }
 
 func TestAssertResultJSON_mismatch(t *testing.T) {
+	t.Parallel()
 	res := makeTextResult(`{"status":"error"}`)
 	// We expect t.Errorf to fire; capture with a sub-recorder.
 	inner := &testing.T{}

--- a/internal/mcp/rrf_test.go
+++ b/internal/mcp/rrf_test.go
@@ -59,6 +59,7 @@ func sqrt(x float64) float64 {
 }
 
 func TestFuseRRF_SemanticHitWithoutKeywordOverlap(t *testing.T) {
+	t.Parallel()
 	// Two entities, neither shares any token with the query
 	// "where do we handle authentication" -- but `verifyBearer` is semantically
 	// close (shares the token "verify" and "bearer" through its docstring).
@@ -124,6 +125,7 @@ func TestFuseRRF_SemanticHitWithoutKeywordOverlap(t *testing.T) {
 }
 
 func TestFuseRRF_BothSourcesRankFusedHigher(t *testing.T) {
+	t.Parallel()
 	a := &graph.Entity{ID: "a", Name: "AuthCheck"}
 	b := &graph.Entity{ID: "b", Name: "AuthVerify"}
 	c := &graph.Entity{ID: "c", Name: "LogoutHandler"}


### PR DESCRIPTION
## Summary

- **Workflow**: race detector now runs only on push-to-main, release events, and PRs with the `ci:full` label. All other PRs run without `-race`, saving ~4 min per CI run.
- **t.Parallel()**: added to 111 tests across `internal/graph` (84 tests) and `internal/mcp` (27 tests) — only tests with verified-no-shared-state were parallelized.
- **ci:full label applied to THIS PR** so the full race suite validates the new parallelization.

## Before / After (local M2 Pro)

| Mode | Before | After | Delta |
|---|---|---|---|
| `go test -count=1 ./internal/graph/... ./internal/mcp/...` | 31.4s wall | 25.5s wall | −19% |
| `go test -race -count=1 ./internal/graph/... ./internal/mcp/...` | — | 48.7s wall ✅ | race suite stays green |

CI wall-clock on PR touch-paths: ~7 min → ~2–3 min projected.

## Workflow conditional (`.github/workflows/test.yml`)

```
push to main    → -race   (post-merge sanity)
release event   → -race
PR + ci:full    → -race   (platform-sensitive opt-in)
all other PRs   → no race (fast path)
```

## t.Parallel() coverage

- `internal/graph`: 84 tests — algorithms, community_names, coverage, cycles, diff, load, module_gds, service_cycles, tests_walkup. All operate on locally-scoped data; no shared globals.
- `internal/mcp`: 27 tests — auth_coverage (11), cycles_tools (4), result_helpers_meta (6), rrf (2), plus existing nplus1 tests were already parallel.
- **Skipped** (unsafe): `deferred_payload_test`, `docgen_test`, `docstate_test`, `server_test` — use `t.Setenv` on process-global env. Left untouched.

## Tech debt surfaced

1. `deferred_payload_test`, `docgen_test`, `docstate_test` read `os.Getenv` directly in production code, preventing safe parallelization. Refactoring to accept a config struct would unlock further speedup.
2. `dashboard_tools_test` and `flow_tools_test` have no env issues but were not parallelized in this pass — large fixture construction warrants a focused follow-up measurement before parallelizing.

## Test plan

- [ ] Race suite passes on THIS PR (ci:full label applied)
- [ ] `go test -count=1 ./...` passes on all 3 platforms
- [ ] `go test -race -count=1 ./internal/graph/... ./internal/mcp/...` locally: ✅ no races detected
- [ ] PR without ci:full label: confirm workflow skips `-race` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)