### PR TITLE
refactor(cmd/daemon): inject rebuildConcurrency + activeDaemonMode at construction

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -137,18 +137,7 @@ func resolveEnvRebuildConcurrency() int {
 	return defaultRebuildConcurrency()
 }
 
-// rebuildConcurrency is the package-level concurrency cap used by
-// daemonRebuildFunc. It is set once by runDaemon before the RPC server
-// starts accepting connections. Concurrent calls to daemonRebuildFunc
-// each get their own semaphore, so different group rebuilds do not share
-// the cap — the cap applies to repos within a single group rebuild.
-var rebuildConcurrency = defaultRebuildConcurrency()
-
-// activeDaemonMode is set by runDaemon after loading the mode config.
-// It is read-only after that point (written once before the RPC server starts).
-var activeDaemonMode string
-
-// rebuildIndexFunc is the per-repo index entrypoint used by daemonRebuildFunc.
+// rebuildIndexFunc is the per-repo index entrypoint used by makeDaemonRebuildFunc.
 // It defaults to the package-level Index function but can be replaced in tests
 // to validate parallelism semantics without running a real extractor pass.
 // Must be set before the daemon accepts connections (write-once, then read-only).
@@ -223,6 +212,10 @@ func runDaemon(argv []string) error {
 	// S7 (#2157): load mode from daemon.config.json then apply env defaults.
 	// Precedence: --mode flag > daemon.config.json > Background default.
 	// Env vars always win over mode defaults (ApplyDefaults only sets unset vars).
+	// activeDaemonMode is captured at construction time and threaded into
+	// daemon.Config.DaemonMode so the Status RPC can surface it — no package-level
+	// singleton needed (issue #2411).
+	var activeDaemonMode string
 	{
 		cfgPath := mode.DefaultConfigPath(layout.Root)
 		modeCfg, _ := mode.LoadConfig(cfgPath) // missing file → zero value; not fatal
@@ -237,7 +230,6 @@ func runDaemon(argv []string) error {
 		}
 		mode.ApplyDefaults(activeMode)
 		gcLog.Printf("daemon mode: %s", activeMode)
-		// Store the active mode in a package-level var so the Status RPC can surface it.
 		activeDaemonMode = string(activeMode)
 	}
 
@@ -290,7 +282,7 @@ func runDaemon(argv []string) error {
 		Layout:       layout,
 		Logger:       logger,
 		Index:        daemonIndexFunc,
-		Rebuild:      daemonRebuildFunc,
+		Rebuild:      makeDaemonRebuildFunc(maxConcurrentGroups),
 		QualityAudit: daemonQualityAuditFunc,
 
 		// Phase B — wire the watcher + scheduler. The fast reactive
@@ -399,12 +391,6 @@ func runDaemon(argv []string) error {
 				},
 			}
 		}(),
-	}
-
-	// Apply the concurrency cap before the RPC server opens so
-	// daemonRebuildFunc picks it up immediately. Written once; no race.
-	if maxConcurrentGroups >= 1 {
-		rebuildConcurrency = maxConcurrentGroups
 	}
 
 	ctx := context.Background()
@@ -605,16 +591,29 @@ func daemonIndexFunc(args proto.IndexArgs) (string, string, error) {
 	return graphPath, statsBuf.String(), nil
 }
 
-// daemonRebuildFunc force-indexes every repo in a group. We deliberately
+// makeDaemonRebuildFunc returns the RebuildFunc injected into daemon.Config.
+// concurrency is captured at construction time from runDaemon's maxConcurrentGroups
+// so no package-level singleton is needed (issue #2411).
+//
+// The returned func force-indexes every repo in a group. We deliberately
 // re-implement the iteration here rather than calling into internal/cli
 // to avoid pulling cobra back into the daemon's call graph.
 //
-// Parallelism (#1276): repos are indexed concurrently up to rebuildConcurrency
+// Parallelism (#1276): repos are indexed concurrently up to concurrency
 // workers. One failing repo does not stop the others — all are attempted and
 // any errors are collected and returned together. Per-repo wall time is logged
 // to stderr for diagnostics. The cross-repo link pass runs only once all
 // per-repo indexes complete.
