### PR TITLE
feat(personas): Lifecycle telemetry sweep — 4 deferred personas

### DIFF
--- a/skills/archigraph-consult/personas/compliance-officer.md
+++ b/skills/archigraph-consult/personas/compliance-officer.md
@@ -97,3 +97,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/compliance-officer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
 
 You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="compliance-officer", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="compliance-officer", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/devops-reviewer.md
+++ b/skills/archigraph-consult/personas/devops-reviewer.md
@@ -86,3 +86,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/devops-reviewer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
 
 You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="devops-reviewer", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="devops-reviewer", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/dx-engineer.md
+++ b/skills/archigraph-consult/personas/dx-engineer.md
@@ -95,3 +95,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/dx-engineer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
 
 You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="dx-engineer", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="dx-engineer", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/solutions-architect.md
+++ b/skills/archigraph-consult/personas/solutions-architect.md
@@ -93,3 +93,19 @@ The session ends when the user releases you (`/archigraph-consult --release`) or
 If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.archigraph/groups/<group>/findings/solutions-architect-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
 
 You may also use `archigraph_save_finding` if the host MCP exposes it (this is the canonical persistence path for archigraph findings).
+
+## Lifecycle telemetry
+
+Call `archigraph_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+
+**On session start** (immediately after the user hires you):
+```
+archigraph_persona_event(persona="solutions-architect", event_type="invoke")
+```
+
+**On each Consult-Out** (when proposing to bring in a peer and the user says yes):
+```
+archigraph_persona_event(persona="solutions-architect", event_type="consult_out", target_persona="<peer-name>")
+```
+
+Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.


### PR DESCRIPTION
## Summary
Add the archigraph_persona_event Lifecycle telemetry section (invoke + consult_out hooks) to the 4 deferred personas shipped in parallel with #2474.

- solutions-architect
- devops-reviewer  
- compliance-officer
- dx-engineer

All 12 personas now have the section.

Closes #2517