### PR TITLE
refactor(engine): plumb Pass 1 field entities to Pass 2.5 — retire parallel regex parser

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -798,7 +798,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 
 		// Pass 2.5 — YAML-driven framework rules.
 		trk.PhaseStart(progress.PhaseResolveRefs, len(files), len(pass1Records))
-		pass2Records, pass2Rels, err = i.runPass25FrameworkRules(ctx, absRepo, classified)
+		pass2Records, pass2Rels, err = i.runPass25FrameworkRules(ctx, absRepo, classified, pass1Records)
 		if err != nil {
 			trk.Fail(err.Error())
 			return nil, fmt.Errorf("pass 2.5: %w", err)
@@ -2197,9 +2197,32 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 // runPass25FrameworkRules applies the YAML rule engine to every classified
 // file. Returns extra entity records (from source_patterns) plus standalone
 // relationship records (from relationship_rules).
-func (i *Indexer) runPass25FrameworkRules(ctx context.Context, absRepo string, classified []classifiedFile) ([]types.EntityRecord, []types.RelationshipRecord, error) {
+func (i *Indexer) runPass25FrameworkRules(ctx context.Context, absRepo string, classified []classifiedFile, pass1Records []types.EntityRecord) ([]types.EntityRecord, []types.RelationshipRecord, error) {
 	if i.skipPasses[PassFramework] {
 		return nil, nil, nil
+	}
+
+	// Pass 1 side-channel (issue #2352): group Pass 1 entity records by
+	// source file so each Pass 2.5 FileInput can carry the canonical
+	// extractor entities for ITS file forward to engine passes (notably
+	// applyORMFieldEdges, which previously re-parsed source with a regex
+	// because field entities weren't visible inside the detector loop).
+	//
+	// Only entity kinds the engine passes actually consume are forwarded
+	// today — SCOPE.Schema(subtype=field) for ORM field-access. Expanding
+	// the filter later is cheap: just relax the predicate.
+	var pass1ByFile map[string][]types.EntityRecord
+	if len(pass1Records) > 0 {
+		pass1ByFile = make(map[string][]types.EntityRecord, len(classified))
+		for _, e := range pass1Records {
+			if e.SourceFile == "" {
+				continue
+			}
+			if e.Kind != "SCOPE.Schema" || e.Subtype != "field" {
+				continue
+			}
+			pass1ByFile[e.SourceFile] = append(pass1ByFile[e.SourceFile], e)
+		}
 	}
 
 	// Pre-pass (#845): build the cross-file Java DI registry before the
@@ -2231,10 +2254,11 @@ func (i *Indexer) runPass25FrameworkRules(ctx context.Context, absRepo string, c
 			defer wg.Done()
 			for cf := range work {
 				input := extractor.FileInput{
-					Path:     cf.relPath,
-					Content:  cf.content,
-					Language: cf.language,
-					RepoRoot: absRepo,
+					Path:          cf.relPath,
+					Content:       cf.content,
+					Language:      cf.language,
+					RepoRoot:      absRepo,
+					Pass1Entities: pass1ByFile[cf.relPath],
 				}
 				res, err := i.detector.Detect(ctx, input)
 				if err != nil || res == nil {

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -449,7 +449,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// pivots off the QUERIES edges that pass emits. Append-only —
 	// cannot regress the surrounding pipeline's bug-rate.
 	entities, relationships = applyORMFieldEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
+		file.Language, file.Path, file.Content, file.Pass1Entities, entities, relationships,
 	)
 
 	// Kafka producer/consumer cross-repo edges (wave 1 of #726). Emits

--- a/internal/engine/field_index.go
+++ b/internal/engine/field_index.go
@@ -12,7 +12,12 @@
 // Refs #2295.
 package engine
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
 
 // djangoClassDeclRe locates Django model class declarations:
 //
@@ -81,6 +86,39 @@ func BuildFieldIndex(src string) map[string]bool {
 			}
 			out[className+"."+fieldName] = true
 		}
+	}
+	return out
+}
+
+// buildPlumbedFieldIndex constructs the same `<Model>.<field>` presence
+// set as BuildFieldIndex, but sources the data from Pass 1's
+// SCOPE.Schema(subtype=field) entities rather than re-parsing source
+// (issue #2352).
+//
+// `path` filters the input slice to entities whose SourceFile matches
+// (or is unset — defensive for in-memory records that don't carry a
+// path). Entries with Name lacking the `<Class>.<field>` dot convention
+// are skipped silently — matches the byte-identical key shape the
+// regex parser emits.
+//
+// Returns an empty map (never nil) when no field entities match; the
+// caller treats an empty result as "side-channel cold, use fallback".
+func buildPlumbedFieldIndex(path string, pass1Entities []types.EntityRecord) map[string]bool {
+	out := map[string]bool{}
+	if len(pass1Entities) == 0 {
+		return out
+	}
+	for _, e := range pass1Entities {
+		if e.Kind != "SCOPE.Schema" || e.Subtype != "field" {
+			continue
+		}
+		if e.SourceFile != "" && path != "" && e.SourceFile != path {
+			continue
+		}
+		if !strings.Contains(e.Name, ".") {
+			continue
+		}
+		out[e.Name] = true
 	}
 	return out
 }

--- a/internal/engine/field_index_test.go
+++ b/internal/engine/field_index_test.go
@@ -17,6 +17,8 @@ package engine
 
 import (
 	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 // (a) Scalar fields — basic smoke test.
@@ -188,5 +190,50 @@ func TestBuildFieldIndex_EmptyOrNonDjango(t *testing.T) {
 		if len(idx) != 0 {
 			t.Errorf("BuildFieldIndex(%q) = %v, want empty map", src, idx)
 		}
+	}
+}
+
+// (h) buildPlumbedFieldIndex — the Pass 1 side-channel introduced in
+// issue #2352. The function takes the Pass 1 entity slice the Python
+// extractor would have emitted at python/extractor.go:1411-1421 and
+// returns the same `<Model>.<field>` presence set BuildFieldIndex
+// would have produced from source. The two paths MUST be byte-identical
+// on the key set, otherwise consumers (notably applyORMFieldEdges) will
+// behave differently depending on which path served them.
+func TestBuildPlumbedFieldIndex_HappyPath(t *testing.T) {
+	pass1 := []types.EntityRecord{
+		{Kind: "SCOPE.Schema", Subtype: "field", Name: "User.cognito_id", SourceFile: "users.py"},
+		{Kind: "SCOPE.Schema", Subtype: "field", Name: "User.email", SourceFile: "users.py"},
+		// Different file — must be filtered out.
+		{Kind: "SCOPE.Schema", Subtype: "field", Name: "Order.total", SourceFile: "orders.py"},
+		// Different kind — must be filtered out.
+		{Kind: "Function", Name: "User.save", SourceFile: "users.py"},
+		// Missing dot in Name — defensive skip.
+		{Kind: "SCOPE.Schema", Subtype: "field", Name: "loose", SourceFile: "users.py"},
+	}
+	idx := buildPlumbedFieldIndex("users.py", pass1)
+	want := map[string]bool{
+		"User.cognito_id": true,
+		"User.email":      true,
+	}
+	if len(idx) != len(want) {
+		t.Fatalf("buildPlumbedFieldIndex returned %d entries, want %d; got %v", len(idx), len(want), idx)
+	}
+	for k := range want {
+		if !idx[k] {
+			t.Errorf("buildPlumbedFieldIndex missing %q; got %v", k, idx)
+		}
+	}
+}
+
+// Empty input → empty (never-nil) map so callers can do an `if len == 0`
+// triage to decide between plumbed and fallback paths.
+func TestBuildPlumbedFieldIndex_EmptyInput(t *testing.T) {
+	idx := buildPlumbedFieldIndex("users.py", nil)
+	if idx == nil {
+		t.Fatal("buildPlumbedFieldIndex returned nil map, want empty non-nil")
+	}
+	if len(idx) != 0 {
+		t.Errorf("buildPlumbedFieldIndex returned %d entries, want 0", len(idx))
 	}
 }

--- a/internal/engine/orm_field_edges.go
+++ b/internal/engine/orm_field_edges.go
@@ -73,6 +73,7 @@ func applyORMFieldEdges(
 	lang string,
 	path string,
 	content []byte,
+	pass1Entities []types.EntityRecord,
 	entities []types.EntityRecord,
 	relationships []types.RelationshipRecord,
 ) ([]types.EntityRecord, []types.RelationshipRecord) {
@@ -85,42 +86,25 @@ func applyORMFieldEdges(
 
 	// Build a per-(model,field) index for THIS file.
 	//
-	// The Python extractor emits SCOPE.Schema(subtype=field) entities for
-	// each class-body assignment (python/extractor.go:1411-1421), but
-	// those run in a SEPARATE pipeline stage (Pass 1) from the YAML
-	// detector (Pass 2.5) — the entities slice handed to this pass
-	// contains only Pass 2.5 output, so the field entities are NOT
-	// visible here. We therefore reconstruct the field index from the
-	// source content directly using BuildFieldIndex (field_index.go),
-	// which uses a coarse `class … :` + indented `<name> = models.<Type>(`
-	// scan that matches the extractor's convention closely enough for
-	// Phase A (Django ORM).
+	// Preferred source: Pass 1 SCOPE.Schema(subtype=field) entities plumbed
+	// in via FileInput.Pass1Entities (issue #2352). These are the canonical
+	// records the Python extractor emits at python/extractor.go:1411-1421
+	// — exact, no regex re-parse.
 	//
-	// The resulting key `<Model>.<field>` is byte-identical to the Name
-	// the Python extractor emits, so consumers that DO see both can
-	// match by name without further normalisation.
-	fieldIdx := BuildFieldIndex(string(content))
-	if len(fieldIdx) == 0 {
-		// Defensive fallback: some files may have field entities visible
-		// in `entities` (e.g. when a future pass forwards them). Honour
-		// those too so we degrade gracefully if the extraction order
-		// changes.
-		for _, e := range entities {
-			if e.SourceFile != "" && e.SourceFile != path {
-				continue
-			}
-			if e.Kind != "SCOPE.Schema" || e.Subtype != "field" {
-				continue
-			}
-			if !strings.Contains(e.Name, ".") {
-				continue
-			}
-			fieldIdx[e.Name] = true
-		}
+	// Fallback: regex scan via BuildFieldIndex. Triggered when the
+	// side-channel is empty, which happens for (a) test fixtures that
+	// construct FileInput directly without going through Pass 1, and
+	// (b) the subprocess-extract path that merges Pass 1+2.5 outside the
+	// per-file detector loop.
+	fieldIdx := buildPlumbedFieldIndex(path, pass1Entities)
+	plumbed := len(fieldIdx) > 0
+	if !plumbed {
+		fieldIdx = BuildFieldIndex(string(content))
 	}
 	if len(fieldIdx) == 0 {
 		return entities, relationships
 	}
+	_ = plumbed // reserved for future telemetry / debug hooks
 
 	// Scan the source directly for Django ORM call chains. We can't
 	// rely on the QUERIES edges' filter_keys alone because orm_queries

--- a/internal/engine/orm_field_edges_test.go
+++ b/internal/engine/orm_field_edges_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 // fieldEdge is the minimal projection of a READS_FIELD / WRITES_FIELD
@@ -210,4 +211,67 @@ def by_author_name(name):
 			t.Errorf("emitted edge with un-split traversal field: %+v", e)
 		}
 	}
+}
+
+// Issue #2352: the plumbed Pass 1 side-channel takes precedence over
+// the regex source-scan. To prove this, we feed Pass1Entities for a
+// model that does NOT exist in the source — if the regex fallback were
+// still load-bearing, no edges would emit (the regex would find the
+// real model and reject "Phantom.id" as unknown). With the plumbed path
+// active, "Phantom.id" is canonically known and the edge IS emitted.
+func TestORMFieldEdges_PlumbedSideChannelTakesPrecedence(t *testing.T) {
+	src := `from django.db import models
+
+def fetch(uid):
+    return Phantom.objects.filter(id=uid)
+`
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	res, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     "phantom.py",
+		Content:  []byte(src),
+		Language: "python",
+		Pass1Entities: []types.EntityRecord{
+			{
+				Kind:       "SCOPE.Schema",
+				Subtype:    "field",
+				Name:       "Phantom.id",
+				SourceFile: "phantom.py",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	found := false
+	for _, r := range res.Relationships {
+		if r.Kind == ormReadsFieldKind && r.Properties["model"] == "Phantom" && r.Properties["field"] == "id" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected READS_FIELD edge on Phantom.id via plumbed side-channel; got %d rels", len(res.Relationships))
+	}
+}
+
+// Symmetrical regression: when Pass1Entities is empty the regex
+// fallback MUST still serve (existing test fixtures that construct
+// FileInput directly continue working). This is implicitly covered by
+// every other test in this file, but assert it explicitly with a Model
+// the source DOES contain.
+func TestORMFieldEdges_FallbackWhenSideChannelEmpty(t *testing.T) {
+	src := `from django.db import models
+
+class User(models.Model):
+    cognito_id = models.CharField(max_length=64)
+
+def get_user(uid):
+    return User.objects.get(cognito_id=uid)
+`
+	edges := detectFieldEdges(t, src) // no Pass1Entities
+	assertFieldEdge(t, edges, ormReadsFieldKind, "User", "cognito_id")
 }

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -180,6 +180,22 @@ type FileInput struct {
 	// Nil is valid — all accessors fall through to the env-var fallbacks.
 	// The indexer populates this from ConfigFromEnv() before dispatch.
 	Config *ExtractorConfig
+	// Pass1Entities is the side-channel that threads Pass 1's per-file
+	// entity records forward to Pass 2.5 engine passes (issue #2352).
+	//
+	// The original ORM field-edge synthesis (#2279 / #2295) reconstructed
+	// the `<Model>.<field>` index by re-parsing the source with a regex
+	// because Pass 1's SCOPE.Schema(subtype=field) entities weren't
+	// visible inside the YAML-driven detector. This field plumbs them
+	// through: the indexer groups Pass 1 records by source file in
+	// runPass25FrameworkRules and stamps the matching slice here before
+	// calling Detector.Detect.
+	//
+	// Nil / empty is valid — engine passes that consume this MUST fall
+	// back to their pre-#2352 source-scan behaviour so direct test
+	// fixtures (which call Detector.Detect without going through the full
+	// pipeline) keep working unchanged.
+	Pass1Entities []types.EntityRecord
 }
 
 // Extractor is the interface all language extractors must implement.


### PR DESCRIPTION
## Summary

- Threads Pass 1's `SCOPE.Schema(subtype=field)` entities into Pass 2.5 via a new `FileInput.Pass1Entities` side-channel, so `applyORMFieldEdges` can consume canonical extractor records directly instead of re-parsing source with a regex.
- `applyORMFieldEdges` is now plumbed-first with regex fallback. The fallback preserves direct-construction tests (which never go through the full pipeline) and the subprocess-extract path (which merges Pass 1+2.5 outside the per-file detector loop).
- The cmd/archigraph indexer groups Pass 1 records by source file in `runPass25FrameworkRules` and stamps the per-file slice onto each FileInput before dispatching to `Detector.Detect`.

Closes #2352.

## What changed by file

- `internal/extractor/extractor.go` — adds `FileInput.Pass1Entities []types.EntityRecord` with docstring covering the side-channel contract.
- `cmd/archigraph/index.go` — Pass1Records → per-file map → FileInput.Pass1Entities at the runPass25 boundary (index.go:2233).
- `internal/engine/detector.go` — forwards `file.Pass1Entities` into `applyORMFieldEdges`.
- `internal/engine/orm_field_edges.go` — accepts `pass1Entities`, prefers them, falls back to `BuildFieldIndex`. Removed the in-pass defensive `entities` scan (its job is now done at the boundary).
- `internal/engine/field_index.go` — adds `buildPlumbedFieldIndex(path, pass1Entities)`.
- `internal/engine/{field_index,orm_field_edges}_test.go` — new tests for plumbed-path precedence + regex fallback.

## Test plan

- [x] `gofmt -l` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `go test ./internal/extractor/... ./internal/extractors/... ./internal/engine/...` all pass
- [x] New test `TestORMFieldEdges_PlumbedSideChannelTakesPrecedence` proves plumbed path is used when Pass1Entities is non-empty (asserts an edge emits on a model that does NOT exist in source — only possible via the plumbed canonical entity).
- [x] New test `TestORMFieldEdges_FallbackWhenSideChannelEmpty` proves the regex fallback still serves when Pass1Entities is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)