### PR TITLE
fix(tests): stop tests from leaking into real ~/.archigraph/store/

### DIFF
--- a/cmd/archigraph/determinism_test.go
+++ b/cmd/archigraph/determinism_test.go
@@ -21,6 +21,9 @@ import (
 // generated_at timestamp is reproducible — verifying that the rest of the
 // document is stable.
 func TestIssue481_GraphJSONIsByteIdenticalAcrossRuns(t *testing.T) {
+	// #2083: pin ARCHIGRAPH_DAEMON_ROOT so Index() writes per-repo state into
+	// an isolated temp dir, not into the real ~/.archigraph/store/.
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
 	fixture := writeFixtureRepo(t)
 	t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
 

--- a/cmd/archigraph/index_internal_test.go
+++ b/cmd/archigraph/index_internal_test.go
@@ -31,6 +31,9 @@ func TestRunIndexInternalBadRepo(t *testing.T) {
 // against an empty temporary directory without panicking. The indexer will
 // produce a graph with zero entities; exit code must be 0.
 func TestRunIndexInternalEmptyDir(t *testing.T) {
+	// #2083: pin ARCHIGRAPH_DAEMON_ROOT so runIndexInternal writes per-repo
+	// state into an isolated temp dir, not into the real ~/.archigraph/store/.
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
 	dir := t.TempDir()
 	// Build a minimal valid-looking repo dir (no files, no git). The
 	// indexer should still succeed with 0 entities.
@@ -50,6 +53,9 @@ func TestRunIndexInternalEmptyDir(t *testing.T) {
 // TestRunIndexInternalSkipPasses verifies that skip-pass parsing works
 // correctly for multi-value comma-separated input.
 func TestRunIndexInternalSkipPasses(t *testing.T) {
+	// #2083: pin ARCHIGRAPH_DAEMON_ROOT so runIndexInternal writes per-repo
+	// state into an isolated temp dir, not into the real ~/.archigraph/store/.
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
 	dir := t.TempDir()
 	// Write a trivial Go file so the indexer has something to chew on.
 	src := filepath.Join(dir, "main.go")

--- a/cmd/archigraph/index_test.go
+++ b/cmd/archigraph/index_test.go
@@ -22,9 +22,13 @@ import (
 // passes to skip — pass nil to run everything.
 func newTestIndexer(t *testing.T, repoTag string, skipPasses []string) *Indexer {
 	t.Helper()
-	// #1626: per-repo state lives in the external store. Pin DAEMON_ROOT
-	// to an isolated temp so indexer runs (a) don't pollute the source
-	// tree fixtures with state and (b) don't load stale state across runs.
+	// #1626 / #2083: per-repo state lives in the external store. Pin
+	// ARCHIGRAPH_DAEMON_ROOT to an isolated temp so indexer runs
+	// (a) don't pollute the source tree fixtures with state and
+	// (b) don't load stale state across runs.
+	// Only set if the caller hasn't already established an isolated root
+	// (e.g. index_enrichment_test.go sets it before seeding resolution files
+	// that the second run must find in the same dir).
 	if os.Getenv("ARCHIGRAPH_DAEMON_ROOT") == "" {
 		t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
 	}

--- a/cmd/archigraph/testmain_test.go
+++ b/cmd/archigraph/testmain_test.go
@@ -1,0 +1,91 @@
+package main
+
+// testmain_test.go — TestMain with a defensive leak detector for #2083.
+//
+// Before all tests run: snapshot the entry-names in ~/.archigraph/store/.
+// After all tests complete: assert no new entries were created.
+//
+// This guard catches tests that write per-repo state to the real store
+// (i.e. tests that call code touching daemon.StateDirForRepo / StoreDir
+// without first pinning ARCHIGRAPH_DAEMON_ROOT or ARCHIGRAPH_HOME to a
+// temp dir).
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	storeDir := realStoreDir()
+	before := snapshotStore(storeDir)
+
+	code := m.Run()
+
+	after := snapshotStore(storeDir)
+	leaked := diffSets(before, after)
+	if len(leaked) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"\n[#2083 leak-detector] %d new entr%s in real store %s after test run:\n",
+			len(leaked), pluralY(len(leaked)), storeDir)
+		for _, e := range leaked {
+			fmt.Fprintf(os.Stderr, "  %s\n", e)
+		}
+		fmt.Fprintf(os.Stderr,
+			"Each leaking test must pin ARCHIGRAPH_DAEMON_ROOT (or ARCHIGRAPH_HOME) "+
+				"to a t.TempDir() before calling any code that invokes daemon.StateDirForRepo.\n\n")
+		// Use exit code 1 to signal failure without overriding a passing run
+		// that has leaks — we report but let the caller decide.
+		if code == 0 {
+			code = 1
+		}
+	}
+
+	os.Exit(code)
+}
+
+// realStoreDir returns the store path the daemon would use when no env
+// overrides are set — i.e. the real ~/.archigraph/store/ on this host.
+// We read it without setting any env vars so we get the user's real path.
+func realStoreDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".archigraph", "store")
+}
+
+// snapshotStore returns the set of top-level entry names in dir.
+// Returns an empty set (not nil) when dir does not exist.
+func snapshotStore(dir string) map[string]struct{} {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return map[string]struct{}{}
+	}
+	set := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		set[e.Name()] = struct{}{}
+	}
+	return set
+}
+
+// diffSets returns names that appear in after but not in before, sorted.
+func diffSets(before, after map[string]struct{}) []string {
+	var leaked []string
+	for name := range after {
+		if _, ok := before[name]; !ok {
+			leaked = append(leaked, name)
+		}
+	}
+	sort.Strings(leaked)
+	return leaked
+}
+
+func pluralY(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -18,6 +18,10 @@ import (
 
 // writeGraph writes a graph.Document to the repo's external store state
 // dir (#1626: per-repo state no longer lives in <repo>/.archigraph).
+// #2083: pins ARCHIGRAPH_DAEMON_ROOT to an isolated temp dir so state never
+// leaks into the real ~/.archigraph/store/. Only sets the env var if the
+// caller hasn't already established a root (so multi-writeGraph tests share
+// one consistent root across calls).
 func writeGraph(t *testing.T, repoDir string, doc *graph.Document) string {
 	t.Helper()
 	if os.Getenv("ARCHIGRAPH_DAEMON_ROOT") == "" {
@@ -2922,6 +2926,9 @@ func TestTOONWire_LiveEnvelopeTool_Topology(t *testing.T) {
 
 // writeGraphFB writes a graph.Document to <repoDir>/.archigraph/graph.fb
 // (FlatBuffers format). Used to verify fix for issue #1374 item #1.
+// #2083: pins ARCHIGRAPH_DAEMON_ROOT to an isolated temp dir so state never
+// leaks into the real ~/.archigraph/store/. Only sets the env var if the
+// caller hasn't already established a root.
 func writeGraphFB(t *testing.T, repoDir string, doc *graph.Document) string {
 	t.Helper()
 	if os.Getenv("ARCHIGRAPH_DAEMON_ROOT") == "" {


### PR DESCRIPTION
## Summary

- **Root cause**: `TestIssue481_GraphJSONIsByteIdenticalAcrossRuns`, `TestRunIndexInternalEmptyDir`, and `TestRunIndexInternalSkipPasses` called production indexer code without pinning `ARCHIGRAPH_DAEMON_ROOT`, causing `enrichment-candidates.json` + `graph.fb` artifacts to land in `~/.archigraph/store/<slug>/refs/_unknown/` on every test run.
- **Fix**: Add `t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())` to each leaking test, routing per-repo state writes to an isolated temp dir that Go's test framework cleans up automatically.
- **Detector**: New `cmd/archigraph/testmain_test.go` snapshots store entry-names before/after all tests and fails the suite (exit 1) if any new entries appear, with a remediation hint.

Closes #2083

## Changes

| File | Change |
|---|---|
| `cmd/archigraph/determinism_test.go` | Pin `ARCHIGRAPH_DAEMON_ROOT` in `TestIssue481_GraphJSONIsByteIdenticalAcrossRuns` |
| `cmd/archigraph/index_internal_test.go` | Pin `ARCHIGRAPH_DAEMON_ROOT` in `TestRunIndexInternalEmptyDir` + `TestRunIndexInternalSkipPasses` |
| `cmd/archigraph/index_test.go` | Expand comment on conditional guard in `newTestIndexer` |
| `internal/mcp/server_test.go` | Add `#2083` comment to `writeGraph` / `writeGraphFB` helpers |
| `cmd/archigraph/testmain_test.go` | **New**: `TestMain` leak detector — fails if any new store entries appear |

## Test plan

- [ ] `gofmt -l <changed-files>` — empty (verified)
- [ ] `go vet ./...` — clean (verified)
- [ ] `go build ./...` — succeeds (verified)
- [ ] `go test ./cmd/archigraph/... -count=1` — 3 consecutive runs, 0 leaks each (verified)
- [ ] `go test ./... -count=1` — 0 net new entries in `~/.archigraph/store/` (verified)
- [ ] `ls ~/.archigraph/store/ | wc -l` before → 186, after → 59 (reduction from prior cleanup by other tests, 0 new from this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)