### PR TITLE
fix(daemon): wire SessionMetrics.FlushRollup into shutdown

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -388,6 +388,14 @@ func runDaemon(argv []string) error {
 				},
 			}
 		}(),
+
+		// Shutdown cleanup: flush MCP session metrics to disk (issue #2530).
+		// Best-effort: does not block shutdown on error.
+		ShutdownCleanup: func() {
+			if mcpSrv, err := mcpServerInstance(); err == nil {
+				mcpSrv.Stop()
+			}
+		},
 	}
 
 	ctx := context.Background()

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -158,6 +158,12 @@ type Config struct {
 	// invalidates stale CrossLinkCache entries keyed to (repo, oldRef) — this
 	// closes the stale-cache bug tracked in issue #2224.
 	BranchSwitchSink func(repoPath, oldRef string)
+
+	// ShutdownCleanup, when non-nil, is called during graceful shutdown to
+	// perform cleanup operations (e.g. flushing metrics). Best-effort: errors
+	// are logged but do not block shutdown. Injected from cmd/archigraph to call
+	// the MCP server's Stop method (issue #2530).
+	ShutdownCleanup func()
 }
 
 // Run starts the daemon. It blocks until either:
@@ -456,6 +462,12 @@ func Run(ctx context.Context, cfg Config) error {
 		// own we should treat that as fatal and exit.
 		logger.Error("listener closed unexpectedly")
 		return errors.New("listener closed")
+	}
+
+	// Cleanup hook: best-effort shutdown operations (e.g. metric flush).
+	// Does not block the shutdown path (issue #2530).
+	if cfg.ShutdownCleanup != nil {
+		cfg.ShutdownCleanup()
 	}
 
 	// Stop accepting new connections, then wait for in-flight ones.

--- a/internal/mcp/metrics_test.go
+++ b/internal/mcp/metrics_test.go
@@ -281,6 +281,59 @@ func TestMCPMetricsToolShape(t *testing.T) {
 	}
 }
 
+// TestServerShutdownFlushed verifies that calling Server.Stop() flushes metrics to disk.
+// This tests the wiring for issue #2530 — ensuring metrics persist on daemon shutdown.
+func TestServerShutdownFlushed(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(regPath, []byte(`{"groups":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Override SessMet's metricsDir to use the temp dir.
+	srv.SessMet = NewSessionMetrics("shutdown-test-session", dir)
+
+	// Record some tool calls.
+	srv.SessMet.Record("archigraph_find", 10*time.Millisecond, false)
+	srv.SessMet.Record("archigraph_find", 20*time.Millisecond, false)
+	srv.SessMet.Record("archigraph_inspect", 50*time.Millisecond, true)
+
+	// Call Stop() to simulate shutdown (should flush metrics).
+	srv.Stop()
+
+	// Verify the rollup file was created with expected content.
+	date := time.Now().UTC().Format("2006-01-02")
+	path := filepath.Join(dir, "mcp-"+date+".jsonl")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("rollup file not created after Stop(): %v", err)
+	}
+
+	records, err := ReadRollups(dir, 1)
+	if err != nil {
+		t.Fatalf("ReadRollups: %v", err)
+	}
+	if len(records) < 2 {
+		t.Fatalf("expected at least 2 rollup records after Stop(), got %d", len(records))
+	}
+
+	// Verify both tools are in the rollup.
+	byTool := map[string]RollupRecord{}
+	for _, r := range records {
+		byTool[r.Tool] = r
+	}
+
+	if _, ok := byTool["archigraph_find"]; !ok {
+		t.Error("archigraph_find not in rollup after Stop()")
+	}
+	if _, ok := byTool["archigraph_inspect"]; !ok {
+		t.Error("archigraph_inspect not in rollup after Stop()")
+	}
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 // splitLines splits raw bytes into individual non-empty lines.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -111,6 +111,15 @@ func (s *Server) ServeStdio() error {
 	return mcpsrv.ServeStdio(s.MCP)
 }
 
+// Stop cleanly shuts down the server. It flushes session metrics (best-effort)
+// before returning. Called during daemon graceful shutdown to persist daily
+// rollups to ~/.archigraph/metrics/ (issue #2530).
+func (s *Server) Stop() {
+	if s.SessMet != nil {
+		s.SessMet.FlushRollup()
+	}
+}
+
 // reloadBeforeCall is the shared mtime-based lazy refresh hook.
 //
 // #1772: when the registry signature (group→repo set) mutated since the


### PR DESCRIPTION
## Summary
Closes #2530

PR #2529 (#2192) shipped SessionMetrics with `FlushRollup()` writing daily rollups to `~/.archigraph/metrics/`, but `FlushRollup()` is **never called** — metrics are discarded on daemon stop.

Wired `FlushRollup()` into the daemon's graceful shutdown path (SIGTERM/SIGINT) so metrics persist to disk.

## Changes
1. **internal/mcp/server.go**: Added `Server.Stop()` method that flushes metrics (best-effort, no error blocking)
2. **internal/daemon/server.go**: Added `Config.ShutdownCleanup` callback field for shutdown hooks
3. **cmd/archigraph/daemon.go**: Wired callback to call `mcpServerInstance().Stop()` during graceful shutdown
4. **internal/mcp/metrics_test.go**: Added `TestServerShutdownFlushed` to verify metrics persist after Stop()

## Test plan
- ✅ `go test ./internal/mcp -run TestServerShutdownFlushed` — verifies metrics file created on Stop()
- ✅ `go test ./internal/mcp/...` — all metrics tests pass
- ✅ `go test ./internal/daemon/...` — daemon tests pass (except pre-existing self-defense test)
- ✅ `go build ./...` — clean build
- ✅ `go vet ./...` — no vet issues
- ✅ `gofmt -l ./...` — properly formatted