### PR TITLE
feat(extract): add Pass1Plumbed counters to BatchStats (#2447)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -275,6 +275,12 @@ type indexerStats struct {
 
 	// PORT-EXT: external-entity synthesis counters (Pass 4.5).
 	extSynth external.Stats
+
+	// Pass1Plumbed counters (issue #2447): files where FileInput.Pass1Entities
+	// was non-empty (True) vs empty (False) when Detector.Detect was called.
+	// Non-zero False count signals the side-channel is being bypassed.
+	pass1PlumbedTrue  int
+	pass1PlumbedFalse int
 }
 
 // Index walks repoPath, runs the orchestrated passes, and writes the
@@ -539,6 +545,13 @@ type JSONStats struct {
 	ExternalSynthesized  int                 `json:"external_synthesized"`
 	ExternalUniqueCount  int                 `json:"external_unique_count"`
 	ExternalRelsResolved int                 `json:"external_rels_resolved"`
+
+	// Pass1PlumbedTrue / Pass1PlumbedFalse (issue #2447): files where
+	// FileInput.Pass1Entities was non-empty (True) vs empty (False) when
+	// Detector.Detect was called for Pass 2.5. A non-zero False count
+	// signals the Pass1Entities side-channel is being bypassed.
+	Pass1PlumbedTrue  int `json:"pass1_plumbed_true"`
+	Pass1PlumbedFalse int `json:"pass1_plumbed_false"`
 }
 
 // emitJSONStats writes a JSONStats record to w. Used by `archigraph index
@@ -580,6 +593,8 @@ func emitJSONStats(w io.Writer, idx *Indexer, doc *graph.Document) error {
 		ExternalSynthesized:  idx.stats.extSynth.Synthesized,
 		ExternalUniqueCount:  idx.stats.extSynth.UniqueExternals,
 		ExternalRelsResolved: idx.stats.extSynth.RelationshipsResolved,
+		Pass1PlumbedTrue:     idx.stats.pass1PlumbedTrue,
+		Pass1PlumbedFalse:    idx.stats.pass1PlumbedFalse,
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -777,6 +792,9 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		for k, v := range res.ByCrossExt {
 			i.stats.pass3RelsByExt[k] += v
 		}
+		// Issue #2447: propagate Pass1Plumbed counters from subprocess path.
+		i.stats.pass1PlumbedTrue += res.Pass1PlumbedTrueCount
+		i.stats.pass1PlumbedFalse += res.Pass1PlumbedFalseCount
 		fmt.Fprintf(os.Stderr,
 			"archigraph: subproc-extract subprocs=%d peak_rss=%.1fMB entities=%d rels=%d\n",
 			res.Subprocesses,
@@ -2241,6 +2259,11 @@ func (i *Indexer) runPass25FrameworkRules(ctx context.Context, absRepo string, c
 		rels     []types.RelationshipRecord
 	)
 
+	// Issue #2447: atomic counters for Pass1Entities plumbing observability.
+	// Incremented per-file before Detect() so a non-zero False count in
+	// production signals the side-channel is being bypassed.
+	var plumbedTrue, plumbedFalse atomic.Int64
+
 	work := make(chan classifiedFile, len(classified))
 	for _, cf := range classified {
 		work <- cf
@@ -2260,6 +2283,12 @@ func (i *Indexer) runPass25FrameworkRules(ctx context.Context, absRepo string, c
 					RepoRoot:      absRepo,
 					Pass1Entities: pass1ByFile[cf.relPath],
 				}
+				// Issue #2447: count plumbed vs unplumbed before Detect.
+				if len(input.Pass1Entities) > 0 {
+					plumbedTrue.Add(1)
+				} else {
+					plumbedFalse.Add(1)
+				}
 				res, err := i.detector.Detect(ctx, input)
 				if err != nil || res == nil {
 					continue
@@ -2275,6 +2304,10 @@ func (i *Indexer) runPass25FrameworkRules(ctx context.Context, absRepo string, c
 		}()
 	}
 	wg.Wait()
+
+	// Fold atomic counters into indexer stats (issue #2447).
+	i.stats.pass1PlumbedTrue += int(plumbedTrue.Load())
+	i.stats.pass1PlumbedFalse += int(plumbedFalse.Load())
 	// Issue #481 — deterministic ordering across runs.
 	sortEntityRecords(entities)
 	sortRelationshipRecords(rels)

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -100,6 +100,11 @@ type Result struct {
 	SubprocessRSS  []uint64
 	Subprocesses   int
 	NonFatalErrors []string
+
+	// Pass1Plumbed counters (issue #2447): aggregated from every subprocess.
+	// See BatchStats for semantics.
+	Pass1PlumbedTrueCount  int
+	Pass1PlumbedFalseCount int
 }
 
 // Coordinate is the daemon-side entrypoint that replaces the in-process
@@ -265,6 +270,8 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 					res.PeakRSSBytes = stats.RSSBytes
 				}
 				res.SubprocessRSS = append(res.SubprocessRSS, stats.RSSBytes)
+				res.Pass1PlumbedTrueCount += stats.Pass1PlumbedTrueCount
+				res.Pass1PlumbedFalseCount += stats.Pass1PlumbedFalseCount
 			}
 			mu.Unlock()
 		}(b)

