### PR TITLE
feat(personas): Consult-Out depth > 1 with cycle detection + context carry-over

### DIFF
--- a/docs/architecture/personas.md
+++ b/docs/architecture/personas.md
@@ -200,18 +200,22 @@ A consultant working on a problem may realise they need a peer's lens. Example: 
 
 ### 5.1 Mechanic
 
-The active consultant signals the need with a structured callout in their response:
+The active consultant signals the need with a structured callout in their response. The callout now carries the full multi-hop envelope (see Section 5.4 for the schema):
 
 ```
-> [CONSULT-OUT] I want to bring in archigraph-performance-reviewer because:
-> - The handler at entity_id `auth.LoginHandler` does a synchronous DB scan
->   (see archigraph_expand result above)
-> - Latency optimisation is outside my (security) lens
->
-> Context to carry over:
-> - Entity under discussion: auth.LoginHandler (entity_id: 4abf…)
-> - The user's original question: "is this login flow safe?"
-> - What I've found so far: <3-bullet summary>
+> [CONSULT-OUT]
+> target: archigraph-performance-reviewer
+> reason: Latency optimisation is outside my (security) lens
+> depth: 1
+> chain: [security-auditor]
+> context:
+>   original_ask: "is this login flow safe?"
+>   prior_findings:
+>     - persona: security-auditor
+>       summary: |
+>         - auth.LoginHandler (entity_id: 4abf…) passes OWASP auth checks
+>         - handler issues a synchronous DB scan per request (~200 ms)
+>         - no injection vectors found in query construction
 >
 > Shall I bring them in?
 ```
@@ -227,17 +231,128 @@ The user replies yes/no. If yes, the orchestrator:
 Every Consult-Out call MUST include:
 
 - The entity_ids under discussion.
-- The user's original question.
+- The user's original question (preserved verbatim from the first hop — do not paraphrase).
 - A 2–4 bullet summary of what the original consultant has found so far.
 - The specific sub-question the peer is being asked to answer.
+- The accumulated `prior_findings` from every prior hop (see Section 5.4).
 
-This avoids the peer re-doing the original consultant's READ phase.
+This avoids the peer re-doing any previous hop's READ phase.
 
 ### 5.3 When NOT to Consult-Out
 
 - The peer's lens overlaps trivially with the active consultant's — handle it inline.
 - The user has not yet engaged deeply with the active consultant's answer.
+- The current depth is already 3 (hard cap — see Section 5.5).
+- The target persona already appears in `chain` (cycle — see Section 5.6).
 - More than 2 Consult-Outs have already happened in this conversation (panel sprawl).
