### PR TITLE
refactor(engine): drop unused entities param from applyORMFieldEdges

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -448,8 +448,8 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// the Python extractor. Runs AFTER applyORMQueries because it
 	// pivots off the QUERIES edges that pass emits. Append-only —
 	// cannot regress the surrounding pipeline's bug-rate.
-	entities, relationships = applyORMFieldEdges(
-		file.Language, file.Path, file.Content, file.Pass1Entities, entities, relationships,
+	relationships = applyORMFieldEdges(
+		file.Language, file.Path, file.Content, file.Pass1Entities, relationships,
 	)
 
 	// Kafka producer/consumer cross-repo edges (wave 1 of #726). Emits

--- a/internal/engine/orm_field_edges.go
+++ b/internal/engine/orm_field_edges.go
@@ -74,14 +74,13 @@ func applyORMFieldEdges(
 	path string,
 	content []byte,
 	pass1Entities []types.EntityRecord,
-	entities []types.EntityRecord,
 	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+) []types.RelationshipRecord {
 	if lang != "python" {
-		return entities, relationships
+		return relationships
 	}
 	if len(content) == 0 {
-		return entities, relationships
+		return relationships
 	}
 
 	// Build a per-(model,field) index for THIS file.
@@ -102,7 +101,7 @@ func applyORMFieldEdges(
 		fieldIdx = BuildFieldIndex(string(content))
 	}
 	if len(fieldIdx) == 0 {
-		return entities, relationships
+		return relationships
 	}
 	_ = plumbed // reserved for future telemetry / debug hooks
 
@@ -154,7 +153,7 @@ func applyORMFieldEdges(
 		}
 	}
 
-	return entities, relationships
+	return relationships
 }
 
 // djangoChainAnchorRe matches the start of every Django ORM queryset


### PR DESCRIPTION
## Summary

- Drops the unused `entities []types.EntityRecord` parameter from `applyORMFieldEdges` in `internal/engine/orm_field_edges.go`
- Updates the call site in `internal/engine/detector.go` (line 451) to pass one fewer argument
- Return type simplified from `([]types.EntityRecord, []types.RelationshipRecord)` to `[]types.RelationshipRecord` since entities was pass-through only

PR #2425 (#2352) made `buildPlumbedFieldIndex` the canonical lookup path. The defensive in-pass-slice scan that consumed the `entities` parameter is gone — the parameter was dead weight threaded for signature consistency with other engine passes.

Closes #2430

## Test plan

- [x] `gofmt -l` clean on changed files
- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `go test ./internal/engine/... -count=1` passes (both `engine` and `engine/httproutes` packages)
- [x] No test directly mocked `applyORMFieldEdges` with `entities` — all tests go through `det.Detect(...)` pipeline, so no mock-breaking occurred

## Tech debt surfaced

The `entities` parameter was the last vestige of a planned "defensive fallback scan" (post-#2352 cleanup note in the file header). With it gone, the return type asymmetry between `applyORMFieldEdges` (now returns only `relationships`) and every other engine pass (returns `entities, relationships`) is explicit. The broader struct-of-args refactor (`DetectorPassArgs`) tracked as a separate concern should normalize this family of signatures in one coordinated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)