### PR TITLE
fix(daemon/extract): ORM field-lookup closure spans all subprocess batches

### DIFF
--- a/cmd/archigraph/extract.go
+++ b/cmd/archigraph/extract.go
@@ -82,6 +82,7 @@ func runExtractSubprocess(argv []string) error {
 		batchID    = fs.String("batch-id", "", "label propagated into stats")
 		skipPasses = fs.String("skip-pass", "", "comma-separated pass names to skip")
 		drfNames   = fs.String("drf-names", "", "path to coordinator-written DRF register-name file (#1292)")
+		ormFields  = fs.String("orm-fields", "", "path to coordinator-written ORM field-name file (#2505)")
 	)
 	if err := fs.Parse(argv); err != nil {
 		return err
@@ -99,12 +100,13 @@ func runExtractSubprocess(argv []string) error {
 	}
 
 	return extract.Run(context.Background(), extract.SubprocessOptions{
-		RepoRoot:     *repo,
-		Language:     *lang,
-		BatchPath:    *batch,
-		BatchID:      *batchID,
-		Output:       os.Stdout,
-		SkipPasses:   skipSet,
-		DRFNamesPath: *drfNames,
+		RepoRoot:      *repo,
+		Language:      *lang,
+		BatchPath:     *batch,
+		BatchID:       *batchID,
+		Output:        os.Stdout,
+		SkipPasses:    skipSet,
+		DRFNamesPath:  *drfNames,
+		ORMFieldsPath: *ormFields,
 	})
 }

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -174,6 +174,23 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 		drfNamesPath = ""
 	}
 
