### PR TITLE
refactor(engine): buildPlumbedFieldIndex accepts generic predicate

### DIFF
--- a/internal/engine/field_index.go
+++ b/internal/engine/field_index.go
@@ -131,29 +131,49 @@ func BuildCrossFileFieldLookup(pass1 []types.EntityRecord) func(modelName string
 	}
 }
 
-// buildPlumbedFieldIndex constructs the same `<Model>.<field>` presence
-// set as BuildFieldIndex, but sources the data from Pass 1's
-// SCOPE.Schema(subtype=field) entities rather than re-parsing source
-// (issue #2352).
+// buildPlumbedFieldIndex constructs a `<Class>.<member>` presence set
+// sourced from Pass 1 entity records rather than re-parsing source
+// (generalised from issue #2352).
 //
-// `path` filters the input slice to entities whose SourceFile matches
-// (or is unset — defensive for in-memory records that don't carry a
-// path). Entries with Name lacking the `<Class>.<field>` dot convention
-// are skipped silently — matches the byte-identical key shape the
-// regex parser emits.
+// Parameters:
+//   - path: when non-empty, only records whose SourceFile equals path are
+//     considered (records with an empty SourceFile are always included as
+//     a defensive allowance for in-memory test fixtures).
+//   - pass1Entities: the flat slice of Pass-1 records for the scope.
+//   - pred: a caller-supplied predicate that decides whether a given record
+//     should be indexed. The predicate runs AFTER the path filter. Pass a
+//     nil pred to accept every record that passes the path filter.
 //
