### PR TITLE
fix(daemon,store): fleet config absolute paths + repo-hash generation cleanup

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -409,29 +409,36 @@ func runDaemon(argv []string) error {
 
 // daemonReposToWatch returns every repo from every registered group
 // (deduped by absolute path). Called once at daemon startup.
+//
+// #2084: fleet config entries with relative paths or paths that no longer
+// exist on disk (e.g. deleted worktrees) are resolved to absolute and then
+// validated — entries that fail the stat check are skipped with a warning
+// log line so the daemon never spawns a watcher for a phantom directory.
 func daemonReposToWatch() []string {
 	groups, err := registry.Groups()
 	if err != nil {
 		return nil
 	}
 	seen := map[string]bool{}
-	var out []string
+	var raw []string
 	for _, g := range groups {
 		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
 		if err != nil {
 			continue
 		}
 		for _, r := range cfg.Repos {
-			abs, err := filepath.Abs(r.Path)
-			if err != nil {
-				abs = r.Path
-			}
-			if seen[abs] {
-				continue
-			}
-			seen[abs] = true
-			out = append(out, abs)
+			raw = append(raw, r.Path)
 		}
+	}
+	// Resolve + validate — drops relative paths to gone worktrees.
+	resolved := daemon.ResolveFleetRepoPaths(raw, slog.Default())
+	var out []string
+	for _, abs := range resolved {
+		if seen[abs] {
+			continue
+		}
+		seen[abs] = true
+		out = append(out, abs)
 	}
 	return out
 }

--- a/internal/daemon/fleet_hygiene.go
+++ b/internal/daemon/fleet_hygiene.go
@@ -1,0 +1,248 @@
+// fleet_hygiene.go — fleet config path validation and store generation pruning.
+//
+// Issue #2084: Relative paths in fleet config re-resolve against the daemon's
+// cwd when the original worktree is deleted, causing infinite watcher respawns.
+// ResolveFleетRepoPaths turns every path absolute and drops entries whose
+// directory does not exist, emitting a warning log line for each skip.
+//
+// Issue #2085: Each content-hash change creates a new store slot but never
+// removes the previous one. PruneStaleGenerations sweeps old generations —
+// keeping the most recent N (default 2, configurable via
+// ARCHIGRAPH_STORE_KEEP_GENERATIONS) — after a successful index.
+package daemon
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// defaultKeepGenerations is the number of store generations to retain per
+// repo (current + one previous). Users can override via the env var
+// ARCHIGRAPH_STORE_KEEP_GENERATIONS.
+const defaultKeepGenerations = 2
+
+// KeepGenerations returns the configured number of store generations to keep.
+// It reads ARCHIGRAPH_STORE_KEEP_GENERATIONS and falls back to defaultKeepGenerations.
+func KeepGenerations() int {
+	if v := os.Getenv("ARCHIGRAPH_STORE_KEEP_GENERATIONS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			return n
+		}
+	}
+	return defaultKeepGenerations
+}
+
+// ResolveFleetRepoPaths takes a raw list of repo paths (as stored in fleet
+// config — potentially relative), resolves each to an absolute path, and
+// returns only those that point to an existing directory. Entries that cannot
+// be resolved or whose directory does not exist are dropped and logged at Warn
+// level so the daemon never spawns a watcher for a deleted worktree (#2084).
+//
+// logger may be nil; in that case skipped paths are silently dropped.
+func ResolveFleetRepoPaths(rawPaths []string, logger *slog.Logger) []string {
+	out := make([]string, 0, len(rawPaths))
+	for _, raw := range rawPaths {
+		if raw == "" {
+			continue
+		}
+		abs, err := filepath.Abs(raw)
+		if err != nil {
+			if logger != nil {
+				logger.Warn("fleet: cannot resolve repo path — skipping",
+					"raw_path", raw, "err", err)
+			}
+			continue
+		}
+		abs = filepath.Clean(abs)
+		fi, err := os.Stat(abs)
+		if err != nil || !fi.IsDir() {
+			if logger != nil {
+				logger.Warn("fleet: repo path does not exist or is not a directory — skipping watcher (deleted worktree?)",
+					"path", abs)
+			}
+			continue
+		}
+		out = append(out, abs)
+	}
+	return out
+}
+
+// PruneStaleGenerations scans storeDir for old generation slots of any repo
+// whose canonical path appears in activePaths. For each repo basename, all
+// slug-hash slots that share the same base name but whose mtime is not among
+// the keepN most recent are deleted.
+//
+// The function is deliberately conservative:
+//   - It only removes directories that match the "<base>-<16hex>" naming
+//     convention produced by repoSlug.
+//   - It always keeps at least keepN entries even when their paths are not in
+//     activePaths (i.e. it prunes ALL repos in the store, not just active ones,
+//     but still honours keepN so recent index data for removed repos is not
+//     immediately discarded).
+//   - Errors during removal are logged but never returned — a failed prune is
+//     non-fatal.
+//
+// Returns the number of directories removed and the total bytes freed.
+func PruneStaleGenerations(storeDir string, keepN int, logger *slog.Logger) (removed int, freedBytes int64) {
+	if keepN < 1 {
+		keepN = defaultKeepGenerations
+	}
+	if storeDir == "" {
+		return
+	}
+	entries, err := os.ReadDir(storeDir)
+	if err != nil {
+		return
+	}
+
+	// Group store entries by base name (the part before the last "-<16hex>" suffix).
+	type slotInfo struct {
+		name  string // full directory name
+		mtime int64  // most recent artifact mtime inside the slot (ns)
+	}
+	byBase := make(map[string][]slotInfo)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		base, ok := extractSlotBase(name)
+		if !ok {
+			continue
+		}
+		mtime := latestMtime(filepath.Join(storeDir, name))
+		byBase[base] = append(byBase[base], slotInfo{name: name, mtime: mtime})
+	}
+
+	for _, slots := range byBase {
+		if len(slots) <= keepN {
+			continue // nothing to prune
+		}
+		// Sort newest first (highest mtime first).
+		sort.Slice(slots, func(i, j int) bool {
+			return slots[i].mtime > slots[j].mtime
+		})
+		// Delete everything after the first keepN.
+		for _, s := range slots[keepN:] {
+			dir := filepath.Join(storeDir, s.name)
+			sz, _ := dirSizeHygiene(dir)
+			if err := os.RemoveAll(dir); err != nil {
+				if logger != nil {
+					logger.Warn("store: prune old generation — remove failed (non-fatal)",
+						"dir", dir, "err", err)
+				}
+				continue
+			}
+			if logger != nil {
+				logger.Info("store: pruned old generation",
+					"dir", dir, "freed_bytes", sz)
+			}
+			removed++
+			freedBytes += sz
+		}
+	}
+	return
+}
+
+// extractSlotBase extracts the human-readable base from a store slot name of
+// the form "<base>-<16hex>". Returns ("", false) when the name does not match.
+func extractSlotBase(name string) (string, bool) {
+	// A valid slot ends with "-<exactly 16 hex chars>".
+	if len(name) < 18 { // at least 1 char base + "-" + 16 hex
+		return "", false
+	}
+	dash := len(name) - 17 // index of "-" before the 16-hex suffix
+	if name[dash] != '-' {
+		return "", false
+	}
+	suffix := name[dash+1:]
+	for _, c := range suffix {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return "", false
+		}
+	}
+	base := name[:dash]
+	if base == "" {
+		return "", false
+	}
+	return base, true
+}
+
+// latestMtime returns the most recent modification time (ns since epoch) of
+// any file inside dir. Useful for ranking generations when the slot directory's
+// own mtime may be stale on some filesystems.
+func latestMtime(dir string) int64 {
+	var latest int64
+	// Recurse at most one level (refs/<ref>/) to capture per-ref graph files.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if fi, sterr := os.Stat(dir); sterr == nil {
+			return fi.ModTime().UnixNano()
+		}
+		return 0
+	}
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if t := info.ModTime().UnixNano(); t > latest {
+			latest = t
+		}
+		if e.IsDir() {
+			// One additional level (refs/<ref>/) only.
+			sub := filepath.Join(dir, e.Name())
+			subs, serr := os.ReadDir(sub)
+			if serr != nil {
+				continue
+			}
+			for _, se := range subs {
+				si, err := se.Info()
+				if err != nil {
+					continue
+				}
+				if t := si.ModTime().UnixNano(); t > latest {
+					latest = t
+				}
+			}
+		}
+	}
+	return latest
+}
+
+// dirSizeHygiene returns the total byte count of a directory tree.
+// Separate from daemon.dirSize (in service.go) to avoid a naming collision
+// within the package — both live in package daemon but in different files.
+func dirSizeHygiene(dir string) (int64, error) {
+	var total int64
+	err := filepath.Walk(dir, func(_ string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !fi.IsDir() {
+			total += fi.Size()
+		}
+		return nil
+	})
+	return total, err
+}
+
+// slugBaseName returns the human-readable base component of a store slot name
+// for the given absolute repo path. Exported so tests can construct expected
+// store slot prefixes without replicating the slug formula.
+func slugBaseName(absRepoPath string) string {
+	base := filepath.Base(absRepoPath)
+	base = unsafeSlugChars.ReplaceAllString(base, "-")
+	base = strings.Trim(base, "-._")
+	if base == "" {
+		base = "repo"
+	}
+	if len(base) > 48 {
+		base = base[:48]
+	}
+	return base
+}

