### PR TITLE
fix(mcp): PersonaEvent accepts depth + chain (Closes #2533)

### DIFF
--- a/internal/mcp/persona_telemetry.go
+++ b/internal/mcp/persona_telemetry.go
@@ -51,6 +51,10 @@ type PersonaEvent struct {
 	EventType string `json:"event_type"`
 	// TargetPersona is the peer persona name on consult_out events. Empty otherwise.
 	TargetPersona string `json:"target_persona,omitempty"`
+	// Depth is the hop count for consult_out events (PR #2531). Empty otherwise.
+	Depth int `json:"depth,omitempty"`
+	// Chain is the ordered sequence of persona names visited in a consult chain (PR #2531). Empty otherwise.
+	Chain []string `json:"chain,omitempty"`
 	// Metadata is an optional free-form map for future extensibility.
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
@@ -118,6 +122,12 @@ func (s *Server) handlePersonaEvent(ctx context.Context, req mcpapi.CallToolRequ
 
 	targetPersona := argString(req, "target_persona", "")
 
+	// Extract depth if present (consult_out events only, but allow all event types for flexibility).
+	depth := argInt(req, "depth", 0)
+
+	// Extract chain if present (consult_out events only, but allow all event types for flexibility).
+	chain := argStringSlice(req, "chain")
+
 	// metadata is accepted as a raw map if the client provides it.
 	var metadata map[string]any
 	if raw, ok := req.GetArguments()["metadata"]; ok {
@@ -132,6 +142,8 @@ func (s *Server) handlePersonaEvent(ctx context.Context, req mcpapi.CallToolRequ
 		Persona:       persona,
 		EventType:     eventType,
 		TargetPersona: targetPersona,
+		Depth:         depth,
+		Chain:         chain,
 		Metadata:      metadata,
 	}
 

--- a/internal/mcp/persona_telemetry_test.go
+++ b/internal/mcp/persona_telemetry_test.go
@@ -125,11 +125,13 @@ func TestPersonaEventJSONLAppend(t *testing.T) {
 		t.Errorf("expected non-empty ts, got %v", got["ts"])
 	}
 
-	// Emit a consult_out event.
+	// Emit a consult_out event with depth and chain.
 	res2 := callTool(t, srv, "archigraph_persona_event", map[string]any{
 		"persona":        "architect",
 		"event_type":     "consult_out",
 		"target_persona": "performance-reviewer",
+		"depth":          2,
+		"chain":          []string{"architect", "security-auditor"},
 	})
 	if res2 == nil || res2.IsError {
 		t.Fatalf("consult_out event failed: %v", resultText(res2))
@@ -179,6 +181,12 @@ func TestPersonaEventJSONLAppend(t *testing.T) {
 	}
 	if evt2.TargetPersona != "performance-reviewer" {
 		t.Errorf("evt2.TargetPersona: want performance-reviewer, got %q", evt2.TargetPersona)
+	}
+	if evt2.Depth != 2 {
+		t.Errorf("evt2.Depth: want 2, got %d", evt2.Depth)
+	}
+	if len(evt2.Chain) != 2 || evt2.Chain[0] != "architect" || evt2.Chain[1] != "security-auditor" {
+		t.Errorf("evt2.Chain: want [architect security-auditor], got %v", evt2.Chain)
 	}
 }
 


### PR DESCRIPTION
## Summary

PR #2531 (#2473) added `depth` + `chain` fields to the [CONSULT-OUT] schema, and persona bodies now pass these to `archigraph_persona_event` calls. But `internal/mcp/persona_telemetry.go` handler was silently ignoring them.

**Changes:**
- Extended `PersonaEvent` struct with `Depth int` and `Chain []string` fields
- Updated `handlePersonaEvent` to extract depth/chain from MCP tool args
- Persisted both fields to the JSONL event log
- Updated test to roundtrip depth and chain values

All pre-commit checks (gofmt, go vet, go build, go test) pass.

Closes #2533

🤖 Generated with Claude Code