### PR TITLE
feat(personas): save-finding affordance + per-persona model recommendations

### DIFF
--- a/docs/architecture/personas.md
+++ b/docs/architecture/personas.md
@@ -47,11 +47,29 @@ name: archigraph-<persona-name>           # lowercase, hyphens, prefixed archigr
 description: >
   One tight sentence: what this consultant is good at, and what kind of
   user question signals "hire this one".
-model: sonnet
+# Recommended model: <tier> — one-line rationale. Host agent may override.
+model: sonnet   # or opus — see Section 2.3 for per-persona recommendations
 ---
 ```
 
 **Tool inheritance:** Personas omit the `tools:` field from frontmatter to inherit the host agent's full toolset (Read, Write, Bash, all user-configured MCPs, etc.). Safety is enforced by the host agent's permission model, not by per-persona allowlists. If a persona has a specific tool restriction by design, document it in the Role section rather than via frontmatter.
+
+### 2.3 Per-persona model recommendations
+
+The `model:` frontmatter field is an **opinionated suggestion** to the host agent's invocation layer. It is not enforced — the host agent picks the active model and may override it based on user settings, cost policy, or context window. When omitted, the host agent decides.
+
+| Persona | Recommended model | Rationale |
+|---|---|---|
+| `architect` | `opus` | Multi-hop structural inference across large dependency graphs requires depth |
+| `security-auditor` | `opus` | Subtle vulnerability detection needs deep reachability and adversarial reasoning |
+| `performance-reviewer` | `opus` | Multi-pass hot-path analysis holds large call-graph contexts simultaneously |
+| `business-analyst` | `sonnet` | Business synthesis from route/flow data does not require deep technical inference |
+| `refactor-critic` | `sonnet` | Refactor signals are clear from graph degree/duplication data |
+| `api-designer` | `sonnet` | API review is primarily inventory and spec comparison work |
+| `data-engineer` | `sonnet` | Schema and query analysis follows clear structural patterns |
+| `qa-reviewer` | `sonnet` | Test inventory and TESTS-edge coverage analysis is structured enumeration |
+
+**Override contract:** The host agent MUST honour an explicit `--model` flag from the user (e.g. `/archigraph-consult --model haiku`) over the persona's own `model:` recommendation. The recommendation is a default, not a lock.
 
 ### 2.2 Body structure (v3)
 
@@ -84,11 +102,26 @@ trigger conditions. See Section 5.
 The persona responds in whatever shape best serves the user's question.
 No fixed report template. If the user asks "is this module too coupled?",
 answer that — don't deliver a 7-section structural audit.
+
+## When the user asks to save this analysis
+Documents how to persist findings on explicit user request. Default path:
+`~/.archigraph/groups/<group>/findings/<persona>-<short-slug>-<YYYY-MM-DD>.md`.
+Confirm path with user if ambiguous. Also offers `archigraph_save_finding`
+as the canonical graph-persistence path when the MCP exposes it.
 ```
 
 There is **no STOP-criteria section** in v3. The session ends when the user releases the persona.
 
 There is **no OUTPUT format section** in v3. Personas respond to questions in domain-appropriate shapes.
+
+### 2.4 Save-finding affordance contract
+
+Findings save **only on explicit user request**. The trigger phrases are: "save this", "write a report", "create a follow-up doc", or equivalent. On trigger:
+
+1. The persona uses the host agent's `Write` tool to save a markdown file at the default path (`~/.archigraph/groups/<group>/findings/<persona>-<short-slug>-<YYYY-MM-DD>.md`).
+2. If the path is ambiguous (e.g. multiple groups, or the user specifies a different location), the persona confirms the path with the user before writing.
+3. If `archigraph_save_finding` is available in the host MCP, the persona SHOULD also call it — this is the canonical path for graph-registered findings that appear in dashboard panels. The `Write` call and the MCP call are not mutually exclusive.
+4. The persona does **not** auto-save at confidence thresholds. There is no background materialisation. This was the v1/v2 model and is retired.
 
 ---
 
@@ -277,9 +310,9 @@ This section is non-negotiable. Any implementation that violates these invariant
 | True multi-persona panel mode | v1/v2 attempted this; postponed until interactive model is validated |
 | Persistent active-persona sidecar for Windsurf | Needs design work; conversation-marker workaround ships in this PR |
 | Codex / generic-markdown wrappers | Low user demand; defer until requested |
-| Persona-emitted findings → graph (opt-in) | User-driven `archigraph_save_finding` call works today; first-class "save this finding" affordance in persona body is followup |
+| Persona-emitted findings → graph (opt-in) | **Shipped in #2472** — "When the user asks to save this analysis" section added to all 8 persona bodies; Section 2.4 defines the contract |
 | Consult-Out depth > 1 (peer of peer) | Single hop only in v3 |
 | Telemetry on persona usage / Consult-Out frequency | Needs privacy review |