+
+### 5.4 Multi-hop [CONSULT-OUT] schema
+
+Starting with this release (issue #2473), the `[CONSULT-OUT]` block is a structured YAML-in-blockquote envelope. All fields are required when depth > 1; `depth` and `chain` are required at all depths for forward compatibility.
+
+```yaml
+# [CONSULT-OUT] envelope (YAML fields, blockquote-formatted in persona output)
+target: archigraph-<persona-name>       # the peer being recruited
+reason: <one-line justification>        # why this peer's lens is needed
+depth: <integer, 1-indexed>             # current hop number (1 = first Consult-Out)
+chain: [<persona-a>, <persona-b>, ...]  # personas already in the chain (NOT including target)
+context:
+  original_ask: "<verbatim user question from hop 0>"
+  prior_findings:
+    - persona: <name>                   # one entry per prior hop
+      summary: |
+        - <2-3 line takeaway from that hop>
+```
+
+**Rules:**
+
+| Field | Rule |
+|---|---|
+| `depth` | Incremented by 1 at each hop. Personas receiving a Consult-Out at depth ≥ 3 MUST refuse to chain further. |
+| `chain` | The invoking persona appends its own name before sending. The target checks that its own name is NOT in `chain`. |
+| `prior_findings` | Each hop appends its own summary entry before handing off. The deepest expert receives all prior findings. |
+| `original_ask` | Copied verbatim from the first hop's `context.original_ask`. Never overwritten or paraphrased by intermediate hops. |
+
+### 5.5 Depth cap
+
+The maximum chain depth is **3 hops** (depth values 1, 2, 3). A persona receiving a Consult-Out at `depth: 3` MUST answer the sub-question itself (within its best-effort lens) rather than chaining further. If the question is genuinely outside its lens, it answers with "evidence insufficient in my lens — consider releasing and switching consultants directly."
+
+The depth cap may be raised by the user via an explicit instruction in the conversation (e.g. "allow up to 5 hops for this investigation"). The persona acknowledges the override and records the new cap in the envelope. Default cap: 3.
+
+### 5.6 Cycle detection
+
+Before emitting a `[CONSULT-OUT]` block, the persona MUST check whether the intended `target` already appears in `chain`. If it does:
+
+- Do NOT emit the `[CONSULT-OUT]` block.
+- Inform the user: "`archigraph-<target>` is already in the consultation chain (<chain>). Consulting them again would create a loop. Would you like me to answer within my own lens instead, or switch to a different expert?"
+
+Cycles are prevented at the persona level; the orchestrator does not need a separate guard (defence-in-depth, not primary enforcement).
+
+### 5.7 Worked example: 2-hop chain (architect → security-auditor → data-engineer)
+
+**Scenario:** The user asks the `architect` persona: *"Is our persistence layer correctly isolated from the HTTP handlers?"*
+
+**Hop 0 — architect is the active consultant**
+
+Architect traces the call graph and finds `api.OrderHandler` calls `db.RawQueryRunner` directly, bypassing the service layer. This is a layering violation. While examining the raw queries, architect spots parameterisation patterns that look suspect — but injection risk assessment is outside the architect's lens.
+
+Architect emits:
+
+```
+> [CONSULT-OUT]
+> target: archigraph-security-auditor
+> reason: Raw query patterns at the layering violation boundary may carry injection risk — security lens needed
+> depth: 1
+> chain: [architect]
+> context:
+>   original_ask: "Is our persistence layer correctly isolated from the HTTP handlers?"
+>   prior_findings:
+>     - persona: architect
+>       summary: |
+>         - api.OrderHandler (entity_id: 7c3a…) calls db.RawQueryRunner directly (CALLS edge, no service hop)
+>         - Layering violation: presentation → persistence bypass confirmed
+>         - 3 other handlers share this pattern (entity_ids: 8b1f…, 9d44…, 2e7c…)
+>
+> Shall I bring them in?
+```
+
+**Hop 1 — security-auditor is consulted**
+
+Security-auditor receives the envelope (`depth: 1`, `chain: [architect]`). They inspect `db.RawQueryRunner` and confirm parameterised queries are used — no injection. But they spot that `db.RawQueryRunner` reads a raw schema column named `user_pii_raw` without any field-level encryption annotation. Data handling is outside the security-auditor's lens (that's schema design territory).
+
+Security-auditor appends their findings and emits:
+
+```
+> [CONSULT-OUT]
+> target: archigraph-data-engineer
+> reason: Unencrypted PII column accessed via raw query — schema and migration hygiene lens needed
+> depth: 2
+> chain: [architect, security-auditor]
+> context:
+>   original_ask: "Is our persistence layer correctly isolated from the HTTP handlers?"
+>   prior_findings:
+>     - persona: architect
+>       summary: |
+>         - api.OrderHandler calls db.RawQueryRunner directly (layering violation)
+>         - 3 additional handlers share the pattern
+>     - persona: security-auditor
+>       summary: |
+>         - Parameterised queries confirmed — no SQL injection risk
+>         - db.RawQueryRunner reads column `user_pii_raw` (entity_id: 1fa9…) without encryption annotation
+>         - No auth check on the column access path
+>
+> Shall I bring them in?
+```
+
+**Hop 2 — data-engineer is consulted**
+
+Data-engineer receives the envelope (`depth: 2`, `chain: [architect, security-auditor]`). They inspect `user_pii_raw`, find no migration that added encryption, and flag it as a schema hygiene issue. Depth cap is not yet reached, but data-engineer has no further peer to bring in for this sub-question — they answer directly.
+
+Data-engineer returns `[CONSULT-IN: data-engineer]` to the conversation with:
+- `user_pii_raw` has no encryption-at-rest annotation in any migration (entity search: 0 results).
+- Recommend adding a column-level encryption migration and updating `db.RawQueryRunner` to decrypt in the service layer.
+
+**Return path:** Each `[CONSULT-IN]` reply bubbles back up. The user sees three tagged responses in sequence. The original `architect` persona remains active for the parent conversation.
 
 ---
 
@@ -344,7 +459,7 @@ Each persona calls `archigraph_persona_event` at two lifecycle points:
 | Lifecycle point | `event_type` | Required fields | Optional fields |
 |---|---|---|---|
 | Session start (user hires the persona) | `invoke` | `persona` | `metadata` |
