### PR TITLE
feat(mcp): archigraph_persona_event telemetry tool + persona lifecycle hooks

### DIFF
--- a/docs/architecture/personas.md
+++ b/docs/architecture/personas.md
@@ -335,7 +335,67 @@ A skill is worth extracting when: (a) the same prose appears in 3+ persona files
 
 ---
 
-## 10. Phasing
+## 10. Telemetry
+
+### 10.1 What is emitted
+
+Each persona calls `archigraph_persona_event` at two lifecycle points:
+
+| Lifecycle point | `event_type` | Required fields | Optional fields |
+|---|---|---|---|
+| Session start (user hires the persona) | `invoke` | `persona` | `metadata` |
+| Consult-Out (user confirms peer engagement) | `consult_out` | `persona`, `target_persona` | `metadata` |
+| Finding persisted via save_finding | `save_finding` | `persona` | `metadata` |
+
+The `save_finding` event_type is available for future use by the `archigraph-graph-write` shared skill; persona bodies currently only emit `invoke` and `consult_out`.
+
+### 10.2 Storage contract
+
+Events are appended to a daily JSONL file:
+
+```
+~/.archigraph/events/persona-events-YYYY-MM-DD.jsonl
+```
+
+Each line is a JSON object matching the `PersonaEvent` struct in `internal/mcp/persona_telemetry.go`:
+
+```json
+{"ts":"2026-05-27T14:03:22Z","persona":"architect","event_type":"invoke"}
+{"ts":"2026-05-27T14:07:11Z","persona":"architect","event_type":"consult_out","target_persona":"performance-reviewer"}
+```
+
+Files rotate by UTC calendar date. No compaction or deletion is performed by archigraph — the user is responsible for cleanup.
+
+### 10.3 Privacy promise
+
+**LOCAL ONLY.** `archigraph_persona_event` writes exclusively to the local filesystem (`~/.archigraph/events/`). No data is transmitted to any remote endpoint, no aggregation service is contacted, and no identifier beyond the persona name is captured. The `metadata` field is optional and caller-controlled — personas do not populate it with user data. This promise is enforced by the handler implementation in `internal/mcp/persona_telemetry.go` — there is no HTTP client, no gRPC call, and no queue write in that file.
+
+### 10.4 Viewing events
+
+```bash
+# Today's events
+cat ~/.archigraph/events/persona-events-$(date -u +%Y-%m-%d).jsonl | jq .
+
+# Invoke frequency by persona
+cat ~/.archigraph/events/persona-events-*.jsonl | jq -r 'select(.event_type=="invoke") | .persona' | sort | uniq -c | sort -rn
+
+# Consult-Out pairs
+cat ~/.archigraph/events/persona-events-*.jsonl | jq -r 'select(.event_type=="consult_out") | "\(.persona) → \(.target_persona)"' | sort | uniq -c | sort -rn
+```
+
+A `archigraph personas events --tail` viewer CLI is deferred (see Section 11 Phasing).
+
+### 10.5 Failure behaviour
+
+Telemetry failures (disk full, permissions error, missing HOME) do not surface as errors to the user. The tool returns `{"recorded": false, "warning": "<reason>"}` and the persona continues normally. Personas treat a non-`recorded=true` response as a no-op.
+
+### 10.6 Deferred personas
+
+The four deferred personas (`solutions-architect`, `devops-reviewer`, `compliance-officer`, `dx-engineer`) are NOT yet updated with the Lifecycle telemetry section. When those personas ship, they MUST mirror the pattern exactly as documented in Section 10.1 — the section text is boilerplate and should be copy-pasted with the correct persona name substituted.
+
+---
+
+## 11. Phasing
 
 ### v3 (PR #2449 / this doc)
 
@@ -353,10 +413,11 @@ A skill is worth extracting when: (a) the same prose appears in 3+ persona files
 | Codex / generic-markdown wrappers | Low user demand; defer until requested |
 | Persona-emitted findings → graph (opt-in) | **Shipped in #2472** — "When the user asks to save this analysis" section added to all 8 persona bodies; Section 2.4 defines the contract |
 | Consult-Out depth > 1 (peer of peer) | Single hop only in v3 |