-| Per-persona model selection strategy | Host-level concern |
+| Per-persona model selection strategy | **Shipped in #2475** — `model:` frontmatter on all 8 personas with opinionated recommendations; Section 2.3 defines the mapping and override contract |
 | Cross-platform renderer CLI | Defer until 3+ platforms stable |
 | Solutions-architect / devops / compliance / dx personas | As per PR #2449 deferral reasons |

--- a/skills/archigraph-consult/personas/api-designer.md
+++ b/skills/archigraph-consult/personas/api-designer.md
@@ -5,6 +5,9 @@ description: >
   OpenAPI/contract coverage, idempotency, pagination, and error-shape uniformity. Use when the
   user asks about API quality, endpoint consistency, contract documentation gaps, or whether
   the API follows its own conventions.
+# Recommended model: sonnet — API review is primarily inventory and spec comparison work;
+# sonnet handles endpoint enumeration and convention-checking at appropriate cost.
+# The host agent may override this recommendation.
 model: sonnet
 ---
 
@@ -71,3 +74,9 @@ Respond to the user's question in whatever shape best serves it. There is no fix
 You may save findings to the graph via `archigraph_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/archigraph-consult --release`) or switches consultants (`/archigraph-consult --switch <name>`). There is no fixed STOP criterion.
+
+## When the user asks to save this analysis
+
+If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/api-designer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
+
+You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).

--- a/skills/archigraph-consult/personas/architect.md
+++ b/skills/archigraph-consult/personas/architect.md
@@ -4,7 +4,9 @@ description: >
   Reviews internal system structure — module layering, coupling, cyclic dependencies, god modules,
   and boundary violations. Use when the user asks for an architectural review, wants to understand
   coupling or cohesion, or needs ADR candidates surfaced.
-model: sonnet
+# Recommended model: opus — architectural reasoning requires multi-hop structural inference
+# across large dependency graphs. The host agent may override this recommendation.
+model: opus
 ---
 
 ## Role
@@ -69,3 +71,9 @@ Respond to the user's question in whatever shape best serves it. There is no fix
 You may save findings to the graph via `archigraph_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/archigraph-consult --release`) or switches consultants (`/archigraph-consult --switch <name>`). There is no fixed STOP criterion.
+
+## When the user asks to save this analysis
+
+If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/architect-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
+
+You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).

--- a/skills/archigraph-consult/personas/business-analyst.md
+++ b/skills/archigraph-consult/personas/business-analyst.md
@@ -5,6 +5,9 @@ description: >
   continuity from the implementation perspective. Use when the user asks what the product
   actually does, wants feature gaps identified, or needs a non-technical summary of what
   is and isn't implemented.
+# Recommended model: sonnet — business synthesis from route/flow data does not require
+# deep technical inference; sonnet provides cost-effective, high-quality narrative output.
+# The host agent may override this recommendation.
 model: sonnet
 ---
 
@@ -69,3 +72,9 @@ Respond to the user's question in whatever shape best serves it. There is no fix
 You may save findings to the graph via `archigraph_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/archigraph-consult --release`) or switches consultants (`/archigraph-consult --switch <name>`). There is no fixed STOP criterion.
+
+## When the user asks to save this analysis
+
+If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/business-analyst-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
+
+You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).

--- a/skills/archigraph-consult/personas/data-engineer.md
+++ b/skills/archigraph-consult/personas/data-engineer.md
@@ -4,6 +4,9 @@ description: >
   Reviews data model quality, migration hygiene, ORM query patterns, missing indexes, and
   foreign-key integrity from the call graph. Use when the user asks about schema quality,
   migration debt, ORM misuse, or which database queries lack supporting indexes.
+# Recommended model: sonnet — schema and query analysis follows clear structural patterns
+# that sonnet handles well; haiku is insufficient for cross-table reasoning.
+# The host agent may override this recommendation.
 model: sonnet
 ---
 
@@ -68,3 +71,9 @@ Respond to the user's question in whatever shape best serves it. There is no fix
 You may save findings to the graph via `archigraph_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/archigraph-consult --release`) or switches consultants (`/archigraph-consult --switch <name>`). There is no fixed STOP criterion.
+
+## When the user asks to save this analysis
+
+If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/data-engineer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
+
+You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).

--- a/skills/archigraph-consult/personas/performance-reviewer.md
+++ b/skills/archigraph-consult/personas/performance-reviewer.md
@@ -4,7 +4,9 @@ description: >
   Reviews hot paths, N+1 queries, synchronous blocking on the request path, unbounded queries,
   and caching opportunities. Use when the user asks about latency, throughput risks, slow
   endpoints, or database query efficiency.
-model: sonnet
+# Recommended model: opus — multi-pass hot-path analysis requires holding large call-graph
+# contexts in working memory simultaneously. The host agent may override this recommendation.
+model: opus
 ---
 
 ## Role
@@ -68,3 +70,9 @@ Respond to the user's question in whatever shape best serves it. There is no fix
 You may save findings to the graph via `archigraph_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/archigraph-consult --release`) or switches consultants (`/archigraph-consult --switch <name>`). There is no fixed STOP criterion.
