### PR TITLE
refactor(engine): standardize pass signatures via DetectorPassArgs/DetectorPassResult

### DIFF
--- a/internal/engine/celery_pubsub_edges_test.go
+++ b/internal/engine/celery_pubsub_edges_test.go
@@ -22,7 +22,8 @@ import (
 
 func runCeleryPass(t *testing.T, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	t.Helper()
-	return applyScheduledJobEdges("python", path, []byte(src), nil, nil)
+	res := applyScheduledJobEdges(DetectorPassArgs{Lang: "python", Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 func celeryRelsByKind(rels []types.RelationshipRecord, kind string) []types.RelationshipRecord {

--- a/internal/engine/debezium_cdc_edges.go
+++ b/internal/engine/debezium_cdc_edges.go
@@ -128,18 +128,17 @@ type debeziumConnectorDoc struct {
 // connector and APPENDS connector / table / topic entities and CAPTURES /
 // PUBLISHES_TO edges. Returns inputs untouched if the file is not a
 // connector or fails to parse.
-func applyDebeziumCDCEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyDebeziumCDCEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if !debeziumCDCSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !debeziumCDCSniff(content) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	// Use a raw map so we can pick up both the typed `name`/`config`
@@ -147,7 +146,7 @@ func applyDebeziumCDCEdges(
 	// pass.
 	var raw map[string]interface{}
 	if err := json.Unmarshal(content, &raw); err != nil {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	connectorName, _ := raw["name"].(string)
@@ -170,7 +169,7 @@ func applyDebeziumCDCEdges(
 		connectorName = derefConnectorNameFromPath(path)
 	}
 	if connectorName == "" {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	// Calibration escape hatches.
@@ -267,7 +266,7 @@ func applyDebeziumCDCEdges(
 	}
 
 	entities = append(entities, connectorEntity)
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // flattenConfig returns the "config" sub-object if present, otherwise the

--- a/internal/engine/debezium_cdc_edges_test.go
+++ b/internal/engine/debezium_cdc_edges_test.go
@@ -36,10 +36,7 @@ const debeziumPolyglotConnector = `{
 }`
 
 func TestDebeziumCDC_PolyglotFixture(t *testing.T) {
-	ents, _ := applyDebeziumCDCEdges("json",
-		"services/cdc/orders-connector.json",
-		[]byte(debeziumPolyglotConnector), nil, nil,
-	)
+	ents := applyDebeziumCDCEdges(DetectorPassArgs{Lang: "json", Path: "services/cdc/orders-connector.json", Content: []byte(debeziumPolyglotConnector)}).Entities
 
 	var connector *struct {
 		captures      map[string]bool
@@ -117,7 +114,8 @@ func TestDebeziumCDC_DerivedTopics(t *testing.T) {
 			"topic.prefix": "cdc"
 		}
 	}`
-	ents, _ := applyDebeziumCDCEdges("json", "cdc/users.json", []byte(doc), nil, nil)
+	_res := applyDebeziumCDCEdges(DetectorPassArgs{Lang: "json", Path: "cdc/users.json", Content: []byte(doc)})
+	ents, _ := _res.Entities, _res.Relationships
 	topics := map[string]bool{}
 	for _, e := range ents {
 		if e.Kind == messageTopicKind {
@@ -142,7 +140,8 @@ func TestDebeziumCDC_LegacyServerNameAsPrefix(t *testing.T) {
 			"table.include.list": "public.orders"
 		}
 	}`
-	ents, _ := applyDebeziumCDCEdges("json", "debezium/legacy.json", []byte(doc), nil, nil)
+	_res := applyDebeziumCDCEdges(DetectorPassArgs{Lang: "json", Path: "debezium/legacy.json", Content: []byte(doc)})
+	ents, _ := _res.Entities, _res.Relationships
 	got := false
 	for _, e := range ents {
 		if e.Kind == messageTopicKind && e.Name == "kafka:legacy.public.orders" {
@@ -155,7 +154,8 @@ func TestDebeziumCDC_LegacyServerNameAsPrefix(t *testing.T) {
 }
 
 func TestDebeziumCDC_NonJSONLanguageNoop(t *testing.T) {
-	ents, rels := applyDebeziumCDCEdges("python", "x.py", []byte(debeziumPolyglotConnector), nil, nil)
+	_res := applyDebeziumCDCEdges(DetectorPassArgs{Lang: "python", Path: "x.py", Content: []byte(debeziumPolyglotConnector)})
+	ents, rels := _res.Entities, _res.Relationships
 	if len(ents) != 0 || len(rels) != 0 {
 		t.Errorf("expected no-op for non-json language, got %d entities, %d rels", len(ents), len(rels))
 	}
@@ -163,7 +163,8 @@ func TestDebeziumCDC_NonJSONLanguageNoop(t *testing.T) {
 
 func TestDebeziumCDC_NonConnectorJSONNoop(t *testing.T) {
 	pkg := `{"name":"some-package","version":"1.0.0","dependencies":{"react":"^18"}}`
-	ents, rels := applyDebeziumCDCEdges("json", "package.json", []byte(pkg), nil, nil)
+	_res := applyDebeziumCDCEdges(DetectorPassArgs{Lang: "json", Path: "package.json", Content: []byte(pkg)})
+	ents, rels := _res.Entities, _res.Relationships
 	if len(ents) != 0 || len(rels) != 0 {
 		t.Errorf("expected no-op for non-connector JSON, got %d entities, %d rels", len(ents), len(rels))
 	}
@@ -175,7 +176,8 @@ func TestDebeziumCDC_SniffGuardsOutNonDebezium(t *testing.T) {
 	// Has connector.class but it's not Debezium; we still accept any
 	// Kafka-Connect connector that declares connector.class.
 	doc := `{"name":"foo","config":{"connector.class":"com.example.Foo"}}`
-	ents, _ := applyDebeziumCDCEdges("json", "cdc/foo.json", []byte(doc), nil, nil)
+	_res := applyDebeziumCDCEdges(DetectorPassArgs{Lang: "json", Path: "cdc/foo.json", Content: []byte(doc)})
+	ents, _ := _res.Entities, _res.Relationships
 	got := false
 	for _, e := range ents {
 		if e.Kind == "SCOPE.Component" && e.Subtype == "cdc_connector" && e.Name == "foo" {
@@ -190,10 +192,7 @@ func TestDebeziumCDC_SniffGuardsOutNonDebezium(t *testing.T) {
 func TestDebeziumCDC_BareTableNameStripsSchema(t *testing.T) {
 	// Edges should target the bare table name so they align with the SQL
 	// extractor's canonical SCOPE.Datastore/table entity names.
-	ents, _ := applyDebeziumCDCEdges("json",
-		"services/cdc/orders-connector.json",
-		[]byte(debeziumPolyglotConnector), nil, nil,
-	)
+	ents := applyDebeziumCDCEdges(DetectorPassArgs{Lang: "json", Path: "services/cdc/orders-connector.json", Content: []byte(debeziumPolyglotConnector)}).Entities
 	for _, e := range ents {
 		if e.Kind != "SCOPE.Component" {
 			continue

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -383,23 +383,45 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		}
 	}
 
+	// Build the base args struct shared across all engine passes.
+	// Each pass reads the fields it needs; unused fields are ignored.
+	// Pass-specific fields (Pass1Entities, RepoRoot) are populated once here
+	// and forwarded opaquely — passes that don't need them pay no call-site
+	// cost. Entities and Relationships are updated after each pass via the
+	// returned DetectorPassResult. Refs #2446.
+	passArgs := DetectorPassArgs{
+		Ctx:           ctx,
+		Lang:          file.Language,
+		Path:          file.Path,
+		RepoRoot:      file.RepoRoot,
+		Content:       file.Content,
+		Pass1Entities: file.Pass1Entities,
+		Entities:      entities,
+		Relationships: relationships,
+	}
+
+	// applyPass is a tiny closure that applies a DetectorPassArgs→DetectorPassResult
+	// pass and threads the updated (entities, relationships) back into passArgs so
+	// the next pass sees the accumulated results.
+	applyPass := func(fn func(DetectorPassArgs) DetectorPassResult) {
+		res := fn(passArgs)
+		passArgs.Entities = res.Entities
+		passArgs.Relationships = res.Relationships
+	}
+
 	// Spring MVC AST pass: compose class-level @RequestMapping prefix with
 	// method-level verb annotations into a single Route. The YAML rules
 	// above can't see lexical scope, so they emit orphan Route:/api +
 	// Route:/orders pairs; this pass replaces them with Route:/api/orders.
 	// No-op for non-Java files. Refs #67.
-	entities, relationships = applySpringRouteComposition(
-		ctx, file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applySpringRouteComposition)
 
 	// Spring MVC AST pass for Kotlin: same prefix-composition logic as the
 	// Java pass above, but adapted for the Kotlin tree-sitter CST shape.
 	// Emits http_endpoint_definition entities directly (no intermediate Route
 	// layer) because there is no YAML rule layer for Kotlin Spring controllers.
 	// No-op for non-Kotlin files. Refs #1421.
-	entities, relationships = applySpringRouteCompositionKotlin(
-		ctx, file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applySpringRouteCompositionKotlin)
 
 	// Django REST Framework AST pass: compose the parent `path("api/",
 	// include(<router>.urls))` prefix with each `<router>.register("name",
@@ -407,9 +429,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// can't see the router-variable binding, so they emit orphan
 	// Route:api/ + Route:users pairs; this pass replaces them with
 	// Route:/api/users. No-op for non-Python files. Refs #64.
-	entities, relationships = applyDjangoRouteComposition(
-		ctx, file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyDjangoRouteComposition)
 
 	// Go HTTP route binding pass: rewrites YAML-emitted
 	// `Route:<path> -ROUTES_TO-> Controller:<receiverVar>` edges to point at
@@ -417,18 +437,14 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// chi, gin, echo, fiber, gorilla_mux — every framework whose YAML rule
 	// captures only the bare receiver identifier with `(\w+)`. Edits ToID
 	// only; never adds/removes entities. No-op for non-Go files. Refs #613.
-	entities, relationships = applyGoRouteComposition(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyGoRouteComposition)
 
 	// Synthetic http_endpoint emission for typed-HTTP cross-repo matching.
 	// Runs AFTER the Spring + Django composition passes so it can re-use
 	// the composed Route entities they emit. Appends new entities/edges
 	// only — never modifies or removes existing ones, so this pass cannot
 	// regress the surrounding pipeline's bug-rate. Refs #534.
-	entities, relationships = applyHTTPEndpointSynthesis(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyHTTPEndpointSynthesis)
 
 	// ORM QUERIES edge synthesis (#723): for every detectable ORM call
 	// site, emit a directed QUERIES edge from the enclosing function to
@@ -437,9 +453,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// entities emitted earlier. Append-only — never modifies existing
 	// entities or edges, so this pass cannot regress bug-rate on files
 	// without ORM calls.
-	entities, relationships = applyORMQueries(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyORMQueries)
 
 	// Django ORM field-access edges (#2279). Lifts the filter_keys
 	// property bag recorded on every QUERIES edge by the pass above
@@ -448,9 +462,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// the Python extractor. Runs AFTER applyORMQueries because it
 	// pivots off the QUERIES edges that pass emits. Append-only —
 	// cannot regress the surrounding pipeline's bug-rate.
-	relationships = applyORMFieldEdges(
-		file.Language, file.Path, file.Content, file.Pass1Entities, relationships,
-	)
+	applyPass(applyORMFieldEdges)
 
 	// Kafka producer/consumer cross-repo edges (wave 1 of #726). Emits
 	// synthetic MessageTopic entities + PUBLISHES_TO / SUBSCRIBES_TO edges
@@ -458,9 +470,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// topic IDs on both sides naturally link via the existing import-
 	// channel linker. Append-only — cannot regress the surrounding
 	// pipeline's bug-rate.
-	entities, relationships = applyKafkaEdges(
-		file.Language, file.Path, file.RepoRoot, file.Content, entities, relationships,
-	)
+	applyPass(applyKafkaEdges)
 
 	// Kafka wrapper + transport idiom detection (#1467). Extends topic
 	// extraction with four new families: Python KafkaBus wrapper
@@ -469,27 +479,21 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// publish (boto3, aws-sdk-java, aws-sdk-js, aws-sdk-go-v2). Emits
 	// MessageTopic entities + PUBLISHES_TO / SUBSCRIBES_TO edges.
 	// Append-only — cannot regress the surrounding pipeline's bug-rate.
-	entities, relationships = applyKafkaWrapperEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyKafkaWrapperEdges)
 
 	// RabbitMQ producer/consumer cross-repo edges (wave 2 of #726). Emits
 	// SCOPE.Queue entities + PUBLISHES_TO / SUBSCRIBES_TO edges for pika
 	// (Python), amqplib (Node), Spring AMQP / direct RabbitMQ client (Java),
 	// amqp091-go (Go), Quarkus RabbitMQ connector, and Celery with AMQP
 	// broker. Append-only — cannot regress the surrounding pipeline's bug-rate.
-	entities, relationships = applyRabbitMQEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyRabbitMQEdges)
 
 	// AWS SQS producer/consumer cross-repo edges (wave 2 of #726). Emits
 	// SCOPE.Queue entities + PUBLISHES_TO / SUBSCRIBES_TO edges for boto3
 	// (Python), aws-sdk v2/v3 (Node), aws-sdk-go-v2 (Go), AWS SDK v2
 	// (Java), and Lambda SQS triggers. Also detects SNS→SQS fanout.
 	// Append-only — cannot regress the surrounding pipeline's bug-rate.
-	entities, relationships = applySQSEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applySQSEdges)
 
 	// IaC-declared SNS → SQS fan-out edges (#1596). Reads SNS→SQS
 	// subscriptions declared in AWS CDK (TS), Terraform (HCL), and
@@ -498,9 +502,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// for the same topic name declared across different IaC tools collapse
 	// onto a single SNS topic node, surfacing the fan-out in /topology.
 	// Append-only — cannot regress the surrounding pipeline's bug-rate.
-	entities, relationships = applyIaCSNSEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyIaCSNSEdges)
 
 	// Debezium / Kafka-Connect CDC connector edges (#1708). Parses the
 	// JSON config of a CDC connector and emits a SCOPE.Component
@@ -513,27 +515,21 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// whose path the classifier narrowed to language="json" (cdc/,
 	// debezium/, kafka-connect/, *-connector.json, …), then content-
 	// sniffed for `connector.class` / `io.debezium`.
-	entities, relationships = applyDebeziumCDCEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyDebeziumCDCEdges)
 
 	// Google Cloud Pub/Sub producer/consumer cross-repo edges (wave 3 of #726).
 	// Emits SCOPE.Queue entities + PUBLISHES_TO / SUBSCRIBES_TO edges for
 	// google-cloud-pubsub (Python/Node/Go/Java), Pub/Sub Lite, and
 	// Eventarc / Cloud Run trigger consumers.
 	// Append-only — cannot regress the surrounding pipeline's bug-rate.
-	entities, relationships = applyPubSubEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyPubSubEdges)
 
 	// NATS producer/consumer cross-repo edges (wave 3 of #726). Emits
 	// SCOPE.Queue entities + PUBLISHES_TO / SUBSCRIBES_TO edges for
 	// nats.go / nats.js / nats.py / nats.java, JetStream, and NATS
 	// Streaming (STAN). Wildcard subjects and request/reply pattern tracked.
 	// Append-only — cannot regress the surrounding pipeline's bug-rate.
-	entities, relationships = applyNATSEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyNATSEdges)
 
 	// Apache Pulsar producer/consumer cross-repo edges (#936). Emits
 	// SCOPE.MessageTopic entities (broker=pulsar) + PUBLISHES_TO /
@@ -542,9 +538,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// canonicalised to the full persistent://tenant/namespace/topic URI so
 	// the cross-repo linker matches producer and consumer sides on the same
 	// entity ID. Append-only — cannot regress the surrounding pipeline.
-	entities, relationships = applyPulsarEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyPulsarEdges)
 
 	// #727: Real-time event channel synthesis. Three append-only passes
 	// for WebSocket, Server-Sent Events, and GraphQL subscriptions. Each
@@ -554,31 +548,21 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// edges. Same architectural shape as applyHTTPEndpointSynthesis: no
 	// existing entity or edge is touched, so these passes cannot regress
 	// the surrounding pipeline.
-	entities, relationships = applyWebSocketSynthesis(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
-	entities, relationships = applySSESynthesis(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
-	entities, relationships = applyGraphQLSubscriptionSynthesis(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyWebSocketSynthesis)
+	applyPass(applySSESynthesis)
+	applyPass(applyGraphQLSubscriptionSynthesis)
 	// #728: Scheduled-job entry-point detection. Emits SCOPE.ScheduledJob
 	// entities + TRIGGERS edges for every major scheduler framework across
 	// Python, Node, Java/Kotlin, Go; plus Kubernetes CronJob YAML and
 	// GitHub Actions schedule triggers (path-driven, not language-gated).
 	// Append-only — cannot regress surrounding passes.
-	entities, relationships = applyScheduledJobEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyScheduledJobEdges)
 	// #728: Webhook endpoint detection. Tags HTTP endpoints that verify
 	// inbound callbacks from external providers (Stripe, GitHub, Twilio,
 	// Slack, Mailgun, Svix, generic) with is_webhook=true +
 	// webhook_provider and emits SUBSCRIBES_TO edges to SCOPE.External
 	// entities. Append-only — cannot regress surrounding passes.
-	entities, relationships = applyWebhookEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyWebhookEdges)
 	// gRPC service definitions + client/server cross-repo edges (#725).
 	// Emits SCOPE.GrpcService + SCOPE.GrpcMethod entities and
 	// GRPC_IMPLEMENTS / GRPC_HANDLES edges for Java/Kotlin, Go, Python,
@@ -586,9 +570,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// entities keyed by `grpc:ServiceName/MethodName`; the import-channel
 	// linker joins them without any new linker code. Append-only — cannot
 	// regress surrounding passes.
-	entities, relationships = applyGRPCEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyGRPCEdges)
 	// Serverless function invocation edges (#925). Emits
 	// SCOPE.ServerlessFunction entities + CALLS / HANDLES edges for AWS Lambda
 	// (boto3, AWS SDK v2/v3, Go SDK v2, Java RequestHandler), Google Cloud
@@ -597,9 +579,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// the same provider-prefixed entity ID so the import-channel linker joins
 	// them without new linker code. Append-only — cannot regress surrounding passes.
 	// Lays groundwork for #927 EventBridge (Lambda synthetics as anchor targets).
-	entities, relationships = applyServerlessEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyServerlessEdges)
 	// Workflow orchestration edges (#934). Emits SCOPE.Workflow, SCOPE.Activity,
 	// and SCOPE.StateMachine entities plus STARTS_WORKFLOW, EXECUTES_ACTIVITY,
 	// and STEPFUNCTION_STEP_INVOKES edges for Temporal (Python, Go, Java, Node),
@@ -607,12 +587,8 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// CDK). Step Functions Task states referencing Lambda ARNs are linked to the
 	// SCOPE.ServerlessFunction entities emitted by #940 (serverless_edges.go)
 	// without new linker code. Append-only — cannot regress surrounding passes.
-	entities, relationships = applyWorkflowEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
-	entities, relationships = applySFNStartExecutionEdges(
-		file.Language, string(file.Content), file.Path, entities, relationships,
-	)
+	applyPass(applyWorkflowEdges)
+	applyPass(applySFNStartExecutionEdges)
 	// Redis pub/sub + Streams channel discovery (#930). Emits SCOPE.Queue
 	// entities keyed by channel:redis-pubsub:<name> or stream:redis:<name>,
 	// plus PUBLISHES_TO / SUBSCRIBES_TO edges. Covers Python (redis-py /
@@ -620,9 +596,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// (redis-rb). Non-pub/sub cache calls (GET/SET/etc.) are filtered out
 	// by the fast-path pre-filter gate. Append-only — cannot regress
 	// surrounding passes.
-	entities, relationships = applyRedisPubSubEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyRedisPubSubEdges)
 	// Managed event-bus edges (#927): AWS EventBridge, Azure EventGrid, and
 	// CNCF CloudEvents. Emits SCOPE.EventBusEvent synthetic entities plus
 	// PUBLISHES_TO / SUBSCRIBES_TO edges for producers/consumers, and
@@ -630,9 +604,11 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// rule-to-target linkage. EventBridge rule targets reference Lambda
 	// entity IDs from #925 (`aws-lambda:<name>`) without reinventing them.
 	// Append-only — cannot regress surrounding passes.
-	entities, relationships = applyEventBusEdges(
-		file.Language, file.Path, file.Content, entities, relationships,
-	)
+	applyPass(applyEventBusEdges)
+
+	// Extract final accumulated entities and relationships from passArgs.
+	entities = passArgs.Entities
+	relationships = passArgs.Relationships
 	// Django models-import suffix rewrite (PR #580 wave-10 Chain-fix A):
 	// The YAML rule `from \S+\.models import (\w+)` emits Model:<name>
 	// for every captured identifier. In Django/DRF projects, a sibling

--- a/internal/engine/django_routes.go
+++ b/internal/engine/django_routes.go
@@ -182,16 +182,15 @@ type composedDjangoRoutes struct {
 //  2. Per-file composed suppression: applied only when the file contains both
 //     include() and .register() calls (same-file composition). Replaces the
 //     bare Route entities with the AST-composed prefixed routes.
-func applyDjangoRouteComposition(
-	ctx context.Context,
-	lang string,
-	path string,
-	content []byte,
-	rawEntities []types.EntityRecord,
-	rawRels []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyDjangoRouteComposition(args DetectorPassArgs) DetectorPassResult {
+	ctx := args.Ctx
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	rawEntities := args.Entities
+	rawRels := args.Relationships
 	if lang != "python" || len(content) == 0 {
-		return rawEntities, rawRels
+		return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 	}
 
 	// Phase 1 — global cross-file suppression (#1278): drop bare YAML Route
@@ -212,12 +211,12 @@ func applyDjangoRouteComposition(
 	// Cheap pre-filter: a DRF-composing urls.py has at minimum a `path(`
 	// and an `include(` somewhere, plus a `.register(` for the router.
 	if !bytesContainsAll(content, "path(", "include(", ".register(") {
-		return rawEntities, rawRels
+		return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 	}
 
 	composed, ok := extractDjangoComposedRoutes(ctx, path, content)
 	if !ok || len(composed.entities) == 0 {
-		return rawEntities, rawRels
+		return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 	}
 
 	// Drop YAML Route entities whose Name matches a claimed register name
@@ -283,7 +282,7 @@ func applyDjangoRouteComposition(
 	}
 	filteredRels = append(filteredRels, composed.relationships...)
 
-	return filteredEntities, filteredRels
+	return DetectorPassResult{Entities: filteredEntities, Relationships: filteredRels}
 }
 
 // suppressedEntities bundles filtered entity + relationship slices.

--- a/internal/engine/etl_pipeline_1638_test.go
+++ b/internal/engine/etl_pipeline_1638_test.go
@@ -20,9 +20,7 @@ import (
 const etlFixtureDir = "/Users/jorgecajas/Documents/Projects/polyglot-platform/data-pipeline/etl"
 
 // brokerPass is the shared signature of every per-file broker synthesis pass.
-type brokerPass func(lang, path string, content []byte,
-	ents []types.EntityRecord, rels []types.RelationshipRecord) (
-	[]types.EntityRecord, []types.RelationshipRecord)
+type brokerPass func(args DetectorPassArgs) DetectorPassResult
 
 // allBrokerPasses runs every broker pass over a file and returns the union of
 // emitted entities + relationships, mirroring detector.go's pass ordering.
@@ -41,7 +39,8 @@ func allBrokerPasses(t *testing.T, path string) ([]types.EntityRecord, []types.R
 		applyPubSubEdges,
 		applyRedisPubSubEdges,
 	} {
-		ents, rels = pass("python", path, content, ents, rels)
+		res := pass(DetectorPassArgs{Lang: "python", Path: path, Content: content, Entities: ents, Relationships: rels})
+		ents, rels = res.Entities, res.Relationships
 	}
 	return ents, rels
 }

--- a/internal/engine/event_bus_edges.go
+++ b/internal/engine/event_bus_edges.go
@@ -87,18 +87,17 @@ func eventBusSynthesisSupportsLanguage(lang string) bool {
 // applyEventBusEdges is the single entry-point pass that runs after
 // applyRedisPubSubEdges. It dispatches to three sub-detectors and is
 // append-only.
-func applyEventBusEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyEventBusEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !eventBusSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -155,7 +154,7 @@ func applyEventBusEdges(
 	applyEventGridEdges(lang, src, path, emitEvent, emitEdge)
 	applyCloudEventEdges(lang, src, path, emitEvent, emitEdge)
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // eventBridgeEventID returns the canonical synthetic ID for an EventBridge

--- a/internal/engine/event_bus_edges_test.go
+++ b/internal/engine/event_bus_edges_test.go
@@ -45,7 +45,8 @@ import (
 
 func runEventBusDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	t.Helper()
-	return applyEventBusEdges(lang, path, []byte(src), nil, nil)
+	res := applyEventBusEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 func eventBusEntityByID(ents []types.EntityRecord, id string) *types.EntityRecord {
@@ -503,7 +504,8 @@ def handle(req):
 }
 
 func TestEventBusEdgesEmptyContent(t *testing.T) {
-	ents, rels := applyEventBusEdges("python", "file.py", nil, nil, nil)
+	_res := applyEventBusEdges(DetectorPassArgs{Lang: "python", Path: "file.py", Content: nil})
+	ents, rels := _res.Entities, _res.Relationships
 	if len(ents) != 0 || len(rels) != 0 {
 		t.Errorf("empty content should be a no-op; ents=%v rels=%v", entNames(ents), relSummary(rels))
 	}

--- a/internal/engine/go_routes.go
+++ b/internal/engine/go_routes.go
@@ -41,8 +41,6 @@ import (
 	"go/parser"
 	"go/token"
 	"strings"
-
-	"github.com/cajasmota/archigraph/internal/types"
 )
 
 // goHTTPVerbs is the union of method names used by the supported Go HTTP
@@ -68,15 +66,14 @@ var goHTTPVerbs = map[string]bool{
 // Non-Go files are returned unchanged. The pass never adds or removes
 // entities and never adds new relationships — it only edits the `ToID` of
 // existing ROUTES_TO records, so it cannot regress the surrounding pipeline.
-func applyGoRouteComposition(
-	lang string,
-	path string,
-	content []byte,
-	rawEntities []types.EntityRecord,
-	rawRels []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyGoRouteComposition(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	rawEntities := args.Entities
+	rawRels := args.Relationships
 	if lang != "go" || len(content) == 0 {
-		return rawEntities, rawRels
+		return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 	}
 	// Cheap pre-filter: skip files that obviously don't register HTTP routes.
 	if !bytesContainsAny(content,
@@ -84,12 +81,12 @@ func applyGoRouteComposition(
 		".GET(", ".POST(", ".PUT(", ".PATCH(", ".DELETE(",
 		".Handle(", ".HandleFunc(", ".Any(", ".All(",
 	) {
-		return rawEntities, rawRels
+		return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 	}
 
 	bindings := extractGoHandlerBindings(path, content)
 	if len(bindings) == 0 {
-		return rawEntities, rawRels
+		return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 	}
 
 	// Build a lookup keyed by `(path, receiverVar)` -> qualified method name.
@@ -145,7 +142,7 @@ func applyGoRouteComposition(
 		rawRels[i] = newRel
 	}
 
-	return rawEntities, rawRels
+	return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 }
 
 // goHandlerBinding pairs a router call site with the qualified method name

--- a/internal/engine/go_routes_test.go
+++ b/internal/engine/go_routes_test.go
@@ -35,7 +35,8 @@ func main() {
 		makeRoutesToRel("/users", "h"),
 		makeRoutesToRel("/users/{id}", "h"),
 	}
-	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 
 	if got[0].ToID != "Controller:UsersHandler.List" {
 		t.Errorf("ToID[0] = %q, want Controller:UsersHandler.List", got[0].ToID)
@@ -66,7 +67,8 @@ func main() {
 	rels := []types.RelationshipRecord{
 		makeRoutesToRel("/users", "h"),
 	}
-	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 	if got[0].ToID != "Controller:UsersHandler.List" {
 		t.Errorf("ToID = %q, want Controller:UsersHandler.List", got[0].ToID)
 	}
@@ -86,7 +88,8 @@ func main() {
 		makeRoutesToRel("/users", "h"),
 		makeRoutesToRel("/teams", "h"),
 	}
-	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 	if got[0].ToID != "Controller:UserAPI.List" {
 		t.Errorf("ToID[0] = %q, want Controller:UserAPI.List", got[0].ToID)
 	}
@@ -107,7 +110,8 @@ func main() {
 	rels := []types.RelationshipRecord{
 		makeRoutesToRel("/users", "h"),
 	}
-	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 	if got[0].ToID != "Controller:UsersHandler.List" {
 		t.Errorf("ToID = %q, want Controller:UsersHandler.List", got[0].ToID)
 	}
@@ -125,7 +129,8 @@ func register() {
 	rels := []types.RelationshipRecord{
 		makeRoutesToRel("/users", "h"),
 	}
-	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 	if got[0].ToID != "Controller:h" {
 		t.Errorf("ToID = %q, want unchanged Controller:h", got[0].ToID)
 	}
@@ -151,7 +156,8 @@ func main() {
 	rels := []types.RelationshipRecord{
 		makeRoutesToRel("/users", "listUsers"),
 	}
-	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 	if got[0].ToID != "Controller:listUsers" {
 		t.Errorf("ToID = %q, want unchanged Controller:listUsers", got[0].ToID)
 	}
@@ -162,7 +168,8 @@ func TestApplyGoRouteComposition_NonGoNoop(t *testing.T) {
 	rels := []types.RelationshipRecord{
 		makeRoutesToRel("/users", "h"),
 	}
-	_, got := applyGoRouteComposition("python", "main.py", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "python", Path: "main.py", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 	if got[0].ToID != "Controller:h" {
 		t.Errorf("python file mutated: %q", got[0].ToID)
 	}
@@ -185,7 +192,8 @@ func main() {
 		},
 		makeRoutesToRel("/users", "h"),
 	}
-	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 	if got[0].ToID != "Controller:h" {
 		t.Errorf("non-ROUTES_TO edge mutated: %q", got[0].ToID)
 	}
@@ -211,7 +219,8 @@ func main() {
 			Properties: map[string]string{"pattern_type": "yaml_driven"},
 		},
 	}
-	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 	if got[0].ToID != "Controller:Existing.Qualified" {
 		t.Errorf("already-qualified ToID mutated: %q", got[0].ToID)
 	}
@@ -228,7 +237,8 @@ func main() {
 	rels := []types.RelationshipRecord{
 		makeRoutesToRel("/users", "h"),
 	}
-	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
 	if got[0].ToID != "Controller:h" {
 		t.Errorf("ToID = %q, want unchanged Controller:h", got[0].ToID)
 	}

--- a/internal/engine/graphql_subscriptions.go
+++ b/internal/engine/graphql_subscriptions.go
@@ -48,15 +48,14 @@ const graphqlSubscriptionKind = "Subscription"
 const graphqlSubscriptionIDPrefix = "graphql_sub:"
 
 // applyGraphQLSubscriptionSynthesis runs per-file. Append-only.
-func applyGraphQLSubscriptionSynthesis(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyGraphQLSubscriptionSynthesis(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	src := string(content)
 
@@ -119,7 +118,7 @@ func applyGraphQLSubscriptionSynthesis(
 	synthGraphQLResolvers(src, path, lang, emitSub, emitEdge)
 	synthGraphQLClientSubscriptions(src, path, lang, emitSub, emitEdge)
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/grpc_edges.go
+++ b/internal/engine/grpc_edges.go
@@ -109,18 +109,17 @@ func grpcSynthesisSupportsLanguage(lang string) bool {
 // applyGRPCEdges runs as an append-only pass after the HTTP synthesis pass.
 // It emits GrpcService + GrpcMethod entities and GRPC_IMPLEMENTS /
 // GRPC_HANDLES edges. It never modifies or removes existing entities or edges.
-func applyGRPCEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyGRPCEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !grpcSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -243,7 +242,7 @@ func applyGRPCEdges(
 		synthesizeNodeGRPC(src, path, emitService, emitMethod, emitImplementsEdge, emitHandlesEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/grpc_edges_test.go
+++ b/internal/engine/grpc_edges_test.go
@@ -27,7 +27,8 @@ import (
 // used by runKafkaDetect in kafka_edges_test.go.
 func runGRPCDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	t.Helper()
-	return applyGRPCEdges(lang, path, []byte(src), nil, nil)
+	res := applyGRPCEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 // grpcEntitiesOfKind returns all entities with the given Kind.

--- a/internal/engine/http_endpoint_php_client_1490_test.go
+++ b/internal/engine/http_endpoint_php_client_1490_test.go
@@ -297,15 +297,15 @@ class GenerateInvoicePdf
 
 	// --- Step 1: Run synthesis on both files ---
 	// Synthesize entities and relationships for InvoiceController.
-	icEntities, _ := applyHTTPEndpointSynthesis(
-		"php", "app/Http/Controllers/InvoiceController.php",
-		[]byte(invoiceControllerSrc), nil, nil,
-	)
+	icEntities := applyHTTPEndpointSynthesis(DetectorPassArgs{
+		Lang: "php", Path: "app/Http/Controllers/InvoiceController.php",
+		Content: []byte(invoiceControllerSrc),
+	}).Entities
 	// Synthesize entities and relationships for GenerateInvoicePdf.
-	pdfEntities, _ := applyHTTPEndpointSynthesis(
-		"php", "app/Jobs/GenerateInvoicePdf.php",
-		[]byte(generateInvoicePdfSrc), nil, nil,
-	)
+	pdfEntities := applyHTTPEndpointSynthesis(DetectorPassArgs{
+		Lang: "php", Path: "app/Jobs/GenerateInvoicePdf.php",
+		Content: []byte(generateInvoicePdfSrc),
+	}).Entities
 
 	// --- Step 2: Build a merged entity table that includes the PHP
 	// tree-sitter extractor entities (class-qualified SCOPE.Operation names).

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -129,15 +129,14 @@ func synthesisSupportsLanguage(lang string) bool {
 //
 // `lang` lets the pass no-op cleanly for files that don't contain any of
 // the supported frameworks.
-func applyHTTPEndpointSynthesis(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	// Dedup-by-ID across all per-language emitters: a single endpoint can
@@ -368,7 +367,7 @@ func applyHTTPEndpointSynthesis(
 	// entities, so it cannot regress the bug-rate of upstream passes.
 	applyResponseShapes(lang, content, entities)
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/iac_sns_edges.go
+++ b/internal/engine/iac_sns_edges.go
@@ -67,25 +67,23 @@ func iacSNSSupportsLanguage(lang string) bool {
 
 // applyIaCSNSEdges is the entry point. Runs after applySQSEdges and is
 // append-only.
-func applyIaCSNSEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyIaCSNSEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !iacSNSSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
 	// Cheap guard: file must mention SNS and a subscription idiom.
 	if !strings.Contains(src, "sns") && !strings.Contains(src, "SNS") &&
 		!strings.Contains(src, "Sns") {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	seenEnt := map[string]bool{}
@@ -173,7 +171,7 @@ func applyIaCSNSEdges(
 		applyCloudFormationSNSSubscriptions(src, emitSubscription)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/iac_sns_edges_test.go
+++ b/internal/engine/iac_sns_edges_test.go
@@ -30,7 +30,8 @@ const orderEvents = new sns.Topic(this, "OrderEvents", { topicName: "order-event
 const analyticsQueue = new sqs.Queue(this, "AQ", { queueName: "order-events-analytics" });
 orderEvents.addSubscription(new SqsSubscription(analyticsQueue));
 `
-	_, rels := applyIaCSNSEdges("typescript", "infra/cdk/lib/stack.ts", []byte(src), nil, nil)
+	_res := applyIaCSNSEdges(DetectorPassArgs{Lang: "typescript", Path: "infra/cdk/lib/stack.ts", Content: []byte(src)})
+	_, rels := _res.Entities, _res.Relationships
 	n, tools := countSNSSubscribers(rels, snsTopicID("order-events"))
 	if n != 1 {
 		t.Fatalf("CDK: want 1 subscriber, got %d (%+v)", n, rels)
@@ -51,7 +52,8 @@ resource "aws_sns_topic_subscription" "order_events_audit" {
   endpoint  = aws_sqs_queue.order_events_audit.arn
 }
 `
-	_, rels := applyIaCSNSEdges("terraform", "infra/terraform/order-events.tf", []byte(src), nil, nil)
+	_res := applyIaCSNSEdges(DetectorPassArgs{Lang: "terraform", Path: "infra/terraform/order-events.tf", Content: []byte(src)})
+	_, rels := _res.Entities, _res.Relationships
 	n, tools := countSNSSubscribers(rels, snsTopicID("order-events"))
 	if n != 1 {
 		t.Fatalf("TF: want 1 subscriber, got %d (%+v)", n, rels)
@@ -79,7 +81,8 @@ Resources:
       Protocol: sqs
       Endpoint: !GetAtt OrderEventsFraudQueue.Arn
 `
-	_, rels := applyIaCSNSEdges("yaml", "infra/cloudformation/order-events-fanout.yaml", []byte(src), nil, nil)
+	_res := applyIaCSNSEdges(DetectorPassArgs{Lang: "yaml", Path: "infra/cloudformation/order-events-fanout.yaml", Content: []byte(src)})
+	_, rels := _res.Entities, _res.Relationships
 	n, tools := countSNSSubscribers(rels, snsTopicID("order-events"))
 	if n != 1 {
 		t.Fatalf("CFN: want 1 subscriber, got %d (%+v)", n, rels)
@@ -116,9 +119,13 @@ resource "aws_sns_topic_subscription" "a" {
 
 	var ents []types.EntityRecord
 	var rels []types.RelationshipRecord
-	ents, rels = applyIaCSNSEdges("typescript", "stack.ts", []byte(cdk), ents, rels)
-	ents, rels = applyIaCSNSEdges("terraform", "x.tf", []byte(tf), ents, rels)
-	ents, rels = applyIaCSNSEdges("yaml", "x.yaml", []byte(cfn), ents, rels)
+	var _res DetectorPassResult
+	_res = applyIaCSNSEdges(DetectorPassArgs{Lang: "typescript", Path: "stack.ts", Content: []byte(cdk), Entities: ents, Relationships: rels})
+	ents, rels = _res.Entities, _res.Relationships
+	_res = applyIaCSNSEdges(DetectorPassArgs{Lang: "terraform", Path: "x.tf", Content: []byte(tf), Entities: ents, Relationships: rels})
+	ents, rels = _res.Entities, _res.Relationships
+	_res = applyIaCSNSEdges(DetectorPassArgs{Lang: "yaml", Path: "x.yaml", Content: []byte(cfn), Entities: ents, Relationships: rels})
+	ents, rels = _res.Entities, _res.Relationships
 
 	n, tools := countSNSSubscribers(rels, snsTopicID("order-events"))
 	if n != 3 {

--- a/internal/engine/kafka_edges.go
+++ b/internal/engine/kafka_edges.go
@@ -69,19 +69,18 @@ func kafkaSynthesisSupportsLanguage(lang string) bool {
 // MessageTopic entities + PUBLISHES_TO / SUBSCRIBES_TO / TRANSFORMS edges.
 // It never modifies or removes existing entities or edges, so it cannot
 // regress the bug-rate of the surrounding pipeline.
-func applyKafkaEdges(
-	lang string,
-	path string,
-	repoRoot string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyKafkaEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	repoRoot := args.RepoRoot
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !kafkaSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -183,7 +182,7 @@ func applyKafkaEdges(
 		synthesizePHPRdKafka(src, emitTopic, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/kafka_edges_test.go
+++ b/internal/engine/kafka_edges_test.go
@@ -28,8 +28,8 @@ func runKafkaDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord,
 	// repoRoot empty: tests that need Quarkus channel resolution pass an
 	// absolute path so the upward walk finds application.properties on its
 	// own; in-memory tests use repo-relative paths and skip resolution.
-	ents, rels := applyKafkaEdges(lang, path, "", []byte(src), nil, nil)
-	return ents, rels
+	res := applyKafkaEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 // topicByName returns the first MessageTopic with the given topic_name

--- a/internal/engine/kafka_wrapper_edges.go
+++ b/internal/engine/kafka_wrapper_edges.go
@@ -62,18 +62,16 @@ func kafkaWrapperSynthesisSupportsLanguage(lang string) bool {
 // applyKafkaWrapperEdges runs after applyKafkaEdges and APPENDS MessageTopic
 // entities + PUBLISHES_TO / SUBSCRIBES_TO edges for the idioms listed above.
 // It never modifies or removes existing entities or edges.
-func applyKafkaWrapperEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyKafkaWrapperEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !kafkaWrapperSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -152,7 +150,7 @@ func applyKafkaWrapperEdges(
 		synthesizeGoSNSPublish(src, emitTopic, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/kafka_wrapper_edges_test.go
+++ b/internal/engine/kafka_wrapper_edges_test.go
@@ -15,7 +15,8 @@ import (
 // runWrapperDetect is the parallel to runKafkaDetect for the wrapper pass.
 func runWrapperDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	t.Helper()
-	return applyKafkaWrapperEdges(lang, path, []byte(src), nil, nil)
+	res := applyKafkaWrapperEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 // ---------------------------------------------------------------------------
@@ -551,7 +552,8 @@ public class NotificationService {
     }
 }
 `
-	ents, rels := applyRedisPubSubEdges("java", "notifications/NotificationService.java", []byte(src), nil, nil)
+	_res := applyRedisPubSubEdges(DetectorPassArgs{Lang: "java", Path: "notifications/NotificationService.java", Content: []byte(src)})
+	ents, rels := _res.Entities, _res.Relationships
 
 	wantID := "channel:redis-pubsub:notifications.channel"
 	var found *types.EntityRecord

--- a/internal/engine/nats_edges.go
+++ b/internal/engine/nats_edges.go
@@ -57,18 +57,16 @@ func natsSynthesisSupportsLanguage(lang string) bool {
 // entities + PUBLISHES_TO / SUBSCRIBES_TO edges for NATS.
 // Append-only — never modifies or removes existing entities or edges, so
 // this pass cannot regress the surrounding pipeline's bug-rate.
-func applyNATSEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyNATSEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !natsSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -143,7 +141,7 @@ func applyNATSEdges(
 		synthesizeGoNATS(src, emitSubject, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // natsSubjectID returns the canonical synthetic ID for a NATS subject.

--- a/internal/engine/orm_field_edges.go
+++ b/internal/engine/orm_field_edges.go
@@ -69,18 +69,18 @@ const ormFieldEdgesPatternType = "orm_field_edges"
 // `lang` is currently honoured only for "python" — Django ORM is the
 // Phase A scope. Other languages no-op cleanly; Phase B will extend
 // the pass to JS/TS Prisma, Java JPA, etc.
-func applyORMFieldEdges(
-	lang string,
-	path string,
-	content []byte,
-	pass1Entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) []types.RelationshipRecord {
+func applyORMFieldEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	pass1Entities := args.Pass1Entities
+	entities := args.Entities
+	relationships := args.Relationships
 	if lang != "python" {
-		return relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if len(content) == 0 {
-		return relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	// Build a per-(model,field) index for THIS file.
@@ -101,7 +101,7 @@ func applyORMFieldEdges(
 		fieldIdx = BuildFieldIndex(string(content))
 	}
 	if len(fieldIdx) == 0 {
-		return relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	_ = plumbed // reserved for future telemetry / debug hooks
 
@@ -153,7 +153,7 @@ func applyORMFieldEdges(
 		}
 	}
 
-	return relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // djangoChainAnchorRe matches the start of every Django ORM queryset

--- a/internal/engine/orm_queries.go
+++ b/internal/engine/orm_queries.go
@@ -80,18 +80,17 @@ const ormQueriesPatternType = "orm_queries"
 // patterns aren't recognised yet (phase-1 deferred languages: Kotlin
 // Exposed/Ktorm, PHP Eloquent/Doctrine, Rust Diesel/SeaORM, C# Entity
 // Framework — file a phase-2 follow-up).
-func applyORMQueries(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !ormQueriesSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -149,7 +148,7 @@ func applyORMQueries(
 		scanRubyORM(src, funcs, emit)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ormQueriesSupportsLanguage reports whether applyORMQueries has at least

--- a/internal/engine/pass_args.go
+++ b/internal/engine/pass_args.go
@@ -1,0 +1,84 @@
+// Package engine — shared arg/result types for engine detector passes.
+//
+// Every pass called from detector.go's Detect method is refactored to accept
+// DetectorPassArgs and return DetectorPassResult.  The structs carry the full
+// set of inputs any pass may need; passes that don't use a field simply ignore
+// it.  This eliminates the previous ad-hoc positional signatures and fixes the
+// asymmetry introduced by PR #2444 (#2430), where applyORMFieldEdges was the
+// only pass that returned bare relationships instead of (entities, relationships).
+//
+// Fields:
+//
+//   - Ctx           — context for passes that spawn spans or do I/O (Spring,
+//     Django route composition).
+//   - Lang          — file language tag ("python", "go", "java", …).
+//   - Path          — repo-relative file path.
+//   - RepoRoot      — absolute filesystem path of the repo root (Kafka edges).
+//   - Content       — raw file bytes.
+//   - Pass1Entities — side-channel with Pass 1 per-file entities (ORM field
+//     edges, see #2352).
+//   - Entities      — entities accumulated so far in the Detect pipeline.
+//   - Relationships — relationships accumulated so far in the Detect pipeline.
+//
+// Refs #2446.
+package engine
+
+import (
+	"context"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// DetectorPassArgs is the single struct-of-args passed to every engine pass
+// called from detector.go's Detect method.
+type DetectorPassArgs struct {
+	// Ctx is the context forwarded from Detect; used by passes that start
+	// OpenTelemetry spans or perform I/O (e.g. Spring/Django route composition).
+	Ctx context.Context
+
+	// Lang is the file's language tag (e.g. "python", "go", "java", "kotlin").
+	Lang string
+
+	// Path is the repo-relative file path.
+	Path string
+
+	// RepoRoot is the absolute filesystem path of the repository root.
+	// Only populated when the Kafka edge pass (or future passes with the same
+	// need) requires it; zero value ("") is safe for all other passes.
+	RepoRoot string
+
+	// Content is the raw file bytes.
+	Content []byte
+
+	// Pass1Entities is the side-channel plumbed in from Pass 1 of the
+	// indexing pipeline.  The ORM field-edges pass uses it to resolve
+	// SCOPE.Schema(subtype=field) entities without a regex re-scan.
+	// Other passes ignore it.
+	Pass1Entities []types.EntityRecord
+
+	// Entities holds the entity slice accumulated so far in the Detect
+	// pipeline.  Passes that emit or modify entities receive this as input
+	// and include their additions in DetectorPassResult.Entities.
+	Entities []types.EntityRecord
+
+	// Relationships holds the relationship slice accumulated so far in the
+	// Detect pipeline.  All passes may append to this and return the grown
+	// slice in DetectorPassResult.Relationships.
+	Relationships []types.RelationshipRecord
+}
+
+// DetectorPassResult is the uniform return type of every engine pass called
+// from detector.go's Detect method.
+//
+// Passes that don't modify the entity slice pass Entities through unchanged.
+// Passes that previously returned only relationships (applyORMFieldEdges) now
+// also return the Entities slice unmodified, restoring the symmetry broken by
+// PR #2444 (#2430).
+type DetectorPassResult struct {
+	// Entities is the (possibly extended) entity slice after the pass ran.
+	Entities []types.EntityRecord
+
+	// Relationships is the (possibly extended) relationship slice after the
+	// pass ran.
+	Relationships []types.RelationshipRecord
+}

--- a/internal/engine/pubsub_edges.go
+++ b/internal/engine/pubsub_edges.go
@@ -60,18 +60,16 @@ func pubsubSynthesisSupportsLanguage(lang string) bool {
 // entities + PUBLISHES_TO / SUBSCRIBES_TO edges for Google Cloud Pub/Sub.
 // Append-only — never modifies or removes existing entities or edges, so
 // this pass cannot regress the surrounding pipeline's bug-rate.
-func applyPubSubEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyPubSubEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !pubsubSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -150,7 +148,7 @@ func applyPubSubEdges(
 		synthesizeGoPubSub(src, emitTopic, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // pubsubTopicID returns the canonical synthetic ID for a Pub/Sub topic.

--- a/internal/engine/pulsar_edges.go
+++ b/internal/engine/pulsar_edges.go
@@ -123,18 +123,16 @@ func pulsarSynthesisSupportsLanguage(lang string) bool {
 // applyPulsarEdges runs after applyNATSEdges and APPENDS synthetic
 // SCOPE.MessageTopic entities + PUBLISHES_TO / SUBSCRIBES_TO edges for
 // Apache Pulsar. Append-only — never touches existing entities or edges.
-func applyPulsarEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyPulsarEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !pulsarSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -196,7 +194,7 @@ func applyPulsarEdges(
 		synthesizeNodePulsar(src, emitTopic, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/rabbitmq_edges.go
+++ b/internal/engine/rabbitmq_edges.go
@@ -54,18 +54,16 @@ func rabbitmqSynthesisSupportsLanguage(lang string) bool {
 // entities + PUBLISHES_TO / SUBSCRIBES_TO edges. Append-only — never
 // modifies or removes existing entities or edges, so this pass cannot
 // regress the surrounding pipeline's bug-rate.
-func applyRabbitMQEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyRabbitMQEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !rabbitmqSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -148,7 +146,7 @@ func applyRabbitMQEdges(
 		synthesizeGoRabbitMQ(src, emitQueue, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // rabbitmqQueueID returns the canonical synthetic ID for a RabbitMQ queue.

--- a/internal/engine/redis_pubsub_edges.go
+++ b/internal/engine/redis_pubsub_edges.go
@@ -93,18 +93,16 @@ func redisPubSubSynthesisSupportsLanguage(lang string) bool {
 // entities + PUBLISHES_TO / SUBSCRIBES_TO edges for Redis pub/sub and Streams.
 // Append-only — never modifies or removes existing entities or edges, so this
 // pass cannot regress the surrounding pipeline's bug-rate.
-func applyRedisPubSubEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyRedisPubSubEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !redisPubSubSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -137,7 +135,7 @@ func applyRedisPubSubEdges(
 	hasChannelTopic := (strings.Contains(src, "ChannelTopic") || strings.Contains(src, "PatternTopic") ||
 		strings.Contains(src, "MessageListenerAdapter")) && hasRedis
 	if !hasPubSub && !hasXadd && !hasXread && !hasConvertAndSend && !hasChannelTopic {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	// Dedup-by-ID: one entity per channel/stream per file; one edge per
@@ -217,7 +215,7 @@ func applyRedisPubSubEdges(
 		synthesizeElixirRedisPubSub(src, emitChannel, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // redisPubSubChannelID returns the canonical synthetic ID for a Redis pub/sub

--- a/internal/engine/scheduled_jobs_edges.go
+++ b/internal/engine/scheduled_jobs_edges.go
@@ -50,15 +50,14 @@ const triggersEdgeKind = "TRIGGERS"
 // applyScheduledJobEdges is the per-file entry point. Appends
 // SCOPE.ScheduledJob entities + TRIGGERS edges; never modifies or removes
 // existing entities or edges. Language dispatches to per-framework helpers.
-func applyScheduledJobEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyScheduledJobEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	src := string(content)
 
@@ -136,7 +135,7 @@ func applyScheduledJobEdges(
 		synthesizeGitHubActionsSchedule(src, path, emitJob)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/serverless_edges.go
+++ b/internal/engine/serverless_edges.go
@@ -96,18 +96,17 @@ func serverlessSynthesisSupportsLanguage(lang string) bool {
 // applyServerlessEdges runs as an append-only pass after the gRPC edges pass.
 // It scans source files for Lambda/GCF/Azure invocation and handler patterns,
 // emitting SCOPE.ServerlessFunction entities plus CALLS and HANDLES edges.
-func applyServerlessEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyServerlessEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !serverlessSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -212,7 +211,7 @@ func applyServerlessEdges(
 		synthesizeCSharpServerless(src, path, emitFn, emitCalls, emitHandles)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // lambdaFunctionID returns the canonical synthetic ID for an AWS Lambda function.

--- a/internal/engine/serverless_edges_test.go
+++ b/internal/engine/serverless_edges_test.go
@@ -30,7 +30,8 @@ import (
 
 func runServerlessDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	t.Helper()
-	return applyServerlessEdges(lang, path, []byte(src), nil, nil)
+	res := applyServerlessEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 func serverlessFnByID(ents []types.EntityRecord, id string) *types.EntityRecord {

--- a/internal/engine/spring_routes.go
+++ b/internal/engine/spring_routes.go
@@ -75,24 +75,23 @@ type composedSpringRoutes struct {
 // dropping the now-redundant flat Routes and orphan class-level Route.
 //
 // `lang` lets the engine no-op cleanly for non-Java files.
-func applySpringRouteComposition(
-	ctx context.Context,
-	lang string,
-	path string,
-	content []byte,
-	rawEntities []types.EntityRecord,
-	rawRels []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applySpringRouteComposition(args DetectorPassArgs) DetectorPassResult {
+	ctx := args.Ctx
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	rawEntities := args.Entities
+	rawRels := args.Relationships
 	if lang != "java" || len(content) == 0 {
-		return rawEntities, rawRels
+		return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 	}
 	if !bytesContainsAny(content, "@RestController", "@Controller") {
-		return rawEntities, rawRels
+		return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 	}
 
 	composed, ok := extractSpringComposedRoutes(ctx, path, content)
 	if !ok || len(composed.entities) == 0 {
-		return rawEntities, rawRels
+		return DetectorPassResult{Entities: rawEntities, Relationships: rawRels}
 	}
 
 	// Drop YAML Route entities whose Name matches a claimed bare method path
@@ -124,7 +123,7 @@ func applySpringRouteComposition(
 	}
 	filteredRels = append(filteredRels, composed.relationships...)
 
-	return filteredEntities, filteredRels
+	return DetectorPassResult{Entities: filteredEntities, Relationships: filteredRels}
 }
 
 // bytesContainsAny is a cheap pre-filter to avoid parsing files that

--- a/internal/engine/spring_routes_kotlin.go
+++ b/internal/engine/spring_routes_kotlin.go
@@ -41,25 +41,24 @@ import (
 // rule layer for Kotlin Spring controllers.
 //
 // Returns new entities and relationships appended to the inputs.
-func applySpringRouteCompositionKotlin(
-	ctx context.Context,
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applySpringRouteCompositionKotlin(args DetectorPassArgs) DetectorPassResult {
+	ctx := args.Ctx
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if lang != "kotlin" || len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !bytesContainsAny(content, "@RestController", "@Controller") {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	newEntities, newRels := extractKotlinSpringEndpoints(ctx, path, content)
 	entities = append(entities, newEntities...)
 	relationships = append(relationships, newRels...)
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // extractKotlinSpringEndpoints parses the Kotlin source with tree-sitter and

--- a/internal/engine/sqs_edges.go
+++ b/internal/engine/sqs_edges.go
@@ -47,18 +47,16 @@ func sqsSynthesisSupportsLanguage(lang string) bool {
 // entities + PUBLISHES_TO / SUBSCRIBES_TO edges. Append-only — never
 // modifies or removes existing entities or edges, so this pass cannot
 // regress the surrounding pipeline's bug-rate.
-func applySQSEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applySQSEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	if !sqsSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -133,7 +131,7 @@ func applySQSEdges(
 		synthesizeGoSQS(src, emitQueue, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // sqsQueueID returns the canonical synthetic ID for an SQS queue.

--- a/internal/engine/sse_edges.go
+++ b/internal/engine/sse_edges.go
@@ -47,15 +47,14 @@ const streamKind = "Stream"
 const streamIDPrefix = "sse:"
 
 // applySSESynthesis runs per-file. Append-only.
-func applySSESynthesis(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applySSESynthesis(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	src := string(content)
 
@@ -116,7 +115,7 @@ func applySSESynthesis(
 		synthSSEQuarkusProduces(src, path, emitStream, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/webhooks_edges.go
+++ b/internal/engine/webhooks_edges.go
@@ -47,15 +47,14 @@ const webhookExternalKind = "SCOPE.External"
 
 // applyWebhookEdges is the per-file entry point. Appends is_webhook-tagged
 // entities + SUBSCRIBES_TO edges; never modifies existing ones.
-func applyWebhookEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyWebhookEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	src := string(content)
 
@@ -129,7 +128,7 @@ func applyWebhookEdges(
 		synthesizeRubyWebhooks(src, path, emitWebhook)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/websocket_edges.go
+++ b/internal/engine/websocket_edges.go
@@ -91,15 +91,14 @@ const channelIDPrefix = "ws:"
 // applyWebSocketSynthesis is the per-file entry point. Appends entities
 // + edges; never modifies or removes existing ones. No-op for content
 // that contains none of the per-framework anchors.
-func applyWebSocketSynthesis(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyWebSocketSynthesis(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 	src := string(content)
 
@@ -165,7 +164,7 @@ func applyWebSocketSynthesis(
 		synthAspNetWebSocket(src, path, emitChannel, emitEdge)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/workflow_edges.go
+++ b/internal/engine/workflow_edges.go
@@ -134,15 +134,14 @@ func workflowSynthesisSupportsLanguage(lang string) bool {
 // Step Functions patterns and emits SCOPE.Workflow, SCOPE.Activity,
 // SCOPE.StateMachine entities plus STARTS_WORKFLOW, EXECUTES_ACTIVITY, and
 // STEPFUNCTION_STEP_INVOKES edges.
-func applyWorkflowEdges(
-	lang string,
-	path string,
-	content []byte,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applyWorkflowEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	path := args.Path
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
 	if len(content) == 0 {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	// Path-based routing: *.asl.json and terraform files go through the ASL
@@ -158,17 +157,20 @@ func applyWorkflowEdges(
 		strings.HasSuffix(lowerPath, "template.json")
 
 	if isASLFile {
-		return applyASLWorkflowEdges(path, content, entities, relationships)
+		e, r := applyASLWorkflowEdges(path, content, entities, relationships)
+		return DetectorPassResult{Entities: e, Relationships: r}
 	}
 	if isTerraformFile {
-		return applyTerraformSFNEdges(path, content, entities, relationships)
+		e, r := applyTerraformSFNEdges(path, content, entities, relationships)
+		return DetectorPassResult{Entities: e, Relationships: r}
 	}
 	if isCloudFormation {
-		return applyCloudFormationSFNEdges(path, content, entities, relationships)
+		e, r := applyCloudFormationSFNEdges(path, content, entities, relationships)
+		return DetectorPassResult{Entities: e, Relationships: r}
 	}
 
 	if !workflowSynthesisSupportsLanguage(lang) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	src := string(content)
@@ -286,7 +288,7 @@ func applyWorkflowEdges(
 		entities, relationships = applyCDKStateMachineJSON(path, content, entities, relationships)
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }
 
 // ---------------------------------------------------------------------------
@@ -1406,14 +1408,13 @@ var sfnInvocationGuardRe = regexp.MustCompile(`(?:StartExecution|start_execution
 // applySFNStartExecutionEdges scans source code (any language) for
 // sfn.start_execution / StartExecution / StartExecutionCommand calls and emits
 // STARTS_WORKFLOW edges from the calling function to the state machine entity.
-func applySFNStartExecutionEdges(
-	lang string,
-	src, path string,
-	entities []types.EntityRecord,
-	relationships []types.RelationshipRecord,
-) ([]types.EntityRecord, []types.RelationshipRecord) {
+func applySFNStartExecutionEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	src := string(args.Content)
+	entities := args.Entities
+	relationships := args.Relationships
 	if !sfnInvocationGuardRe.MatchString(src) {
-		return entities, relationships
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 
 	seenEdge := map[string]bool{}
@@ -1488,5 +1489,5 @@ func applySFNStartExecutionEdges(
 		}
 	}
 
-	return entities, relationships
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
 }

--- a/internal/engine/workflow_edges_test.go
+++ b/internal/engine/workflow_edges_test.go
@@ -30,12 +30,14 @@ import (
 
 func runWorkflowEdges(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	t.Helper()
-	return applyWorkflowEdges(lang, path, []byte(src), nil, nil)
+	res := applyWorkflowEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 func runSFNStartEdges(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	t.Helper()
-	return applySFNStartExecutionEdges(lang, src, path, nil, nil)
+	res := applySFNStartExecutionEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 func workflowEntityByID(ents []types.EntityRecord, kind, id string) *types.EntityRecord {
@@ -414,7 +416,8 @@ func TestASLLambdaTaskEdges(t *testing.T) {
 
 // applyASLWorkflowEdges is also reachable via the main applyWorkflowEdges path for .asl.json files.
 func TestASLRoutedThroughApplyWorkflowEdges(t *testing.T) {
-	ents, rels := applyWorkflowEdges("json", "infra/order-flow.asl.json", []byte(aslJSON), nil, nil)
+	_res := applyWorkflowEdges(DetectorPassArgs{Lang: "json", Path: "infra/order-flow.asl.json", Content: []byte(aslJSON)})
+	ents, rels := _res.Entities, _res.Relationships
 
 	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("order-flow"), "routed ASL → StateMachine")
 	if len(wfEdgesOfKind(rels, stepFunctionStepInvokesEdgeKind)) == 0 {


### PR DESCRIPTION
## Summary

- Introduces `DetectorPassArgs` and `DetectorPassResult` in `internal/engine/pass_args.go` — every engine pass called from `Detect()` now takes the same struct in and returns the same struct out
- Eliminates the asymmetry introduced by PR #2444 (#2430): `applyORMFieldEdges` was the only pass returning bare `[]RelationshipRecord` instead of `(entities, relationships)`; it now returns `DetectorPassResult` like all peers
- Refactors all 27 engine passes + 12 test helpers to use the new types; updates `detector.go` to use an `applyPass` closure that threads accumulated results into successive passes

## Tech debt surfaced

- `applySFNStartExecutionEdges` had a silent unused `path` parameter in its old signature (positional `lang, src, path, entities, rels` — `path` was never read). The struct refactor makes this explicit: the field is carried in `DetectorPassArgs` and available for future use (e.g. per-file state machine ARN lookup), but the pass still ignores it. Filed as a minor latent issue for a Phase B pass.
- `go_routes.go` was importing `github.com/cajasmota/archigraph/internal/types` only for parameter types; removing the positional signature removed the only explicit reference. Import dropped.
- Several passes (`applyIaCSNSEdges`, `applyKafkaWrapperEdges`, etc.) accepted `path string` as a parameter but never used it — previously invisible because Go allows unused function parameters. Turned visible (and pruned) when converting to local variable declarations.

## Test plan

- [x] `gofmt -l internal/engine/*.go` — empty
- [x] `go vet ./...` — clean
- [x] `go build ./...` — succeeds
- [x] `go test ./internal/engine/... -count=1` — 1002 tests pass

Closes #2446

🤖 Generated with [Claude Code](https://claude.com/claude-code)