### PR TITLE
fix(daemon): idempotent Stop() + runLinks/runAlgo ctx + coordinator caller audit

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -287,7 +287,11 @@ func runDaemon(argv []string) error {
 			if stateDir == "" {
 				stateDir = daemon.StateDirForRepo(repoPath)
 			}
-			res := extractors.TryIncremental(context.Background(), repoPath, stateDir, nil, &extractorCfg)
+			// Use the caller-supplied ctx (the scheduler's shutdownCtx) so that
+			// daemon SIGTERM cancels any in-flight incremental subprocess —
+			// matching the fix applied to runIndex in issue #2176/#2491.
+			// Fixes issue #2495.
+			res := extractors.TryIncremental(ctx, repoPath, stateDir, nil, &extractorCfg)
 			if res.Done {
 				invalidateAfterIndex(repoPath)
 				tierAfterIndex(repoPath, ref)

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -223,13 +223,14 @@ type enqueueRequest struct {
 //   - per-repo algorithm debounce timers,
 //   - an RSS-budget ledger that gates dispatch.
 type Scheduler struct {
-	cfg    Config
-	logger *slog.Logger
-	enq    chan enqueueRequest // public enqueue input → dedup → pending queue
-	jobs   chan jobToken       // admitted jobs handed to workers
-	wake   chan struct{}       // poked when a worker frees budget
-	stop   chan struct{}
-	wg     sync.WaitGroup
+	cfg      Config
+	logger   *slog.Logger
+	enq      chan enqueueRequest // public enqueue input → dedup → pending queue
+	jobs     chan jobToken       // admitted jobs handed to workers
+	wake     chan struct{}       // poked when a worker frees budget
+	stop     chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
 
 	// shutdownCtx is cancelled by Stop() so in-flight IndexFn / Incremental /
 	// Clone calls — which may have spawned child processes — receive a
@@ -371,18 +372,18 @@ func (s *Scheduler) Start() {
 // Stop signals shutdown, cancels any in-flight index jobs (so subprocess
 // children receive SIGTERM via exec.CommandContext), and waits for the worker
 // pool to drain. It is safe to call Stop more than once; subsequent calls are
-// no-ops because close(s.stop) panics on a closed channel — the once-flag is
-// implicit in the channel close semantics (closing an already-closed channel
-// panics, so callers must not call Stop concurrently; this matches the
-// existing contract).
+// no-ops — the close(s.stop) and shutdownCancel() are wrapped in a sync.Once
+// so a second call returns immediately after the first call's wg.Wait()
+// completes. This is the fix for the double-Stop panic described in issue #2494.
 func (s *Scheduler) Stop() {
-	// Cancel the shutdown context first so any in-flight IndexFn /
-	// Incremental / Clone call that spawned a child process via
-	// exec.CommandContext receives SIGTERM immediately. This is the fix for
-	// the zombie accumulation described in issue #2176.
-	s.shutdownCancel()
-
-	close(s.stop)
+	s.stopOnce.Do(func() {
+		// Cancel the shutdown context first so any in-flight IndexFn /
+		// Incremental / Clone call that spawned a child process via
+		// exec.CommandContext receives SIGTERM immediately. This is the fix for
+		// the zombie accumulation described in issue #2176.
+		s.shutdownCancel()
+		close(s.stop)
+	})
 	s.wg.Wait()
 
 	s.mu.Lock()
@@ -828,15 +829,19 @@ func (s *Scheduler) scheduleLinks(group string) {
 		s.linkPending[group] = false
 		delete(s.linkTimers, group)
 		s.mu.Unlock()
-		s.runLinks(group)
+		// Pass shutdownCtx so that if Stop() is called while the link pass is
+		// running (or if it ever spawns subprocesses in the future), the
+		// cancellation signal propagates correctly — matching the fix applied to
+		// runIndex in issue #2176/#2491. Fixes issue #2493.
+		s.runLinks(s.shutdownCtx, group)
 	})
 	s.mu.Unlock()
 }
 
-func (s *Scheduler) runLinks(group string) {
+func (s *Scheduler) runLinks(ctx context.Context, group string) {
 	s.logEvent("links_start", "", group)
 	t0 := time.Now()
-	err := s.cfg.Links(context.Background(), group)
+	err := s.cfg.Links(ctx, group)
 	if err != nil {
 		s.logEvent("links_err", "", group+": "+err.Error())
 		s.logger.Error("sched: links failed", "group", group, "err", err)
@@ -879,7 +884,11 @@ func (s *Scheduler) scheduleAlgo(repoPath string) {
 		s.mu.Lock()
 		s.algoPending[repoPath] = false
 		delete(s.algoTimers, repoPath)
-		ctx, cancel := context.WithCancel(context.Background())
+		// Derive the per-run cancel context from shutdownCtx (not
+		// context.Background()) so that when Stop() is called, all in-flight
+		// algo passes receive cancellation — matching the treatment of runIndex
+		// and runLinks. Fixes issue #2493.
+		ctx, cancel := context.WithCancel(s.shutdownCtx)
 		s.algoCancel[repoPath] = cancel
 		s.mu.Unlock()
 

--- a/internal/daemon/sched/scheduler_test.go
+++ b/internal/daemon/sched/scheduler_test.go
@@ -381,3 +381,86 @@ func TestResolveAlgoCap(t *testing.T) {
 		t.Errorf("resolveAlgoCap(0) = %d, want %d (NumCPU=%d)", auto, expected, runtime.NumCPU())
 	}
 }
+
+// TestSchedulerStop_Idempotent verifies that calling Stop() twice does not
+// panic. Prior to the sync.Once fix (issue #2494), the second call would
+// panic with "close of closed channel".
+func TestSchedulerStop_Idempotent(t *testing.T) {
+	s := New(Config{
+		Workers: 1,
+		Index: func(_ context.Context, _ string, _ string) error {
+			return nil
+		},
+	})
+	s.Start()
+
+	// First Stop — normal path.
+	s.Stop()
+
+	// Second Stop — must be a no-op and MUST NOT panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Stop() panicked on second call: %v", r)
+		}
+	}()
+	s.Stop()
+}
+
+// TestRunLinksUsesShutdownCtx verifies that the Links callback receives a
+// cancellable context derived from the scheduler's shutdownCtx, not a
+// context.Background() orphan. When Stop() is called, any in-flight Links
+// call should observe ctx.Done() — this is the fix for issue #2493.
+func TestRunLinksUsesShutdownCtx(t *testing.T) {
+	t.Helper()
+
+	linkStarted := make(chan struct{})
+	linkCtxCancelled := make(chan struct{})
+
+	s := New(Config{
+		Workers:      1,
+		LinkDebounce: 10 * time.Millisecond,
+		Index: func(_ context.Context, _ string, _ string) error {
+			return nil
+		},
+		Links: func(ctx context.Context, _ string) error {
+			close(linkStarted)
+			select {
+			case <-ctx.Done():
+				close(linkCtxCancelled)
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+				return nil // should not reach here in this test
+			}
+		},
+		GroupsForRepo: func(_ string) []string { return []string{"g"} },
+	})
+	s.Start()
+	s.Enqueue("/repo")
+
+	// Wait until the Links callback is running.
+	select {
+	case <-linkStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Links callback never started")
+	}
+
+	// Stop should cancel shutdownCtx, which must propagate to the Links ctx.
+	done := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-linkCtxCancelled:
+		// correct: shutdownCtx cancellation reached the Links callback
+	case <-time.After(2 * time.Second):
+		t.Error("Stop() did not cancel the Links callback context (issue #2493 regression)")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("Stop() did not return after Links callback exited")
+	}
+}


### PR DESCRIPTION
## Summary

- **#2494** Wrap `close(s.stop)` and `shutdownCancel()` in a `sync.Once` so `Stop()` is idempotent — second call was panicking with \"close of closed channel\"
- **#2493** `runLinks` and `runAlgo` timer callbacks now receive `shutdownCtx` (derived via `context.WithCancel(s.shutdownCtx)` for algo) instead of `context.Background()` — cancellation propagates on daemon SIGTERM
- **#2495** `SchedulerIncremental` closure in `cmd/archigraph/daemon.go` was calling `extractors.TryIncremental(context.Background(), ...)` — changed to use the caller-supplied `ctx` (the scheduler's `shutdownCtx`) so incremental subprocess children are SIGTERM'd on daemon shutdown

Continues shutdown-correctness hardening from PR #2491 (#2176).

Closes #2493
Closes #2494
Closes #2495

## Test plan

- [x] `TestSchedulerStop_Idempotent` — calls `Stop()` twice; second call MUST NOT panic (new)
- [x] `TestRunLinksUsesShutdownCtx` — verifies that the `Links` callback receives a context that is cancelled when `Stop()` is called (new)
- [x] Full `./internal/daemon/sched/...` suite green (15s)
- [x] Full `./cmd/archigraph/...` suite green (68s)
- [x] `gofmt -l` clean on changed files
- [x] `go vet ./internal/daemon/sched/... ./cmd/archigraph/...` clean
- [x] `go build ./...` succeeds

## Coordinator caller audit (#2495)

| File | Caller | Before | After |
|------|--------|--------|-------|
| `cmd/archigraph/daemon.go:290` | `SchedulerIncremental` closure → `extractors.TryIncremental` | `context.Background()` | `ctx` (scheduler's `shutdownCtx`) |
| `cmd/archigraph/index.go:779` | Phase-F `extract.Coordinate` | already uses `ctx` | no change needed |
| `cmd/archigraph/index.go:362` | `idx.Run` (indexer internals, not coordinator) | `context.Background()` | out of scope — not a `Coordinate` caller |

🤖 Generated with [Claude Code](https://claude.com/claude-code)