### PR TITLE
refactor(cmd/daemon): inject rebuildIndexFunc + rebuildLinksFunc — drop package singletons

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -137,20 +137,6 @@ func resolveEnvRebuildConcurrency() int {
 	return defaultRebuildConcurrency()
 }
 
-// rebuildIndexFunc is the per-repo index entrypoint used by makeDaemonRebuildFunc.
-// It defaults to the package-level Index function but can be replaced in tests
-// to validate parallelism semantics without running a real extractor pass.
-// Must be set before the daemon accepts connections (write-once, then read-only).
-var rebuildIndexFunc = func(repoPath, outPath, repoTag string, skipPasses []string, pretty, jsonStats bool, opts ...IndexOption) error {
-	return Index(repoPath, outPath, repoTag, skipPasses, pretty, jsonStats, opts...)
-}
-
-// rebuildLinksFunc is the cross-repo link hook used by daemonRebuildFunc.
-// Defaults to runLinksHook but can be swapped in tests.
-var rebuildLinksFunc = func(group string) error {
-	return runLinksHook(group)
-}
-
 // runDaemon is the long-running mode of the archigraph binary. It is
 // wired into the CLI as a hidden `archigraph daemon` subcommand —
 // users normally reach it via `archigraph start`, which forks this
@@ -594,6 +580,8 @@ func daemonIndexFunc(args proto.IndexArgs) (string, string, error) {
 // makeDaemonRebuildFunc returns the RebuildFunc injected into daemon.Config.
 // concurrency is captured at construction time from runDaemon's maxConcurrentGroups
 // so no package-level singleton is needed (issue #2411).
+// indexFn and linksFn are captured at construction time so no package-level
+// singleton is needed (issue #2414).
 //
 // The returned func force-indexes every repo in a group. We deliberately
 // re-implement the iteration here rather than calling into internal/cli
@@ -605,15 +593,30 @@ func daemonIndexFunc(args proto.IndexArgs) (string, string, error) {
 // to stderr for diagnostics. The cross-repo link pass runs only once all
 // per-repo indexes complete.
 func makeDaemonRebuildFunc(concurrency int) daemon.RebuildFunc {
+	indexFn := func(repoPath, outPath, repoTag string, skipPasses []string, pretty, jsonStats bool, opts ...IndexOption) error {
+		return Index(repoPath, outPath, repoTag, skipPasses, pretty, jsonStats, opts...)
+	}
+	linksFn := func(group string) error {
+		return runLinksHook(group)
+	}
 	return func(args proto.RebuildArgs) ([]string, string, error) {
-		return daemonRebuildFuncCore(concurrency, args)
+		return daemonRebuildFuncCore(concurrency, args, indexFn, linksFn)
 	}
 }
 
 // daemonRebuildFuncCore is the testable inner implementation of the rebuild
 // logic. concurrency is supplied by the caller (captured in the closure
-// returned by makeDaemonRebuildFunc, or set directly in tests).
-func daemonRebuildFuncCore(concurrency int, args proto.RebuildArgs) ([]string, string, error) {
+// returned by makeDaemonRebuildFunc, or set directly in tests). indexFn and
+// linksFn are the per-repo index and cross-repo link hooks; production callers
+// pass the real implementations (captured at construction time in
+// makeDaemonRebuildFunc); tests pass mocks directly — no package-level
+// singleton mutation required (issue #2414).
+func daemonRebuildFuncCore(
+	concurrency int,
+	args proto.RebuildArgs,
+	indexFn func(repoPath, outPath, repoTag string, skipPasses []string, pretty, jsonStats bool, opts ...IndexOption) error,
+	linksFn func(group string) error,
+) ([]string, string, error) {
 	rebuildStart := time.Now()
 	fmt.Fprintf(os.Stderr, "archigraph: rebuild start group=%s slug=%q wipe=%v incremental=%v\n",
 		args.Group, args.Slug, args.Wipe, args.Incremental)
@@ -707,7 +710,7 @@ func daemonRebuildFuncCore(concurrency int, args proto.RebuildArgs) ([]string, s
 				// link endpoint prefix. When the wizard slugifies a repo name
 				// (e.g. upvate_core → upvate-core) an empty repoTag would fall back
 				// to the dir basename and diverge, dropping every cross-repo edge.
-				indexErr = rebuildIndexFunc(rw.r.Path, "", rw.r.Slug, nil, false, false, opts...)
+				indexErr = indexFn(rw.r.Path, "", rw.r.Slug, nil, false, false, opts...)
 			}(w, i)
 			results[i] = repoResult{
 				path: w.r.Path,
@@ -719,7 +722,7 @@ func daemonRebuildFuncCore(concurrency int, args proto.RebuildArgs) ([]string, s
 	} else {
 		// --- Parallel path: semaphore-bounded worker pool ---
 		//
-		// Panic recovery (#2097): a panic inside rebuildIndexFunc would
+		// Panic recovery (#2097): a panic inside indexFn would
 		// propagate out of the goroutine and crash the daemon. We recover,
 		// convert the panic to an error stored in results[idx], and release
 		// the semaphore slot via defer so subsequent goroutines are not
@@ -767,7 +770,7 @@ func daemonRebuildFuncCore(concurrency int, args proto.RebuildArgs) ([]string, s
 						WithPublisher(daemonProgressBroker),
 						WithProgressSlugs(args.Group, rw.r.Slug))
 					// #1576: tag with the CONFIG slug — see serial path above.
-					indexErr = rebuildIndexFunc(rw.r.Path, "", rw.r.Slug, nil, false, false, opts...)
+					indexErr = indexFn(rw.r.Path, "", rw.r.Slug, nil, false, false, opts...)
 				}()
 
 				results[idx] = repoResult{
@@ -820,7 +823,7 @@ func daemonRebuildFuncCore(concurrency int, args proto.RebuildArgs) ([]string, s
 
 	// Cross-repo link passes run after every member is indexed.
 	warning := ""
-	if err := rebuildLinksFunc(args.Group); err != nil {
+	if err := linksFn(args.Group); err != nil {
 		// Best-effort — surface as a warning, not a hard failure.
 		warning = fmt.Sprintf("link passes failed: %v", err)
 	}

--- a/cmd/archigraph/daemon_parallel_test.go
+++ b/cmd/archigraph/daemon_parallel_test.go
@@ -48,9 +48,8 @@ func TestDaemonRebuildParallel(t *testing.T) {
 	// Track peak concurrency across all stub Index calls.
 	var currentConc, peakConc int64
 
-	// Swap in a stub that sleeps and records concurrency.
-	origIndexFn := rebuildIndexFunc
-	rebuildIndexFunc = func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+	// mockIndexFn sleeps and records concurrency.
+	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
 		cur := atomic.AddInt64(&currentConc, 1)
 		defer atomic.AddInt64(&currentConc, -1)
 		for {
@@ -62,16 +61,11 @@ func TestDaemonRebuildParallel(t *testing.T) {
 		time.Sleep(60 * time.Millisecond)
 		return nil
 	}
-	defer func() { rebuildIndexFunc = origIndexFn }()
-
-	// Stub out the links pass so it doesn't try real registry lookups.
-	origLinksFn := rebuildLinksFunc
-	rebuildLinksFunc = func(_ string) error { return nil }
-	defer func() { rebuildLinksFunc = origLinksFn }()
+	mockLinksFn := func(_ string) error { return nil }
 
 	// --- Serial run (concurrency=1) ---
 	t0 := time.Now()
-	rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: "test-group"})
+	rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: "test-group"}, mockIndexFn, mockLinksFn)
 	serialDur := time.Since(t0)
 	if err != nil {
 		t.Fatalf("serial rebuild: %v", err)
@@ -86,7 +80,7 @@ func TestDaemonRebuildParallel(t *testing.T) {
 
 	// --- Parallel run (concurrency=2) ---
 	t1 := time.Now()
-	rebuilt2, _, err2 := daemonRebuildFuncCore(2, proto.RebuildArgs{Group: "test-group"})
+	rebuilt2, _, err2 := daemonRebuildFuncCore(2, proto.RebuildArgs{Group: "test-group"}, mockIndexFn, mockLinksFn)
 	parallelDur := time.Since(t1)
 	if err2 != nil {
 		t.Fatalf("parallel rebuild: %v", err2)
@@ -133,15 +127,10 @@ func TestDaemonRebuildSerial(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origIndexFn := rebuildIndexFunc
-	rebuildIndexFunc = func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error { return nil }
-	defer func() { rebuildIndexFunc = origIndexFn }()
+	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error { return nil }
+	mockLinksFn := func(_ string) error { return nil }
 
-	origLinksFn := rebuildLinksFunc
-	rebuildLinksFunc = func(_ string) error { return nil }
-	defer func() { rebuildLinksFunc = origLinksFn }()
-
-	rebuilt, warning, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: "serial-group"})
+	rebuilt, warning, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: "serial-group"}, mockIndexFn, mockLinksFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -176,22 +165,17 @@ func TestDaemonRebuildFailureIsolation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origIndexFn := rebuildIndexFunc
-	rebuildIndexFunc = func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+	mockIndexFn := func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
 		if repoPath == repoBase+"/bad-repo" {
 			return os.ErrPermission
 		}
 		return nil
 	}
-	defer func() { rebuildIndexFunc = origIndexFn }()
-
-	origLinksFn := rebuildLinksFunc
-	rebuildLinksFunc = func(_ string) error { return nil }
-	defer func() { rebuildLinksFunc = origLinksFn }()
+	mockLinksFn := func(_ string) error { return nil }
 
 	// Both serial and parallel should return partial results + an error.
 	for _, conc := range []int{1, 2} {
-		rebuilt, _, err := daemonRebuildFuncCore(conc, proto.RebuildArgs{Group: "mixed-group"})
+		rebuilt, _, err := daemonRebuildFuncCore(conc, proto.RebuildArgs{Group: "mixed-group"}, mockIndexFn, mockLinksFn)
 		if err == nil {
 			t.Errorf("conc=%d: expected error for bad-repo, got nil", conc)
 		}

--- a/cmd/archigraph/daemon_rebuild_test.go
+++ b/cmd/archigraph/daemon_rebuild_test.go
@@ -49,29 +49,26 @@ func setupTestGroup(t *testing.T, groupName string, slugs []string) string {
 	return groupName
 }
 
+// noopLinksFn is a stub links hook used across tests.
+var noopLinksFn = func(_ string) error { return nil }
+
 // TestRebuildPanicRecoveryReleasesSemaphore verifies that a panic inside
-// rebuildIndexFunc does not leak the semaphore slot. With concurrency=1 and
+// the index function does not leak the semaphore slot. With concurrency=1 and
 // 3 repos where the first panics, all three should produce a result (the
 // first an error, the remaining two success).
 func TestRebuildPanicRecoveryReleasesSemaphore(t *testing.T) {
 	group := setupTestGroup(t, "panic-group", []string{"first", "second", "third"})
 
-	origIndexFn := rebuildIndexFunc
 	var callCount int32
-	rebuildIndexFunc = func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+	mockIndexFn := func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
 		n := atomic.AddInt32(&callCount, 1)
 		if n == 1 {
 			panic("simulated extractor panic")
 		}
 		return nil
 	}
-	defer func() { rebuildIndexFunc = origIndexFn }()
 
-	origLinksFn := rebuildLinksFunc
-	rebuildLinksFunc = func(_ string) error { return nil }
-	defer func() { rebuildLinksFunc = origLinksFn }()
-
-	_, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group})
+	_, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn)
 	// Expect an error because one repo panicked.
 	if err == nil {
 		t.Error("expected error from panicking repo, got nil")
@@ -87,10 +84,9 @@ func TestRebuildPanicRecoveryReleasesSemaphore(t *testing.T) {
 func TestRebuildPanicParallelReleasesSemaphore(t *testing.T) {
 	group := setupTestGroup(t, "panic-parallel-group", []string{"a", "b", "c", "d"})
 
-	origIndexFn := rebuildIndexFunc
 	var callCount int32
 	var panicked int32
-	rebuildIndexFunc = func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+	mockIndexFn := func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
 		n := atomic.AddInt32(&callCount, 1)
 		if n == 2 && atomic.CompareAndSwapInt32(&panicked, 0, 1) {
 			panic("parallel extractor panic")
@@ -98,13 +94,8 @@ func TestRebuildPanicParallelReleasesSemaphore(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		return nil
 	}
-	defer func() { rebuildIndexFunc = origIndexFn }()
 
-	origLinksFn := rebuildLinksFunc
-	rebuildLinksFunc = func(_ string) error { return nil }
-	defer func() { rebuildLinksFunc = origLinksFn }()
-
-	_, _, _ = daemonRebuildFuncCore(2, proto.RebuildArgs{Group: group})
+	_, _, _ = daemonRebuildFuncCore(2, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn)
 
 	if got := atomic.LoadInt32(&callCount); got != 4 {
 		t.Errorf("callCount = %d, want 4 (panic in one goroutine must not starve others)", got)
@@ -117,26 +108,20 @@ func TestRebuildPanicParallelReleasesSemaphore(t *testing.T) {
 func TestRebuildFiveSequentialAlwaysComplete(t *testing.T) {
 	group := setupTestGroup(t, "five-seq-group", []string{"r1", "r2"})
 
-	origIndexFn := rebuildIndexFunc
 	var totalCalls int32
-	rebuildIndexFunc = func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+	mockIndexFn := func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
 		atomic.AddInt32(&totalCalls, 1)
 		if atomic.LoadInt32(&totalCalls)%4 == 0 {
 			return errors.New("injected error")
 		}
 		return nil
 	}
-	defer func() { rebuildIndexFunc = origIndexFn }()
-
-	origLinksFn := rebuildLinksFunc
-	rebuildLinksFunc = func(_ string) error { return nil }
-	defer func() { rebuildLinksFunc = origLinksFn }()
 
 	for i := 0; i < 5; i++ {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}) //nolint:errcheck
+			daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn) //nolint:errcheck
 		}()
 		select {
 		case <-done:
@@ -147,24 +132,22 @@ func TestRebuildFiveSequentialAlwaysComplete(t *testing.T) {
 	}
 }
 
-// TestConcurrentRebuildSameGroupIsSerialised verifies that two concurrent
-// Rebuild RPCs for the same group do NOT overlap execution. Because
-// daemonRebuildFunc itself doesn't hold the per-group mutex (that lives
-// in Service.Rebuild), this test verifies the per-group mutex at the
-// daemonRebuildFunc level is NOT present — and instead validates the
-// semaphore behaviour within a single call.
+// TestRebuildConcurrentGroupsMutex verifies that two concurrent goroutines
+// both calling daemonRebuildFunc for the same group do not execute
+// the indexer simultaneously. Because daemonRebuildFunc itself doesn't hold
+// the per-group mutex (that lives in Service.Rebuild), this test verifies the
+// per-group mutex at the daemonRebuildFunc level is NOT present — and instead
+// validates the semaphore behaviour within a single call.
 //
-// The actual group-mutex serialisation is tested in
-// internal/daemon/service_test.go (TestServiceRebuildGroupSerialisedUnderLoad).
+// (Full per-group serialisation is covered by TestServiceRebuildGroupSerialisedUnderLoad.)
 func TestRebuildSemaphoreCapRespected(t *testing.T) {
 	if testing.Short() {
 		t.Skip("semaphore cap timing test skipped in short mode")
 	}
 	group := setupTestGroup(t, "sem-cap-group", []string{"x1", "x2", "x3", "x4"})
 
-	origIndexFn := rebuildIndexFunc
 	var peakConc, current int64
-	rebuildIndexFunc = func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
 		cur := atomic.AddInt64(&current, 1)
 		defer atomic.AddInt64(&current, -1)
 		for {
@@ -176,13 +159,8 @@ func TestRebuildSemaphoreCapRespected(t *testing.T) {
 		time.Sleep(30 * time.Millisecond)
 		return nil
 	}
-	defer func() { rebuildIndexFunc = origIndexFn }()
 
-	origLinksFn := rebuildLinksFunc
-	rebuildLinksFunc = func(_ string) error { return nil }
-	defer func() { rebuildLinksFunc = origLinksFn }()
-
-	_, _, err := daemonRebuildFuncCore(2, proto.RebuildArgs{Group: group})
+	_, _, err := daemonRebuildFuncCore(2, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -208,23 +186,17 @@ func TestRebuildResultsSliceNotRacedOnConcurrentCalls(t *testing.T) {
 	// Each should complete with 2 rebuilt repos or a consistent error.
 	group := setupTestGroup(t, "results-race-group", []string{"p", "q"})
 
-	origIndexFn := rebuildIndexFunc
-	rebuildIndexFunc = func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
 		time.Sleep(5 * time.Millisecond)
 		return nil
 	}
-	defer func() { rebuildIndexFunc = origIndexFn }()
-
-	origLinksFn := rebuildLinksFunc
-	rebuildLinksFunc = func(_ string) error { return nil }
-	defer func() { rebuildLinksFunc = origLinksFn }()
 
 	var wg sync.WaitGroup
 	for i := 0; i < 4; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group})
+			rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn)
 			if err != nil {
 				return // errors are acceptable
 			}


### PR DESCRIPTION
## Summary

- Removes `rebuildIndexFunc` and `rebuildLinksFunc` package-level `var` declarations from `cmd/archigraph/daemon.go`
- Converts `daemonRebuildFuncCore` to accept `indexFn` and `linksFn` as explicit parameters instead of reading package globals
- `makeDaemonRebuildFunc` captures the real implementations at construction time (same DI pattern as #2413/#2411 for `rebuildConcurrency`/`activeDaemonMode`)
- 8 tests across `daemon_rebuild_test.go` and `daemon_parallel_test.go` updated to pass mocks directly as arguments — no more save/restore of package vars

## Motivation

Mutating package-level function pointers from tests is a data race under `t.Parallel()`, which was enabled repo-wide by PR #2408. This is the same hazard pattern eliminated for `rebuildConcurrency` and `activeDaemonMode` in #2413.

## Test plan

- [x] `gofmt -l` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — succeeds
- [x] `go test ./cmd/archigraph/... -count=1` — passes (69s)

Closes #2414

🤖 Generated with [Claude Code](https://claude.com/claude-code)