### PR TITLE
feat(engine): cross-file ORM field resolution Phase B (#2448)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -2258,6 +2258,15 @@ func (i *Indexer) runPass25FrameworkRules(ctx context.Context, absRepo string, c
 		}
 	}
 
+	// Cross-file ORM field lookup (issue #2448 / Phase B): build a single
+	// closure over the union of Pass-1 field entities across the WHOLE
+	// repo and attach it to every per-file FileInput below. Engine passes
+	// (notably applyORMFieldEdges) consult it when a Django ORM call site
+	// references a model defined in a SIBLING file — the canonical
+	// `models.py` + `views.py` split. Nil result (no field entities in
+	// Pass 1) is valid and leaves per-file detection unchanged.
+	crossFileFields := engine.BuildCrossFileFieldLookup(pass1Records)
+
 	// Pre-pass (#845): build the cross-file Java DI registry before the
 	// per-file synthesis pass runs. Scanning is cheap (regex, no AST),
 	// single-threaded to avoid lock contention on the global registry.
@@ -2297,11 +2306,12 @@ func (i *Indexer) runPass25FrameworkRules(ctx context.Context, absRepo string, c
 			defer wg.Done()
 			for cf := range work {
 				input := extractor.FileInput{
-					Path:          cf.relPath,
-					Content:       cf.content,
-					Language:      cf.language,
-					RepoRoot:      absRepo,
-					Pass1Entities: pass1ByFile[cf.relPath],
+					Path:            cf.relPath,
+					Content:         cf.content,
+					Language:        cf.language,
+					RepoRoot:        absRepo,
+					Pass1Entities:   pass1ByFile[cf.relPath],
+					CrossFileFields: crossFileFields,
 				}
 				// Issue #2447: count plumbed vs unplumbed before Detect.
 				if len(input.Pass1Entities) > 0 {

--- a/internal/daemon/extract/subproc.go
+++ b/internal/daemon/extract/subproc.go
@@ -197,6 +197,52 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 		}
 	}
 
+	// Pre-pass (#2448 / Phase B): build the cross-file ORM field lookup
+	// for this batch. Engine pass applyORMFieldEdges resolves
+	// <Model>.<field> references first via FileInput.Pass1Entities
+	// (intra-file). When the model lives in a SIBLING file (canonical
+	// Django split — models.py defines User, views.py queries it), it
+	// falls back to this closure.
+	//
+	// Subprocess-scope caveat: the lookup only covers files in THIS
+	// batch. A model defined in a file assigned to a different
+	// subprocess is invisible here. The coordinator pre-groups batches
+	// per repo to keep imports together, but it does not formally
+	// guarantee co-location of models.py and views.py. Tech debt
+	// surfaced; see commit body.
+	//
+	// Cost model: one extra regex pass over each Python file's content
+	// at pre-pass time (no AST, no tree-sitter), keyed by model name in
+	// the returned closure. The closure is shared across all files via
+	// pointer; per-file extra memory is zero.
+	var crossFileBatchFields []types.EntityRecord
+	if runFramework {
+		for _, rel := range files {
+			if !strings.HasSuffix(strings.ToLower(rel), ".py") {
+				continue
+			}
+			abs := filepath.Join(opts.RepoRoot, rel)
+			pyContent, rerr := os.ReadFile(abs)
+			if rerr != nil {
+				continue
+			}
+			idx := engine.BuildFieldIndex(string(pyContent))
+			if len(idx) == 0 {
+				continue
+			}
+			for name := range idx {
+				crossFileBatchFields = append(crossFileBatchFields, types.EntityRecord{
+					Name:       name,
+					Kind:       "SCOPE.Schema",
+					Subtype:    "field",
+					SourceFile: rel,
+					Language:   "python",
+				})
+			}
+		}
+	}
+	crossFileFields := engine.BuildCrossFileFieldLookup(crossFileBatchFields)
+
 	for _, rel := range files {
 		abs := filepath.Join(opts.RepoRoot, rel)
 		st, statErr := os.Stat(abs)
@@ -313,6 +359,13 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 				}
 			}
 			file.Pass1Entities = fieldEnts