+	// Pre-pass (#2505): build the repo-wide ORM field-name index by scanning
+	// ALL Python files before any extraction batch spawns. This ensures every
+	// subprocess receives the complete set of Django model field names
+	// regardless of which batch those model files land in.
+	//
+	// Without this, each subprocess only scanned its own partial batch, so
+	// model fields defined in batch N were invisible to batch M — causing
+	// applyORMFieldEdges in batch M to emit no READS_FIELD edges for cross-
+	// batch ORM references (e.g. views.py in batch M querying User.cognito_id
+	// where User is defined in models.py in batch N).
+	ormFieldsPath, ormWriteErr := writeORMFieldsFile(batchDir, repoRoot, buckets["python"])
+	if ormWriteErr != nil {
+		// Non-fatal: fall back to per-batch scan (original #2448 behaviour,
+		// correct for single-batch repos and avoids a hard failure on I/O error).
+		ormFieldsPath = ""
+	}
+
 	skip := strings.Join(cfg.SkipPasses, ",")
 	stderr := cfg.Stderr
 	if stderr == nil {
@@ -219,6 +236,9 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 			}
 			if drfNamesPath != "" {
 				args = append(args, "--drf-names", drfNamesPath)
+			}
+			if ormFieldsPath != "" {
+				args = append(args, "--orm-fields", ormFieldsPath)
 			}
 			if skip != "" {
 				args = append(args, "--skip-pass", skip)
@@ -452,6 +472,71 @@ func writeDRFNamesFile(dir, repoRoot string, pyFiles []string) (string, error) {
 	}
 	if err := w.Flush(); err != nil {
 		return "", fmt.Errorf("flush drf-names file: %w", err)
+	}
+	return f.Name(), nil
+}
+
+// writeORMFieldsFile scans all Python files in pyFiles for Django model field
+// declarations and writes one "<Model>.<field>" name per line to a temp file
+// in dir. Returns the absolute path of the written file, or ("", nil) when no
+// field names were found (so subprocesses stay in fallback mode).
+//
+// This is the coordinator side of the #2505 multi-batch ORM cross-file fix.
+// By scanning ALL Python files at once (before any subprocess spawns), we
+// produce a complete, repo-wide set of Django model field names. Each
+// subprocess then loads this file via --orm-fields instead of scanning only
+// its own partial batch — eliminating the cross-batch visibility gap that
+// caused applyORMFieldEdges to miss READS_FIELD edges for models defined in
+// other batches (e.g. User.cognito_id defined in models.py, queried in
+// views.py, where the two files land in different subprocess batches).
+//
+// The temp file lives in batchDir and is cleaned up by the caller's
+// `defer os.RemoveAll(batchDir)` — no separate cleanup is required.
+func writeORMFieldsFile(dir, repoRoot string, pyFiles []string) (string, error) {
+	if len(pyFiles) == 0 {
+		return "", nil
+	}
+
+	// Collect all "<Model>.<field>" names across every Python file using
+	// the shared regex-based BuildFieldIndex. No AST / tree-sitter needed.
+	seen := map[string]bool{}
+	for _, rel := range pyFiles {
+		abs := filepath.Join(repoRoot, rel)
+		content, err := os.ReadFile(abs)
+		if err != nil {
+			continue // skip unreadable files; don't fail the whole pre-pass
+		}
+		idx := engine.BuildFieldIndex(string(content))
+		for name := range idx {
+			seen[name] = true
+		}
+	}
+
+	if len(seen) == 0 {
+		return "", nil // no Django model fields found; subprocesses use fallback
+	}
+
+	// Sort for determinism so that the file is byte-identical across runs.
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	f, err := os.CreateTemp(dir, "orm-fields-*.txt")
+	if err != nil {
+		return "", fmt.Errorf("create orm-fields file: %w", err)
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	for _, n := range names {
+		if _, err := fmt.Fprintln(w, n); err != nil {
+			return "", fmt.Errorf("write orm-fields file: %w", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return "", fmt.Errorf("flush orm-fields file: %w", err)
 	}
 	return f.Name(), nil
 }

--- a/internal/daemon/extract/coordinator_test.go
+++ b/internal/daemon/extract/coordinator_test.go
@@ -180,6 +180,96 @@ func TestCoordinate_EmitsConfigEntities(t *testing.T) {
 	}
 }
 
+// TestCoordinate_CrossBatchORMFieldLookup is the multi-batch integration test
+// for issue #2505.
+//
+// Setup:
+//   - Batch A: models.py — defines the Django User model with field cognito_id.
+//   - Batch B: views.py  — queries User.objects.filter(cognito_id=...).
+//
+// The coordinator must scan ALL Python files before spawning subprocesses and
+// write a shared ORM-fields file. Each subprocess loads this file so models
+// from other batches are visible.
+//
+// Expected outcome:
+//   - At least one READS_FIELD relationship emitted for cognito_id (the cross-
+//     batch field reference in views.py).
+//
+// Skipped under `go test -short`.
+func TestCoordinate_CrossBatchORMFieldLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test — skipped in -short mode")
+	}
+	bin := buildArchigraph(t)
+
+	repo := t.TempDir()
+	must := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	// Batch A source: Django model definition in models.py.
+	must("models.py", `from django.db import models
+
+class User(models.Model):
+    cognito_id = models.CharField(max_length=200)
+    email = models.EmailField()
+`)
+
+	// Batch B source: ORM query in views.py — references User.cognito_id
+	// which is defined in a DIFFERENT file (models.py).
+	must("views.py", `from django.http import JsonResponse
+from .models import User
+
+def get_user_by_cognito(request, uid):
+    user = User.objects.filter(cognito_id=uid).first()
+    return JsonResponse({"found": user is not None})
+`)
+
+	files := []string{"models.py", "views.py"}
+
+	// Run via Coordinate — the coordinator must write an ORM-fields file
+	// and pass --orm-fields to each subprocess so that views.py (which
+	// may land in a separate batch from models.py) can resolve cognito_id.
+	var stderrBuf bytes.Buffer
+	res, err := Coordinate(context.Background(), repo, files, CoordinatorConfig{
+		BinaryPath: bin,
+		BatchSize:  1, // force 1 file per subprocess → guaranteed cross-batch
+		Stderr:     &stderrBuf,
+	})
+	if err != nil {
+		t.Fatalf("Coordinate: %v\n---stderr---\n%s", err, stderrBuf.String())
+	}
+
+	// Count READS_FIELD relationships in the result.
+	var readsField int
+	for _, r := range res.Relationships {
+		if r.Kind == string(types.RelationshipKindReadsField) {
+			readsField++
+		}
+	}
+
+	t.Logf("cross-batch ORM test: READS_FIELD=%d subprocesses=%d stderr=%s",
+		readsField, res.Subprocesses, stderrBuf.String())
+
+	// With the fix: at least one READS_FIELD edge must exist for
+	// User.cognito_id resolved from views.py across the batch boundary.
+	if readsField == 0 {
+		t.Errorf("expected at least one READS_FIELD edge for cross-batch ORM reference "+
+			"(views.py → User.cognito_id defined in models.py); got 0\n"+
+			"subprocesses=%d — confirm BatchSize=1 forced cross-batch split\n"+
+			"stderr:\n%s", res.Subprocesses, stderrBuf.String())
+	}
+
+	// Confirm the coordinator actually spawned multiple subprocesses (one
+	// per file with BatchSize=1) — otherwise we're testing intra-batch only.
+	if res.Subprocesses < 2 {
+		t.Errorf("expected >=2 subprocesses with BatchSize=1 for 2 Python files; got %d", res.Subprocesses)
+	}
+}
+
 func buildArchigraph(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/daemon/extract/subproc.go
+++ b/internal/daemon/extract/subproc.go
@@ -63,6 +63,17 @@ type SubprocessOptions struct {
 	// calls in files assigned to other batches. This is the fix for the
 	// multi-batch ghost path regression described in issue #1292.
 	DRFNamesPath string
+
+	// ORMFieldsPath is the absolute path of a newline-delimited file that
+	// contains every "<Model>.<field>" name collected by the coordinator's
+	// repo-wide pre-pass across ALL Python files (not just this batch).
+	// When set, the subprocess uses it as the cross-file ORM field-lookup
+	// closure instead of building one from its own (partial) batch — which
+	// would miss models defined in files assigned to other batches.
+	// This is the fix for the multi-batch correctness gap described in
+	// issue #2505. When empty (single-batch mode or tests) the subprocess
+	// falls back to scanning its own batch (the original #2448 behaviour).
+	ORMFieldsPath string
 }
 
 // Run is the subprocess-side entrypoint. It is invoked from
@@ -197,19 +208,23 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 		}
 	}
 
