### PR TITLE
cleanup: refresh warnEmptyLanguageEntities comment + delete dead stepAdj nil-guard

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1363,8 +1363,10 @@ var knownLanguageExtensions = map[string]string{
 }
 
 // warnEmptyLanguageEntities logs a warning to stderr when entities with a
-// recognized source-file extension have an empty Language tag. Issue #2341 —
-// prevents the bug from silently recurring after a future regression.
+// recognized source-file extension have an empty Language tag. The language
+// slot is canonical in Entity (FlatBuffers, post-PR #2432); extractors must
+// tag via extractor.TagEntitiesLanguage. Issue #2341 — prevents regressions
+// where extractors forget to tag.
 func warnEmptyLanguageEntities(doc *graph.Document) {
 	type bad struct{ kind, name, src string }
 	var bads []bad

--- a/internal/mcp/traces.go
+++ b/internal/mcp/traces.go
@@ -383,7 +383,6 @@ func buildProcessSteps(r *LoadedRepo, proc *graph.Entity, verbose ...bool) []map
 // entities that live in companion repos.
 func buildProcessStepsWithCrossRepo(r *LoadedRepo, proc *graph.Entity, crossRepo crossRepoLookup, verbose ...bool) []map[string]any {
 	wantVerbose := len(verbose) > 0 && verbose[0]
-	doc := r.Doc
 	repo := r.Repo
 	byID := r.ByID
 	type indexed struct {
@@ -392,25 +391,9 @@ func buildProcessStepsWithCrossRepo(r *LoadedRepo, proc *graph.Entity, crossRepo
 	}
 	var ordered []indexed
 	// Consume the pre-built STEP_IN_PROCESS adjacency index (#2417).
-	// Falls back to the O(R) Doc.Relationships scan only when StepAdj is nil
-	// (e.g. a *LoadedRepo constructed in a test without calling buildStepAdjacency).
-	if r.StepAdj != nil {
-		for _, se := range r.StepAdj[proc.ID] {
-			ordered = append(ordered, indexed{se.idx, se.toID})
-		}
-	} else {
-		for i := range doc.Relationships {
-			rel := &doc.Relationships[i]
-			if rel.Kind != stepInProcessEdge || rel.FromID != proc.ID {
-				continue
-			}
-			idxStr := ""
-			if rel.Properties != nil {
-				idxStr = rel.Properties["step_index"]
-			}
-			n, _ := strconv.Atoi(idxStr)
-			ordered = append(ordered, indexed{n, rel.ToID})
-		}
+	// StepAdj is always populated by reloadLocked (state.go) since PR #2439.
+	for _, se := range r.StepAdj[proc.ID] {
+		ordered = append(ordered, indexed{se.idx, se.toID})
 	}
 	if len(ordered) == 0 {
 		// Fallback to the chain property if the edges weren't emitted.


### PR DESCRIPTION
## Summary
- #2437: Updated `warnEmptyLanguageEntities` comment block post-PR #2432 (language slot is now canonical in Entity FlatBuffers; property tunnel retired)
- #2440: Deleted the defensive nil-guard fallback in `buildProcessStepsWithCrossRepo` — StepAdj is always populated by reloadLocked since PR #2439

## Pre-commit gates
- gofmt: clean
- go vet: clean
- go build: succeeds
- Tests: 525 passed (excluding pre-existing TestElapsedMSCoverageAllTools failure)

## parseStepIndex extraction
Skipped — only 1 decode site remains after deletion of the else block (buildStepAdjacency in traversal.go).

Generated with Claude Haiku 4.5