### PR TITLE
refactor(graph): add language slot to Entity FlatBuffers — retire property-tunnel

### DIFF
--- a/internal/graph/fbgraph/Entity.go
+++ b/internal/graph/fbgraph/Entity.go
@@ -246,9 +246,6 @@ func (rcv *Entity) MutateIsArticulationPoint(n bool) bool {
 	return rcv._tab.MutateBoolSlot(34, n)
 }
 
-// EmbeddingRef returns the content-hash pointer into the shared embedding
-// cache (PH8 / #2100). Returns nil when the field is absent (old graphs) or
-// empty — callers should treat nil and "" identically as "no cache ref".
 func (rcv *Entity) EmbeddingRef() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(36))
 	if o != 0 {
@@ -257,8 +254,16 @@ func (rcv *Entity) EmbeddingRef() []byte {
 	return nil
 }
 
+func (rcv *Entity) Language() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(38))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
 func EntityStart(builder *flatbuffers.Builder) {
-	builder.StartObject(17)
+	builder.StartObject(18)
 }
 func EntityAddId(builder *flatbuffers.Builder, id flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(id), 0)
@@ -308,11 +313,14 @@ func EntityAddIsGodNode(builder *flatbuffers.Builder, isGodNode bool) {
 func EntityAddIsSurpriseEndpoint(builder *flatbuffers.Builder, isSurpriseEndpoint bool) {
 	builder.PrependBoolSlot(14, isSurpriseEndpoint, false)
 }
+func EntityAddIsArticulationPoint(builder *flatbuffers.Builder, isArticulationPoint bool) {
+	builder.PrependBoolSlot(15, isArticulationPoint, false)
+}
 func EntityAddEmbeddingRef(builder *flatbuffers.Builder, embeddingRef flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(16, flatbuffers.UOffsetT(embeddingRef), 0)
 }
-func EntityAddIsArticulationPoint(builder *flatbuffers.Builder, isArticulationPoint bool) {
-	builder.PrependBoolSlot(15, isArticulationPoint, false)
+func EntityAddLanguage(builder *flatbuffers.Builder, language flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(17, flatbuffers.UOffsetT(language), 0)
 }
 func EntityEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/internal/graph/fbgraph/Graph.go
+++ b/internal/graph/fbgraph/Graph.go
@@ -238,9 +238,6 @@ func (rcv *Graph) MutateIsWorktree(n bool) bool {
 	return rcv._tab.MutateBoolSlot(32, n)
 }
 
-// CoverageStatus returns the coverage status string ("" / "full" / "partial").
-// Field slot 15 / vtable offset 34 — appended after is_worktree (#2181 / M4).
-// Returns nil (empty) for graphs written before this field was added.
 func (rcv *Graph) CoverageStatus() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(34))
 	if o != 0 {
@@ -306,13 +303,9 @@ func GraphAddIndexedSha(builder *flatbuffers.Builder, indexedSha flatbuffers.UOf
 func GraphAddIsWorktree(builder *flatbuffers.Builder, isWorktree bool) {
 	builder.PrependBoolSlot(14, isWorktree, false)
 }
-
-// GraphAddCoverageStatus writes the M4 sparse-checkout coverage_status field
-// (#2181). Slot 15, vtable offset 34. Empty string = omitted by FlatBuffers.
 func GraphAddCoverageStatus(builder *flatbuffers.Builder, coverageStatus flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(15, flatbuffers.UOffsetT(coverageStatus), 0)
 }
-
 func GraphEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -23,7 +23,12 @@ import (
 
 // FormatVersion is the FlatBuffers schema version this writer emits.
 // Matches the default of Graph.version in graph.fbs.
-const FormatVersion = 2
+//
+// Bumped for #2370 — Entity now carries `language` slot directly; old
+// graph.fb files must be reindexed. archigraph is pre-1.0; there is no
+// backward-compat read path for older versions (the loader fails loudly
+// and instructs the user to run `archigraph index <repo>`).
+const FormatVersion = 3
 
 // WriteAtomic serializes doc to a FlatBuffers buffer and writes it to
 // outPath atomically via a sibling .tmp + rename. The on-disk file is
@@ -81,26 +86,20 @@ func buildEntity(b *flatbuffers.Builder, e *graph.Entity) flatbuffers.UOffsetT {
 	nameOff := b.CreateString(e.Name)
 	srcOff := b.CreateString(e.SourceFile)
 
-	// Issue #2341 — persist Language via Properties["language"] so that the
-	// load.go reader's workaround (fbEntityToGraphEntity restores Language from
-	// props["language"]) can recover it on read. The FlatBuffers schema has no
-	// top-level language slot, so we inject the value into the props map before
-	// building the property vector. We work on a shallow copy of the map to
-	// avoid mutating the caller's entity struct.
-	props := e.Properties
-	if e.Language != "" {
-		if _, alreadySet := props["language"]; !alreadySet {
-			// Shallow-copy only when we need to add the key so the common
-			// "extractor already stamped it" path stays zero-alloc.
-			copied := make(map[string]string, len(props)+1)
-			for k, v := range props {
-				copied[k] = v
-			}
-			copied["language"] = e.Language
-			props = copied
-		}
+	// Issue #2370 — Language is persisted via the dedicated top-level
+	// `language` FlatBuffers slot (see EntityAddLanguage below). The
+	// PR #2365 property-tunnel workaround (writing into Properties["language"])
+	// is retired. We still build the property vector from e.Properties as-is.
+	propsVec := buildPropertyVector(b, e.Properties)
+
+	// PH8 (#2100) embedding_ref offset is created up-front below; the
+	// language offset is similarly created here so it sits with the rest
+	// of the child-string offsets before the parent table opens.
+	var langOff flatbuffers.UOffsetT
+	hasLang := e.Language != ""
+	if hasLang {
+		langOff = b.CreateString(e.Language)
 	}
-	propsVec := buildPropertyVector(b, props)
 
 	// PH8 (#2100): embedding_ref — only create string offset when non-empty
 	// to preserve bytewise identity for pre-PH8 graphs.
@@ -148,6 +147,11 @@ func buildEntity(b *flatbuffers.Builder, e *graph.Entity) flatbuffers.UOffsetT {
 	// PH8 (#2100): emit embedding_ref only when present (slot 16, offset 36).
 	if hasEmbRef {
 		fb.EntityAddEmbeddingRef(b, embRefOff)
+	}
+	// Issue #2370: emit language only when present so empty-language entities
+	// stay byte-identical to the pre-#2370 shape (modulo FormatVersion bump).
+	if hasLang {
+		fb.EntityAddLanguage(b, langOff)
 	}
 	return fb.EntityEnd(b)
 }

--- a/internal/graph/fbwriter/writer_test.go
+++ b/internal/graph/fbwriter/writer_test.go
@@ -1,11 +1,14 @@
 package fbwriter_test
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/graph"
+	fb "github.com/cajasmota/archigraph/internal/graph/fbgraph"
 	"github.com/cajasmota/archigraph/internal/graph/fbreader"
 	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
 )
@@ -268,8 +271,9 @@ func TestRoundtripCoverageStatus(t *testing.T) {
 }
 
 // TestRoundtripLanguage verifies that Entity.Language survives a write→read
-// cycle through graph.fb (issue #2341). Before the fix, Language was never
-// serialized into the FlatBuffer so every entity read back with Language="".
+// cycle through graph.fb (issue #2341, refined by #2370). Before #2341,
+// Language was never serialized; #2341 tunneled it via Properties["language"];
+// #2370 retires the tunnel and persists it via the dedicated FB slot.
 func TestRoundtripLanguage(t *testing.T) {
 	doc := &graph.Document{
 		Version:     1,
@@ -316,11 +320,12 @@ func TestRoundtripLanguage(t *testing.T) {
 	if ea.Language != "python" {
 		t.Errorf("entity a Language: got %q want %q", ea.Language, "python")
 	}
-	// Properties["language"] must also be set so MCP query handlers that read
-	// props directly (not the top-level field) see the value.
-	if ea.Properties["language"] != "python" {
-		t.Errorf("entity a Properties[language]: got %q want %q",
-			ea.Properties["language"], "python")
+	// #2370: Properties["language"] is no longer tunneled by the FB writer.
+	// Entity a was written with Properties unset for "language", so on read
+	// back the props map must not contain a synthesized "language" key.
+	if _, present := ea.Properties["language"]; present {
+		t.Errorf("entity a Properties[language]: unexpectedly present after #2370 retired the property-tunnel; props=%v",
+			ea.Properties)
 	}
 
 	// entity b: Language="go" already in Properties — must not be duplicated
@@ -377,5 +382,99 @@ func TestRoundtripNoAlgoData(t *testing.T) {
 	}
 	if got.Entities[0].CommunityID != nil {
 		t.Errorf("entity community_id: got %v want nil", got.Entities[0].CommunityID)
+	}
+}
+
+// TestLanguageSlotInRawFB verifies that #2370's dedicated `language` slot is
+// actually written into the on-disk FlatBuffer — not just exposed through the
+// high-level loader. We open the raw FB and inspect Entity.Language() directly,
+// which catches any future regression where the writer silently stops emitting
+// the slot.
+func TestLanguageSlotInRawFB(t *testing.T) {
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		Repo:        "fixture-language-slot",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "Foo", Kind: "class",
+				SourceFile: "foo.py", Language: "python"},
+			{ID: "ent0000000000000b", Name: "Bar", Kind: "function",
+				SourceFile: "bar.rs", Language: "rust"},
+			// Entity with no language — slot must be absent (empty string).
+			{ID: "ent0000000000000c", Name: "Baz", Kind: "external", SourceFile: ""},
+		},
+	}
+	doc.Stats.Entities = len(doc.Entities)
+
+	out := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(out, doc); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	r, err := fbreader.Open(out)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer r.Close()
+
+	want := map[string]string{
+		"ent0000000000000a": "python",
+		"ent0000000000000b": "rust",
+		"ent0000000000000c": "",
+	}
+	for i := 0; i < r.EntityCount(); i++ {
+		ent := r.EntityAt(i)
+		if ent == nil {
+			t.Fatalf("entity %d: nil", i)
+		}
+		id := string(ent.Id())
+		got := string(ent.Language())
+		if got != want[id] {
+			t.Errorf("entity %s Language(): got %q want %q", id, got, want[id])
+		}
+	}
+}
+
+// TestLoaderRejectsOldFormatVersion verifies that the loader fails loudly with
+// the reindex-required error when graph.fb carries an older FormatVersion
+// (#2370). archigraph is pre-1.0; there is no compat path.
+func TestLoaderRejectsOldFormatVersion(t *testing.T) {
+	// Build a minimal graph.fb in-memory with Version=2 (the pre-#2370 format).
+	doc := &graph.Document{
+		Version: 1, GeneratedAt: time.Now().UTC(), Repo: "fixture-old-version",
+		Entities: []graph.Entity{{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"}},
+	}
+	doc.Stats.Entities = 1
+	buf, err := fbwriter.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Patch the on-disk Graph.version field down to 2 to simulate an old file.
+	root := fb.GetRootAsGraph(buf, 0)
+	if !root.MutateVersion(2) {
+		t.Fatalf("MutateVersion(2) returned false — slot missing?")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "graph.fb")
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, loadErr := graph.LoadGraphFromDir(dir)
+	if loadErr == nil {
+		t.Fatal("expected reindex error, got nil")
+	}
+	msg := loadErr.Error()
+	// Spot-check the operative phrases — verbatim error string is part of the
+	// loader contract and must point the user at `archigraph index`.
+	for _, want := range []string{
+		"graph.fb format version 2 is older than required version 3",
+		"please reindex",
+		"archigraph index <repo>",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q\nfull message: %s", want, msg)
+		}
 	}
 }

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -23,6 +23,13 @@ import (
 	"github.com/cajasmota/archigraph/internal/graph/fbreader"
 )
 
+// minSupportedFBFormatVersion is the lowest graph.fb FormatVersion the loader
+// will accept. It must stay in sync with fbwriter.FormatVersion; we keep a
+// local copy here to avoid an import cycle (fbwriter imports the graph
+// package). Bumped for #2370 — Entity now carries `language` directly; old
+// graph.fb files lack the slot and must be reindexed.
+const minSupportedFBFormatVersion = 3
+
 // LoadGraphFromDir loads a graph.Document from dir, where dir is the
 // .archigraph state directory for a repo (the directory that contains
 // graph.fb / graph.json).
@@ -80,6 +87,17 @@ func loadFBDocument(path string) (*Document, error) {
 		return nil, fmt.Errorf("graph.loadFBDocument: open %s: %w", path, err)
 	}
 	defer r.Close()
+
+	// #2370 — refuse to read old-format graph.fb files. archigraph is
+	// pre-1.0; there is no on-disk compat path. The user is expected to
+	// rerun `archigraph index <repo>` to regenerate graph.fb against the
+	// current schema.
+	if v := r.Version(); v < minSupportedFBFormatVersion {
+		return nil, fmt.Errorf(
+			"graph.loadFBDocument: graph.fb format version %d is older than required version %d — please reindex (run: archigraph index <repo>)",
+			v, minSupportedFBFormatVersion,
+		)
+	}
 
 	meta := r.LoadGraphMeta()
 	generatedAt, _ := time.Parse(time.RFC3339, meta.ComputedAt)
@@ -209,8 +227,9 @@ func fbEntityToGraphEntity(e *fb.Entity) Entity {
 		props["module"] = mod
 		ent.Properties = props
 	}
-	// Restore Language from Properties if the indexer stored it there.
-	if lang, ok := props["language"]; ok {
+	// Issue #2370 — Language is read directly from the dedicated FB slot.
+	// The PR #2365 property-tunnel restore (props["language"]) is retired.
+	if lang := string(e.Language()); lang != "" {
 		ent.Language = lang
 	}
 	// Restore Pass 4 (graph-algorithm) attributes (#1620). community_id uses

--- a/internal/graph/schema/graph.fbs
+++ b/internal/graph/schema/graph.fbs
@@ -53,6 +53,14 @@ table Entity {
   // graphs have this field absent (FlatBuffers defaults to "") and continue
   // to work — their vectors are served from embeddings.bin as before.
   embedding_ref: string;
+
+  // Issue #2370: dedicated top-level slot for the entity language tag
+  // (e.g. "python", "rust", "ocaml"). Previously tunneled through
+  // Properties["language"] by PR #2365 because the FB schema had no
+  // such slot. Adding it here retires the property-tunnel workaround;
+  // FormatVersion is bumped to force a clean reindex (archigraph is
+  // pre-1.0; no backward-compat path).
+  language: string;
 }
 
 // Community is one Louvain modularity community summarised for the


### PR DESCRIPTION
## Summary

Closes #2370.

- Adds a dedicated `language: string` slot to the `Entity` table in `internal/graph/schema/graph.fbs` and regenerates Go bindings.
- Migrates `fbwriter.buildEntity` to write the slot directly, and `load.fbEntityToGraphEntity` to read from it.
- Deletes the PR #2365 property-tunnel workaround (writer no longer shallow-copies into `Properties["language"]`; loader no longer restores from it).
- Bumps `FormatVersion` 2 → 3. The loader rejects older `graph.fb` files with the verbatim error:
  `graph.fb format version N is older than required version 3 — please reindex (run: archigraph index <repo>)`

Schema bump + codegen. FormatVersion bumped; old graph.fb files trigger reindex (no compat path — pre-1.0 policy per [[feedback_archigraph_no_backward_compat]]).

`TagEntitiesLanguage` (PR #2371) still sets both `entity.Language` and `Properties["language"]` for the in-memory shape; only the FB-persist path uses the slot directly.

## Test plan

- [x] `gofmt -l` on changed Go files — empty
- [x] `go vet ./...` — clean
- [x] `go build ./...` — succeeds (regenerated bindings compile)
- [x] `go test ./internal/graph/... ./cmd/archigraph/...` — passes
- [x] New `TestLanguageSlotInRawFB` reads the raw FB to confirm `Entity.Language()` is populated via the slot for non-empty values and absent (empty string) when unset
- [x] New `TestLoaderRejectsOldFormatVersion` mutates a fresh FB down to `Version=2` and asserts `LoadGraphFromDir` returns the reindex-required error
- [x] Existing `TestRoundtripLanguage` updated: post-#2370, `Properties["language"]` is NOT synthesized by the FB writer; the test now asserts the tunnel is gone
- [x] Property-tunnel grep: `git grep -nE 'Properties\["language"\]' internal/graph/` matches only comments + tests; zero production read/write paths