--- a/internal/daemon/fleet_hygiene_test.go
+++ b/internal/daemon/fleet_hygiene_test.go
@@ -1,0 +1,152 @@
+package daemon
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestResolveFleetRepoPaths_SkipsNonexistentDir covers issue #2084:
+// when a fleet config entry holds a relative or nonexistent path (e.g. a
+// deleted worktree), ResolveFleetRepoPaths must skip it with a warning and
+// never return it in the output list.  The daemon must not panic and must not
+// spawn a watcher for a path that cannot be stat'd as a directory.
+func TestResolveFleetRepoPaths_SkipsNonexistentDir(t *testing.T) {
+	// Create one real directory and one that does not exist.
+	realDir := t.TempDir()
+	gonePath := filepath.Join(t.TempDir(), "deleted-worktree")
+	// gonePath intentionally NOT created — it simulates a removed worktree.
+
+	// Use a relative path for the nonexistent entry to mirror the bug report
+	// (go-chi-mini.fleet.json had "path": "internal/quality/golden/go-chi-mini").
+	// We pass the raw relative string; it will be resolved but won't exist.
+	relativeNonexistent := "some/relative/path/to/nowhere"
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	got := ResolveFleetRepoPaths([]string{realDir, gonePath, relativeNonexistent}, logger)
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 path (the real dir), got %d: %v", len(got), got)
+	}
+	if got[0] != realDir {
+		t.Fatalf("expected %q, got %q", realDir, got[0])
+	}
+}
+
+// TestResolveFleetRepoPaths_EmptyInput checks the nil/empty-slice edge case.
+func TestResolveFleetRepoPaths_EmptyInput(t *testing.T) {
+	got := ResolveFleetRepoPaths(nil, nil)
+	if len(got) != 0 {
+		t.Fatalf("expected empty result for nil input, got %v", got)
+	}
+}
+
+// TestResolveFleetRepoPaths_FileNotDir verifies that a path that exists but is
+// a regular file (not a directory) is also skipped.
+func TestResolveFleetRepoPaths_FileNotDir(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "notadir.txt")
+	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := ResolveFleetRepoPaths([]string{filePath}, nil)
+	if len(got) != 0 {
+		t.Fatalf("expected file path to be skipped, got %v", got)
+	}
+}
+
+// TestPruneStaleGenerations covers issue #2085: after simulating 3 store
+// generations of the same logical repo (same base name, different 16-hex hash
+// suffix), PruneStaleGenerations must remove the oldest one and retain the two
+// most recent (defaultKeepGenerations = 2).
+func TestPruneStaleGenerations_KeepsRecentN(t *testing.T) {
+	storeDir := t.TempDir()
+	base := "myrepo"
+
+	// Create 3 generation directories with distinct mtimes.
+	// We use fake 16-hex hashes that follow the naming convention.
+	slots := []struct {
+		name  string
+		delay time.Duration
+	}{
+		{base + "-aabbccddeeff0011", 0},                      // oldest
+		{base + "-1122334455667788", 50 * time.Millisecond},  // middle
+		{base + "-99aabbccddeeff00", 100 * time.Millisecond}, // newest
+	}
+	for _, s := range slots {
+		dir := filepath.Join(storeDir, s.name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Write a sentinel file so latestMtime has something to read.
+		f := filepath.Join(dir, "graph.fb")
+		if err := os.WriteFile(f, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// Space out mtimes so sorting is deterministic.
+		if s.delay > 0 {
+			mtime := time.Now().Add(s.delay)
+			if err := os.Chtimes(f, mtime, mtime); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chtimes(dir, mtime, mtime); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	removed, _ := PruneStaleGenerations(storeDir, 2, logger)
+
+	if removed != 1 {
+		t.Fatalf("expected 1 generation removed (oldest), got %d", removed)
+	}
+
+	// The oldest slot must be gone.
+	if _, err := os.Stat(filepath.Join(storeDir, slots[0].name)); !os.IsNotExist(err) {
+		t.Errorf("oldest generation %q should have been removed", slots[0].name)
+	}
+	// The two most recent must still exist.
+	for _, s := range slots[1:] {
+		if _, err := os.Stat(filepath.Join(storeDir, s.name)); err != nil {
+			t.Errorf("recent generation %q should still exist: %v", s.name, err)
+		}
+	}
+}
+
+// TestPruneStaleGenerations_NoPruneWhenFewSlots verifies that no directories
+// are removed when the number of slots is already ≤ keepN.
+func TestPruneStaleGenerations_NoPruneWhenFewSlots(t *testing.T) {
+	storeDir := t.TempDir()
+	base := "svc"
+	// Create exactly 2 slots (= keepN default).
+	for _, hash := range []string{"aabbccddeeff0011", "1122334455667788"} {
+		dir := filepath.Join(storeDir, base+"-"+hash)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removed, _ := PruneStaleGenerations(storeDir, 2, nil)
+	if removed != 0 {
+		t.Fatalf("expected 0 removals when slot count == keepN, got %d", removed)
+	}
+}
+
+// TestKeepGenerations_EnvOverride verifies that ARCHIGRAPH_STORE_KEEP_GENERATIONS
+// overrides the default.
+func TestKeepGenerations_EnvOverride(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_STORE_KEEP_GENERATIONS", "5")
+	if got := KeepGenerations(); got != 5 {
+		t.Fatalf("expected 5, got %d", got)
+	}
+}
+
+// TestKeepGenerations_Default verifies the default value when no env var is set.
+func TestKeepGenerations_Default(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_STORE_KEEP_GENERATIONS", "")
+	if got := KeepGenerations(); got != defaultKeepGenerations {
+		t.Fatalf("expected %d (defaultKeepGenerations), got %d", defaultKeepGenerations, got)
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -205,6 +205,14 @@ func Run(ctx context.Context, cfg Config) error {
 			logger.Info("startup: MigrateToRefStore complete", "store", storeDir)
 		}
 
+		// #2085: prune old repo-hash generations so ~/.archigraph/store/ does not
+		// grow unboundedly. Runs after MigrateToRefStore so the layout is
+		// normalised before we inspect mtime order. Non-fatal.
+		keepN := KeepGenerations()
+		if removed, freed := PruneStaleGenerations(storeDir, keepN, logger); removed > 0 {
+			logger.Info("startup: pruned stale store generations",
+				"removed", removed, "freed_bytes", freed, "keep_n", keepN)
+		}
 	}
 
 	releasePID, err := AcquirePIDFile(cfg.Layout.PIDPath)


### PR DESCRIPTION
## Summary

- **#2084**: `ResolveFleetRepoPaths` resolves every fleet config `path` entry to absolute before registering with the watcher. Entries that cannot be stat'd as a directory are skipped with a `WARN` log line, preventing infinite watcher respawn cycles when a worktree is deleted.
- **#2085**: `PruneStaleGenerations` sweeps `~/.archigraph/store/` at daemon startup, removing old `<slug>-<hash>` generations and keeping the most recent `N` (default 2, configurable via `ARCHIGRAPH_STORE_KEEP_GENERATIONS`).

Closes #2084
Closes #2085

## Files changed

- `internal/daemon/fleet_hygiene.go` — new: `ResolveFleetRepoPaths`, `PruneStaleGenerations`, `KeepGenerations`, helpers
- `internal/daemon/fleet_hygiene_test.go` — new: 6 unit tests
- `cmd/archigraph/daemon.go` — `daemonReposToWatch()` uses `ResolveFleetRepoPaths`
- `internal/daemon/server.go` — startup calls `PruneStaleGenerations` after `MigrateToRefStore`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l <changed>` empty
- [x] `TestResolveFleetRepoPaths_SkipsNonexistentDir` — PASS (covers #2084)
- [x] `TestPruneStaleGenerations_KeepsRecentN` — PASS (covers #2085)
- [x] `go test ./internal/daemon/... ./cmd/archigraph/... -count=1` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)