-	// Pre-pass (#2448 / Phase B): build the cross-file ORM field lookup
-	// for this batch. Engine pass applyORMFieldEdges resolves
-	// <Model>.<field> references first via FileInput.Pass1Entities
-	// (intra-file). When the model lives in a SIBLING file (canonical
-	// Django split — models.py defines User, views.py queries it), it
-	// falls back to this closure.
+	// Pre-pass (#2448 / Phase B, #2505): build the cross-file ORM field
+	// lookup. Engine pass applyORMFieldEdges resolves <Model>.<field>
+	// references first via FileInput.Pass1Entities (intra-file). When
+	// the model lives in a SIBLING file (canonical Django split —
+	// models.py defines User, views.py queries it), it falls back to
+	// this closure.
 	//
-	// Subprocess-scope caveat: the lookup only covers files in THIS
-	// batch. A model defined in a file assigned to a different
-	// subprocess is invisible here. The coordinator pre-groups batches
-	// per repo to keep imports together, but it does not formally
-	// guarantee co-location of models.py and views.py. Tech debt
-	// surfaced; see commit body.
+	// Multi-batch path (#2505): when the coordinator provides an
+	// ORMFieldsPath file, we load the globally-collected field names from
+	// it — those names span ALL Python files in the repo, not just the
+	// files in this batch. This eliminates the cross-batch visibility gap
+	// from #2448 Phase B: models defined in a file assigned to a different
+	// subprocess are now visible to every batch.
+	//
+	// Single-batch / fallback path (#2448 original): when ORMFieldsPath
+	// is empty, we scan only this batch's Python files (the original
+	// behaviour, correct for single-batch repos and tests).
 	//
 	// Cost model: one extra regex pass over each Python file's content
 	// at pre-pass time (no AST, no tree-sitter), keyed by model name in