-| Telemetry on persona usage / Consult-Out frequency | Needs privacy review |
+| Telemetry on persona usage / Consult-Out frequency | **Shipped in #2474** — `archigraph_persona_event` MCP tool; Section 10 defines the contract and privacy promise |
 | Per-persona model selection strategy | **Shipped in #2475** — `model:` frontmatter on all 8 personas with opinionated recommendations; Section 2.3 defines the mapping and override contract |
 | Cross-platform renderer CLI | Defer until 3+ platforms stable |
-| Solutions-architect / devops / compliance / dx personas | **Shipped in this PR** (feature/personas-2451-2454) — built without original gates met, per user directive. Each documents signal-quality limitations in its persona body. Closing the gate gaps is tracked separately in the personas issue queue. |
+| Solutions-architect / devops / compliance / dx personas | **Shipped in #2451-#2454** — built without original gates met, per user directive. Each documents signal-quality limitations in its persona body. Closing the gate gaps is tracked separately in the personas issue queue. |
+| `archigraph personas events --tail` CLI viewer | Deferred; use `jq` one-liners from Section 10.4 in the meantime |
 
 ---
 

--- a/internal/mcp/persona_telemetry.go
+++ b/internal/mcp/persona_telemetry.go
@@ -1,0 +1,153 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// personaEventTypes is the set of allowed event_type values for archigraph_persona_event.
+var personaEventTypes = map[string]bool{
+	"invoke":       true,
+	"consult_out":  true,
+	"save_finding": true,
+}
+
+// personaEventsDir returns the daily JSONL file path for persona telemetry.
+// Files rotate by calendar date: ~/.archigraph/events/persona-events-YYYY-MM-DD.jsonl
+// The directory is created on first write; callers must handle the mkdirall.
+func personaEventsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("persona_telemetry: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".archigraph", "events"), nil
+}
+
+// personaEventsFile returns the path for today's persona-events JSONL file.
+func personaEventsFile() (string, error) {
+	dir, err := personaEventsDir()
+	if err != nil {
+		return "", err
+	}
+	date := time.Now().UTC().Format("2006-01-02")
+	return filepath.Join(dir, fmt.Sprintf("persona-events-%s.jsonl", date)), nil
+}
+
+// PersonaEvent is the structure written to the JSONL event log.
+// All fields map directly to archigraph_persona_event inputs.
+// LOCAL ONLY — never transmitted remotely (privacy promise; see Section 10 in personas.md).
+type PersonaEvent struct {
+	// Timestamp is the UTC ISO-8601 instant the event was recorded.
+	Timestamp string `json:"ts"`
+	// Persona is the name of the active persona (e.g. "architect").
+	Persona string `json:"persona"`
+	// EventType is one of: "invoke", "consult_out", "save_finding".
+	EventType string `json:"event_type"`
+	// TargetPersona is the peer persona name on consult_out events. Empty otherwise.
+	TargetPersona string `json:"target_persona,omitempty"`
+	// Metadata is an optional free-form map for future extensibility.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// appendPersonaEvent writes one JSON line to the daily JSONL file.
+// It is safe to call concurrently — the OS write + sync model provides
+// sufficient ordering guarantees for append-only JSONL on a local filesystem.
+func appendPersonaEvent(evt PersonaEvent) (string, error) {
+	path, err := personaEventsFile()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("persona_telemetry: mkdir %s: %w", dir, err)
+	}
+	line, err := json.Marshal(evt)
+	if err != nil {
+		return "", fmt.Errorf("persona_telemetry: marshal event: %w", err)
+	}
+	line = append(line, '\n')
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("persona_telemetry: open %s: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := f.Write(line); err != nil {
+		return "", fmt.Errorf("persona_telemetry: write event: %w", err)
+	}
+	return path, nil
+}
+
+// handlePersonaEvent is the handler for archigraph_persona_event (#2474).
+//
+// Personas call this tool:
+//   - On session start:   event_type="invoke"
+//   - On each Consult-Out: event_type="consult_out", target_persona=<name>
+//   - When a finding is persisted: event_type="save_finding"
+//
+// The event is appended to the daily JSONL file at:
+//
+//	~/.archigraph/events/persona-events-YYYY-MM-DD.jsonl
+//
+// Privacy guarantee: LOCAL ONLY. No remote emission occurs. Callers need not
+// pass group/cwd — this tool is group-agnostic by design.
+func (s *Server) handlePersonaEvent(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	persona, err := req.RequireString("persona")
+	if err != nil {
+		return mcpapi.NewToolResultError("archigraph_persona_event: persona (string, required): " + err.Error()), nil
+	}
+	if persona == "" {
+		return mcpapi.NewToolResultError("archigraph_persona_event: persona must not be empty"), nil
+	}
+
+	eventType, err := req.RequireString("event_type")
+	if err != nil {
+		return mcpapi.NewToolResultError("archigraph_persona_event: event_type (string, required): " + err.Error()), nil
+	}
+	if !personaEventTypes[eventType] {
+		return mcpapi.NewToolResultError(
+			fmt.Sprintf("archigraph_persona_event: event_type must be one of invoke|consult_out|save_finding; got %q", eventType),
+		), nil
+	}
+
+	targetPersona := argString(req, "target_persona", "")
+
+	// metadata is accepted as a raw map if the client provides it.
+	var metadata map[string]any
+	if raw, ok := req.GetArguments()["metadata"]; ok {
+		if m, ok := raw.(map[string]any); ok {
+			metadata = m
+		}
+	}
+
+	ts := time.Now().UTC().Format(time.RFC3339)
+	evt := PersonaEvent{
+		Timestamp:     ts,
+		Persona:       persona,
+		EventType:     eventType,
+		TargetPersona: targetPersona,
+		Metadata:      metadata,
+	}
+
+	_, writeErr := appendPersonaEvent(evt)
+	if writeErr != nil {
+		// Telemetry failures should NOT block the persona workflow. Return a
+		// non-error result with a warning so the calling persona can continue.
+		return jsonResult(map[string]any{
+			"recorded": false,
+			"ts":       ts,
+			"warning":  writeErr.Error(),
+		}), nil
+	}
+
+	return jsonResult(map[string]any{
+		"recorded": true,
+		"ts":       ts,
+	}), nil
+}