+
+## When the user asks to save this analysis
+
+If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/performance-reviewer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
+
+You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).

--- a/skills/archigraph-consult/personas/qa-reviewer.md
+++ b/skills/archigraph-consult/personas/qa-reviewer.md
@@ -5,6 +5,9 @@ description: >
   paths, and fixture hygiene visible from the graph's TESTS edges. Use when the user asks what
   is untested, where the highest-risk coverage gaps are, or whether the test suite covers the
   critical paths identified by other personas.
+# Recommended model: sonnet — test inventory and TESTS-edge coverage analysis is structured
+# enumeration; sonnet provides cost-effective output for this pattern-matching work.
+# The host agent may override this recommendation.
 model: sonnet
 ---
 
@@ -69,3 +72,9 @@ Respond to the user's question in whatever shape best serves it. There is no fix
 You may save findings to the graph via `archigraph_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/archigraph-consult --release`) or switches consultants (`/archigraph-consult --switch <name>`). There is no fixed STOP criterion.
+
+## When the user asks to save this analysis
+
+If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/qa-reviewer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
+
+You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).

--- a/skills/archigraph-consult/personas/refactor-critic.md
+++ b/skills/archigraph-consult/personas/refactor-critic.md
@@ -4,6 +4,9 @@ description: >
   Reviews complexity hotspots, duplication, dead code, over-indirection, and tech-debt surface.
   Use when the user asks what is worth refactoring, where the most complexity lives, what dead
   code exists, or what the highest-impact cleanup targets are.
+# Recommended model: sonnet — refactor signals are clear from graph degree/duplication data;
+# sonnet produces actionable output without needing deep architectural inference.
+# The host agent may override this recommendation.
 model: sonnet
 ---
 
@@ -68,3 +71,9 @@ Respond to the user's question in whatever shape best serves it. There is no fix
 You may save findings to the graph via `archigraph_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/archigraph-consult --release`) or switches consultants (`/archigraph-consult --switch <name>`). There is no fixed STOP criterion.
+
+## When the user asks to save this analysis
+
+If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/refactor-critic-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
+
+You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).

--- a/skills/archigraph-consult/personas/security-auditor.md
+++ b/skills/archigraph-consult/personas/security-auditor.md
@@ -4,7 +4,9 @@ description: >
   Reviews auth gaps, PII exposure, injection risks, secrets, and attack surface. Deduplicates
   against /archigraph-security-audit static findings when available. Use when the user asks for
   a security review, wants to know what an attacker could exploit, or asks about auth/authz gaps.
-model: sonnet
+# Recommended model: opus — subtle vulnerability detection requires deep reachability analysis
+# and multi-step adversarial reasoning. The host agent may override this recommendation.
+model: opus
 ---
 
 ## Role
@@ -69,3 +71,9 @@ Respond to the user's question in whatever shape best serves it. There is no fix
 You may save findings to the graph via `archigraph_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/archigraph-consult --release`) or switches consultants (`/archigraph-consult --switch <name>`). There is no fixed STOP criterion.
+
+## When the user asks to save this analysis
+
+If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/security-auditor-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
+
+You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).


### PR DESCRIPTION
## Summary

- **#2472** — Adds `## When the user asks to save this analysis` section to all 8 persona bodies, documenting the `Write`-tool path and `archigraph_save_finding` MCP path for explicit user-requested persistence. Architecture doc gains Section 2.4 defining the full affordance contract (trigger phrases, path template, dual-write behaviour, no-auto-save invariant).
- **#2475** — Adds opinionated `model:` frontmatter to all 8 personas: `opus` for architect / security-auditor / performance-reviewer (deep reasoning tasks); `sonnet` for business-analyst / refactor-critic / api-designer / data-engineer / qa-reviewer (structured enumeration/synthesis). Architecture doc gains Section 2.3 with the full mapping table and the host-agent-can-override contract.

Closes #2472
Closes #2475

## Files changed

- `skills/archigraph-consult/personas/*.md` — all 8 persona files (model frontmatter + save-finding section)
- `docs/architecture/personas.md` — Sections 2.1, 2.3, 2.4 added/updated; Deferred table updated

## Pre-commit gates

- [x] YAML frontmatter valid on all 8 personas (validated with `yaml.safe_load`)
- [x] All 8 personas have `## When the user asks to save this analysis` section
- [x] `go build ./...` clean (no Go changes)
- [x] Markdown files parse

## Test plan

- [ ] Hire `archigraph-architect` persona and say "save this" — confirm Write tool is invoked to `~/.archigraph/groups/<group>/findings/architect-*.md`
- [ ] Hire `archigraph-qa-reviewer` — confirm `model: sonnet` is in frontmatter and no behavioural regression
- [ ] Hire `archigraph-security-auditor` — confirm `model: opus` is in frontmatter
- [ ] Verify host agent can override model via `--model haiku` flag without persona blocking it

🤖 Generated with [Claude Code](https://claude.com/claude-code)