-| Consult-Out (user confirms peer engagement) | `consult_out` | `persona`, `target_persona` | `metadata` |
+| Consult-Out (user confirms peer engagement) | `consult_out` | `persona`, `target_persona` | `depth`, `chain`, `metadata` |
 | Finding persisted via save_finding | `save_finding` | `persona` | `metadata` |
 
 The `save_finding` event_type is available for future use by the `archigraph-graph-write` shared skill; persona bodies currently only emit `invoke` and `consult_out`.
@@ -412,7 +527,7 @@ The four deferred personas (`solutions-architect`, `devops-reviewer`, `complianc
 | Persistent active-persona sidecar for Windsurf | Needs design work; conversation-marker workaround ships in this PR |
 | Codex / generic-markdown wrappers | Low user demand; defer until requested |
 | Persona-emitted findings → graph (opt-in) | **Shipped in #2472** — "When the user asks to save this analysis" section added to all 8 persona bodies; Section 2.4 defines the contract |
-| Consult-Out depth > 1 (peer of peer) | Single hop only in v3 |
+| Consult-Out depth > 1 (peer of peer) | **Shipped in #2473** — multi-hop with depth cap (3), cycle detection, and context carry-over. Section 5.4–5.7 define the full protocol. |
 | Telemetry on persona usage / Consult-Out frequency | **Shipped in #2474** — `archigraph_persona_event` MCP tool; Section 10 defines the contract and privacy promise |
 | Per-persona model selection strategy | **Shipped in #2475** — `model:` frontmatter on all 8 personas with opinionated recommendations; Section 2.3 defines the mapping and override contract |
 | Cross-platform renderer CLI | Defer until 3+ platforms stable |

--- a/skills/archigraph-consult/personas/api-designer.md
+++ b/skills/archigraph-consult/personas/api-designer.md
@@ -54,7 +54,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-business-analyst` — when a missing endpoint maps to an unimplemented capability.
 - `archigraph-data-engineer` — when payload shape exposes ORM internals.
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -78,7 +85,7 @@ archigraph_persona_event(persona="api-designer", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="api-designer", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="api-designer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/architect.md
+++ b/skills/archigraph-consult/personas/architect.md
@@ -52,7 +52,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-data-engineer` — when the layering violation crosses into the persistence layer (e.g. handlers calling raw queries).
 - `archigraph-api-designer` — when boundary violations are at the HTTP edge (controllers reaching into other modules).
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -76,7 +83,7 @@ archigraph_persona_event(persona="architect", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="architect", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="architect", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/business-analyst.md
+++ b/skills/archigraph-consult/personas/business-analyst.md
@@ -53,7 +53,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-security-auditor` — when a business rule involves access control or PII handling.
 - `archigraph-architect` — when a capability is spread across too many modules to reason about cleanly.
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -77,7 +84,7 @@ archigraph_persona_event(persona="business-analyst", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="business-analyst", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="business-analyst", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/compliance-officer.md
+++ b/skills/archigraph-consult/personas/compliance-officer.md
@@ -80,7 +80,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-api-designer` — when a PII-containing endpoint's API contract is the root issue (over-returning sensitive fields in response shapes).
 - `archigraph-architect` — when PII flows cross module boundaries in a way that suggests a missing data-handling abstraction.
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -109,7 +116,7 @@ archigraph_persona_event(persona="compliance-officer", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="compliance-officer", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="compliance-officer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/data-engineer.md
+++ b/skills/archigraph-consult/personas/data-engineer.md
@@ -52,7 +52,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-architect` — when persistence concerns leak across module boundaries.
 - `archigraph-qa-reviewer` — to confirm migration coverage in tests.
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -76,7 +83,7 @@ archigraph_persona_event(persona="data-engineer", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="data-engineer", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="data-engineer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/devops-reviewer.md
+++ b/skills/archigraph-consult/personas/devops-reviewer.md
@@ -71,7 +71,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-solutions-architect` — when CI/CD topology reveals cross-service deployment coupling concerns.
 - `archigraph-dx-engineer` — when CI slowness or test flakiness is a developer experience concern rather than a config correctness concern.
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -98,7 +105,7 @@ archigraph_persona_event(persona="devops-reviewer", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="devops-reviewer", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="devops-reviewer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/dx-engineer.md
+++ b/skills/archigraph-consult/personas/dx-engineer.md
@@ -80,7 +80,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-qa-reviewer` — when test desert modules need a test strategy decision (what types of tests to add, not just "add tests").
 - `archigraph-devops-reviewer` — when build or CI configuration is adding friction to the developer loop (slow CI, missing local dev targets).
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -107,7 +114,7 @@ archigraph_persona_event(persona="dx-engineer", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="dx-engineer", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="dx-engineer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/performance-reviewer.md
+++ b/skills/archigraph-consult/personas/performance-reviewer.md
@@ -51,7 +51,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-api-designer` — when over-fetching at the edge implies a payload/contract change.
 - `archigraph-security-auditor` — when adding caching would change the auth/freshness contract.
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -75,7 +82,7 @@ archigraph_persona_event(persona="performance-reviewer", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="performance-reviewer", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="performance-reviewer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/qa-reviewer.md
+++ b/skills/archigraph-consult/personas/qa-reviewer.md
@@ -53,7 +53,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-business-analyst` — when missing tests map to a claimed business capability.
 - `archigraph-architect` — when test gaps cluster around a structural seam.
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -77,7 +84,7 @@ archigraph_persona_event(persona="qa-reviewer", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="qa-reviewer", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="qa-reviewer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/refactor-critic.md
+++ b/skills/archigraph-consult/personas/refactor-critic.md
@@ -52,7 +52,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-performance-reviewer` — when a complexity hotspot is also a hot path.
 - `archigraph-data-engineer` — when the duplication is in the persistence layer.
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -76,7 +83,7 @@ archigraph_persona_event(persona="refactor-critic", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="refactor-critic", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="refactor-critic", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/security-auditor.md
+++ b/skills/archigraph-consult/personas/security-auditor.md
@@ -52,7 +52,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-api-designer` — when an endpoint's auth model is inconsistent with peers in the same surface.
 - `archigraph-business-analyst` — when the question is 'does this PII handling match what the product claims?'.
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -76,7 +83,7 @@ archigraph_persona_event(persona="security-auditor", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="security-auditor", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="security-auditor", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/archigraph-consult/personas/solutions-architect.md
+++ b/skills/archigraph-consult/personas/solutions-architect.md
@@ -78,7 +78,14 @@ If your analysis reaches a sub-question that lives in another consultant's lens,
 - `archigraph-api-designer` — when the cross-service contract is HTTP and the API design quality matters (versioning, naming, error contracts).
 - `archigraph-devops-reviewer` — when blast-radius analysis suggests infrastructure-level mitigations (circuit breakers, retry policies, k8s health probes).
 
-Use the Consult-Out callout shape defined in `skills/archigraph-consult/SKILL.md`. Always include the entity_ids under discussion, the user's original question, your findings so far (2–4 bullets), and the specific sub-question for the peer. Ask the user before bringing in the peer.
+Use the multi-hop `[CONSULT-OUT]` envelope defined in `docs/architecture/personas.md` Section 5.4. Before emitting the block:
+
+1. **Cycle guard**: check that the intended `target` does not already appear in the incoming `chain`. If it does, do NOT emit — inform the user of the cycle and offer an alternative.
+2. **Depth guard**: check the incoming `depth`. If `depth >= 3`, do NOT chain further — answer the sub-question within your best-effort lens or acknowledge evidence is insufficient.
+3. **Envelope construction**: append your own persona name to `chain`, increment `depth` by 1, append a 2–3 line `prior_findings` summary for your hop, and preserve `original_ask` verbatim.
+4. **User approval**: always ask the user before bringing in the peer.
+
+Always include the entity_ids under discussion, the user's original question (verbatim from `context.original_ask`), all accumulated `prior_findings`, and the specific sub-question for the peer.
 
 ## Response shape
 
@@ -105,7 +112,7 @@ archigraph_persona_event(persona="solutions-architect", event_type="invoke")
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-archigraph_persona_event(persona="solutions-architect", event_type="consult_out", target_persona="<peer-name>")
+archigraph_persona_event(persona="solutions-architect", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.


### PR DESCRIPTION
## Summary

- Extends the `[CONSULT-OUT]` block with a multi-hop YAML envelope: `target`, `reason`, `depth`, `chain`, and `context.prior_findings`
- Adds cycle detection (persona refuses if `target` is already in `chain`) and a depth cap of 3 (user-overridable)
- Updates all 12 persona files to follow the new protocol: append self to `chain`, increment `depth`, accumulate `prior_findings`, and enforce both guards
- Extends `docs/architecture/personas.md` Section 5 with: schema table (5.4), depth cap rules (5.5), cycle detection (5.6), and a full 2-hop worked example (5.7)

Closes #2473

## Test plan

- [x] `go test ./internal/personas/... -count=1` — PASS (all 12 personas, structural invariants + file count)
- [x] `go build ./...` — clean
- [x] Verified `[CONSULT-OUT]` schema fields present in architecture doc and all 12 personas
- [x] Worked example covers architect → security-auditor → data-engineer (depth 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)