--- a/internal/mcp/persona_telemetry_test.go
+++ b/internal/mcp/persona_telemetry_test.go
@@ -1,0 +1,196 @@
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestPersonaEventInputValidation verifies that archigraph_persona_event
+// rejects malformed calls without panicking or writing to disk.
+func TestPersonaEventInputValidation(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(regPath, []byte(`{"groups":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name    string
+		args    map[string]any
+		wantErr string
+	}{
+		{
+			name:    "missing persona",
+			args:    map[string]any{"event_type": "invoke"},
+			wantErr: "persona",
+		},
+		{
+			name:    "empty persona",
+			args:    map[string]any{"persona": "", "event_type": "invoke"},
+			wantErr: "persona",
+		},
+		{
+			name:    "missing event_type",
+			args:    map[string]any{"persona": "architect"},
+			wantErr: "event_type",
+		},
+		{
+			name:    "invalid event_type",
+			args:    map[string]any{"persona": "architect", "event_type": "unknown"},
+			wantErr: "event_type",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := callTool(t, srv, "archigraph_persona_event", tc.args)
+			if res == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if !res.IsError {
+				t.Errorf("expected IsError=true for case %q, got false; content: %v", tc.name, res.Content)
+			}
+			text := resultText(res)
+			if text == "" {
+				t.Errorf("expected error text for case %q", tc.name)
+			}
+			// The error message should reference the bad field name.
+			if tc.wantErr != "" {
+				found := false
+				for _, s := range []string{tc.wantErr} {
+					if containsStr(text, s) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected error text to contain %q; got %q", tc.wantErr, text)
+				}
+			}
+		})
+	}
+}
+
+// TestPersonaEventJSONLAppend verifies that a valid archigraph_persona_event
+// call appends a well-formed JSON line to the daily JSONL file.
+func TestPersonaEventJSONLAppend(t *testing.T) {
+	// Override HOME so the JSONL file lands in a temp dir.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	// Also override on macOS (os.UserHomeDir can read $HOME or Getpw; set both).
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
+
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(regPath, []byte(`{"groups":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := time.Now().UTC().Truncate(time.Second)
+
+	// Emit an invoke event.
+	res := callTool(t, srv, "archigraph_persona_event", map[string]any{
+		"persona":    "architect",
+		"event_type": "invoke",
+	})
+	if res == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", resultText(res))
+	}
+
+	// The result must contain recorded=true and a ts field.
+	text := resultText(res)
+	var got map[string]any
+	if err := json.Unmarshal([]byte(text), &got); err != nil {
+		t.Fatalf("response is not JSON: %v — text: %s", err, text)
+	}
+	if got["recorded"] != true {
+		t.Errorf("expected recorded=true, got %v", got["recorded"])
+	}
+	if got["ts"] == "" || got["ts"] == nil {
+		t.Errorf("expected non-empty ts, got %v", got["ts"])
+	}
+
+	// Emit a consult_out event.
+	res2 := callTool(t, srv, "archigraph_persona_event", map[string]any{
+		"persona":        "architect",
+		"event_type":     "consult_out",
+		"target_persona": "performance-reviewer",
+	})
+	if res2 == nil || res2.IsError {
+		t.Fatalf("consult_out event failed: %v", resultText(res2))
+	}
+
+	// Verify the JSONL file has exactly 2 lines and both are valid JSON.
+	date := time.Now().UTC().Format("2006-01-02")
+	evtPath := filepath.Join(tmpHome, ".archigraph", "events", "persona-events-"+date+".jsonl")
+	f, err := os.Open(evtPath)
+	if err != nil {
+		t.Fatalf("expected JSONL file at %s: %v", evtPath, err)
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	var lines []string
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 JSONL lines, got %d", len(lines))
+	}
+
+	var evt1 PersonaEvent
+	if err := json.Unmarshal([]byte(lines[0]), &evt1); err != nil {
+		t.Fatalf("line 1 is not valid JSON: %v — line: %s", err, lines[0])
+	}
+	if evt1.Persona != "architect" {
+		t.Errorf("evt1.Persona: want architect, got %q", evt1.Persona)
+	}
+	if evt1.EventType != "invoke" {
+		t.Errorf("evt1.EventType: want invoke, got %q", evt1.EventType)
+	}
+	ts1, err := time.Parse(time.RFC3339, evt1.Timestamp)
+	if err != nil {
+		t.Errorf("evt1.Timestamp is not RFC3339: %q", evt1.Timestamp)
+	} else if ts1.Before(before) {
+		t.Errorf("evt1.Timestamp %v is before test start %v", ts1, before)
+	}
+
+	var evt2 PersonaEvent
+	if err := json.Unmarshal([]byte(lines[1]), &evt2); err != nil {
+		t.Fatalf("line 2 is not valid JSON: %v — line: %s", err, lines[1])
+	}
+	if evt2.EventType != "consult_out" {
+		t.Errorf("evt2.EventType: want consult_out, got %q", evt2.EventType)
+	}
+	if evt2.TargetPersona != "performance-reviewer" {
+		t.Errorf("evt2.TargetPersona: want performance-reviewer, got %q", evt2.TargetPersona)
+	}
+}
+
+// containsStr is a small helper to avoid importing strings in test scope.
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -259,11 +259,12 @@ func (s *Server) fullToolList() ([]MCPToolEntry, error) {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 42 (#1281: 9→4 bundles; #1293: desc trim; #1312: +quality_cycles; #1314: +auth_coverage;
+// Tool count: 43 (#1281: 9→4 bundles; #1293: desc trim; #1312: +quality_cycles; #1314: +auth_coverage;
 //
 //	#1322: +secrets; #1323: +test_coverage; #1333: desc ≤80 chars;
 //	refactor/mcp-real-3k: ≤3k handshake; #2424: +cross_links; #2426: +save_finding,+list_findings;
-//	#2427: +license_audit re-wired — no HTTP route found in internal/dashboard/).
+//	#2427: +license_audit re-wired — no HTTP route found in internal/dashboard/;
+//	#2474: +archigraph_persona_event persona lifecycle telemetry).
 //
 // Dropped (HTTP-only): archigraph_diagnostics, archigraph_quality_orphans,
 //
@@ -748,6 +749,18 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("group", mcpapi.Required()),
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_docgen_list", s.handleDocgenList))
+
+	// archigraph_persona_event — persona lifecycle telemetry (#2474).
+	// Personas call this at session start (event_type=invoke) and on each
+	// Consult-Out (event_type=consult_out, target_persona=<name>). Group-agnostic.
+	// Appends to ~/.archigraph/events/persona-events-YYYY-MM-DD.jsonl (LOCAL ONLY).
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_persona_event",
+		mcpapi.WithDescription("Record a persona lifecycle event (invoke/consult_out/save_finding). LOCAL ONLY."),
+		mcpapi.WithString("persona", mcpapi.Required()),
+		mcpapi.WithString("event_type", mcpapi.Required()),
+		mcpapi.WithAny("target_persona"),
+		mcpapi.WithAny("metadata"),
+	), s.wrap("archigraph_persona_event", s.handlePersonaEvent))
 
 	// archigraph_status — cwd-gate sentinel (#1769).
 	// Registered as a real callable tool so agents can invoke it and receive

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -516,9 +516,9 @@ func TestToolNameSurface(t *testing.T) {
 	for _, st := range srv.MCP.ListTools() {
 		registered[st.Tool.Name] = true
 	}
-	// 42 tools as of PR #2442 re-wires. 1 remaining intentional drop:
-	// archigraph_recent_activity (≤3k budget). 3 tools re-wired in #2442:
-	// archigraph_save_finding, archigraph_list_findings, archigraph_cross_links.
+	// 43 tools as of #2474 (+archigraph_persona_event). 42 baseline from PR #2442 re-wires.
+	// 1 remaining intentional drop: archigraph_recent_activity (≤3k budget).
+	// 3 tools re-wired in #2442: archigraph_save_finding, archigraph_list_findings, archigraph_cross_links.
 	// 4 dashboard-only tools dropped: archigraph_diagnostics, archigraph_quality_orphans,
 	//   archigraph_get_next_enrichment_task, archigraph_get_telemetry.
 	wantPresent := []string{
@@ -569,6 +569,8 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_module_analysis", "archigraph_diff_refs",
 		// #1742 subgraph retained (despite deprecation)
 		"archigraph_subgraph",
+		// #2474 persona lifecycle telemetry
+		"archigraph_persona_event",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -649,8 +651,9 @@ func TestToolNameSurface(t *testing.T) {
 	// find_callers + find_callees behind direction=) + archigraph_status
 	// sentinel registered as a real callable tool (#1769). find_callers /
 	// find_callees stay registered as deprecated aliases for one release.
-	if got := len(allRegisteredTools); got != 42 {
-		t.Errorf("expected 42 registered tools, got %d — update this count if tools are added/removed (added archigraph_docgen_* #2214)", got)
+	// +1 archigraph_persona_event (#2474 persona lifecycle telemetry).
+	if got := len(allRegisteredTools); got != 43 {
+		t.Errorf("expected 43 registered tools, got %d — update this count if tools are added/removed (added archigraph_persona_event #2474)", got)
 	}
 }
 
@@ -3138,6 +3141,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_list_findings": {"group": "g"},
 		"archigraph_cross_links":   {"group": "g", "action": "list"},
 		"archigraph_license_audit": {"group": "g"},
+		// #2474 persona lifecycle telemetry
+		"archigraph_persona_event": {"persona": "architect", "event_type": "invoke"},
 	}
 
 	// extractElapsedMS mirrors the bench extraction logic:
@@ -3182,8 +3187,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 42 {
-		t.Errorf("expected 42 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_docgen_* #2214)", len(tools))
+	if len(tools) != 43 {
+		t.Errorf("expected 43 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_persona_event #2474)", len(tools))
 	}
 
 	for _, st := range tools {

--- a/skills/archigraph-consult/personas/api-designer.md
+++ b/skills/archigraph-consult/personas/api-designer.md
@@ -66,3 +66,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 
 ## When the user asks to save this analysis
 Follow `archigraph-graph-write` (explicit request only — never auto-save).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="api-designer", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="api-designer", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/architect.md
+++ b/skills/archigraph-consult/personas/architect.md
@@ -64,3 +64,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 
 ## When the user asks to save this analysis
 Follow `archigraph-graph-write` (explicit request only — never auto-save).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="architect", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="architect", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/business-analyst.md
+++ b/skills/archigraph-consult/personas/business-analyst.md
@@ -65,3 +65,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 
 ## When the user asks to save this analysis
 Follow `archigraph-graph-write` (explicit request only — never auto-save).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="business-analyst", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="business-analyst", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/data-engineer.md
+++ b/skills/archigraph-consult/personas/data-engineer.md
@@ -64,3 +64,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 
 ## When the user asks to save this analysis
 Follow `archigraph-graph-write` (explicit request only — never auto-save).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="data-engineer", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="data-engineer", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/performance-reviewer.md
+++ b/skills/archigraph-consult/personas/performance-reviewer.md
@@ -63,3 +63,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 
 ## When the user asks to save this analysis
 Follow `archigraph-graph-write` (explicit request only — never auto-save).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="performance-reviewer", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="performance-reviewer", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/qa-reviewer.md
+++ b/skills/archigraph-consult/personas/qa-reviewer.md
@@ -65,3 +65,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 
 ## When the user asks to save this analysis
 Follow `archigraph-graph-write` (explicit request only — never auto-save).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="qa-reviewer", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="qa-reviewer", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/refactor-critic.md
+++ b/skills/archigraph-consult/personas/refactor-critic.md
@@ -64,3 +64,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 
 ## When the user asks to save this analysis
 Follow `archigraph-graph-write` (explicit request only — never auto-save).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="refactor-critic", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="refactor-critic", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/security-auditor.md
+++ b/skills/archigraph-consult/personas/security-auditor.md
@@ -64,3 +64,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 
 ## When the user asks to save this analysis
 Follow `archigraph-graph-write` (explicit request only — never auto-save).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="security-auditor", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="security-auditor", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.


### PR DESCRIPTION
Replaces #2516 (closed when remote branch was inadvertently deleted; rebased onto current main).

## Summary
Closes #2474

Adds an MCP tool personas can call to record:
- session start (event_type=invoke)
- Consult-Out invocations (event_type=consult_out, target_persona=...)
- save-finding events (event_type=save_finding)

Persisted to `~/.archigraph/events/persona-events.jsonl` (LOCAL ONLY, no remote emission per privacy promise).

8 v3 personas updated with a "## Lifecycle telemetry" section. Architecture doc gains a Section 10 documenting the contract.

## Tests
- TestPersonaEventInputValidation (4 subtests)
- TestPersonaEventJSONLAppend
- TestToolNameSurface count 42→43

## Test plan
- [x] go test ./internal/mcp/... -count=1 PASS (pre-rebase)
- [ ] CI green post-rebase