### PR TITLE
fix(personas): remove restrictive tools: inheritance

### DIFF
--- a/docs/architecture/personas.md
+++ b/docs/architecture/personas.md
@@ -47,10 +47,11 @@ name: archigraph-<persona-name>           # lowercase, hyphens, prefixed archigr
 description: >
   One tight sentence: what this consultant is good at, and what kind of
   user question signals "hire this one".
-tools: Read, Glob, mcp__archigraph__*
 model: sonnet
 ---
 ```
+
+**Tool inheritance:** Personas omit the `tools:` field from frontmatter to inherit the host agent's full toolset (Read, Write, Bash, all user-configured MCPs, etc.). Safety is enforced by the host agent's permission model, not by per-persona allowlists. If a persona has a specific tool restriction by design, document it in the Role section rather than via frontmatter.
 
 ### 2.2 Body structure (v3)
 

--- a/skills/archigraph-consult/personas/api-designer.md
+++ b/skills/archigraph-consult/personas/api-designer.md
@@ -5,7 +5,6 @@ description: >
   OpenAPI/contract coverage, idempotency, pagination, and error-shape uniformity. Use when the
   user asks about API quality, endpoint consistency, contract documentation gaps, or whether
   the API follows its own conventions.
-tools: Read, Glob, mcp__archigraph__*
 model: sonnet
 ---
 

--- a/skills/archigraph-consult/personas/architect.md
+++ b/skills/archigraph-consult/personas/architect.md
@@ -4,7 +4,6 @@ description: >
   Reviews internal system structure — module layering, coupling, cyclic dependencies, god modules,
   and boundary violations. Use when the user asks for an architectural review, wants to understand
   coupling or cohesion, or needs ADR candidates surfaced.
-tools: Read, Glob, mcp__archigraph__*
 model: sonnet
 ---
 

--- a/skills/archigraph-consult/personas/business-analyst.md
+++ b/skills/archigraph-consult/personas/business-analyst.md
@@ -5,7 +5,6 @@ description: >
   continuity from the implementation perspective. Use when the user asks what the product
   actually does, wants feature gaps identified, or needs a non-technical summary of what
   is and isn't implemented.
-tools: Read, Glob, mcp__archigraph__*
 model: sonnet
 ---
 

--- a/skills/archigraph-consult/personas/data-engineer.md
+++ b/skills/archigraph-consult/personas/data-engineer.md
@@ -4,7 +4,6 @@ description: >
   Reviews data model quality, migration hygiene, ORM query patterns, missing indexes, and
   foreign-key integrity from the call graph. Use when the user asks about schema quality,
   migration debt, ORM misuse, or which database queries lack supporting indexes.
-tools: Read, Glob, mcp__archigraph__*
 model: sonnet
 ---
 

--- a/skills/archigraph-consult/personas/performance-reviewer.md
+++ b/skills/archigraph-consult/personas/performance-reviewer.md
@@ -4,7 +4,6 @@ description: >
   Reviews hot paths, N+1 queries, synchronous blocking on the request path, unbounded queries,
   and caching opportunities. Use when the user asks about latency, throughput risks, slow
   endpoints, or database query efficiency.
-tools: Read, Glob, mcp__archigraph__*
 model: sonnet
 ---
 

--- a/skills/archigraph-consult/personas/qa-reviewer.md
+++ b/skills/archigraph-consult/personas/qa-reviewer.md
@@ -5,7 +5,6 @@ description: >
   paths, and fixture hygiene visible from the graph's TESTS edges. Use when the user asks what
   is untested, where the highest-risk coverage gaps are, or whether the test suite covers the
   critical paths identified by other personas.
-tools: Read, Glob, mcp__archigraph__*
 model: sonnet
 ---
 

--- a/skills/archigraph-consult/personas/refactor-critic.md
+++ b/skills/archigraph-consult/personas/refactor-critic.md
@@ -4,7 +4,6 @@ description: >
   Reviews complexity hotspots, duplication, dead code, over-indirection, and tech-debt surface.
   Use when the user asks what is worth refactoring, where the most complexity lives, what dead
   code exists, or what the highest-impact cleanup targets are.
-tools: Read, Glob, mcp__archigraph__*
 model: sonnet
 ---
 

--- a/skills/archigraph-consult/personas/security-auditor.md
+++ b/skills/archigraph-consult/personas/security-auditor.md
@@ -4,7 +4,6 @@ description: >
   Reviews auth gaps, PII exposure, injection risks, secrets, and attack surface. Deduplicates
   against /archigraph-security-audit static findings when available. Use when the user asks for
   a security review, wants to know what an attacker could exploit, or asks about auth/authz gaps.
-tools: Read, Glob, mcp__archigraph__*
 model: sonnet
 ---
 


### PR DESCRIPTION
## Summary
- Removed `tools:` declarations from all 8 persona frontmatter files
- Personas now inherit the host agent's full toolset (Read/Write/Bash/user MCPs)
- Updated architecture doc to document tool inheritance contract and safety model

## Changes
- 8 persona files: api-designer, architect, business-analyst, data-engineer, performance-reviewer, qa-reviewer, refactor-critic, security-auditor
- docs/architecture/personas.md: Added tool inheritance note to Section 2.1

## Why
PR #2449 (v2) added restrictive `tools:` allowlists for "safety" but broke the core use case of personas responding to requests like "write a report to FILE.md" or using user-configured MCPs. Safety is enforced by the host agent's permission model, not per-persona allowlists.

Closes #2465