### PR TITLE
refactor(mcp): resolve orphan handlers — re-wire 4 capability leaks (STOP: token budget overflow)

### DIFF
--- a/internal/mcp/schema_contract_ast_test.go
+++ b/internal/mcp/schema_contract_ast_test.go
@@ -135,6 +135,30 @@ var intentionalGaps = []intentionalGap{
 
 	// archigraph_traces: branching_factor — follow-action-only arg, undeclared for token budget (#1639).
 	{"archigraph_traces", "branching_factor", "#1639 token ceiling pattern — follow-only arg"},
+
+	// archigraph_save_finding: optional args undeclared for token budget (#2426 / #1639 pattern).
+	{"archigraph_save_finding", "type", "#2426 token ceiling pattern — optional note type"},
+	{"archigraph_save_finding", "nodes", "#2426 token ceiling pattern — optional node list"},
+	{"archigraph_save_finding", "repo_filter", "#2426 token ceiling pattern — optional repo filter"},
+
+	// archigraph_list_findings: optional args undeclared for token budget (#2426 / #1639 pattern).
+	{"archigraph_list_findings", "since", "#2426 token ceiling pattern — optional RFC3339 filter"},
+	{"archigraph_list_findings", "entity_id", "#2426 token ceiling pattern — optional entity filter"},
+	{"archigraph_list_findings", "limit", "#2426 token ceiling pattern — optional result limit"},
+
+	// archigraph_cross_links: per-action args undeclared for token budget (#2424 / #1639 pattern).
+	{"archigraph_cross_links", "channel", "#2424 token ceiling pattern — list filter"},
+	{"archigraph_cross_links", "method", "#2424 token ceiling pattern — list filter"},
+	{"archigraph_cross_links", "limit", "#2424 token ceiling pattern — list limit"},
+	{"archigraph_cross_links", "repo_filter", "#2424 token ceiling pattern — list filter"},
+	{"archigraph_cross_links", "candidate_id", "#2424 token ceiling pattern — accept/reject arg"},
+	{"archigraph_cross_links", "override_target", "#2424 token ceiling pattern — accept override"},
+	{"archigraph_cross_links", "reason", "#2424 token ceiling pattern — reject reason"},
+
+	// archigraph_license_audit: optional args undeclared for token budget (#2427 / #1639 pattern).
+	{"archigraph_license_audit", "include_transitive", "#2427 token ceiling pattern — optional transitive flag"},
+	{"archigraph_license_audit", "severity", "#2427 token ceiling pattern — optional severity filter"},
+	{"archigraph_license_audit", "limit", "#2427 token ceiling pattern — optional result limit"},
 }
 
 // handlerToTool and dispatchTree have been REMOVED.
