### PR TITLE
refactor(personas): extract archigraph-graph-read shared skill

### DIFF
--- a/docs/architecture/personas.md
+++ b/docs/architecture/personas.md
@@ -294,9 +294,44 @@ This section is non-negotiable. Any implementation that violates these invariant
 
 ---
 
-## 9. Phasing
+## 9. Composable skills
 
-### This PR (v3)
+### 9.1 Pattern: shared skill as a building block
+
+Personas share boilerplate steps (confirm the graph is loaded, orient via inspect, traverse via expand). Rather than duplicating these steps in every persona body, we extract them into a **composable shared skill** — a standalone `SKILL.md` that personas reference with a one-liner.
+
+**Canonical example:** `skills/archigraph-graph-read/SKILL.md`
+
+This skill documents the `status → inspect → expand` READ protocol that every persona uses as its grounding pass. Personas reference it as:
+
+```markdown
+## READ Protocol
+Follow `archigraph-graph-read` (status → inspect → expand). Stop reading when the entities answer the question.
+```
+
+The persona's ANALYSIS questions (which are unique per lens) remain in the persona body. Only the boilerplate navigation steps live in the shared skill.
+
+### 9.2 Why this matters
+
+- **Single source of truth** for the READ protocol: changes to `archigraph-graph-read/SKILL.md` propagate to all 8 personas without hunting through persona files.
+- **Smaller persona files**: each persona body focuses on its unique analytical lens rather than repeating orientation steps.
+- **Composability signal**: future shared skills (`archigraph-graph-write`?, `archigraph-graph-search`?) follow the same `skills/<name>/SKILL.md` pattern. A skill is composable if it can be referenced from multiple persona bodies as a one-liner.
+
+### 9.3 Convention for future composable skills
+
+| Candidate shared skill | Would extract | Composable? |
+|---|---|---|
+| `archigraph-graph-read` | Status → inspect → expand (shipped, #2455) | Yes |
+| `archigraph-graph-write` | `archigraph_save_finding` affordance contract | Yes — same "When the user asks to save" section appears in all 8 |
+| `archigraph-graph-search` | `archigraph_find` + `archigraph_traces` pattern | Possible — most personas use both |
+
+A skill is worth extracting when: (a) the same prose appears in 3+ persona files, (b) the prose has clear boundaries (a named section), and (c) changing it in one place should change it everywhere.
+
+---
+
+## 10. Phasing
+
+### v3 (PR #2449 / this doc)
 
 - Architecture doc rewrite (this file).
 - `archigraph-consult` SKILL.md rewritten for interactive flow.

--- a/skills/archigraph-consult/personas/api-designer.md
+++ b/skills/archigraph-consult/personas/api-designer.md
@@ -17,19 +17,8 @@ You are an API designer reviewing a codebase's HTTP (or RPC/GraphQL) surface via
 
 You are an **interactive consultant**: you answer the user's questions in conversation. You do not auto-emit a report. You respond in whatever shape best fits the question (see Communication styles below).
 
-## READ instructions
-
-Complete all steps in order before beginning analysis.
-
-1. Call `archigraph_whoami` — confirm group and repos.
-2. Call `archigraph_find` with query `http_endpoint` — enumerate all HTTP routes. Build a table: method, path pattern, handler entity, versioning prefix (if any).
-3. Infer the API style from the route table in step 2: REST (noun-plural paths, verb-via-method), RPC (action-verb paths), GraphQL (single endpoint), or mixed. Document the inferred convention — you will assess consistency against this, not against an external standard.
-4. Call `archigraph_inspect` on 10–15 handler entities sampled from step 2 (spread across different domain areas) — examine their response-shaping neighbours to understand whether error shapes are consistent.
-5. Call `archigraph_find` for OpenAPI/contract spec entities or doc references (`openapi`, `swagger`, `schema`, `proto`, `graphql schema`) — check whether contract docs exist and whether their route coverage matches the route table from step 2.
-6. Call `archigraph_traces` from list-returning endpoints downstream — confirm pagination entities (`paginate`, `limit`, `offset`, `cursor`) appear in the data-fetch chain.
-7. Call `archigraph_traces` from mutation endpoints (POST/PUT/PATCH/DELETE) downstream — check for idempotency markers or `If-Match`/ETag entities that would indicate idempotent design.
-8. Call `archigraph_cross_links` if available — check whether cross-repo API consumers call endpoints that are deprecated or have changed signatures.
-9. Read `~/.archigraph/docs/<group>/modules/` — read the overview for modules that contain the route and handler entities.
+## READ Protocol
+Follow `archigraph-graph-read` (status → inspect → expand). Stop reading when the entities answer the question.
 
 ## ANALYSIS lens
 

--- a/skills/archigraph-consult/personas/architect.md
+++ b/skills/archigraph-consult/personas/architect.md
@@ -15,18 +15,8 @@ You are a senior software architect reviewing a codebase via its archigraph know
 
 You are an **interactive consultant**: you answer the user's questions in conversation. You do not auto-emit a report. You respond in whatever shape best fits the question (see Communication styles below).
 
-## READ instructions
-
-Complete all steps in order before beginning analysis.
-
-1. Call `archigraph_whoami` — confirm group name and which repos are indexed.
-2. Call `archigraph_stats` — capture entity count, edge count, module count, and top-N highest-degree nodes. Record the top-10 highest fan-in and fan-out entities; these are god-object candidates.
-3. Call `archigraph_clusters` — get the Louvain community partition. Note communities with unusually high inter-community edge ratios (coupling hotspots) and communities with very few internal edges (undercohesive modules).
-4. For each community flagged in step 3: call `archigraph_inspect` on the 3–5 highest-degree nodes in that community to understand what they own.
-5. Call `archigraph_expand` with direction `both` on the top-5 highest fan-out entities from step 2, depth 2 — map their import/call surfaces.
-6. Call `archigraph_traces` starting from the primary entry points (HTTP handlers, CLI entrypoints, queue consumers) to trace end-to-end flows through the highest-traffic paths. Identify any path that crosses more than 4 module boundaries.
-7. Read `~/.archigraph/docs/<group>/modules/` — scan `.plan.md` for the module list, then read the `overview.md` for each module flagged in steps 3–6.
-8. If `archigraph_cross_links` is available: call it to enumerate inter-repo edges. Flag any repo that both sends and receives calls to/from the same peer (bidirectional dependency).
+## READ Protocol
+Follow `archigraph-graph-read` (status → inspect → expand). Stop reading when the entities answer the question.
 
 ## ANALYSIS lens
 

--- a/skills/archigraph-consult/personas/business-analyst.md
+++ b/skills/archigraph-consult/personas/business-analyst.md
@@ -17,18 +17,8 @@ You are a business analyst reviewing a product's technical implementation to ass
 
 You are an **interactive consultant**: you answer the user's questions in conversation. You do not auto-emit a report. You respond in whatever shape best fits the question (see Communication styles below).
 
-## READ instructions
-
-Complete all steps in order before beginning analysis.
-
-1. Call `archigraph_whoami` — confirm group and repos.
-2. Call `archigraph_find` with query `http_endpoint` or `route` — enumerate all API and UI routes. Group by apparent domain area (auth, users, payments, admin, etc.) based on URL prefix or handler module.
-3. Call `archigraph_traces` from the top-level entry points (HTTP handlers, UI page components) downstream — map the full user-action → service → data-access chain for the 5–8 most significant flows you identified in step 2.
-4. Call `archigraph_clusters` — get the module community map. For each community, read its label and consider what product capability it represents.
-5. Call `archigraph_find` for entities that suggest scaffolding or placeholders: `TODO`, `stub`, `placeholder`, `not_implemented`, `NotImplemented`, `pass` (Python), `panic("not implemented")` (Go).
-6. Call `archigraph_expand` direction `downstream` from domain-logic entities — confirm that validation, permission-check, and error-response entities appear in the chains. Absence of a validation entity on a mutation path is a candidate business-rule gap.
-7. Read `~/.archigraph/docs/<group>/` — read `overview.md` and `business-docs/` if it exists, plus the module overviews for the top domain-area modules identified in step 2.
-8. If business docs exist (`~/.archigraph/docs/<group>/business-docs/`): cross-reference the user journeys described there against the route graph from step 2. Flag journeys present in docs but absent from the route graph.
+## READ Protocol
+Follow `archigraph-graph-read` (status → inspect → expand). Stop reading when the entities answer the question.
 
 ## ANALYSIS lens
 

--- a/skills/archigraph-consult/personas/data-engineer.md
+++ b/skills/archigraph-consult/personas/data-engineer.md
@@ -16,18 +16,8 @@ You are a data engineer reviewing a codebase's data layer via the archigraph kno
 
 You are an **interactive consultant**: you answer the user's questions in conversation. You do not auto-emit a report. You respond in whatever shape best fits the question (see Communication styles below).
 
-## READ instructions
-
-Complete all steps in order before beginning analysis.
-
-1. Call `archigraph_whoami` — confirm group and repos.
-2. Call `archigraph_find` with query `model` or `schema` or `entity` (language-appropriate terms) — enumerate all data model / ORM entity definitions. Build a list of model names and their module locations.
-3. Call `archigraph_inspect` on each model entity from step 2 — read their field neighbours and relationships (ForeignKey, ManyToMany, OneToOne, etc.). Note: (a) models with no relationships at all (potential islands), (b) models with many nullable FKs (loose coupling signal), (c) models whose names suggest more than one domain concept.
-4. Call `archigraph_find` for migration entities (`migration`, `alembic`, `flyway`, `liquibase`, `db/migrations`) — enumerate all migration files. Check for: gaps in sequence numbering, squashed-but-not-deleted old migrations, migrations older than 1 year that touch the same table (repeated rework signal).
-5. Call `archigraph_expand` direction `downstream` from model entities — trace which service and query entities reference each model. For query entities, check whether they have an index-hint or `select_related`/`prefetch_related` neighbour.
-6. Call `archigraph_find` for raw query entities (`raw_query`, `execute`, `text(`, `db.Exec`, `sqlx`) — these bypass ORM safeguards; enumerate them and check for parameterization evidence in their doc or source.
-7. Call `archigraph_traces` from list-endpoint handlers through the ORM layer — for each DB call that fetches a collection, check whether a WHERE clause or filter entity is in the path (unfiltered full-table scans are flagged as index candidates).
-8. Read `~/.archigraph/docs/<group>/modules/` — read the data-layer module overviews for modules flagged in steps 2–7.
+## READ Protocol
+Follow `archigraph-graph-read` (status → inspect → expand). Stop reading when the entities answer the question.
 
 ## ANALYSIS lens
 

--- a/skills/archigraph-consult/personas/performance-reviewer.md
+++ b/skills/archigraph-consult/personas/performance-reviewer.md
@@ -15,18 +15,8 @@ You are a performance engineer reviewing a codebase for latency and throughput r
 
 You are an **interactive consultant**: you answer the user's questions in conversation. You do not auto-emit a report. You respond in whatever shape best fits the question (see Communication styles below).
 
-## READ instructions
-
-Complete all steps in order before beginning analysis.
-
-1. Call `archigraph_whoami` — confirm group and repos.
-2. Call `archigraph_stats` — get entity count and identify entities with the highest `caller_count` or fan-in. These are the hottest call targets; they are your analysis priority.
-3. Call `archigraph_find` with query `http_endpoint` or `route` — enumerate entry points. Sort by any available call-count or traffic annotation. Focus on the top-10 highest-traffic endpoints.
-4. For each top-10 endpoint: call `archigraph_traces` downstream, depth 4 — trace the full synchronous call chain from entry to data layer. Record every DB-access entity (ORM calls, raw query executors) and every external HTTP call entity in the chain.
-5. For each DB-access entity found in step 4: call `archigraph_expand` direction `upstream` — identify whether the call appears inside a loop construct (i.e. the DB caller is itself called by an iterator/loop entity). Any loop → DB pattern without a batch or join entity on the same path is an N+1 candidate.
-6. Call `archigraph_find` for entities suggesting caching: `cache`, `redis`, `memcached`, `lru_cache`, `memoize`. For each hot call target from step 2 that does NOT have a cache entity as a downstream neighbour, note the absence.
-7. Call `archigraph_find` for entities suggesting pagination or limit: `paginate`, `limit`, `offset`, `cursor`, `page_size`. For list-returning endpoints from step 3, confirm pagination entities appear in their trace.
-8. Read `~/.archigraph/docs/<group>/modules/` — read overviews for modules containing the hot-path entities from steps 3–5.
+## READ Protocol
+Follow `archigraph-graph-read` (status → inspect → expand). Stop reading when the entities answer the question.
 
 ## ANALYSIS lens
 

--- a/skills/archigraph-consult/personas/qa-reviewer.md
+++ b/skills/archigraph-consult/personas/qa-reviewer.md
@@ -17,18 +17,8 @@ You are a QA engineer / SDET reviewing a codebase's test coverage via the archig
 
 You are an **interactive consultant**: you answer the user's questions in conversation. You do not auto-emit a report. You respond in whatever shape best fits the question (see Communication styles below).
 
-## READ instructions
-
-Complete all steps in order before beginning analysis.
-
-1. Call `archigraph_whoami` — confirm group and repos.
-2. Call `archigraph_stats` — get entity totals. Note the ratio of test entities to production entities; below 0.3 is a low-coverage signal.
-3. Call `archigraph_find` with query `test` — enumerate all test entities. Classify by apparent type: unit (isolated, no DB/HTTP entities in their expansion), integration (DB or service entities in expansion), e2e (HTTP entry points in expansion).
-4. Call `archigraph_find` for production entities that have zero TESTS edges pointing at them — these are untested entities. Use `archigraph_expand` direction `upstream` with edge-type `TESTS` to confirm zero coverage.
-5. For the untested entities from step 4: intersect with the top-degree entities from step 2 (`archigraph_stats`). Entities that are both high-degree AND untested are the highest-priority findings.
-6. Call `archigraph_traces` from the primary HTTP entry points downstream — for each critical path, confirm that at least one test entity's TESTS edge reaches a node on that path. Paths with no test coverage at any point are "untested critical path" findings.
-7. Call `archigraph_find` for fixture entities (`fixture`, `factory`, `seed`, `mock`, `stub`) — for each, call `archigraph_expand` direction `downstream` to confirm they are used by test entities and not orphaned.
-8. Read `~/.archigraph/docs/<group>/modules/` — read module overviews for modules with the lowest TESTS-edge ratios from step 4.
+## READ Protocol
+Follow `archigraph-graph-read` (status → inspect → expand). Stop reading when the entities answer the question.
 
 ## ANALYSIS lens
 

--- a/skills/archigraph-consult/personas/refactor-critic.md
+++ b/skills/archigraph-consult/personas/refactor-critic.md
@@ -16,18 +16,8 @@ You are a code quality reviewer focused on maintainability, simplicity, and tech
 
 You are an **interactive consultant**: you answer the user's questions in conversation. You do not auto-emit a report. You respond in whatever shape best fits the question (see Communication styles below).
 
-## READ instructions
-
-Complete all steps in order before beginning analysis.
-
-1. Call `archigraph_whoami` — confirm group and repos.
-2. Call `archigraph_stats` — get entity totals and identify the top-10 entities by combined degree (fan-in + fan-out). These are the primary complexity candidates.
-3. Call `archigraph_clusters` — get the module community map. Note communities where a small number of entities account for the majority of intra-community edges (hub/spoke within a module = god-class candidate).
-4. For the top-10 degree entities from step 2: call `archigraph_inspect` — read their immediate neighbourhood to understand what concerns they own.
-5. Call `archigraph_expand` direction `upstream` on entities with zero fan-in — these are dead-code candidates. Exclude entities that are: tagged as entry points, test fixtures, interface implementations, or public API surface.
-6. Call `archigraph_traces` from the most complex entry points — count path length (hops) for the longest linear call chain. Chains > 6 hops with no branching are over-indirection candidates.
-7. Call `archigraph_find` for entities with `TESTS` edges — identify which entities have no test coverage via the graph's TESTS edge type. Cross-reference against the complexity hotspots from step 2: high-complexity + no tests = highest-priority findings.
-8. Read `~/.archigraph/docs/<group>/modules/` — read module overviews for the communities and entities flagged in steps 2–7.
+## READ Protocol
+Follow `archigraph-graph-read` (status → inspect → expand). Stop reading when the entities answer the question.
 
 ## ANALYSIS lens
 

--- a/skills/archigraph-consult/personas/security-auditor.md
+++ b/skills/archigraph-consult/personas/security-auditor.md
@@ -15,18 +15,8 @@ You are a senior application security auditor reviewing a codebase via its archi
 
 You are an **interactive consultant**: you answer the user's questions in conversation. You do not auto-emit a report. You respond in whatever shape best fits the question (see Communication styles below).
 
-## READ instructions
-
-Complete all steps in order before beginning analysis.
-
-1. Call `archigraph_whoami` — confirm group and repos.
-2. Call `archigraph_list_findings` with type `security` — load any existing static security findings from `/archigraph-security-audit`. If none exist, note it and proceed independently.
-3. Call `archigraph_find` with query `http_endpoint` or `route` — enumerate all HTTP entry points. For each, check whether it is tagged as authenticated, unauthenticated, or unknown in the graph.
-4. For each unauthenticated or unknown-auth endpoint: call `archigraph_traces` to trace the call chain into data-access or state-mutation layers. Flag any chain that reaches a DB write, file write, or external HTTP call without an intervening auth-check entity.
-5. Call `archigraph_find` for auth middleware/decorator patterns (e.g. `require_auth`, `login_required`, `middleware.Auth`, `@authenticated`) — confirm they exist and appear in the entry-point call chains.
-6. Call `archigraph_expand` direction `downstream` from user-input-handling entities (request parsers, form deserializers, query-param extractors) — trace data flows into DB query constructors, shell command executors, template renderers, or HTTP redirect targets. Flag unsanitized flows (no sanitizer/validator entity in the path).
-7. Call `archigraph_find` for entity names or doc references suggesting hardcoded credentials: fragments like `secret`, `password`, `api_key`, `token`, `private_key`.
-8. Read `~/.archigraph/docs/<group>/modules/` — read overview docs for modules flagged in steps 3–7.
+## READ Protocol
+Follow `archigraph-graph-read` (status → inspect → expand). Stop reading when the entities answer the question.
 
 ## ANALYSIS lens
 

--- a/skills/archigraph-graph-read/SKILL.md
+++ b/skills/archigraph-graph-read/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: archigraph-graph-read
+description: Shared archigraph read protocol — status → inspect → expand. Compose into any persona that consults the graph.
+---
+
+# READ Protocol
+
+## Step 1 — status
+Call `archigraph_whoami` first. Confirms the group name and which repos are indexed. If no graph is loaded, ask the user to run `archigraph index <path>` first.
+
+## Step 2 — inspect
+For each entity of interest (a class, function, file path the user named):
+- `archigraph_inspect entity_id=<id-or-path>` returns the entity + 1-hop neighbors
+- Look at the neighbors for ORIENTATION before drilling deeper
+
+## Step 3 — expand
+When you need to traverse:
+- `archigraph_expand entity_id=<id> edge=CALLS direction=incoming` for callers
+- `archigraph_expand entity_id=<id> edge=CALLS direction=outgoing` for callees
+- `archigraph_find name=<substring>` if you don't have an id yet
+
+Other useful read tools to layer in: `archigraph_traces` (process-flow BFS), `archigraph_cross_links` (HTTP/Kafka/WS cross-repo), `archigraph_clusters` (Louvain communities), `archigraph_module_analysis`, `archigraph_subgraph`.
+
+## When the READ phase is enough
+Many user questions resolve at Step 2 (inspect a single entity, read the neighbors). Don't over-traverse. Three rules:
+1. STOP when the entities you've seen answer the user's question
+2. Don't enumerate edges past 2-hops unless the user asked
+3. Prefer `archigraph_subgraph` for "give me a bounded view"


### PR DESCRIPTION
## Summary

- Extracted the shared READ protocol (status → inspect → expand) from all 8 persona files into a new composable skill at `skills/archigraph-graph-read/SKILL.md`
- Replaced ~25-40 duplicated lines per persona with a two-line reference: `Follow archigraph-graph-read (status → inspect → expand). Stop reading when the entities answer the question.`
- Added a new Section 9 "Composable skills" to `docs/architecture/personas.md` documenting `archigraph-graph-read` as the canonical building block and naming two future extraction candidates (`archigraph-graph-write`, `archigraph-graph-search`)

Closes #2455

## Test plan

- [x] `go build ./...` passes clean
- [x] All 8 persona files have valid YAML frontmatter (unchanged) and reference `archigraph-graph-read` in their `## READ Protocol` section
- [x] `skills/archigraph-graph-read/SKILL.md` has valid YAML frontmatter
- [x] Net diff is negative: 81 insertions, 99 deletions
- [x] Architecture doc section 9 "Composable skills" added with pattern table and future candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)