@@ -217,27 +232,35 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 	// pointer; per-file extra memory is zero.
 	var crossFileBatchFields []types.EntityRecord
 	if runFramework {
-		for _, rel := range files {
-			if !strings.HasSuffix(strings.ToLower(rel), ".py") {
-				continue
+		if opts.ORMFieldsPath != "" {
+			// Multi-batch path (#2505): load the coordinator-written global set.
+			if recs, err := readORMFieldsFile(opts.ORMFieldsPath); err == nil {
+				crossFileBatchFields = recs
 			}
-			abs := filepath.Join(opts.RepoRoot, rel)
-			pyContent, rerr := os.ReadFile(abs)
-			if rerr != nil {
-				continue
-			}
-			idx := engine.BuildFieldIndex(string(pyContent))
-			if len(idx) == 0 {
-				continue
-			}
-			for name := range idx {
-				crossFileBatchFields = append(crossFileBatchFields, types.EntityRecord{
-					Name:       name,
-					Kind:       "SCOPE.Schema",
-					Subtype:    "field",
-					SourceFile: rel,
-					Language:   "python",
-				})
+		} else {
+			// Single-batch / fallback path (#2448): scan only the files in this batch.
+			for _, rel := range files {
+				if !strings.HasSuffix(strings.ToLower(rel), ".py") {
+					continue
+				}
+				abs := filepath.Join(opts.RepoRoot, rel)
+				pyContent, rerr := os.ReadFile(abs)
+				if rerr != nil {
+					continue
+				}
+				idx := engine.BuildFieldIndex(string(pyContent))
+				if len(idx) == 0 {
+					continue
+				}
+				for name := range idx {
+					crossFileBatchFields = append(crossFileBatchFields, types.EntityRecord{
+						Name:       name,
+						Kind:       "SCOPE.Schema",
+						Subtype:    "field",
+						SourceFile: rel,
+						Language:   "python",
+					})
+				}
 			}
 		}
 	}
@@ -433,6 +456,45 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 	emit(Envelope{Type: KindStats, Stats: &stats})
 
 	return bw.Flush()
+}
+
+// readORMFieldsFile reads the coordinator-written ORM field-name file and
+// returns a slice of EntityRecord stubs — one per "<Model>.<field>" line —
+// suitable for feeding into engine.BuildCrossFileFieldLookup. The file
+// format is one "<Model>.<field>" name per line; blank lines and lines
+// beginning with '#' are skipped.
+//
+// This is the subprocess side of the #2505 multi-batch ORM fix. The
+// coordinator writes ALL repo-wide ORM field names before spawning any
+// subprocesses; each subprocess loads this file instead of scanning only
+// its own (partial) batch — eliminating the cross-batch visibility gap
+// introduced by #2448 Phase B.
+//
+// SourceFile is intentionally left blank for records loaded from this file:
+// the model may live in any batch, so we cannot claim a specific source file
+// without risking misattribution. BuildCrossFileFieldLookup only uses
+// Name+Kind+Subtype for its model-keyed closure, so the omission is safe.
+func readORMFieldsFile(path string) ([]types.EntityRecord, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	var out []types.EntityRecord
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		out = append(out, types.EntityRecord{
+			Name:     line,
+			Kind:     "SCOPE.Schema",
+			Subtype:  "field",
+			Language: "python",
+		})
+	}
+	return out, sc.Err()
 }
 
 // readBatch reads a newline-delimited file of repo-relative paths.

--- a/internal/daemon/extract/subproc_test.go
+++ b/internal/daemon/extract/subproc_test.go
@@ -207,6 +207,86 @@ def get_pending():
 	t.Logf("subprocess Run(): field_entities=%d reads_field_rels=%d", fieldEntities, readsFieldRels)
 }
 
