### PR TITLE
refactor(graph): extract fbversion leaf package — eliminate FormatVersion drift hazard

### DIFF
--- a/internal/graph/fbversion/version.go
+++ b/internal/graph/fbversion/version.go
@@ -1,0 +1,14 @@
+// Package fbversion holds the single source of truth for the on-disk
+// FlatBuffers format version written by internal/graph/fbwriter and
+// read (with a minimum-version gate) by internal/graph/load.go.
+//
+// This is intentionally a leaf package with no imports so that both
+// internal/graph (load.go) and internal/graph/fbwriter can import it
+// without creating an import cycle.
+package fbversion
+
+// Version is the on-disk FB format version that fbwriter writes and
+// load expects. Bump together with any schema change in graph.fbs that
+// breaks readers. Both internal/graph and internal/graph/fbwriter
+// import this package — drift is now compile-time impossible.
+const Version = 3

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -19,16 +19,13 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/graph"
 	fb "github.com/cajasmota/archigraph/internal/graph/fbgraph"
+	"github.com/cajasmota/archigraph/internal/graph/fbversion"
 )
 
 // FormatVersion is the FlatBuffers schema version this writer emits.
-// Matches the default of Graph.version in graph.fbs.
-//
-// Bumped for #2370 — Entity now carries `language` slot directly; old
-// graph.fb files must be reindexed. archigraph is pre-1.0; there is no
-// backward-compat read path for older versions (the loader fails loudly
-// and instructs the user to run `archigraph index <repo>`).
-const FormatVersion = 3
+// The actual value lives in internal/graph/fbversion to avoid drift
+// with the loader's minimum-version gate (import-cycle-safe leaf pkg).
+const FormatVersion = fbversion.Version
 
 // WriteAtomic serializes doc to a FlatBuffers buffer and writes it to
 // outPath atomically via a sibling .tmp + rename. The on-disk file is

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -21,14 +21,13 @@ import (
 
 	fb "github.com/cajasmota/archigraph/internal/graph/fbgraph"
 	"github.com/cajasmota/archigraph/internal/graph/fbreader"
+	"github.com/cajasmota/archigraph/internal/graph/fbversion"
 )
 
 // minSupportedFBFormatVersion is the lowest graph.fb FormatVersion the loader
-// will accept. It must stay in sync with fbwriter.FormatVersion; we keep a
-// local copy here to avoid an import cycle (fbwriter imports the graph
-// package). Bumped for #2370 — Entity now carries `language` directly; old
-// graph.fb files lack the slot and must be reindexed.
-const minSupportedFBFormatVersion = 3
+// will accept. The value is sourced from internal/graph/fbversion — a leaf
+// package shared with fbwriter — so drift becomes a compile-time error.
+const minSupportedFBFormatVersion = fbversion.Version
 
 // LoadGraphFromDir loads a graph.Document from dir, where dir is the
 // .archigraph state directory for a repo (the directory that contains


### PR DESCRIPTION
## Summary

- Extracts `internal/graph/fbversion` (zero-import leaf package) holding `const Version = 3`
- Updates `internal/graph/fbwriter/writer.go`: `FormatVersion` is now an alias for `fbversion.Version` instead of a literal `3`
- Updates `internal/graph/load.go`: `minSupportedFBFormatVersion` is now an alias for `fbversion.Version` instead of a literal `3`
- Both sites share one source of truth; drift between them becomes a compile-time error

Closes #2435

## Test plan

- [ ] `gofmt -l` on changed files — clean (no output)
- [ ] `go vet ./...` — clean
- [ ] `go build ./...` — succeeds, no new import cycles
- [ ] `go test ./internal/graph/... ./cmd/archigraph/...` — all pass
- [ ] `git grep -nE "FormatVersion|minSupportedFBFormatVersion" internal/graph/` — no bare literal `= 3` remains; only leaf package + consumer aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)