--- a/internal/daemon/extract/jsonl.go
+++ b/internal/daemon/extract/jsonl.go
@@ -77,4 +77,15 @@ type BatchStats struct {
 	ByLang     map[string]int `json:"by_lang,omitempty"`
 	ByCrossExt map[string]int `json:"by_cross_ext,omitempty"`
 	RSSBytes   uint64         `json:"rss_bytes"`
+
+	// Pass1Plumbed counters (issue #2447): track how many files had
+	// FileInput.Pass1Entities non-empty (True) vs empty (False) when
+	// Detector.Detect was called for Pass 2.5.
+	//
+	// A non-zero False count in production signals the Pass1Entities
+	// side-channel is being bypassed. Future engine passes that rely
+	// exclusively on Pass1Entities (with no regex fallback) would
+	// silently produce zero edges when False > 0.
+	Pass1PlumbedTrueCount  int `json:"pass1_plumbed_true"`
+	Pass1PlumbedFalseCount int `json:"pass1_plumbed_false"`
 }

--- a/internal/daemon/extract/subproc.go
+++ b/internal/daemon/extract/subproc.go
@@ -315,6 +315,15 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 			file.Pass1Entities = fieldEnts
 		}
 		if runFramework {
+			// Issue #2447: count how many files enter Detect() with
+			// Pass1Entities plumbed (True) vs empty (False). A non-zero
+			// False count post-PR #2445 signals the side-channel is being
+			// bypassed somewhere new.
+			if len(file.Pass1Entities) > 0 {
+				stats.Pass1PlumbedTrueCount++
+			} else {
+				stats.Pass1PlumbedFalseCount++
+			}
 			if res, derr := detector.Detect(ctx, file); derr == nil && res != nil {
 				for k := range res.Entities {
 					e := res.Entities[k]

--- a/internal/daemon/extract/subproc_test.go
+++ b/internal/daemon/extract/subproc_test.go
@@ -206,3 +206,105 @@ def get_pending():
 
 	t.Logf("subprocess Run(): field_entities=%d reads_field_rels=%d", fieldEntities, readsFieldRels)
 }
+
+// TestRun_Pass1PlumbedCounters verifies that BatchStats.Pass1PlumbedTrueCount
+// and Pass1PlumbedFalseCount are correctly incremented by Run() (issue #2447).
+//
+// A Python fixture with a Django model produces SCOPE.Schema(subtype=field)
+// entities in Pass 1, which the subprocess collects and stamps onto
+// FileInput.Pass1Entities before Pass 2.5 runs. The True counter must be 1
+// and False must be 0 for that file. A plain Go file (no field entities)
+// must increment False instead.
+func TestRun_Pass1PlumbedCounters(t *testing.T) {
+	// Fixture 1: Python file with a Django model — Pass1Entities will be plumbed.
+	pyRepo := t.TempDir()
+	pySrc := `from django.db import models
+
+class Widget(models.Model):
+    name = models.CharField(max_length=100)
+
+def find(n):
+    return Widget.objects.filter(name=n)
+`
+	if err := os.WriteFile(filepath.Join(pyRepo, "widget.py"), []byte(pySrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pyBatch := filepath.Join(t.TempDir(), "batch.txt")
+	if err := os.WriteFile(pyBatch, []byte("widget.py\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var pyBuf bytes.Buffer
+	if err := Run(context.Background(), SubprocessOptions{
+		RepoRoot:  pyRepo,
+		BatchPath: pyBatch,
+		BatchID:   "py-plumb",
+		Output:    &pyBuf,
+	}); err != nil {
+		t.Fatalf("Run (python): %v", err)
+	}
+
+	var pyStats *BatchStats
+	dec := json.NewDecoder(strings.NewReader(pyBuf.String()))
+	for dec.More() {
+		var env Envelope
+		if err := dec.Decode(&env); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if env.Type == KindStats {
+			pyStats = env.Stats
+		}
+	}
+	if pyStats == nil {
+		t.Fatal("no stats envelope from python Run()")
+	}
+	// For the Python/Django fixture, at least one file should have
+	// Pass1Entities plumbed (True > 0, False == 0).
+	t.Logf("python fixture: pass1_plumbed_true=%d pass1_plumbed_false=%d",
+		pyStats.Pass1PlumbedTrueCount, pyStats.Pass1PlumbedFalseCount)
+	if pyStats.Pass1PlumbedTrueCount == 0 {
+		t.Errorf("expected Pass1PlumbedTrueCount > 0 for Django model fixture; got 0 (side-channel not plumbed?)")
+	}
+	if pyStats.Pass1PlumbedFalseCount != 0 {
+		t.Errorf("expected Pass1PlumbedFalseCount == 0 for Django model fixture; got %d", pyStats.Pass1PlumbedFalseCount)
+	}
+
+	// Fixture 2: Go file — no SCOPE.Schema(subtype=field) entities from Pass 1,
+	// so Pass1Entities will be empty → FalseCount must be 1, TrueCount must be 0.
+	goRepo := writeTree(t) // produces demo.go with two Go functions
+	goBatch := filepath.Join(t.TempDir(), "batch.txt")
+	if err := os.WriteFile(goBatch, []byte("demo.go\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var goBuf bytes.Buffer
+	if err := Run(context.Background(), SubprocessOptions{
+		RepoRoot:  goRepo,
+		BatchPath: goBatch,
+		BatchID:   "go-plumb",
+		Output:    &goBuf,
+	}); err != nil {
+		t.Fatalf("Run (go): %v", err)
+	}
+
+	var goStats *BatchStats
+	dec2 := json.NewDecoder(strings.NewReader(goBuf.String()))
+	for dec2.More() {
+		var env Envelope
+		if err := dec2.Decode(&env); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if env.Type == KindStats {
+			goStats = env.Stats
+		}
+	}
+	if goStats == nil {
+		t.Fatal("no stats envelope from go Run()")
+	}
+	t.Logf("go fixture: pass1_plumbed_true=%d pass1_plumbed_false=%d",
+		goStats.Pass1PlumbedTrueCount, goStats.Pass1PlumbedFalseCount)
+	if goStats.Pass1PlumbedTrueCount != 0 {
+		t.Errorf("expected Pass1PlumbedTrueCount == 0 for Go fixture; got %d", goStats.Pass1PlumbedTrueCount)
+	}
+	if goStats.Pass1PlumbedFalseCount == 0 {
+		t.Errorf("expected Pass1PlumbedFalseCount > 0 for Go fixture; got 0")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Pass1PlumbedTrueCount` and `Pass1PlumbedFalseCount` to `BatchStats` in `internal/daemon/extract/jsonl.go`
- Subprocess path (`subproc.go`) increments per-file counters before `Detector.Detect()` for Pass 2.5, based on whether `FileInput.Pass1Entities` is non-empty
- Coordinator (`coordinator.go`) aggregates subprocess counters into `Result`; in-process path (`index.go`) uses `sync/atomic` per-goroutine and folds into `indexerStats`
- Both paths surface counters in `--json-stats` output (`JSONStats.Pass1PlumbedTrue` / `Pass1PlumbedFalse`) and in the subprocess JSONL `stats` envelope
- Adds `TestRun_Pass1PlumbedCounters` covering both the plumbed (Django model → True=1, False=0) and unplumbed (Go file → True=0, False=1) cases

## Test plan

- [ ] `gofmt -l <changed-files>` — empty (verified)
- [ ] `go vet ./...` — clean (verified)
- [ ] `go build ./...` — passes (verified)
- [ ] `go test ./internal/daemon/extract/... ./cmd/archigraph/...` — both packages pass (verified)
- [ ] Smoke run: `archigraph extract` against Django fixture → `pass1_plumbed_true: 1`, `pass1_plumbed_false: 0` (verified)

Closes #2447

🤖 Generated with [Claude Code](https://claude.com/claude-code)