+// TestRun_ORMFieldsPath_CrossBatchLookup tests the ORMFieldsPath subprocess
+// path introduced by issue #2505. The fixture simulates a cross-batch split:
+// the ORM field names (User.cognito_id) are written to a shared file (as if
+// the coordinator had pre-scanned models.py from another batch), and the
+// subprocess is given only views.py — which references User.cognito_id.
+//
+// Without the fix (ORMFieldsPath empty, batch-only fallback): the subprocess
+// builds its field index only from views.py, which has no model definitions,
+// so the crossFileFields closure is nil → applyORMFieldEdges cannot resolve
+// cognito_id as a known field → 0 READS_FIELD edges from the cross-file path.
+//
+// With the fix (ORMFieldsPath set): the subprocess loads User.cognito_id from
+// the coordinator-written file → BuildCrossFileFieldLookup builds a closure
+// over it → applyORMFieldEdges emits READS_FIELD for the filter() call.
+//
+// Note: the intra-file regex fallback inside applyORMFieldEdges can still emit
+// READS_FIELD edges if it finds a model body in the SAME file. This test uses
+// a views.py that has NO model body, so any READS_FIELD edge that appears when
+// ORMFieldsPath is set comes exclusively from the cross-file closure.
+func TestRun_ORMFieldsPath_CrossBatchLookup(t *testing.T) {
+	repo := t.TempDir()
+
+	// views.py only — no model definition. Simulates Batch B in a cross-batch split.
+	viewsSrc := `from django.http import JsonResponse
+from .models import User
+
+def get_by_cognito(request, uid):
+    user = User.objects.filter(cognito_id=uid).first()
+    return JsonResponse({"found": user is not None})
+`
+	if err := os.WriteFile(filepath.Join(repo, "views.py"), []byte(viewsSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	batch := filepath.Join(t.TempDir(), "batch.txt")
+	if err := os.WriteFile(batch, []byte("views.py\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write the shared ORM-fields file — mimics what the coordinator would
+	// write after scanning models.py from a different batch.
+	ormFile := filepath.Join(t.TempDir(), "orm-fields.txt")
+	if err := os.WriteFile(ormFile, []byte("User.cognito_id\nUser.email\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := Run(context.Background(), SubprocessOptions{
+		RepoRoot:      repo,
+		BatchPath:     batch,
+		BatchID:       "test-orm-cross-batch",
+		Output:        &buf,
+		ORMFieldsPath: ormFile,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var readsField int
+	dec := json.NewDecoder(strings.NewReader(buf.String()))
+	for dec.More() {
+		var env Envelope
+		if derr := dec.Decode(&env); derr != nil {
+			t.Fatalf("decode: %v\n---stream---\n%s", derr, buf.String())
+		}
+		if env.Type == KindRelationship && env.Rel != nil &&
+			env.Rel.Kind == string(types.RelationshipKindReadsField) {
+			readsField++
+		}
+	}
+
+	t.Logf("cross-batch ORM (ORMFieldsPath set): READS_FIELD=%d", readsField)
+
+	// With ORMFieldsPath set, the cross-file closure covers User.cognito_id,
+	// so applyORMFieldEdges should emit at least one READS_FIELD edge.
+	if readsField == 0 {
+		t.Errorf("expected at least one READS_FIELD relationship when ORMFieldsPath provides "+
+			"User.cognito_id; got 0\n---stream---\n%s", buf.String())
+	}
+}
+
 // TestRun_Pass1PlumbedCounters verifies that BatchStats.Pass1PlumbedTrueCount
 // and Pass1PlumbedFalseCount are correctly incremented by Run() (issue #2447).
 //


### PR DESCRIPTION
## Summary

- Fixes issue #2505: the cross-file ORM field-lookup closure built in `internal/daemon/extract/subproc.go` was batch-scoped — models defined in files assigned to a different subprocess batch were invisible, producing no `READS_FIELD` edges for cross-batch ORM references.
- Fix mirrors PR #1292 (DRF register names): the coordinator scans ALL Python files before spawning any subprocess and writes a shared `orm-fields-*.txt` file (one `Model.field` name per line). Each subprocess loads this file via `--orm-fields` and uses it as the cross-file closure instead of rebuilding from its own batch.
- Cleanup is automatic: the shared file lives in `batchDir` which is removed by `defer os.RemoveAll(batchDir)` when the coordinator returns.

## Test plan

- [ ] `TestRun_ORMFieldsPath_CrossBatchLookup` (new, `subproc_test.go`): unit-level — writes a shared ORM-fields file with `User.cognito_id`, runs `Run()` against `views.py` only (no model body), asserts `READS_FIELD=1` from the cross-file closure. **PASS**
- [ ] `TestCoordinate_CrossBatchORMFieldLookup` (new, `coordinator_test.go`): integration-level — `BatchSize=1` forces `models.py` and `views.py` into separate subprocesses; asserts `READS_FIELD>=1` and `Subprocesses>=2`. **PASS** (`READS_FIELD=1 subprocesses=2`)
- [ ] All pre-existing `internal/daemon/extract` tests pass (11/11)
- [ ] `gofmt -l` empty on changed files
- [ ] `go vet ./internal/daemon/...` clean
- [ ] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)