### PR TITLE
docs(extract): clarify Pass1Plumbed heterogeneous-repo semantics

### DIFF
--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -102,7 +102,9 @@ type Result struct {
 	NonFatalErrors []string
 
 	// Pass1Plumbed counters (issue #2447): aggregated from every subprocess.
-	// See BatchStats for semantics.
+	// See BatchStats for full semantics, including heterogeneous-repo
+	// expectations (issue #2464): FalseCount > 0 is normal on multi-language
+	// repos. Use TrueCount / (TrueCount + FalseCount) as the health ratio.
 	Pass1PlumbedTrueCount  int
 	Pass1PlumbedFalseCount int
 }

--- a/internal/daemon/extract/jsonl.go
+++ b/internal/daemon/extract/jsonl.go
@@ -82,10 +82,27 @@ type BatchStats struct {
 	// FileInput.Pass1Entities non-empty (True) vs empty (False) when
 	// Detector.Detect was called for Pass 2.5.
 	//
-	// A non-zero False count in production signals the Pass1Entities
-	// side-channel is being bypassed. Future engine passes that rely
-	// exclusively on Pass1Entities (with no regex fallback) would
-	// silently produce zero edges when False > 0.
+	// Heterogeneous-repo semantics (issue #2464): runPass25FrameworkRules
+	// runs Pass 2.5 against ALL classified files regardless of language.
+	// Non-Django files (Go, JS, TypeScript, etc.) never produce
+	// SCOPE.Schema(subtype=field) entities in Pass 1, so they legitimately
+	// contribute to FalseCount. A non-zero FalseCount is therefore EXPECTED
+	// on any multi-language repository and does NOT indicate a plumbing bug.
+	//
+	// Correct production diagnostic:
+	//   ratio = TrueCount / (TrueCount + FalseCount)
+	// For Django-only repos this ratio should be near 1.0. For heterogeneous
+	// repos it will be proportional to the fraction of files that are Django
+	// models. A ratio near 0.0 on a known-Django repo is the signal worth
+	// alerting on.
+	//
+	// The naive check "FalseCount == 0" is only valid on Django-only test
+	// fixtures (e.g. the unit-test fixture from PR #2463). Do NOT use it
+	// as a production health gate.
+	//
+	// Pre-Pass-2.5 language filtering (run Detect only on Python files) is
+	// the deeper fix that would eliminate FalseCount noise entirely; tracked
+	// as a follow-up to issue #2464.
 	Pass1PlumbedTrueCount  int `json:"pass1_plumbed_true"`
 	Pass1PlumbedFalseCount int `json:"pass1_plumbed_false"`
 }

--- a/internal/daemon/extract/subproc.go
+++ b/internal/daemon/extract/subproc.go
@@ -316,9 +316,12 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 		}
 		if runFramework {
 			// Issue #2447: count how many files enter Detect() with
-			// Pass1Entities plumbed (True) vs empty (False). A non-zero
-			// False count post-PR #2445 signals the side-channel is being
-			// bypassed somewhere new.
+			// Pass1Entities plumbed (True) vs empty (False).
+			// Note (issue #2464): FalseCount > 0 is EXPECTED on heterogeneous
+			// repos — Pass 2.5 runs against all classified files regardless of
+			// language, so non-Django files (Go, JS, etc.) always contribute to
+			// FalseCount. Use the True/(True+False) ratio as the health signal,
+			// not the raw FalseCount. See BatchStats for full diagnostic guidance.
 			if len(file.Pass1Entities) > 0 {
 				stats.Pass1PlumbedTrueCount++
 			} else {


### PR DESCRIPTION
## Summary

- `BatchStats.Pass1PlumbedTrueCount`/`FalseCount` field comments updated in `jsonl.go` to document that `FalseCount > 0` is **expected** on multi-language repos — Pass 2.5 runs against all classified files, so non-Django files (Go, JS, etc.) legitimately contribute to `FalseCount`.
- Production diagnostic guidance changed from `FalseCount == 0` to the `TrueCount / (TrueCount + FalseCount)` ratio approach.
- Same note added to the call-site in `subproc.go` and the `Result` struct in `coordinator.go`.
- No counter values changed; no production assertions existed (the `FalseCount == 0` check was test-only and remains valid for the Django-only fixture it targets).

Closes #2464

## Test plan

- [ ] `gofmt -l` on changed files — empty (clean)
- [ ] `go vet ./...` — clean
- [ ] `go build ./...` — succeeds
- [ ] `go test ./internal/daemon/extract/... -count=1` — passes (19.9s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)