### PR TITLE
fix(mcp): move 3 re-wired tools from wantAbsent to wantPresent

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -525,7 +525,7 @@ func TestToolNameSurface(t *testing.T) {
 		// renamed (5)
 		"archigraph_find", "archigraph_inspect", "archigraph_expand",
 		"archigraph_clusters", "archigraph_stats",
-		// bundled (2 retained; cross_links dropped)
+		// bundled (2 retained; cross_links re-wired)
 		"archigraph_enrichments", "archigraph_repairs",
 		// unchanged — trace included here as it was not renamed
 		"archigraph_trace",
@@ -553,6 +553,10 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_auth_coverage",
 		// #1659 docgen→graph repair feedback loop
 		"archigraph_apply_docgen_repairs",
+		// #2442 re-wired agent-facing tools (restored from ≤3k budget cut)
+		"archigraph_save_finding",
+		"archigraph_list_findings",
+		"archigraph_cross_links",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -594,13 +598,12 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_get_next_enrichment_task",
 		"archigraph_get_telemetry",
 		// agent-facing tools dropped in refactor/mcp-real-3k (≤3k budget)
+		// NOTE: archigraph_save_finding, archigraph_list_findings, archigraph_cross_links
+		// were re-wired in #2442; see wantPresent list.
 		"archigraph_recent_activity",
-		"archigraph_save_finding",
 		// deprecated shims dropped in feat/drop-subgraph-shims (no real callers per #1742)
 		"archigraph_get_subgraph",
 		"archigraph_summarize_subgraph",
-		"archigraph_list_findings",
-		"archigraph_cross_links",
 	}
 	for _, n := range wantAbsent {
 		if registered[n] {


### PR DESCRIPTION
Closes #2487

PR #2442 re-wired archigraph_save_finding, archigraph_list_findings, and archigraph_cross_links back into the live tool surface. PR #2467 updated TestServerToolRegistration and TestElapsedMSCoverageAllTools but missed TestToolNameSurface's wantAbsent slice.

Result: TestToolNameSurface fails deterministically on every CI run, blocking #2408 and any new PR's CI.

## Changes
- Move 3 tool names from wantAbsent → wantPresent
- Update inline comment noting re-wiring via #2442
- Test passes: go test ./internal/mcp/... -run TestToolNameSurface -count=1 PASS
- Full suite passes: go test ./internal/mcp/... -count=1 PASS