@@ -155,33 +179,26 @@ var intentionalGaps = []intentionalGap{
 // Adding a new entry requires a comment explaining which tool was dropped and why.
 // Removing an entry means the dead code has been deleted — also correct.
 var orphanedHandlers = map[string]string{
-	// archigraph_cross_links was dropped (niche; see server.go line ~398).
-	// handleCrossLinks is gone but its sub-handlers still exist.
-	"handleListLinkCandidates":         "archigraph_cross_links dropped (niche; see registerTools comment)",
-	"handleResolveLinkCandidate":       "archigraph_cross_links dropped (niche; see registerTools comment)",
-	"handleResolveLinkCandidateAction": "archigraph_cross_links dropped (niche; see registerTools comment)",
+	// archigraph_recent_activity — superseded by MCPActivityBroker SSE/HTTP (#2428).
+	// Function body still exists pending deletion in this PR.
+	"handleRecentActivity": "archigraph_recent_activity dropped (superseded by MCPActivityBroker SSE/HTTP; #2428)",
 
-	// archigraph_save_result / archigraph_list_findings were dropped (use enrichments instead;
-	// see server.go registerTools comment).
-	"handleSaveResult":   "archigraph_save_result dropped (use enrichments; see registerTools comment)",
-	"handleListFindings": "archigraph_list_findings dropped (use enrichments; see registerTools comment)",
+	// archigraph_get_next_enrichment_task — subsumed by archigraph_enrichments(action=list,limit=1) (#2428).
+	// Function body still exists pending deletion in this PR.
+	"handleGetNextEnrichmentTask": "archigraph_get_next_enrichment_task dropped (use enrichments action=list; #2428)",
 
-	// archigraph_recent_activity was dropped (absorbed into whoami/dashboard).
-	"handleRecentActivity": "archigraph_recent_activity dropped (absorbed into whoami/dashboard)",
+	// handleQualityOrphans — HTTP served at /api/quality/orphans/{group}; archigraph_find_dead_code
+	// is the agent-facing substitute (#2428). Function body still exists pending deletion in this PR.
+	"handleQualityOrphans": "handleQualityOrphans orphaned from archigraph_quality_cycles (HTTP-served; #2428)",
 
-	// archigraph_get_next_enrichment_task was dropped (niche).
-	"handleGetNextEnrichmentTask": "archigraph_get_next_enrichment_task dropped (niche)",
+	// handleSubmitRepair — duplicate of handleSubmitRepairFromBundle (#2428).
+	// Function body still exists pending deletion in this PR.
+	"handleSubmitRepair": "standalone repair-submit superseded by handleSubmitRepairFromBundle (#2428)",
 
-	// archigraph_quality_cycles sub-handler handleQualityOrphans — the orphan
-	// sub-action was removed from the cycles bundle but the function body remains.
-	"handleQualityOrphans": "handleQualityOrphans orphaned from archigraph_quality_cycles (sub-action removed)",
-
-	// archigraph_license_audit was dropped (HTTP API still available).
-	"handleLicenseAudit": "archigraph_license_audit dropped (HTTP API still available; see registerTools comment)",
-
-	// handleSubmitRepair — standalone repair-submit handler, superseded by the
-	// bundled submit action in handleRepairs (handleSubmitRepairFromBundle).
-	"handleSubmitRepair": "standalone repair-submit superseded by handleSubmitRepairFromBundle",
+	// handleResolveLinkCandidate — legacy standalone pre-bundle version.
+	// archigraph_cross_links now dispatches via handleResolveLinkCandidateAction
+	// (the bundle-aware shim); this standalone is never called. Delete in #2428.
+	"handleResolveLinkCandidate": "pre-bundle standalone; superseded by handleResolveLinkCandidateAction (#2428)",
 }
 
 // sharedHelpers are functions that call argXxx but are not handlers — their

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -259,20 +259,17 @@ func (s *Server) fullToolList() ([]MCPToolEntry, error) {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 28 (#1281: 9→4 bundles; #1293: desc trim; #1312: +quality_cycles; #1314: +auth_coverage;
+// Tool count: 42 (#1281: 9→4 bundles; #1293: desc trim; #1312: +quality_cycles; #1314: +auth_coverage;
 //
 //	#1322: +secrets; #1323: +test_coverage; #1333: desc ≤80 chars;
-//	refactor/mcp-real-3k: ≤3k handshake, -license_audit for token ceiling).
+//	refactor/mcp-real-3k: ≤3k handshake; #2424: +cross_links; #2426: +save_finding,+list_findings;
+//	#2427: +license_audit re-wired — no HTTP route found in internal/dashboard/).
 //
 // Dropped (HTTP-only): archigraph_diagnostics, archigraph_quality_orphans,
 //
 //	archigraph_get_next_enrichment_task, archigraph_get_telemetry.
 //
-// Dropped (agent-facing, ≤3k): archigraph_recent_activity (UI), archigraph_save_finding,
-//
-//	archigraph_list_findings (use enrichments), archigraph_cross_links (niche).
-//
-// Dropped (HTTP-only, ≤3k optimization): archigraph_license_audit (#1334, HTTP API still available).
+// Dropped (agent-facing, superseded): archigraph_recent_activity (superseded by MCPActivityBroker SSE/HTTP).
 func (s *Server) registerTools() {
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_whoami",
 		mcpapi.WithDescription("Infer group/repo/ref for caller (cwd_resolved_to, indexed_ref, is_worktree)."),
@@ -395,7 +392,17 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_enrichments", s.handleEnrichments))
 
 	// archigraph_get_next_enrichment_task dropped (use enrichments(action=list,limit=1) instead).
-	// archigraph_cross_links dropped (niche; agents rarely invoke; saves 164 tokens).
+
+	// archigraph_cross_links — action=list|accept|reject (#2424).
+	// Per-action optional args read from the request map but undeclared to
+	// stay under the token ceiling (#1639 pattern): channel, method,
+	// limit, repo_filter, candidate_id, override_target.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_cross_links",
+		mcpapi.WithDescription("Cross-repo link candidates: list=pending, accept|reject=resolve."),
+		mcpapi.WithString("action", mcpapi.Required()),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_cross_links", s.handleCrossLinks))
 
 	// archigraph_repairs — action: list|submit. ADR-0015 residual-edge repair.
 	// Submit-only optional args are read from request map but undeclared in
@@ -654,7 +661,33 @@ func (s *Server) registerTools() {
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200)),
 	), s.wrap("archigraph_secrets", s.handleSecrets))
 
-	// archigraph_license_audit dropped (HTTP API still available); see registerTools comments.
+	// archigraph_save_finding + archigraph_list_findings (#2426).
+	// Optional args read from the request map but undeclared to stay under
+	// the token ceiling (#1639 pattern):
+	//   save_finding: type, nodes, repo_filter.
+	//   list_findings: since, entity_id, limit.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_save_finding",
+		mcpapi.WithDescription("Persist a Q&A finding to the group memory store."),
+		mcpapi.WithString("question", mcpapi.Required()),
+		mcpapi.WithString("answer", mcpapi.Required()),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_save_finding", s.handleSaveResult))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_list_findings",
+		mcpapi.WithDescription("List findings from the group memory store."),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_list_findings", s.handleListFindings))
+
+	// archigraph_license_audit — re-wired (#2427): no HTTP route found in internal/dashboard/.
+	// Optional args read from the request map but undeclared to stay under
+	// the token ceiling (#1639 pattern): include_transitive, severity, limit.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_license_audit",
+		mcpapi.WithDescription("Audit dependency licenses; flag GPL/AGPL conflicts."),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_license_audit", s.handleLicenseAudit))
 
 	// archigraph_diff_refs — PH5 (#2093): compare two indexed git refs.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_diff_refs",


### PR DESCRIPTION
## Summary

- **#2424** Re-wired `archigraph_cross_links` → `handleCrossLinks` (action=list|accept|reject)
- **#2426** Re-wired `archigraph_save_finding` → `handleSaveResult` + `archigraph_list_findings` → `handleListFindings`
- **#2427** Re-wired `archigraph_license_audit` → `handleLicenseAudit` (Step 1 confirmed: no HTTP route in `internal/dashboard/`)
- **#2428 NOT ATTEMPTED** — `make mcp-audit` FAILS after re-wires; per protocol, deletions skipped

## STOP: Token Budget Overflow

`make mcp-audit` result after re-wires:

```
tools: 42    handshake: 4476 tokens    ceiling: 4200
FAIL  handshake 4476 tokens > ceiling 4200
```

The 4 new tool registrations cost **+316 tokens** (84 + 91 + 70 + 72). Baseline was 4160/4200 (40 token headroom). Overflow = **276 tokens**.

### Decision required (pick one)

| Option | Action | Impact |
|--------|--------|--------|
| A | Bump `TokenCeiling` in `internal/mcp/budget.go` from 4200 → 4500 | All 4 re-wired, but #2428 deletions can proceed without freeing budget |
| B | Drop `archigraph_list_findings` (70 tokens) + `archigraph_save_finding` (91 tokens) = 161 tokens saved → still over (4321 > 4200) | Not enough |
| C | Drop 3 of the 4 re-wired tools (keep only the one with highest value) | Fixes budget, partial capability restore |
| D | Bump ceiling to 4500 now, then consider trimming descriptions/params to come back down | Most flexible |

**Recommendation**: Option A (bump to 4500) then do #2428 deletions, since the deleted handlers were never in the handshake and don't save tokens.

## Step 1 — license_audit HTTP audit

`git grep -nE "license" internal/dashboard/` returned **no matches**. The comment in `server.go:275` claiming "HTTP API still available" was **incorrect**. Re-wire is appropriate (#2427).

## Re-wires landed (4 total, schemas minimal via #1639 pattern)

All 4 tools use minimal schemas with most optional args in `intentionalGaps` to minimize token cost:

| Tool | Handler | Schema tokens |
|------|---------|--------------|
| `archigraph_cross_links` | `handleCrossLinks` | 84 |
| `archigraph_save_finding` | `handleSaveResult` | 91 |
| `archigraph_list_findings` | `handleListFindings` | 70 |
| `archigraph_license_audit` | `handleLicenseAudit` | 72 |

## orphanedHandlers allowlist

Trimmed from 10 → 5 entries:
- **Removed** (now re-wired): `handleListLinkCandidates`, `handleResolveLinkCandidateAction`, `handleSaveResult`, `handleListFindings`, `handleLicenseAudit`
- **Retained** (pending #2428 deletion): `handleRecentActivity`, `handleGetNextEnrichmentTask`, `handleQualityOrphans`, `handleSubmitRepair`
- **Added** (discovered dead code): `handleResolveLinkCandidate` — the pre-bundle legacy standalone is never called from `handleCrossLinks` (which dispatches via `handleResolveLinkCandidateAction` shim); also a #2428 deletion candidate

## Tech debt surfaced

1. **`handleResolveLinkCandidate` (legacy standalone)** — never called after `archigraph_cross_links` bundling. The new `handleResolveLinkCandidateAction` shim handles accept/reject. The standalone was in the orphan allowlist for the same reason as the bundle, but cleaning up the re-wire reveals it's now independently dead code. Add to #2428 deletion list (currently in orphanedHandlers with explanation).
2. **Token ceiling headroom is effectively zero** — 4160/4200 baseline means any new MCP tool requires either bumping the ceiling or retiring another. A deliberate policy decision is needed.
3. **Comment inaccuracy at server.go:275** — "HTTP API still available" for license_audit was wrong; the route never existed in `internal/dashboard/`. Fixed in this PR.

## Gates (pre-STOP state)

- `gofmt -l`: clean
- `go vet ./...`: clean
- `go build ./...`: clean
- `TestSchemaContract_AllHandlerArgsDeclared`: PASS
- `make mcp-audit`: **FAIL** (4476 > 4200) — this is the STOP point

## Test plan

1. Decide on token budget strategy (see Decision Required above)
2. If bumping ceiling: update `internal/mcp/budget.go`, re-run `make mcp-audit` (should PASS)
3. Then proceed with #2428 (delete 5 dead/duplicate handlers)
4. Clear remaining 4 entries from `orphanedHandlers` (after handlers deleted)
5. `go test ./internal/mcp/... -count=1` with empty allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)