### PR TITLE
feat(personas): machine-validate persona structure invariants

### DIFF
--- a/internal/personas/validate_test.go
+++ b/internal/personas/validate_test.go
@@ -1,0 +1,252 @@
+// Package personas contains structural validation tests for archigraph persona files.
+//
+// Each persona lives in skills/archigraph-consult/personas/*.md and must satisfy the
+// invariants defined here. These tests act as a CI gate preventing template drift.
+package personas
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// personaDir returns the absolute path to skills/archigraph-consult/personas/
+// relative to this test file's source location (two levels up from internal/personas/).
+func personaDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// thisFile = .../internal/personas/validate_test.go
+	// repo root = two directories up
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	dir := filepath.Join(repoRoot, "skills", "archigraph-consult", "personas")
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("cannot resolve persona dir: %v", err)
+	}
+	return abs
+}
+
+// allowedModels contains every accepted value for the "model" frontmatter key.
+// Empty string is allowed (model may be omitted).
+var allowedModels = map[string]bool{
+	"opus":   true,
+	"sonnet": true,
+	"haiku":  true,
+	"":       true,
+}
+
+// requiredSectionsPrimary are sections every non-limited persona must have, IN ORDER.
+// "Limited" personas (those with ## Current-state limitations) use a slightly different
+// READ heading and a custom save block — see requiredSectionsLimited below.
+var requiredSectionsPrimary = []string{
+	"## Role",
+	"## READ Protocol",
+	"## ANALYSIS lens",
+	"## Communication styles for this domain",
+	"## When to ask for an expert (Consult-Out)",
+	"## Response shape",
+	"## When the user asks to save this analysis",
+	"## Lifecycle telemetry",
+}
+
+// requiredSectionsLimited are sections a limited persona must have (Current-state
+// limitations present, READ heading is "## READ instructions" not "## READ Protocol").
+var requiredSectionsLimited = []string{
+	"## Current-state limitations",
+	"## Role",
+	"## READ instructions",
+	"## ANALYSIS lens",
+	"## Communication styles for this domain",
+	"## When to ask for an expert (Consult-Out)",
+	"## Response shape",
+	"## When the user asks to save this analysis",
+	"## Lifecycle telemetry",
+}
+
+// sharedSkillReadRef is the exact substring that must appear in the READ Protocol body
+// of primary (non-limited) personas.
+const sharedSkillReadRef = "archigraph-graph-read"
+
+// sharedSkillWriteRef is the exact substring that must appear in the save section body
+// of primary personas.
+const sharedSkillWriteRef = "archigraph-graph-write"
+
+// telemetryCall is the MCP tool that must appear in every persona's Lifecycle telemetry section.
+const telemetryCall = "archigraph_persona_event"
+
+// frontmatter holds the parsed YAML frontmatter of a persona file.
+type frontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Model       string `yaml:"model"`
+}
+
+// parseFrontmatter extracts the YAML between the opening --- and closing --- delimiters.
+// Returns the parsed struct and the remaining body (after the closing ---).
+func parseFrontmatter(t *testing.T, filename, content string) (frontmatter, string) {
+	t.Helper()
+	if !strings.HasPrefix(content, "---") {
+		t.Errorf("%s: file does not start with YAML frontmatter delimiter ---", filename)
+		return frontmatter{}, content
+	}
+	// Find the closing ---
+	rest := content[3:]
+	idx := strings.Index(rest, "\n---")
+	if idx == -1 {
+		t.Errorf("%s: no closing --- found for YAML frontmatter", filename)
+		return frontmatter{}, content
+	}
+	rawYAML := rest[:idx]
+	body := rest[idx+4:] // skip \n---
+
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(rawYAML), &fm); err != nil {
+		t.Errorf("%s: frontmatter YAML parse error: %v", filename, err)
+	}
+	return fm, body
+}
+
+// sectionOffsets returns a map from section heading (e.g. "## Role") to the byte offset
+// at which it first appears in body. Headings must be at the start of a line.
+func sectionOffsets(body string) map[string]int {
+	offsets := make(map[string]int)
+	lines := strings.Split(body, "\n")
+	pos := 0
+	for _, line := range lines {
+		trimmed := strings.TrimRight(line, " \t\r")
+		if strings.HasPrefix(trimmed, "## ") {
+			if _, seen := offsets[trimmed]; !seen {
+				offsets[trimmed] = pos
+			}
+		}
+		pos += len(line) + 1 // +1 for the newline
+	}
+	return offsets
+}
+
+// sectionBody returns the text between section heading `from` and the next `##` heading
+// (or end of body), given the full body string.
+func sectionBody(body, heading string) string {
+	headingRe := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(heading) + `\s*$`)
+	loc := headingRe.FindStringIndex(body)
+	if loc == nil {
+		return ""
+	}
+	after := body[loc[1]:]
+	// Find the next ## heading
+	nextRe := regexp.MustCompile(`(?m)^## `)
+	next := nextRe.FindStringIndex(after)
+	if next == nil {
+		return after
+	}
+	return after[:next[0]]
+}
+
+// TestPersonaStructuralInvariants walks all *.md files in the personas directory and
+// asserts that each satisfies the structural contract.
+func TestPersonaStructuralInvariants(t *testing.T) {
+	dir := personaDir(t)
+	entries, err := filepath.Glob(filepath.Join(dir, "*.md"))
+	if err != nil {
+		t.Fatalf("glob failed: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("no persona .md files found in %s", dir)
+	}
+
+	t.Logf("validating %d persona files in %s", len(entries), dir)
+
+	for _, path := range entries {
+		path := path // capture
+		name := filepath.Base(path)
+		t.Run(name, func(t *testing.T) {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("cannot read file: %v", err)
+			}
+			content := string(raw)
+
+			// ── 1. Parse + validate frontmatter ──────────────────────────────────
+			fm, body := parseFrontmatter(t, name, content)
+
+			if fm.Name == "" {
+				t.Errorf("frontmatter key 'name' is missing or empty")
+			}
+			if fm.Description == "" {
+				t.Errorf("frontmatter key 'description' is missing or empty")
+			}
+			if !allowedModels[fm.Model] {
+				t.Errorf("frontmatter key 'model' has unrecognized value %q (allowed: opus, sonnet, haiku, or omitted)", fm.Model)
+			}
+
+			// ── 2. Determine persona class ────────────────────────────────────────
+			isLimited := strings.Contains(body, "## Current-state limitations")
+
+			// ── 3. Assert required sections exist in the correct order ────────────
+			requiredSections := requiredSectionsPrimary
+			if isLimited {
+				requiredSections = requiredSectionsLimited
+			}
+
+			offsets := sectionOffsets(body)
+
+			prevOffset := -1
+			prevHeading := "(start)"
+			for _, heading := range requiredSections {
+				offset, found := offsets[heading]
+				if !found {
+					t.Errorf("required section %q not found", heading)
+					continue
+				}
+				if offset <= prevOffset {
+					t.Errorf("section order violation: %q must appear after %q", heading, prevHeading)
+				}
+				prevOffset = offset
+				prevHeading = heading
+			}
+
+			// ── 4. Shared-skill reference wording (primary personas only) ─────────
+			if !isLimited {
+				readBody := sectionBody(body, "## READ Protocol")
+				if !strings.Contains(readBody, sharedSkillReadRef) {
+					t.Errorf("## READ Protocol section must reference %q but does not", sharedSkillReadRef)
+				}
+
+				saveBody := sectionBody(body, "## When the user asks to save this analysis")
+				if !strings.Contains(saveBody, sharedSkillWriteRef) {
+					t.Errorf("## When the user asks to save this analysis section must reference %q but does not", sharedSkillWriteRef)
+				}
+			}
+
+			// ── 5. Lifecycle telemetry calls archigraph_persona_event ─────────────
+			telemetryBody := sectionBody(body, "## Lifecycle telemetry")
+			if telemetryBody == "" {
+				t.Errorf("## Lifecycle telemetry section is empty or missing")
+			} else if !strings.Contains(telemetryBody, telemetryCall) {
+				t.Errorf("## Lifecycle telemetry must call %q but does not", telemetryCall)
+			}
+		})
+	}
+}
+
+// TestPersonaFileCount asserts the expected number of persona files exists so that
+// accidentally deleted personas fail CI instead of silently disappearing.
+func TestPersonaFileCount(t *testing.T) {
+	const expectedCount = 12
+	dir := personaDir(t)
+	entries, err := filepath.Glob(filepath.Join(dir, "*.md"))
+	if err != nil {
+		t.Fatalf("glob failed: %v", err)
+	}
+	if len(entries) != expectedCount {
+		t.Errorf("expected %d persona files, found %d — add/remove the expectation if the count is intentionally changing", expectedCount, len(entries))
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/personas` package with `validate_test.go` — zero production code, test-only CI gate (closes #2513)
- Walks all 12 `skills/archigraph-consult/personas/*.md` and asserts structural invariants on every file
- Two persona classes detected automatically: primary (8 files) and limited (4 files with `## Current-state limitations`)

## Invariants enforced

| Invariant | Primary personas | Limited personas |
|---|---|---|
| Frontmatter: `name` non-empty | ✓ | ✓ |
| Frontmatter: `description` non-empty | ✓ | ✓ |
| Frontmatter: `model` in {opus, sonnet, haiku, ""} | ✓ | ✓ |
| `## Role` present and ordered | ✓ | ✓ |
| `## READ Protocol` present and ordered | ✓ | — |
| `## READ instructions` present and ordered | — | ✓ |
| `## ANALYSIS lens` present and ordered | ✓ | ✓ |
| `## Communication styles for this domain` present and ordered | ✓ | ✓ |
| `## When to ask for an expert (Consult-Out)` present and ordered | ✓ | ✓ |
| `## Response shape` present and ordered | ✓ | ✓ |
| `## When the user asks to save this analysis` present and ordered | ✓ | ✓ |
| `## Lifecycle telemetry` present and ordered | ✓ | ✓ |
| READ Protocol body references `archigraph-graph-read` | ✓ | — |
| Save section body references `archigraph-graph-write` | ✓ | — |
| Lifecycle telemetry calls `archigraph_persona_event` | ✓ | ✓ |
| File count guard (exactly 12 personas) | ✓ | ✓ |

## Test plan

- [ ] `go test ./internal/personas/... -count=1` passes on main (all 12 personas currently pass)
- [ ] `gofmt -l` returns empty output
- [ ] `go vet ./...` clean
- [ ] `go build ./...` clean
- [ ] Manually verified: removing a required section from one persona causes the test to fail
- [ ] Manually verified: misspelling `name` as `namen` in frontmatter causes the test to fail

## No persona updates needed

All 12 current personas already satisfy the invariants — tests pass on the current main HEAD without any persona modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)