-func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
+func makeDaemonRebuildFunc(concurrency int) daemon.RebuildFunc {
+	return func(args proto.RebuildArgs) ([]string, string, error) {
+		return daemonRebuildFuncCore(concurrency, args)
+	}
+}
+
+// daemonRebuildFuncCore is the testable inner implementation of the rebuild
+// logic. concurrency is supplied by the caller (captured in the closure
+// returned by makeDaemonRebuildFunc, or set directly in tests).
+func daemonRebuildFuncCore(concurrency int, args proto.RebuildArgs) ([]string, string, error) {
 	rebuildStart := time.Now()
 	fmt.Fprintf(os.Stderr, "archigraph: rebuild start group=%s slug=%q wipe=%v incremental=%v\n",
 		args.Group, args.Slug, args.Wipe, args.Incremental)
@@ -660,7 +659,7 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 	}
 
 	// Serial fast path: single worker or single repo skips goroutine overhead.
-	conc := rebuildConcurrency
+	conc := concurrency
 	if conc < 1 {
 		conc = 1
 	}

--- a/cmd/archigraph/daemon_parallel_test.go
+++ b/cmd/archigraph/daemon_parallel_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
-// TestDaemonRebuildParallel verifies that daemonRebuildFunc respects
-// rebuildConcurrency: with concurrency=2 and 4 repos that each sleep
+// TestDaemonRebuildParallel verifies that daemonRebuildFuncCore respects
+// the concurrency parameter: with concurrency=2 and 4 repos that each sleep
 // briefly, the parallel run should complete in meaningfully less wall
 // time than the serial run, and peak observed concurrency should be ≥2.
 func TestDaemonRebuildParallel(t *testing.T) {
@@ -70,9 +70,8 @@ func TestDaemonRebuildParallel(t *testing.T) {
 	defer func() { rebuildLinksFunc = origLinksFn }()
 
 	// --- Serial run (concurrency=1) ---
-	rebuildConcurrency = 1
 	t0 := time.Now()
-	rebuilt, _, err := daemonRebuildFunc(proto.RebuildArgs{Group: "test-group"})
+	rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: "test-group"})
 	serialDur := time.Since(t0)
 	if err != nil {
 		t.Fatalf("serial rebuild: %v", err)
@@ -86,9 +85,8 @@ func TestDaemonRebuildParallel(t *testing.T) {
 	atomic.StoreInt64(&currentConc, 0)
 
 	// --- Parallel run (concurrency=2) ---
-	rebuildConcurrency = 2
 	t1 := time.Now()
-	rebuilt2, _, err2 := daemonRebuildFunc(proto.RebuildArgs{Group: "test-group"})
+	rebuilt2, _, err2 := daemonRebuildFuncCore(2, proto.RebuildArgs{Group: "test-group"})
 	parallelDur := time.Since(t1)
 	if err2 != nil {
 		t.Fatalf("parallel rebuild: %v", err2)
@@ -143,8 +141,7 @@ func TestDaemonRebuildSerial(t *testing.T) {
 	rebuildLinksFunc = func(_ string) error { return nil }
 	defer func() { rebuildLinksFunc = origLinksFn }()
 
-	rebuildConcurrency = 1
-	rebuilt, warning, err := daemonRebuildFunc(proto.RebuildArgs{Group: "serial-group"})
+	rebuilt, warning, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: "serial-group"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -194,8 +191,7 @@ func TestDaemonRebuildFailureIsolation(t *testing.T) {
 
 	// Both serial and parallel should return partial results + an error.
 	for _, conc := range []int{1, 2} {
-		rebuildConcurrency = conc
-		rebuilt, _, err := daemonRebuildFunc(proto.RebuildArgs{Group: "mixed-group"})
+		rebuilt, _, err := daemonRebuildFuncCore(conc, proto.RebuildArgs{Group: "mixed-group"})
 		if err == nil {
 			t.Errorf("conc=%d: expected error for bad-repo, got nil", conc)
 		}

--- a/cmd/archigraph/daemon_rebuild_test.go
+++ b/cmd/archigraph/daemon_rebuild_test.go
@@ -71,9 +71,7 @@ func TestRebuildPanicRecoveryReleasesSemaphore(t *testing.T) {
 	rebuildLinksFunc = func(_ string) error { return nil }
 	defer func() { rebuildLinksFunc = origLinksFn }()
 
-	rebuildConcurrency = 1
-
-	_, _, err := daemonRebuildFunc(proto.RebuildArgs{Group: group})
+	_, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group})
 	// Expect an error because one repo panicked.
 	if err == nil {
 		t.Error("expected error from panicking repo, got nil")
@@ -106,8 +104,7 @@ func TestRebuildPanicParallelReleasesSemaphore(t *testing.T) {
 	rebuildLinksFunc = func(_ string) error { return nil }
 	defer func() { rebuildLinksFunc = origLinksFn }()
 
-	rebuildConcurrency = 2
-	_, _, _ = daemonRebuildFunc(proto.RebuildArgs{Group: group})
+	_, _, _ = daemonRebuildFuncCore(2, proto.RebuildArgs{Group: group})
 
 	if got := atomic.LoadInt32(&callCount); got != 4 {
 		t.Errorf("callCount = %d, want 4 (panic in one goroutine must not starve others)", got)
@@ -135,12 +132,11 @@ func TestRebuildFiveSequentialAlwaysComplete(t *testing.T) {
 	rebuildLinksFunc = func(_ string) error { return nil }
 	defer func() { rebuildLinksFunc = origLinksFn }()
 
-	rebuildConcurrency = 1
 	for i := 0; i < 5; i++ {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			daemonRebuildFunc(proto.RebuildArgs{Group: group}) //nolint:errcheck
+			daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}) //nolint:errcheck
 		}()
 		select {
 		case <-done:
@@ -186,8 +182,7 @@ func TestRebuildSemaphoreCapRespected(t *testing.T) {
 	rebuildLinksFunc = func(_ string) error { return nil }
 	defer func() { rebuildLinksFunc = origLinksFn }()
 
-	rebuildConcurrency = 2
-	_, _, err := daemonRebuildFunc(proto.RebuildArgs{Group: group})
+	_, _, err := daemonRebuildFuncCore(2, proto.RebuildArgs{Group: group})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -224,14 +219,12 @@ func TestRebuildResultsSliceNotRacedOnConcurrentCalls(t *testing.T) {
 	rebuildLinksFunc = func(_ string) error { return nil }
 	defer func() { rebuildLinksFunc = origLinksFn }()
 
-	rebuildConcurrency = 1
-
 	var wg sync.WaitGroup
 	for i := 0; i < 4; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			rebuilt, _, err := daemonRebuildFunc(proto.RebuildArgs{Group: group})
+			rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group})
 			if err != nil {
 				return // errors are acceptable
 			}


### PR DESCRIPTION
## Summary

- Deletes `var rebuildConcurrency` (daemon.go:145) and `var activeDaemonMode` (daemon.go:149) — both write-once package-level singletons
- Introduces `makeDaemonRebuildFunc(concurrency int) daemon.RebuildFunc` constructor (mirrors `makeDaemonDashboardServe`) that captures concurrency at build time and delegates to `daemonRebuildFuncCore`
- Hoists `activeDaemonMode` as a local `var` in `runDaemon`, assigned from the mode-resolution block, and threads it directly into `daemon.Config.DaemonMode`
- Updates `daemon_parallel_test.go` and `daemon_rebuild_test.go` to call `daemonRebuildFuncCore(concurrency, args)` directly instead of mutating the package-level singleton before each call

## Test plan

- [x] `gofmt -l` returns empty on all changed files
- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `go test ./cmd/archigraph/...` passes (66s, all tests including parallel timing tests)

Closes #2411

🤖 Generated with [Claude Code](https://claude.com/claude-code)