-// Returns an empty map (never nil) when no field entities match; the
-// caller treats an empty result as "side-channel cold, use fallback".
-func buildPlumbedFieldIndex(path string, pass1Entities []types.EntityRecord) map[string]bool {
+// The predicate pattern lets different consumers (Django ORM fields, future
+// SQLAlchemy columns, non-ORM entity kinds, …) reuse the same index
+// machinery without copy-pasting the path-filter loop. Example:
+//
+//	// Accept only Python ORM SCOPE.Schema(subtype=field) records:
+//	buildPlumbedFieldIndex(path, records, isPythonORMField)
+//
+//	// Accept every record that passes the path filter (useful in tests):
+//	buildPlumbedFieldIndex(path, records, nil)
+//
+// Entries with Name lacking the dot convention (`<Class>.<member>`) are
+// skipped silently — preserving the byte-identical key shape the Python
+// extractor emits at python/extractor.go:1411.
+//
+// Returns an empty map (never nil) when no records match; callers treat
+// an empty result as "side-channel cold, use fallback".
+func buildPlumbedFieldIndex(
+	path string,
+	pass1Entities []types.EntityRecord,
+	pred func(types.EntityRecord) bool,
+) map[string]bool {
 	out := map[string]bool{}
 	if len(pass1Entities) == 0 {
 		return out
 	}
 	for _, e := range pass1Entities {
-		if e.Kind != "SCOPE.Schema" || e.Subtype != "field" {
+		if e.SourceFile != "" && path != "" && e.SourceFile != path {
 			continue
 		}
-		if e.SourceFile != "" && path != "" && e.SourceFile != path {
+		if pred != nil && !pred(e) {
 			continue
 		}
 		if !strings.Contains(e.Name, ".") {
@@ -162,4 +182,25 @@ func buildPlumbedFieldIndex(path string, pass1Entities []types.EntityRecord) map
 		out[e.Name] = true
 	}
 	return out
+}
+
+// isPythonORMField is the predicate that restricts buildPlumbedFieldIndex
+// to Django / Python-ORM SCOPE.Schema(subtype=field) entities — the only
+// record kind the original hardcoded filter accepted (issue #2431).
+//
+// It is exported as a package-level variable so tests and future wrappers
+// can compose it without repeating the Kind/Subtype literals.
+var isPythonORMField = func(e types.EntityRecord) bool {
+	return e.Kind == "SCOPE.Schema" && e.Subtype == "field"
+}
+
+// buildPlumbedPythonORMFieldIndex is a thin wrapper around
+// buildPlumbedFieldIndex that preserves the pre-#2431 call-site API used
+// by orm_field_edges.go. It hard-wires the isPythonORMField predicate so
+// existing callers need no changes.
+//
+// New consumers that need a different record type should call
+// buildPlumbedFieldIndex directly with their own predicate.
+func buildPlumbedPythonORMFieldIndex(path string, pass1Entities []types.EntityRecord) map[string]bool {
+	return buildPlumbedFieldIndex(path, pass1Entities, isPythonORMField)
 }

--- a/internal/engine/field_index_test.go
+++ b/internal/engine/field_index_test.go
@@ -193,35 +193,36 @@ func TestBuildFieldIndex_EmptyOrNonDjango(t *testing.T) {
 	}
 }
 
-// (h) buildPlumbedFieldIndex — the Pass 1 side-channel introduced in
-// issue #2352. The function takes the Pass 1 entity slice the Python
-// extractor would have emitted at python/extractor.go:1411-1421 and
-// returns the same `<Model>.<field>` presence set BuildFieldIndex
-// would have produced from source. The two paths MUST be byte-identical
-// on the key set, otherwise consumers (notably applyORMFieldEdges) will
-// behave differently depending on which path served them.
+// (h) buildPlumbedPythonORMFieldIndex — the Pass 1 side-channel introduced
+// in issue #2352. The function (now a thin wrapper over buildPlumbedFieldIndex
+// with the isPythonORMField predicate) takes the Pass 1 entity slice the
+// Python extractor would have emitted at python/extractor.go:1411-1421 and
+// returns the same `<Model>.<field>` presence set BuildFieldIndex would have
+// produced from source. The two paths MUST be byte-identical on the key set,
+// otherwise consumers (notably applyORMFieldEdges) will behave differently
+// depending on which path served them.
 func TestBuildPlumbedFieldIndex_HappyPath(t *testing.T) {
 	pass1 := []types.EntityRecord{
 		{Kind: "SCOPE.Schema", Subtype: "field", Name: "User.cognito_id", SourceFile: "users.py"},
 		{Kind: "SCOPE.Schema", Subtype: "field", Name: "User.email", SourceFile: "users.py"},
 		// Different file — must be filtered out.
 		{Kind: "SCOPE.Schema", Subtype: "field", Name: "Order.total", SourceFile: "orders.py"},
-		// Different kind — must be filtered out.
+		// Different kind — must be filtered out by isPythonORMField.
 		{Kind: "Function", Name: "User.save", SourceFile: "users.py"},
 		// Missing dot in Name — defensive skip.
 		{Kind: "SCOPE.Schema", Subtype: "field", Name: "loose", SourceFile: "users.py"},
 	}
-	idx := buildPlumbedFieldIndex("users.py", pass1)
+	idx := buildPlumbedPythonORMFieldIndex("users.py", pass1)
 	want := map[string]bool{
 		"User.cognito_id": true,
 		"User.email":      true,
 	}
 	if len(idx) != len(want) {
-		t.Fatalf("buildPlumbedFieldIndex returned %d entries, want %d; got %v", len(idx), len(want), idx)
+		t.Fatalf("buildPlumbedPythonORMFieldIndex returned %d entries, want %d; got %v", len(idx), len(want), idx)
 	}
 	for k := range want {
 		if !idx[k] {
-			t.Errorf("buildPlumbedFieldIndex missing %q; got %v", k, idx)
+			t.Errorf("buildPlumbedPythonORMFieldIndex missing %q; got %v", k, idx)
 		}
 	}
 }
@@ -229,11 +230,90 @@ func TestBuildPlumbedFieldIndex_HappyPath(t *testing.T) {
 // Empty input → empty (never-nil) map so callers can do an `if len == 0`
 // triage to decide between plumbed and fallback paths.
 func TestBuildPlumbedFieldIndex_EmptyInput(t *testing.T) {
-	idx := buildPlumbedFieldIndex("users.py", nil)
+	idx := buildPlumbedPythonORMFieldIndex("users.py", nil)
 	if idx == nil {
-		t.Fatal("buildPlumbedFieldIndex returned nil map, want empty non-nil")
+		t.Fatal("buildPlumbedPythonORMFieldIndex returned nil map, want empty non-nil")
 	}
 	if len(idx) != 0 {
-		t.Errorf("buildPlumbedFieldIndex returned %d entries, want 0", len(idx))
+		t.Errorf("buildPlumbedPythonORMFieldIndex returned %d entries, want 0", len(idx))
+	}
+}
+
+// (i) buildPlumbedFieldIndex with a generic predicate (issue #2431).
+//
+// Exercises the refactored generic core directly with a non-ORM predicate —
+// here a predicate that accepts ANY entity whose Kind is "Function". This
+// verifies that the predicate is evaluated and that path-filtering still
+// works when the ORM-specific isPythonORMField predicate is NOT used.
+//
+// The test intentionally uses a contrived, non-ORM kind so it is clearly
+// decoupled from the Python/Django domain and can serve as the template
+// for future consumers (e.g. SQLAlchemy columns, GraphQL resolvers).
+func TestBuildPlumbedFieldIndex_GenericPredicate(t *testing.T) {
+	// acceptAnyFunction matches any entity with Kind == "Function",
+	// regardless of Subtype. This is the "contrived filter" required by
+	// issue #2431 to prove the generic predicate path works.
+	acceptAnyFunction := func(e types.EntityRecord) bool {
+		return e.Kind == "Function"
+	}
+
+	pass1 := []types.EntityRecord{
+		// Should be included: Function kind, correct file, has dot.
+		{Kind: "Function", Name: "Foo.bar", SourceFile: "foo.py"},
+		{Kind: "Function", Name: "Foo.baz", SourceFile: "foo.py"},
+		// Should be excluded: ORM field kind — predicate rejects it.
+		{Kind: "SCOPE.Schema", Subtype: "field", Name: "Foo.col", SourceFile: "foo.py"},
+		// Should be excluded: wrong file.
+		{Kind: "Function", Name: "Bar.qux", SourceFile: "bar.py"},
+		// Should be excluded: Name has no dot — defensive skip.
+		{Kind: "Function", Name: "nodot", SourceFile: "foo.py"},
+		// Should be included: empty SourceFile is treated as "any file" (defensive allowance).
+		{Kind: "Function", Name: "Baz.method", SourceFile: ""},
+	}
+
+	idx := buildPlumbedFieldIndex("foo.py", pass1, acceptAnyFunction)
+
+	want := map[string]bool{
+		"Foo.bar":    true,
+		"Foo.baz":    true,
+		"Baz.method": true,
+	}
+	if len(idx) != len(want) {
+		t.Fatalf("buildPlumbedFieldIndex(generic) returned %d entries, want %d; got %v", len(idx), len(want), idx)
+	}
+	for k := range want {
+		if !idx[k] {
+			t.Errorf("buildPlumbedFieldIndex(generic) missing %q; got %v", k, idx)
+		}
+	}
+	// ORM record must not appear — predicate rejected it.
+	if idx["Foo.col"] {
+		t.Errorf("buildPlumbedFieldIndex(generic) should NOT include ORM field Foo.col; got %v", idx)
+	}
+}
+
+// (j) buildPlumbedFieldIndex with nil predicate — nil is treated as
+// "accept all" (after the path filter), so every record with a dotted
+// Name on the target file is indexed regardless of Kind/Subtype.
+func TestBuildPlumbedFieldIndex_NilPredicateAcceptsAll(t *testing.T) {
+	pass1 := []types.EntityRecord{
+		{Kind: "SCOPE.Schema", Subtype: "field", Name: "User.email", SourceFile: "x.py"},
+		{Kind: "Function", Name: "User.save", SourceFile: "x.py"},
+		{Kind: "Class", Name: "User.Meta", SourceFile: "x.py"},
+		// No dot — must be skipped even with nil predicate.
+		{Kind: "Function", Name: "helper", SourceFile: "x.py"},
+	}
+	idx := buildPlumbedFieldIndex("x.py", pass1, nil)
+	if !idx["User.email"] {
+		t.Errorf("nil pred: missing User.email; got %v", idx)
+	}
+	if !idx["User.save"] {
+		t.Errorf("nil pred: missing User.save; got %v", idx)
+	}
+	if !idx["User.Meta"] {
+		t.Errorf("nil pred: missing User.Meta; got %v", idx)
+	}
+	if idx["helper"] {
+		t.Errorf("nil pred: 'helper' (no dot) should not be indexed; got %v", idx)
 	}
 }

--- a/internal/engine/orm_field_edges.go
+++ b/internal/engine/orm_field_edges.go
@@ -95,7 +95,7 @@ func applyORMFieldEdges(args DetectorPassArgs) DetectorPassResult {
 	// construct FileInput directly without going through Pass 1, and
 	// (b) the subprocess-extract path that merges Pass 1+2.5 outside the
 	// per-file detector loop.
-	fieldIdx := buildPlumbedFieldIndex(path, pass1Entities)
+	fieldIdx := buildPlumbedPythonORMFieldIndex(path, pass1Entities)
 	plumbed := len(fieldIdx) > 0
 	if !plumbed {
 		fieldIdx = BuildFieldIndex(string(content))


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `Kind == "SCOPE.Schema" && Subtype == "field"` filter inside `buildPlumbedFieldIndex` with a caller-supplied `pred func(types.EntityRecord) bool` parameter.
- Extracts the original ORM-specific logic into a package-level `isPythonORMField` predicate variable.
- Adds `buildPlumbedPythonORMFieldIndex` as a thin wrapper that calls `buildPlumbedFieldIndex(path, records, isPythonORMField)` — zero disruption to existing call sites (`orm_field_edges.go`).
- `nil` predicate is accepted and treated as "accept all" (after path filter).

Closes #2431. Refs #2425.

## Test plan

- [ ] `TestBuildPlumbedFieldIndex_GenericPredicate` — exercises the new generic predicate path with a `Kind == "Function"` filter; verifies ORM records are excluded and path filtering still works.
- [ ] `TestBuildPlumbedFieldIndex_NilPredicateAcceptsAll` — verifies nil pred accepts all dotted-Name records from the target file.
- [ ] Existing `TestBuildPlumbedFieldIndex_HappyPath` and `TestBuildPlumbedFieldIndex_EmptyInput` updated to call `buildPlumbedPythonORMFieldIndex` (the wrapper), confirming the ORM path is unbroken.
- [ ] `go test ./internal/engine/... -count=1` — PASS (17 s, no failures).
- [ ] `go build ./...`, `go vet ./...`, `gofmt -l` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)