### PR TITLE
refactor(daemon): finish slog migration — tier/clone/worktree + retire bridge

### DIFF
--- a/cmd/archigraph/daemon_tier.go
+++ b/cmd/archigraph/daemon_tier.go
@@ -91,9 +91,7 @@ func startDaemonTierManager(ctx context.Context, logger *slog.Logger) {
 		ttl.SystemMemoryBytes = uint64(sysMB) * 1024 * 1024
 	}
 
-	// tier.NewManager still accepts *log.Logger; bridge via slog.NewLogLogger.
-	tierLog := slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
-	daemonTierMgr = tier.NewManager(ctx, ttl, tierEvictCallback, tierReloadCallback, tierDiskEvictCallback, tierLog)
+	daemonTierMgr = tier.NewManager(ctx, ttl, tierEvictCallback, tierReloadCallback, tierDiskEvictCallback, logger)
 
 	// Wire the MCP graph-cache access hook so every GetForRepoRef call
 	// updates lastAccessedAt in the tier manager without extra call-sites.

--- a/internal/daemon/clone/clone.go
+++ b/internal/daemon/clone/clone.go
@@ -29,7 +29,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,7 +82,7 @@ type Result struct {
 // Config wires TryClone. ReExtractFiles is required for a useful clone.
 type Config struct {
 	// Logger receives structured log lines. nil → os.Stderr.
-	Logger *log.Logger
+	Logger *slog.Logger
 
 	// ReExtractFiles re-indexes a list of files within a repo and returns
 	// the updated graph document. The passed document is the cloned base;
@@ -109,13 +109,12 @@ type Config struct {
 func TryClone(repoPath, newRef string, cfg Config) (Result, error) {
 	logger := cfg.Logger
 	if logger == nil {
-		logger = log.New(os.Stderr, "clone: ", log.LstdFlags)
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "clone")
 	}
 
 	slug := filepath.Base(repoPath)
 	abort := func(reason string) (Result, error) {
-		logger.Printf("clone-from-parent: %s/refs/%s ABORTED reason=%q → full reindex",
-			slug, newRef, reason)
+		logger.Info("clone-from-parent: ABORTED → full reindex", "repo", slug, "ref", newRef, "reason", reason)
 		return Result{Done: false}, nil
 	}
 
@@ -238,8 +237,7 @@ func TryClone(repoPath, newRef string, cfg Config) (Result, error) {
 	}
 
 	took := time.Since(t0)
-	logger.Printf("clone-from-parent: %s/refs/%s from=%s changed_files=%d took=%s (skip_full_reindex=true)",
-		slug, newRef, parentRef, len(changedFiles), took.Truncate(time.Millisecond))
+	logger.Info("clone-from-parent: OK skip_full_reindex=true", "repo", slug, "ref", newRef, "from", parentRef, "changed_files", len(changedFiles), "took", took.Truncate(time.Millisecond))
 
 	return Result{
 		Done:         true,

--- a/internal/daemon/clone/clone_test.go
+++ b/internal/daemon/clone/clone_test.go
@@ -3,7 +3,7 @@ package clone
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -110,7 +110,7 @@ func TestTryClone_NilCallbackAborts(t *testing.T) {
 	repoPath := t.TempDir()
 
 	res, err := TryClone(repoPath, "feat/x", Config{
-		Logger:         log.New(os.Stderr, "test: ", 0),
+		Logger:         slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "clone-test"),
 		ReExtractFiles: nil,
 	})
 	if err != nil {
@@ -138,7 +138,7 @@ func TestTryClone_ExistingGraphSkipped(t *testing.T) {
 	}
 
 	res, err := TryClone(repoPath, "feat/already-indexed", Config{
-		Logger:         log.New(os.Stderr, "test: ", 0),
+		Logger:         slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "clone-test"),
 		ReExtractFiles: noopReExtract,
 	})
 	if err != nil {
@@ -157,7 +157,7 @@ func TestTryClone_NoParentCandidateAborts(t *testing.T) {
 	repoPath := t.TempDir()
 
 	res, err := TryClone(repoPath, "feat/no-parent", Config{
-		Logger:         log.New(os.Stderr, "test: ", 0),
+		Logger:         slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "clone-test"),
 		ReExtractFiles: noopReExtract,
 	})
 	if err != nil {
@@ -187,7 +187,7 @@ func TestTryClone_CorruptParentGraphAborts(t *testing.T) {
 	}
 
 	res, err := TryClone(repoPath, "feat/from-corrupt", Config{
-		Logger:         log.New(os.Stderr, "test: ", 0),
+		Logger:         slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "clone-test"),
 		ReExtractFiles: noopReExtract,
 	})
 	if err != nil {
@@ -224,7 +224,7 @@ func TestTryClone_ZeroDiff_MetadataUpdated(t *testing.T) {
 
 	var reExtractFiles []string
 	res, err := TryClone(repoPath, "feat/zero-diff", Config{
-		Logger: log.New(os.Stderr, "test: ", 0),
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "clone-test"),
 		ReExtractFiles: func(_ string, files []string, base *graph.Document) (*graph.Document, error) {
 			reExtractFiles = files
 			return base, nil
@@ -301,7 +301,7 @@ func TestTryClone_ReExtractCalled(t *testing.T) {
 
 	var gotFiles []string
 	res, err := TryClone(repoPath, "feat/with-change", Config{
-		Logger: log.New(os.Stderr, "test: ", 0),
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "clone-test"),
 		ReExtractFiles: func(_ string, files []string, base *graph.Document) (*graph.Document, error) {
 			gotFiles = append(gotFiles, files...)
 			return base, nil
@@ -401,7 +401,7 @@ func TestDiffOverLimitAborts(t *testing.T) {
 	buildFakeGraph(t, mainDir, 50, 5, "main", "abc123")
 
 	res, err := TryClone(repoPath, "feat/big-diff", Config{
-		Logger:         log.New(os.Stderr, "test: ", 0),
+		Logger:         slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "clone-test"),
 		ReExtractFiles: noopReExtract,
 	})
 	if err != nil {

--- a/internal/daemon/tier/tier.go
+++ b/internal/daemon/tier/tier.go
@@ -45,7 +45,7 @@ package tier
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"os"
 	"runtime"
 	"sort"
@@ -293,7 +293,7 @@ type Manager struct {
 	onEvict     EvictionCallback
 	reload      ReloadCallback
 	onDiskEvict DiskEvictCallback // PH6: nil = no disk deletion
-	logger      *log.Logger
+	logger      *slog.Logger
 	clock       func() time.Time
 	// watcher is optional (PH2a #2096). When non-nil, Pause is called on
 	// WARM→COLD and Resume is called on COLD→HOT.
@@ -314,9 +314,9 @@ const defaultScanInterval = 30 * time.Second
 // NewManager creates and starts a Manager. The scanner runs until ctx is
 // cancelled. onEvict and reload must not be nil. onDiskEvict may be nil
 // (disables disk deletion).
-func NewManager(ctx context.Context, ttl TTLConfig, onEvict EvictionCallback, reload ReloadCallback, onDiskEvict DiskEvictCallback, logger *log.Logger) *Manager {
+func NewManager(ctx context.Context, ttl TTLConfig, onEvict EvictionCallback, reload ReloadCallback, onDiskEvict DiskEvictCallback, logger *slog.Logger) *Manager {
 	if logger == nil {
-		logger = log.Default()
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "tier")
 	}
 	m := &Manager{
 		slots:       make(map[SlotKey]*slot),
@@ -342,7 +342,7 @@ func NewManagerForTest(ttl TTLConfig, clock func() time.Time, onEvict EvictionCa
 		ttl:      ttl,
 		onEvict:  onEvict,
 		reload:   reload,
-		logger:   log.Default(),
+		logger:   slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "tier"),
 		clock:    clock,
 		sysMemFn: readSysMemBytes,
 		heapFn:   readHeapInuse,
@@ -358,7 +358,7 @@ func NewManagerForTestWithDiskEvict(ttl TTLConfig, clock func() time.Time, onEvi
 		onEvict:     onEvict,
 		reload:      reload,
 		onDiskEvict: onDiskEvict,
-		logger:      log.Default(),
+		logger:      slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "tier"),
 		clock:       clock,
 		sysMemFn:    readSysMemBytes,
 		heapFn:      readHeapInuse,
@@ -373,7 +373,7 @@ func NewManagerForTestWithHeap(ttl TTLConfig, clock func() time.Time, onEvict Ev
 		ttl:      ttl,
 		onEvict:  onEvict,
 		reload:   reload,
-		logger:   log.Default(),
+		logger:   slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "tier"),
 		clock:    clock,
 		sysMemFn: sysMemFn,
 		heapFn:   heapFn,
@@ -454,11 +454,11 @@ func (m *Manager) Touch(key SlotKey) error {
 		m.mu.Unlock()
 		if wh != nil {
 			resumeElapsed := wh.Resume(key.RepoPath, key.Ref)
-			m.logger.Printf("tier: cold-wake watcher resumed %s@%s (took %s)", key.RepoPath, key.Ref, resumeElapsed.Round(time.Millisecond))
+			m.logger.Info("tier: cold-wake watcher resumed", "repo", key.RepoPath, "ref", key.Ref, "took", resumeElapsed.Round(time.Millisecond))
 		}
 
 		if err := m.reload(key); err != nil {
-			m.logger.Printf("tier: cold-load failed %s@%s: %v", key.RepoPath, key.Ref, err)
+			m.logger.Error("tier: cold-load failed", "repo", key.RepoPath, "ref", key.Ref, "err", err)
 			return err
 		}
 		m.mu.Lock()
@@ -467,7 +467,7 @@ func (m *Manager) Touch(key SlotKey) error {
 			s2.lastAccessedAt = m.clock()
 		}
 		m.mu.Unlock()
-		m.logger.Printf("tier: cold-load OK %s@%s → HOT", key.RepoPath, key.Ref)
+		m.logger.Info("tier: cold-load OK → HOT", "repo", key.RepoPath, "ref", key.Ref)
 	}
 	return nil
 }
@@ -554,20 +554,20 @@ func (m *Manager) scan() {
 		case TierHot:
 			if idle >= m.ttl.HotWindow {
 				s.tier = TierWarm
-				m.logger.Printf("tier: %s@%s HOT→WARM (idle %s, kind=%s)", k.RepoPath, k.Ref, idle.Round(time.Second), s.kind)
+				m.logger.Info("tier: HOT→WARM", "repo", k.RepoPath, "ref", k.Ref, "idle", idle.Round(time.Second), "kind", s.kind)
 			}
 		case TierWarm:
 			if idle >= coldWindow {
 				s.tier = TierCold
 				toEvict = append(toEvict, k)
-				m.logger.Printf("tier: %s@%s WARM→COLD (idle %s, kind=%s)", k.RepoPath, k.Ref, idle.Round(time.Second), s.kind)
+				m.logger.Info("tier: WARM→COLD", "repo", k.RepoPath, "ref", k.Ref, "idle", idle.Round(time.Second), "kind", s.kind)
 			}
 		case TierCold:
 			// PH6 (#2094): COLD→EXPIRED — delete disk artifacts when not pinned.
 			if !s.isPinnedMain && idle >= expiredWindow {
 				s.tier = TierExpired
 				toExpire = append(toExpire, k)
-				m.logger.Printf("tier: %s@%s COLD→EXPIRED (idle %s, kind=%s)", k.RepoPath, k.Ref, idle.Round(time.Hour), s.kind)
+				m.logger.Info("tier: COLD→EXPIRED", "repo", k.RepoPath, "ref", k.Ref, "idle", idle.Round(time.Hour), "kind", s.kind)
 			}
 		}
 	}
@@ -594,9 +594,9 @@ func (m *Manager) scan() {
 		for _, k := range toExpire {
 			freed, err := m.onDiskEvict(k)
 			if err != nil {
-				m.logger.Printf("tier: expired-evict %s@%s FAILED: %v", k.RepoPath, k.Ref, err)
+				m.logger.Error("tier: expired-evict FAILED", "repo", k.RepoPath, "ref", k.Ref, "err", err)
 			} else {
-				m.logger.Printf("tier: expired-evict %s@%s freed=%.1fMB", k.RepoPath, k.Ref, float64(freed)/(1024*1024))
+				m.logger.Info("tier: expired-evict freed", "repo", k.RepoPath, "ref", k.Ref, "freed_mb", float64(freed)/(1024*1024))
 			}
 		}
 	}
@@ -625,8 +625,7 @@ func (m *Manager) scanPressureEvict() int {
 		return 0
 	}
 	heapMB := float64(heapBytes) / (1024 * 1024)
-	m.logger.Printf("tier: pressure-evict triggered heap=%.1fMB threshold=%d%% sys=%.0fMB",
-		heapMB, m.ttl.HeapMaxPct, float64(sysBytes)/(1024*1024))
+	m.logger.Info("tier: pressure-evict triggered", "heap_mb", heapMB, "threshold_pct", m.ttl.HeapMaxPct, "sys_mb", float64(sysBytes)/(1024*1024))
 
 	// Collect all evictable HOT/WARM slots sorted oldest-accessed first.
 	// Pinned-main slots are excluded.
@@ -663,8 +662,7 @@ func (m *Manager) scanPressureEvict() int {
 		oldTier := s.tier.String()
 		s.tier = TierCold
 		toEvict = append(toEvict, k)
-		m.logger.Printf("tier: pressure-evict %s@%s %s→COLD reason=heap_threshold heap_now=%.0fMB",
-			k.RepoPath, k.Ref, oldTier, heapMB)
+		m.logger.Info("tier: pressure-evict →COLD", "repo", k.RepoPath, "ref", k.Ref, "from", oldTier, "reason", "heap_threshold", "heap_mb", heapMB)
 	}
 	m.mu.Unlock()
 

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -44,7 +44,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -449,7 +449,7 @@ type Watcher struct {
 	store    *Store
 	parents  func() []ParentRepo // called on every tick to get the current set
 	interval time.Duration
-	logger   *log.Logger
+	logger   *slog.Logger
 }
 
 // defaultPollInterval is the default discovery interval.
@@ -467,9 +467,9 @@ func pollInterval() time.Duration {
 
 // NewWatcher creates a Watcher.  parents is called on each poll tick to get
 // the current set of parent repos; it must be safe for concurrent use.
-func NewWatcher(store *Store, parents func() []ParentRepo, logger *log.Logger) *Watcher {
+func NewWatcher(store *Store, parents func() []ParentRepo, logger *slog.Logger) *Watcher {
 	if logger == nil {
-		logger = log.Default()
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "worktree")
 	}
 	return &Watcher{
 		store:    store,
@@ -509,15 +509,13 @@ func (w *Watcher) poll() {
 	for _, p := range parents {
 		linked, err := runWorktreeList(p.Path)
 		if err != nil {
-			w.logger.Printf("worktree: git worktree list failed for %s (%s/%s): %v",
-				p.Path, p.GroupName, p.Slug, err)
+			w.logger.Error("worktree: git worktree list failed", "path", p.Path, "group", p.GroupName, "slug", p.Slug, "err", err)
 			continue
 		}
 
 		kept, skipped := enforceCap(linked, cap)
 		if skipped > 0 {
-			w.logger.Printf("worktree: %s/%s has %d linked worktrees; keeping %d most-recent, skipping %d (cap=%d, override ARCHIGRAPH_MAX_WORKTREES_PER_REPO)",
-				p.GroupName, p.Slug, len(linked), cap, skipped, cap)
+			w.logger.Warn("worktree: per-parent cap enforced", "group", p.GroupName, "slug", p.Slug, "total", len(linked), "kept", cap, "skipped", skipped, "cap", cap, "override_env", "ARCHIGRAPH_MAX_WORKTREES_PER_REPO")
 		}
 
 		w.store.mu.Lock()
@@ -536,8 +534,7 @@ func (w *Watcher) poll() {
 					Status:       StatusActive,
 				}
 				w.store.upsert(child)
-				w.logger.Printf("worktree: registered %s/%s worktree %s @ %s",
-					p.GroupName, p.Slug, raw.Path, raw.Branch)
+				w.logger.Info("worktree: registered", "group", p.GroupName, "slug", p.Slug, "path", raw.Path, "branch", raw.Branch)
 			} else {
 				// Refresh.
 				existing.LastSeenAt = now
@@ -546,8 +543,7 @@ func (w *Watcher) poll() {
 				if existing.Status == StatusExpired {
 					existing.Status = StatusActive
 					existing.StaleAt = nil
-					w.logger.Printf("worktree: re-activated %s/%s worktree %s",
-						p.GroupName, p.Slug, raw.Path)
+					w.logger.Info("worktree: re-activated", "group", p.GroupName, "slug", p.Slug, "path", raw.Path)
 				}
 			}
 		}
@@ -559,12 +555,11 @@ func (w *Watcher) poll() {
 	for _, c := range w.store.children {
 		if c.Status == StatusActive && !seenPaths[normPath(c.Path)] {
 			w.store.markExpired(c.Path)
-			w.logger.Printf("worktree: expired %s/%s worktree %s (no longer listed by git)",
-				c.GroupName, c.ParentSlug, c.Path)
+			w.logger.Info("worktree: expired", "group", c.GroupName, "slug", c.ParentSlug, "path", c.Path, "reason", "no longer listed by git")
 		}
 	}
 	if err := w.store.save(); err != nil {
-		w.logger.Printf("worktree: failed to persist store: %v", err)
+		w.logger.Error("worktree: failed to persist store", "err", err)
 	}
 	w.store.mu.Unlock()
 }


### PR DESCRIPTION
## Summary

- Migrates `internal/daemon/tier/` (`tier.NewManager` + 3 test constructors) from `*log.Logger` to `*slog.Logger`; converts all `Printf` call sites to structured `Info`/`Warn`/`Error` with key-value pairs
- Migrates `internal/daemon/clone/clone.go` (`Config.Logger` field) from `*log.Logger` to `*slog.Logger`; updates `clone_test.go` accordingly
- Migrates `internal/daemon/worktree/worktree.go` (`Watcher.logger` field, `NewWatcher` parameter) from `*log.Logger` to `*slog.Logger`
- Deletes the `slog.NewLogLogger` bridge in `cmd/archigraph/daemon_tier.go` (lines 94–95); passes `*slog.Logger` directly to `tier.NewManager`

Net result: `git grep -nE "\*log\.Logger\b" internal/daemon/` returns zero matches.

## Test plan

- [ ] `gofmt -l` on changed files returned empty (no reformatting needed)
- [ ] `go vet ./...` clean
- [ ] `go build ./...` succeeds
- [ ] `go test ./internal/daemon/...` — all 15 packages pass (including tier, clone, worktree)
- [ ] Grep verification: zero `*log.Logger` references in `internal/daemon/`

Closes #2401

🤖 Generated with [Claude Code](https://claude.com/claude-code)