### PR TITLE
feat(personas): interactive resume session for archigraph-consult

### DIFF
--- a/docs/architecture/personas.md
+++ b/docs/architecture/personas.md
@@ -510,7 +510,58 @@ The four deferred personas (`solutions-architect`, `devops-reviewer`, `complianc
 
 ---
 
-## 11. Phasing
+## 11. Session State
+
+### 11.1 Motivation
+
+The `archigraph-consult` skill is interactive and stateless by default: each invocation starts fresh. Issue #2459 adds optional persistence so a user can resume a mid-conversation consultation across sessions — same active persona, same Consult-Out chain, same accumulated context and notes.
+
+### 11.2 Storage
+
+Session state persists to `~/.archigraph/sessions/<session-id>.yaml`. The directory is created on first save. No new MCP tools are introduced — personas use the host agent's `Read` and `Write` tools (inherited via the tool-inheritance contract in Section 2.1).
+
+### 11.3 Schema
+
+```yaml
+session_id: <uuid-or-timestamp-slug>        # e.g. "20260527-143022-architect"
+created: <iso8601>
+last_active: <iso8601>
+active_persona: <name>                       # e.g. "architect"
+consult_chain: [persona-a, persona-b]        # active chain at save time
+context:
+  original_ask: "<verbatim user question>"
+  prior_findings:
+    - persona: <name>
+      summary: "<2-4 line text summary>"
+notes: |
+  <free-form scratch — any persona may append>
+```
+
+### 11.4 Lifecycle
+
+| Event | Action |
+|---|---|
+| First invocation (no `--new`/`--resume`) | Skill scans `~/.archigraph/sessions/*.yaml`, presents active sessions + "Start new session" |
+| User picks existing session | Skill reads YAML, re-primes agent with active persona + context, announces resume |
+| User picks "Start new session" | Normal hire flow; a new session file is created on first save |
+| Explicit save ("save session", "checkpoint") | Persona uses `Write` to write/overwrite `<session-id>.yaml` with current state |
+| Approved Consult-Out | Skill saves session before spawning the peer |
+| `[END SESSION]` / `--release` with confirmation | Session YAML moved to `~/.archigraph/sessions/archive/<session-id>.yaml` |
+| `last_active` > 30 days | Session shown as `[stale]` in picker; user must confirm resume or archive |
+
+### 11.5 Cross-persona notes field
+
+The `notes` field in the session YAML is a free-form string any persona may append to during a conversation. This is the intended mechanism for mid-conversation scratch notes that don't yet warrant a formal finding (which would go through `archigraph_save_finding`). Notes are preserved across resumes.
+
+### 11.6 Anti-patterns
+
+- **Do not auto-save on every turn.** Save on explicit request or Consult-Out only. Constant writes create noise and inflate the session file unnecessarily.
+- **Do not store PII or sensitive findings in `notes`.** The session file is plaintext on the local filesystem. Sensitive findings should go through `archigraph_save_finding` or the user's own secure note-taking.
+- **Do not read another session's YAML without user approval.** Each session file belongs to one conversation context. Cross-session reading would conflate unrelated consultation threads.
+
+---
+
+## 12. Phasing
 
 ### v3 (PR #2449 / this doc)
 
@@ -524,7 +575,8 @@ The four deferred personas (`solutions-architect`, `devops-reviewer`, `complianc
 | Item | Reason |
 |---|---|
 | True multi-persona panel mode | v1/v2 attempted this; postponed until interactive model is validated |
-| Persistent active-persona sidecar for Windsurf | Needs design work; conversation-marker workaround ships in this PR |
+| Persistent active-persona sidecar for Windsurf | Needs design work; conversation-marker workaround ships in this PR. Session file (Section 11) partially mitigates by preserving context across invocations. |
+| Interactive resume session for archigraph-consult | **Shipped in #2459** — session state persisted to `~/.archigraph/sessions/<id>.yaml`; session picker on first invocation; resume, save, end/archive flows. Section 11 defines the full contract. |
 | Codex / generic-markdown wrappers | Low user demand; defer until requested |
 | Persona-emitted findings → graph (opt-in) | **Shipped in #2472** — "When the user asks to save this analysis" section added to all 8 persona bodies; Section 2.4 defines the contract |
 | Consult-Out depth > 1 (peer of peer) | **Shipped in #2473** — multi-hop with depth cap (3), cycle detection, and context carry-over. Section 5.4–5.7 define the full protocol. |

--- a/skills/archigraph-consult/SKILL.md
+++ b/skills/archigraph-consult/SKILL.md
@@ -42,10 +42,12 @@ The active persona MUST use archigraph MCP tools for ALL graph navigation. Pre-f
 - `--list` / `--catalog` — print the catalog and exit.
 - `--release` — release the currently active consultant.
 - `--switch <name>` — release the current consultant and hire `<name>`.
+- `--resume <session-id>` — resume a specific saved session by ID (skips the session picker).
+- `--new` — force a new session, skipping the active-session list.
 
 ## Shipped catalog
 
-Eight consultants ship as persona files in `skills/archigraph-consult/personas/`. Users may add their own under `~/.claude/agents/archigraph-<persona>.md`.
+Twelve consultants ship as persona files in `skills/archigraph-consult/personas/`. Users may add their own under `~/.claude/agents/archigraph-<persona>.md`.
 
 | Consultant | File | Lens |
 |---|---|---|
@@ -57,6 +59,85 @@ Eight consultants ship as persona files in `skills/archigraph-consult/personas/`
 | api-designer | `personas/api-designer.md` | Endpoint naming, REST/RPC convention consistency, versioning, error-shape uniformity |
 | data-engineer | `personas/data-engineer.md` | Schema quality, migration hygiene, ORM query patterns, index candidates, FK integrity |
 | qa-reviewer | `personas/qa-reviewer.md` | TESTS-edge coverage by module, untested critical paths, fixture hygiene |
+| solutions-architect | `personas/solutions-architect.md` | Cross-service boundaries, inter-repo contracts, coupling, blast-radius (limited: cross_links coverage) |
+| devops-reviewer | `personas/devops-reviewer.md` | CI/CD config, GitHub Actions pinning, build hygiene, graph-visible infra config (limited: no IaC indexer) |
+| compliance-officer | `personas/compliance-officer.md` | PII field detection, audit-trail gaps, sensitive data flow surface scan (limited: name-match heuristics only) |
+| dx-engineer | `personas/dx-engineer.md` | Test deserts, circular imports, god entry-points, module size outliers (limited: test/import-graph signals only) |
+
+## Session state
+
+Session state is persisted to `~/.archigraph/sessions/<session-id>.yaml` using the host agent's `Read` and `Write` tools. No new MCP tools are required — all personas inherit `Read` and `Write` from the host agent.
+
+### Schema
+
+```yaml
+session_id: <uuid-or-timestamp-slug>        # e.g. "20260527-143022-architect"
+created: <iso8601>                           # e.g. "2026-05-27T14:30:22Z"
+last_active: <iso8601>                       # updated on every save
+active_persona: <name>                       # e.g. "architect"
+consult_chain: [persona-a, persona-b]        # active Consult-Out chain at save time
+context:
+  original_ask: "<verbatim user question>"
+  prior_findings:
+    - persona: <name>
+      summary: "<2-4 line text summary of that hop's findings>"
+notes: |
+  <free-form scratch — any persona may append mid-conversation>
+```
+
+### First-invocation flow (session picker)
+
+On every invocation (unless `--new` or `--resume <id>` is passed):
+
+1. Scan `~/.archigraph/sessions/*.yaml` for files whose `last_active` is within the past 30 days.
+2. If any active sessions exist, present them:
+   ```
+   Active sessions:
+     [1] 20260527-143022-architect    last active: 2026-05-27  persona: architect
+     [2] 20260525-091500-security     last active: 2026-05-25  persona: security-auditor
+     [N] Start new session
+   ```
+   Ask: "Resume a session, or start new?"
+3. If no active sessions exist (or the user picks "Start new session"), proceed to Persona selection below.
+
+### Resume flow
+
+When the user picks an existing session (or passes `--resume <session-id>`):
+
+1. Read `~/.archigraph/sessions/<session-id>.yaml`.
+2. Re-prime the host agent:
+   - Set `active_persona` to the saved value.
+   - Inject the saved `context.original_ask`, `prior_findings`, `consult_chain`, and `notes` into the conversation as a system reminder block:
+     ```
+     [archigraph-consult] RESUMING SESSION <session-id>
+     Active persona: archigraph-<name>
+     Original ask: <original_ask>
+     Prior findings: <prior_findings as bullet list>
+     Consult chain: <consult_chain>
+     Notes: <notes>
+     ```
+3. Activate the persona (load its body inline, same as a new hire).
+4. Announce to the user:
+   > Resumed session `<session-id>` with consultant `archigraph-<name>`. Context restored. Pick up where you left off.
+
+### Save flow
+
+Session state is written under two conditions:
+
+1. **Explicit user request** — user says "save session", "checkpoint this", "save my place", or equivalent.
+2. **On Consult-Out** — when the active persona emits a `[CONSULT-OUT]` block and the user approves, the skill writes current state before spawning the peer (so the carry-over context is recoverable if the peer chain is interrupted).
+
+To save, the persona uses the host agent's `Write` tool:
+- Path: `~/.archigraph/sessions/<session-id>.yaml`
+- Content: full YAML schema above, with `last_active` updated to the current UTC time.
+
+The session directory `~/.archigraph/sessions/` is created if it does not exist (use `Bash` with `mkdir -p`).
+
+### End / archive policy
+
+- **Explicit end**: user says `[END SESSION]` or runs `/archigraph-consult --release` and confirms archiving. The YAML is moved to `~/.archigraph/sessions/archive/<session-id>.yaml`.
+- **Staleness auto-archive**: sessions whose `last_active` is more than 30 days ago are shown in the session picker with a `[stale]` label. Selecting a stale session prompts: "This session is >30 days old. Resume anyway, or archive it?" Archiving moves it to `~/.archigraph/sessions/archive/`.
+- The `archive/` directory is never auto-deleted. The user is responsible for cleanup.
 
 ## Procedure
 
@@ -66,6 +147,7 @@ Eight consultants ship as persona files in `skills/archigraph-consult/personas/`
 2. Verify tech docs exist at `~/.archigraph/docs/<group>/modules/`. If not, abort with the message above.
 3. Scan `skills/archigraph-consult/personas/*.md` + `~/.claude/agents/archigraph-*.md` to build the catalog.
 4. If `--list` / `--catalog`: print the catalog (name + one-line description from frontmatter) and exit.
+5. **Session picker**: unless `--new` or `--resume <id>` was passed, scan `~/.archigraph/sessions/` and present active sessions (see Session state above). If the user resumes, skip Persona selection and go straight to Activation.
 
 ### Persona selection
 
@@ -119,6 +201,7 @@ The active persona may, at any time, request a peer's input via a structured cal
 
 When the user approves:
 
+- **Save session first**: before spawning the peer, write the current session state to `~/.archigraph/sessions/<session-id>.yaml` (see Session state → Save flow). This ensures the Consult-Out carry-over context is recoverable if the chain is interrupted.
 - **Claude Code:** spawn the peer as a subagent via the Task tool, with the carry-over context as the opening message and the peer's persona body as system prompt. The peer answers the sub-question and returns. Summarise back to the user prefixed `[CONSULT-IN: <peer>]`. The original consultant remains active in the parent conversation.
 - **Windsurf:** for the current turn only, layer the peer's lens onto Cascade by inlining the peer's body alongside the original. After the turn, the peer's marker expires; the original consultant remains.
 - **Cursor:** open a new Agents Window tab with the peer, passing carry-over context. Bring the answer back to the original tab manually or via paste.

--- a/skills/archigraph-consult/personas/api-designer.md
+++ b/skills/archigraph-consult/personas/api-designer.md
@@ -89,3 +89,9 @@ archigraph_persona_event(persona="api-designer", event_type="consult_out", targe
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/architect.md
+++ b/skills/archigraph-consult/personas/architect.md
@@ -87,3 +87,9 @@ archigraph_persona_event(persona="architect", event_type="consult_out", target_p
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/business-analyst.md
+++ b/skills/archigraph-consult/personas/business-analyst.md
@@ -88,3 +88,9 @@ archigraph_persona_event(persona="business-analyst", event_type="consult_out", t
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/compliance-officer.md
+++ b/skills/archigraph-consult/personas/compliance-officer.md
@@ -120,3 +120,9 @@ archigraph_persona_event(persona="compliance-officer", event_type="consult_out",
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/data-engineer.md
+++ b/skills/archigraph-consult/personas/data-engineer.md
@@ -87,3 +87,9 @@ archigraph_persona_event(persona="data-engineer", event_type="consult_out", targ
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/devops-reviewer.md
+++ b/skills/archigraph-consult/personas/devops-reviewer.md
@@ -109,3 +109,9 @@ archigraph_persona_event(persona="devops-reviewer", event_type="consult_out", ta
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/dx-engineer.md
+++ b/skills/archigraph-consult/personas/dx-engineer.md
@@ -118,3 +118,9 @@ archigraph_persona_event(persona="dx-engineer", event_type="consult_out", target
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/performance-reviewer.md
+++ b/skills/archigraph-consult/personas/performance-reviewer.md
@@ -86,3 +86,9 @@ archigraph_persona_event(persona="performance-reviewer", event_type="consult_out
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/qa-reviewer.md
+++ b/skills/archigraph-consult/personas/qa-reviewer.md
@@ -88,3 +88,9 @@ archigraph_persona_event(persona="qa-reviewer", event_type="consult_out", target
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/refactor-critic.md
+++ b/skills/archigraph-consult/personas/refactor-critic.md
@@ -87,3 +87,9 @@ archigraph_persona_event(persona="refactor-critic", event_type="consult_out", ta
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/security-auditor.md
+++ b/skills/archigraph-consult/personas/security-auditor.md
@@ -87,3 +87,9 @@ archigraph_persona_event(persona="security-auditor", event_type="consult_out", t
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.

--- a/skills/archigraph-consult/personas/solutions-architect.md
+++ b/skills/archigraph-consult/personas/solutions-architect.md
@@ -116,3 +116,9 @@ archigraph_persona_event(persona="solutions-architect", event_type="consult_out"
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.
+
+## Session state
+
+Any persona — including this one — may persist in-progress findings to `~/.archigraph/sessions/<id>.yaml` at any point during the conversation. The session file stores the active persona name, the current Consult-Out chain, the original user question, accumulated prior findings, and free-form notes.
+
+Use the host agent's `Write` tool to save. Use `Read` to restore context on resume. Saves happen on explicit user request ("save session", "checkpoint this") and automatically on any approved Consult-Out. See `skills/archigraph-consult/SKILL.md` (Session state) for the full schema and archive policy.


### PR DESCRIPTION
## Summary

- Adds session-state persistence to `~/.archigraph/sessions/<id>.yaml` so users can resume mid-conversation consultations across runs with the same active persona, Consult-Out chain, and accumulated context.
- Uses host agent `Read`/`Write` tools only — no new MCP tools introduced.
- All 12 personas updated with a `## Session state` section.
- `docs/architecture/personas.md` gains Section 11 (Session State) documenting schema, lifecycle, cross-persona notes field, and anti-patterns.
- `skills/archigraph-consult/SKILL.md` gains full session state documentation: schema, first-invocation flow (session picker), resume flow, save flow, and end/archive policy.
- `--resume <id>` and `--new` flags added.
- Session auto-archived after 30-day staleness.

## Test plan

- [x] `go test ./internal/personas/... -count=1` — all 12 personas PASS `TestPersonaStructuralInvariants`; `TestPersonaFileCount` PASS (count = 12)
- [x] `go build ./...` — clean, no errors
- [ ] Manual: invoke `/archigraph-consult`, verify session picker appears when `~/.archigraph/sessions/` has existing YAMLs
- [ ] Manual: save a session mid-conversation, exit, re-invoke, pick the saved session, verify context restored
- [ ] Manual: invoke with `--new` flag, verify session picker is skipped

Closes #2459

🤖 Generated with [Claude Code](https://claude.com/claude-code)