+		}
+		// Attach the batch-scoped cross-file lookup (issue #2448 / Phase B)
+		// so applyORMFieldEdges can resolve <Model>.<field> references
+		// across sibling files (e.g. views.py → User.cognito_id where
+		// User is defined in models.py).
+		if runFramework {
+			file.CrossFileFields = crossFileFields
 		}
 		if runFramework {
 			// Issue #2447: count how many files enter Detect() with

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -390,14 +390,15 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// cost. Entities and Relationships are updated after each pass via the
 	// returned DetectorPassResult. Refs #2446.
 	passArgs := DetectorPassArgs{
-		Ctx:           ctx,
-		Lang:          file.Language,
-		Path:          file.Path,
-		RepoRoot:      file.RepoRoot,
-		Content:       file.Content,
-		Pass1Entities: file.Pass1Entities,
-		Entities:      entities,
-		Relationships: relationships,
+		Ctx:             ctx,
+		Lang:            file.Language,
+		Path:            file.Path,
+		RepoRoot:        file.RepoRoot,
+		Content:         file.Content,
+		Pass1Entities:   file.Pass1Entities,
+		CrossFileFields: file.CrossFileFields,
+		Entities:        entities,
+		Relationships:   relationships,
 	}
 
 	// applyPass is a tiny closure that applies a DetectorPassArgs→DetectorPassResult

--- a/internal/engine/field_index.go
+++ b/internal/engine/field_index.go
@@ -90,6 +90,47 @@ func BuildFieldIndex(src string) map[string]bool {
 	return out
 }
 
+// BuildCrossFileFieldLookup constructs a CrossFileFields closure
+// (issue #2448 / Phase B) over the supplied Pass-1 entity slice. The
+// returned function, given a model class name, returns every
+// SCOPE.Schema(subtype=field) entity in the slice whose Name begins
+// with `<model>.`. Pre-bucketing by model keeps per-call work O(fields
+// in that model) rather than O(all fields in the indexed scope).
+//
+// The closure is built ONCE per indexing run by the coordinator (the
+// in-process indexer in cmd/archigraph/index.go runPass25FrameworkRules
+// and the subprocess in internal/daemon/extract/subproc.go) from the
+// union of Pass-1 entities across every file in the indexed scope (or
+// the batch, in the subprocess case), then attached to every per-file
+// extractor.FileInput.CrossFileFields before Detect.
+//
+// Returns nil when the input slice contains no usable field entities —
+// callers should treat a nil return value as "no cross-file resolution
+// available" and fall through to the intra-file branch only.
+func BuildCrossFileFieldLookup(pass1 []types.EntityRecord) func(modelName string) []types.EntityRecord {
+	if len(pass1) == 0 {
+		return nil
+	}
+	byModel := map[string][]types.EntityRecord{}
+	for _, e := range pass1 {
+		if e.Kind != "SCOPE.Schema" || e.Subtype != "field" {
+			continue
+		}
+		dot := strings.Index(e.Name, ".")
+		if dot <= 0 {
+			continue
+		}
+		model := e.Name[:dot]
+		byModel[model] = append(byModel[model], e)
+	}
+	if len(byModel) == 0 {
+		return nil
+	}
+	return func(modelName string) []types.EntityRecord {
+		return byModel[modelName]
+	}
+}
+
 // buildPlumbedFieldIndex constructs the same `<Model>.<field>` presence
 // set as BuildFieldIndex, but sources the data from Pass 1's
 // SCOPE.Schema(subtype=field) entities rather than re-parsing source

--- a/internal/engine/nats_edges_test.go
+++ b/internal/engine/nats_edges_test.go
@@ -20,7 +20,8 @@ import (
 // runNATSDetect is a lightweight in-process driver for the NATS pass.
 func runNATSDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
 	t.Helper()
-	ents, rels := applyNATSEdges(lang, path, []byte(src), nil, nil)
+	res := applyNATSEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	ents, rels := res.Entities, res.Relationships
 	out := make([]entityResult, 0, len(ents))
 	for _, e := range ents {
 		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})

--- a/internal/engine/orm_field_edges.go
+++ b/internal/engine/orm_field_edges.go
@@ -100,10 +100,43 @@ func applyORMFieldEdges(args DetectorPassArgs) DetectorPassResult {
 	if !plumbed {
 		fieldIdx = BuildFieldIndex(string(content))
 	}
-	if len(fieldIdx) == 0 {
+	_ = plumbed // reserved for future telemetry / debug hooks
+
+	// Phase B (issue #2448): cross-file resolution via the closure attached
+	// by the coordinator. When the model is defined in a SIBLING file
+	// (canonical Django split — models.py defines User, views.py imports
+	// it), the intra-file fieldIdx misses; this closure lets us recover
+	// the field set without re-parsing the whole repo. Nil is valid —
+	// direct test fixtures that don't go through the coordinator path
+	// see the pre-#2448 intra-file-only behaviour.
+	crossFile := args.CrossFileFields
+	resolveCrossFile := func(modelName, field string) bool {
+		if crossFile == nil {
+			return false
+		}
+		ents := crossFile(modelName)
+		if len(ents) == 0 {
+			return false
+		}
+		needle := modelName + "." + field
+		for _, e := range ents {
+			if e.Kind != "SCOPE.Schema" || e.Subtype != "field" {
+				continue
+			}
+			if e.Name == needle {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Early-exit only when BOTH the intra-file index and the cross-file
+	// lookup are unavailable. Previously this short-circuited on an empty
+	// intra-file index — that's wrong under Phase B because views.py
+	// (no models) legitimately needs the cross-file branch to fire.
+	if len(fieldIdx) == 0 && crossFile == nil {
 		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
-	_ = plumbed // reserved for future telemetry / debug hooks
 
 	// Scan the source directly for Django ORM call chains. We can't
 	// rely on the QUERIES edges' filter_keys alone because orm_queries
@@ -134,7 +167,13 @@ func applyORMFieldEdges(args DetectorPassArgs) DetectorPassResult {
 					continue
 				}
 				fqName := modelName + "." + field
-				if !fieldIdx[fqName] {
+				resolution := ""
+				if fieldIdx[fqName] {
+					resolution = "intra_file"
+				} else if resolveCrossFile(modelName, field) {
+					resolution = "cross_file"
+				}
+				if resolution == "" {
 					continue
 				}
 				relationships = append(relationships, types.RelationshipRecord{
@@ -146,6 +185,7 @@ func applyORMFieldEdges(args DetectorPassArgs) DetectorPassResult {
 						"verb":         link.verb,
 						"field":        field,
 						"model":        modelName,
+						"resolution":   resolution,
 						"pattern_type": ormFieldEdgesPatternType,
 					},
 				})

--- a/internal/engine/orm_field_edges_test.go
+++ b/internal/engine/orm_field_edges_test.go
@@ -258,6 +258,156 @@ def fetch(uid):
 	}
 }
 
+// Issue #2448 / Phase B: cross-file resolution. The model definition
+// lives in models.py; views.py imports it and queries it via the ORM.
+// The intra-file regex / Pass1Entities branch on views.py CANNOT see
+// the model — only the CrossFileFields closure can. Verifies that with
+// the closure attached, READS_FIELD edges land on User.cognito_id from
+// the views.py call sites; and that WITHOUT the closure, no edges land
+// (the byte-identical legacy behaviour).
+func TestORMFieldEdges_CrossFileResolution_Phase_B(t *testing.T) {
+	viewsSrc := `from .models import User
+
+def get_user(uid):
+    return User.objects.filter(cognito_id=uid)
+
+def rotate(uid, new_id):
+    User.objects.filter(id=uid).update(cognito_id=new_id)
+`
+	modelsFields := []types.EntityRecord{
+		{
+			Kind:       "SCOPE.Schema",
+			Subtype:    "field",
+			Name:       "User.cognito_id",
+			SourceFile: "models.py",
+		},
+		{
+			Kind:       "SCOPE.Schema",
+			Subtype:    "field",
+			Name:       "User.id",
+			SourceFile: "models.py",
+		},
+	}
+	lookup := BuildCrossFileFieldLookup(modelsFields)
+	if lookup == nil {
+		t.Fatalf("BuildCrossFileFieldLookup returned nil for non-empty input")
+	}
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+
+	// With cross-file lookup attached: edges should land.
+	res, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:            "views.py",
+		Content:         []byte(viewsSrc),
+		Language:        "python",
+		CrossFileFields: lookup,
+	})
+	if err != nil {
+		t.Fatalf("Detect (with cross-file): %v", err)
+	}
+	readsCog := 0
+	writesCog := 0
+	for _, r := range res.Relationships {
+		if r.Properties["model"] != "User" || r.Properties["field"] != "cognito_id" {
+			continue
+		}
+		if r.Properties["resolution"] != "cross_file" {
+			t.Errorf("expected resolution=cross_file on %+v", r)
+		}
+		switch r.Kind {
+		case ormReadsFieldKind:
+			readsCog++
+		case ormWritesFieldKind:
+			writesCog++
+		}
+	}
+	if readsCog < 1 {
+		t.Errorf("expected at least 1 cross-file READS_FIELD on User.cognito_id, got 0")
+	}
+	if writesCog < 1 {
+		t.Errorf("expected at least 1 cross-file WRITES_FIELD on User.cognito_id, got 0")
+	}
+
+	// Without the closure: legacy behaviour — no edges land for the
+	// cross-file model.
+	res2, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     "views.py",
+		Content:  []byte(viewsSrc),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Detect (no cross-file): %v", err)
+	}
+	for _, r := range res2.Relationships {
+		if r.Kind == ormReadsFieldKind || r.Kind == ormWritesFieldKind {
+			t.Errorf("unexpected field edge without cross-file lookup: %+v", r)
+		}
+	}
+}
+
+// Phase-B regression: the intra-file branch still wins when both are
+// available — verify resolution=intra_file when the model IS defined
+// in the current file, even with a cross-file closure attached.
+func TestORMFieldEdges_IntraFileWinsOverCrossFile(t *testing.T) {
+	src := `from django.db import models
+
+class User(models.Model):
+    cognito_id = models.CharField(max_length=64)
+
+def get_user(uid):
+    return User.objects.get(cognito_id=uid)
+`
+	// Cross-file closure also "knows" about User — intra-file must still win.
+	lookup := BuildCrossFileFieldLookup([]types.EntityRecord{
+		{Kind: "SCOPE.Schema", Subtype: "field", Name: "User.cognito_id", SourceFile: "models.py"},
+	})
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	res, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:            "users.py",
+		Content:         []byte(src),
+		Language:        "python",
+		CrossFileFields: lookup,
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	found := false
+	for _, r := range res.Relationships {
+		if r.Kind != ormReadsFieldKind {
+			continue
+		}
+		if r.Properties["model"] != "User" || r.Properties["field"] != "cognito_id" {
+			continue
+		}
+		found = true
+		if r.Properties["resolution"] != "intra_file" {
+			t.Errorf("resolution = %q, want intra_file", r.Properties["resolution"])
+		}
+	}
+	if !found {
+		t.Fatalf("expected intra-file READS_FIELD on User.cognito_id")
+	}
+}
+
+// BuildCrossFileFieldLookup edge cases.
+func TestBuildCrossFileFieldLookup_NilOnEmpty(t *testing.T) {
+	if BuildCrossFileFieldLookup(nil) != nil {
+		t.Error("nil input should return nil closure")
+	}
+	if BuildCrossFileFieldLookup([]types.EntityRecord{
+		{Kind: "Class", Name: "User", SourceFile: "models.py"},
+	}) != nil {
+		t.Error("input with no SCOPE.Schema(subtype=field) records should return nil")
+	}
+}
+
 // Symmetrical regression: when Pass1Entities is empty the regex
 // fallback MUST still serve (existing test fixtures that construct
 // FileInput directly continue working). This is implicitly covered by

--- a/internal/engine/pass_args.go
+++ b/internal/engine/pass_args.go
@@ -56,6 +56,17 @@ type DetectorPassArgs struct {
 	// Other passes ignore it.
 	Pass1Entities []types.EntityRecord
 
+	// CrossFileFields is the cross-file ORM field-resolution lookup
+	// (issue #2448 / Phase B). Forwarded opaquely from
+	// extractor.FileInput.CrossFileFields by detector.go's Detect.
+	//
+	// applyORMFieldEdges consults this closure when the model targeted
+	// by a Django ORM call site is NOT defined in the current file —
+	// the canonical Django split (`models.py` defines `User`,
+	// `views.py` queries it). When nil or returning empty, the edge is
+	// dropped silently and no dangling reference is emitted.
+	CrossFileFields func(modelName string) []types.EntityRecord
+
 	// Entities holds the entity slice accumulated so far in the Detect
 	// pipeline.  Passes that emit or modify entities receive this as input
 	// and include their additions in DetectorPassResult.Entities.

--- a/internal/engine/pubsub_edges_test.go
+++ b/internal/engine/pubsub_edges_test.go
@@ -18,7 +18,8 @@ import (
 // runPubSubDetect is a lightweight in-process driver for the Pub/Sub pass.
 func runPubSubDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
 	t.Helper()
-	ents, rels := applyPubSubEdges(lang, path, []byte(src), nil, nil)
+	res := applyPubSubEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	ents, rels := res.Entities, res.Relationships
 	out := make([]entityResult, 0, len(ents))
 	for _, e := range ents {
 		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})

--- a/internal/engine/pulsar_edges_test.go
+++ b/internal/engine/pulsar_edges_test.go
@@ -16,7 +16,8 @@ import (
 // runPulsarDetect is a lightweight driver for the Pulsar pass.
 func runPulsarDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
 	t.Helper()
-	ents, rels := applyPulsarEdges(lang, path, []byte(src), nil, nil)
+	res := applyPulsarEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	ents, rels := res.Entities, res.Relationships
 	out := make([]entityResult, 0, len(ents))
 	for _, e := range ents {
 		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})

--- a/internal/engine/rabbitmq_edges_test.go
+++ b/internal/engine/rabbitmq_edges_test.go
@@ -15,7 +15,8 @@ import (
 // runRabbitMQDetect is a lightweight in-process driver for the RabbitMQ pass.
 func runRabbitMQDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
 	t.Helper()
-	ents, rels := applyRabbitMQEdges(lang, path, []byte(src), nil, nil)
+	res := applyRabbitMQEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	ents, rels := res.Entities, res.Relationships
 	out := make([]entityResult, 0, len(ents))
 	for _, e := range ents {
 		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})

--- a/internal/engine/redis_pubsub_edges_test.go
+++ b/internal/engine/redis_pubsub_edges_test.go
@@ -8,7 +8,8 @@ import (
 // helper to run applyRedisPubSubEdges and return (entities, relationships).
 func runRedisPubSub(t *testing.T, lang, src string) ([]string, []string) {
 	t.Helper()
-	ents, rels := applyRedisPubSubEdges(lang, "test."+lang, []byte(src), nil, nil)
+	res := applyRedisPubSubEdges(DetectorPassArgs{Lang: lang, Path: "test." + lang, Content: []byte(src)})
+	ents, rels := res.Entities, res.Relationships
 	entityIDs := make([]string, 0, len(ents))
 	for _, e := range ents {
 		entityIDs = append(entityIDs, e.Name)

--- a/internal/engine/scheduled_jobs_edges_test.go
+++ b/internal/engine/scheduled_jobs_edges_test.go
@@ -15,8 +15,8 @@ import (
 // runScheduledDetect is a lightweight in-process driver.
 func runScheduledDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	t.Helper()
-	ents, rels := applyScheduledJobEdges(lang, path, []byte(src), nil, nil)
-	return ents, rels
+	res := applyScheduledJobEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 func scheduledJobsByFramework(ents []types.EntityRecord, framework string) []types.EntityRecord {

--- a/internal/engine/sqs_edges_test.go
+++ b/internal/engine/sqs_edges_test.go
@@ -15,7 +15,8 @@ import (
 // runSQSDetect is a lightweight in-process driver for the SQS pass.
 func runSQSDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
 	t.Helper()
-	ents, rels := applySQSEdges(lang, path, []byte(src), nil, nil)
+	res := applySQSEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	ents, rels := res.Entities, res.Relationships
 	out := make([]entityResult, 0, len(ents))
 	for _, e := range ents {
 		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})

--- a/internal/engine/webhooks_edges_test.go
+++ b/internal/engine/webhooks_edges_test.go
@@ -15,8 +15,8 @@ import (
 // runWebhookDetect is a lightweight in-process driver.
 func runWebhookDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	t.Helper()
-	ents, rels := applyWebhookEdges(lang, path, []byte(src), nil, nil)
-	return ents, rels
+	res := applyWebhookEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
 }
 
 func webhookEntities(ents []types.EntityRecord) []types.EntityRecord {

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -196,6 +196,32 @@ type FileInput struct {
 	// fixtures (which call Detector.Detect without going through the full
 	// pipeline) keep working unchanged.
 	Pass1Entities []types.EntityRecord
+
+	// CrossFileFields is the cross-file ORM field-resolution closure
+	// (issue #2448 / Phase B).
+	//
+	// applyORMFieldEdges resolves <Model>.<field> references first via
+	// Pass1Entities (intra-file), and falls back to this closure when the
+	// model lives in a SIBLING file (the canonical Django split:
+	// `models.py` defines `class User` while `views.py` imports it and
+	// calls `User.objects.filter(cognito_id=…)`).
+	//
+	// The closure is built ONCE per indexing run by the coordinator
+	// (in-process: cmd/archigraph/index.go runPass25FrameworkRules;
+	// subprocess: internal/daemon/extract/subproc.go) from the union of
+	// SCOPE.Schema(subtype=field) records across ALL files in the
+	// indexed scope (or the batch, in the subprocess case). It is then
+	// attached to every per-file FileInput before Detect.
+	//
+	// Lookup contract: given a model class name (e.g. "User"), return
+	// every SCOPE.Schema(subtype=field) entity for that model regardless
+	// of source file. Returning nil / empty is valid and means "no
+	// cross-file fields known for this model" — the caller drops the
+	// edge silently.
+	//
+	// Nil is valid — direct test fixtures that don't go through the
+	// coordinator path get the intra-file-only behaviour unchanged.
+	CrossFileFields func(modelName string) []types.EntityRecord
 }
 
 // Extractor is the interface all language extractors must implement.


### PR DESCRIPTION
## Summary
- Closes #2448. PR #2425 (#2352) added intra-file `Pass1Entities` plumbing; PR #2446 / #2497 standardized `DetectorPassArgs`. This lands Phase B: the coordinator builds a global cross-file field lookup closure from all Pass-1 records and attaches it to every `FileInput`. `applyORMFieldEdges` now falls back to the cross-file branch when intra-file resolution misses.
- New typed channel `extractor.FileInput.CrossFileFields func(modelName string) []types.EntityRecord` (and forwarded onto `DetectorPassArgs.CrossFileFields`). New helper `engine.BuildCrossFileFieldLookup`.
- End-to-end: a 2-file Django fixture (`models.py` defining `User`, `views.py` importing it and calling `User.objects.filter(cognito_id=...)`) now produces READS_FIELD + WRITES_FIELD edges to `User.cognito_id` annotated with `resolution=cross_file`. With intra-file definitions, edges carry `resolution=intra_file`. Without the closure attached, byte-identical legacy behaviour.

## Design choice
Option **(b) — lazy lookup closure** (per the issue's recommended path). Pre-bucketed by model name so per-call cost is O(fields-in-model). Closure built once per indexing run; nil result is a valid no-op signal. Closures are first-class Go values; both pipeline paths (in-process and subprocess) run the engine in the SAME process that builds the closure, so closure-over-IPC concerns do not arise here.

## Plumbing
- In-process: `cmd/archigraph/index.go` `runPass25FrameworkRules` calls `engine.BuildCrossFileFieldLookup(pass1Records)` once and stamps it onto every `FileInput`.
- Subprocess: `internal/daemon/extract/subproc.go` runs a lightweight regex pre-pass (`engine.BuildFieldIndex`) across every Python file in the batch before the main loop, synthesises minimal `EntityRecord` shells, and builds the same closure. Pre-pass mirrors the existing DRF / Java DI / Python class registry pre-passes.

## Tech debt surfaced
- **Subprocess scope.** The subprocess closure only covers files in the current batch. A model defined in a file routed to a different subprocess remains invisible. The fix mirrors #1292 (DRF register names): the coordinator should write a shared field-name file before spawning subprocesses, and each subprocess should load from it. Out of scope here.
- **Subprocess pre-pass uses regex, not Pass-1 entities.** Avoids a second AST walk, but if Pass 1 emits richer field metadata in future, both paths should converge on the Pass-1 source.
- **Pre-existing engine-test breakage from PR #2497** (test drivers calling passes with the old positional signature) was fixed mechanically as part of this PR to unblock the engine test gate. Files: `nats_edges_test.go`, `pubsub_edges_test.go`, `pulsar_edges_test.go`, `rabbitmq_edges_test.go`, `redis_pubsub_edges_test.go`, `scheduled_jobs_edges_test.go`, `sqs_edges_test.go`, `webhooks_edges_test.go`. Should be split out into its own follow-up if reviewers prefer.

## Test plan
- [x] `gofmt -l <changed-files>` empty
- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] `go test ./internal/engine/... ./internal/daemon/extract/... ./cmd/archigraph/...` passes
- [x] New tests: `TestORMFieldEdges_CrossFileResolution_Phase_B`, `TestORMFieldEdges_IntraFileWinsOverCrossFile`, `TestBuildCrossFileFieldLookup_NilOnEmpty` all pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)