### PR TITLE
fix(dashboard): bump TestSearchIndex_Scale_50k deadline 500ms → 1000ms (macOS CI flake)

### DIFF
--- a/internal/dashboard/search_index_test.go
+++ b/internal/dashboard/search_index_test.go
@@ -158,9 +158,9 @@ func TestSearchIndex_Scale_10k(t *testing.T) {
 
 func TestSearchIndex_Scale_50k(t *testing.T) {
 	grp := makeScaleGroup(50_000)
-	assertSearchFast(t, grp, "alpha", 500*time.Millisecond)
-	assertSearchFast(t, grp, "entity", 500*time.Millisecond)
-	assertSearchFast(t, grp, "beta", 500*time.Millisecond)
+	assertSearchFast(t, grp, "alpha", 1000*time.Millisecond)  // 1000ms — bumped from 500ms (#2477) to accommodate macOS CI runners (639ms p99 measured). Ubuntu/Linux still well within budget.
+	assertSearchFast(t, grp, "entity", 1000*time.Millisecond) // 1000ms — bumped from 500ms (#2477) to accommodate macOS CI runners (639ms p99 measured). Ubuntu/Linux still well within budget.
+	assertSearchFast(t, grp, "beta", 1000*time.Millisecond)   // 1000ms — bumped from 500ms (#2477) to accommodate macOS CI runners (639ms p99 measured). Ubuntu/Linux still well within budget.
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2477

macOS Azure runners deliver 639ms on the worst-case "entity" prefix
over 50k entries — 28% over the 500ms deadline. Ubuntu/Linux pass.
PR #2408 (and others) get blocked by this flake.

Bumping to 1000ms gives reasonable headroom on slower CI while still
asserting non-degenerate search performance.