### PR TITLE
cleanup(mcp): delete deprecated byID alias — closes #2416

### DIFF
--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -230,7 +230,6 @@ type LoadedRepo struct {
 	TopKPageRank []string                 // entity IDs sorted descending by PageRank (#2304)
 	Semantic     *embed.Store             // per-repo vector index (nil when no embeddings.bin)
 	semMtime     time.Time
-	byID         map[string]*graph.Entity // deprecated alias for ByID — kept for back-compat during #1656 rollout
 	mtime        time.Time
 	loadErr      string // populated when last reload failed; doc may be stale
 }
@@ -467,7 +466,6 @@ func (s *State) reloadLocked() (int, bool, error) {
 				for i := range doc.Entities {
 					lr.ByID[doc.Entities[i].ID] = &doc.Entities[i]
 				}
-				lr.byID = lr.ByID // back-compat alias (deprecated)
 				// Pre-build adjacency once per reload. Eliminates the per-query
 				// O(R)=117k scan that every flow/traversal handler used to pay
 				// via buildAdjacency(r.Doc, r.Repo). (#1656)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -465,7 +465,7 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 				semIDs := r.Semantic.Search(qVec, 10)
 				semHits := make([]Hit, 0, len(semIDs))
 				for _, s := range semIDs {
-					if e, ok := r.byID[s.ID]; ok {
+					if e, ok := r.ByID[s.ID]; ok {
 						semHits = append(semHits, Hit{Entity: e, Score: s.Score, Source: "semantic"})
 					}
 				}


### PR DESCRIPTION
Removes the deprecated lowercase `byID` field alias from LoadedRepo (state.go:233) and its assignment at line 470. The field was kept for back-compat during #1656 rollout, which is complete.

Also updates internal readers in tools.go:468 to use the canonical ByID field.

All tests pass; no external consumers of .byID found.