### PR TITLE
refactor(tests): explicit stateDir param in newTestIndexer

### DIFF
--- a/cmd/archigraph/groovy_mini_test.go
+++ b/cmd/archigraph/groovy_mini_test.go
@@ -22,7 +22,7 @@ func TestGroovyGrailsDynamic(t *testing.T) {
 		t.Skipf("groovy-grails-mini fixture not found at %s", abs)
 	}
 
-	idx := newTestIndexer(t, "groovy-grails-mini", nil)
+	idx := newTestIndexer(t, "groovy-grails-mini", nil, "")
 	doc, err := idx.Run(context.Background(), abs)
 	if err != nil {
 		t.Fatalf("Run: %v", err)

--- a/cmd/archigraph/index_enrichment_test.go
+++ b/cmd/archigraph/index_enrichment_test.go
@@ -16,8 +16,8 @@ import (
 func TestEnrichmentCandidates_DjangoFixture(t *testing.T) {
 	// Copy the django_app fixture into a tmp dir so we can inspect the
 	// state output without polluting source-tree fixtures.
-	// #1626: per-repo state lives in the external store; pin DAEMON_ROOT.
-	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
+	// #1626: per-repo state lives in the external store; use explicit stateDir.
+	stateDir := t.TempDir()
 	tmp := t.TempDir()
 	src, err := filepath.Abs("testdata/django_app")
 	if err != nil {
@@ -27,7 +27,7 @@ func TestEnrichmentCandidates_DjangoFixture(t *testing.T) {
 		t.Fatalf("copyTree: %v", err)
 	}
 
-	idx := newTestIndexer(t, "django_app", nil)
+	idx := newTestIndexer(t, "django_app", nil, stateDir)
 	doc, err := idx.Run(context.Background(), tmp)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -65,8 +65,9 @@ func TestEnrichmentCandidates_DjangoFixture(t *testing.T) {
 // next emit, and that the previously-resolved entity no longer produces
 // a describe_entity candidate.
 func TestEnrichmentResolutions_MergeBack(t *testing.T) {
-	// #1626: per-repo state lives in the external store; pin DAEMON_ROOT.
-	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
+	// #1626: per-repo state lives in the external store; use explicit stateDir
+	// shared across both runs so the second run can load the pre-seeded resolutions.
+	stateDir := t.TempDir()
 	tmp := t.TempDir()
 	src, err := filepath.Abs("testdata/django_app")
 	if err != nil {
@@ -77,7 +78,7 @@ func TestEnrichmentResolutions_MergeBack(t *testing.T) {
 	}
 
 	// First run — discover an entity ID we can pre-resolve.
-	idx := newTestIndexer(t, "django_app", nil)
+	idx := newTestIndexer(t, "django_app", nil, stateDir)
 	doc, err := idx.Run(context.Background(), tmp)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -105,7 +106,7 @@ func TestEnrichmentResolutions_MergeBack(t *testing.T) {
 
 	// Second run — Pass 6 should merge the resolution back AND skip
 	// describe_entity for that subject.
-	idx2 := newTestIndexer(t, "django_app", nil)
+	idx2 := newTestIndexer(t, "django_app", nil, stateDir)
 	doc2, err := idx2.Run(context.Background(), tmp)
 	if err != nil {
 		t.Fatalf("Run 2: %v", err)

--- a/cmd/archigraph/index_test.go
+++ b/cmd/archigraph/index_test.go
@@ -19,19 +19,18 @@ import (
 
 // newTestIndexer constructs an Indexer wired up to the embedded YAML rules
 // and the default classifier/parser. skipPasses is the optional set of
-// passes to skip — pass nil to run everything.
-func newTestIndexer(t *testing.T, repoTag string, skipPasses []string) *Indexer {
+// passes to skip — pass nil to run everything. stateDir is the per-repo state
+// directory; if empty, defaults to a fresh t.TempDir(). Callers needing
+// shared state across multiple runs should pass the same stateDir.
+func newTestIndexer(t *testing.T, repoTag string, skipPasses []string, stateDir string) *Indexer {
 	t.Helper()
-	// #1626 / #2083: per-repo state lives in the external store. Pin
-	// ARCHIGRAPH_DAEMON_ROOT to an isolated temp so indexer runs
-	// (a) don't pollute the source tree fixtures with state and
-	// (b) don't load stale state across runs.
-	// Only set if the caller hasn't already established an isolated root
-	// (e.g. index_enrichment_test.go sets it before seeding resolution files
-	// that the second run must find in the same dir).
-	if os.Getenv("ARCHIGRAPH_DAEMON_ROOT") == "" {
-		t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
+	if stateDir == "" {
+		stateDir = t.TempDir()
 	}
+	// #1626 / #2083: pin ARCHIGRAPH_DAEMON_ROOT to an isolated temp so
+	// indexer runs (a) don't pollute the source tree fixtures with state
+	// and (b) don't load stale state across runs.
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", stateDir)
 	cls, err := classifier.New("", nil)
 	if err != nil {
 		t.Fatalf("classifier: %v", err)
@@ -65,7 +64,7 @@ func runIndexerOn(t *testing.T, repoPath, repoTag string, skipPasses []string) *
 	if err != nil {
 		t.Fatalf("abs: %v", err)
 	}
-	idx := newTestIndexer(t, repoTag, skipPasses)
+	idx := newTestIndexer(t, repoTag, skipPasses, "")
 	doc, err := idx.Run(context.Background(), abs)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -653,7 +652,7 @@ func TestCSharpQuartzNetBuilderDynamic(t *testing.T) {
 		t.Skipf("csharp-quartz-net-mini fixture not found at %s: %v", abs, serr)
 	}
 
-	idx := newTestIndexer(t, "csharp-quartz-net-mini", nil)
+	idx := newTestIndexer(t, "csharp-quartz-net-mini", nil, "")
 	doc, err := idx.Run(context.Background(), abs)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -696,7 +695,7 @@ func TestKotlinSpringResponseEntityDynamic(t *testing.T) {
 		t.Skipf("kotlin-spring-mini fixture not found at %s: %v", abs, serr)
 	}
 
-	idx := newTestIndexer(t, "kotlin-spring-mini", nil)
+	idx := newTestIndexer(t, "kotlin-spring-mini", nil, "")
 	doc, err := idx.Run(context.Background(), abs)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -750,7 +749,7 @@ func TestScalaPlayMiniFutureStdlibDynamic(t *testing.T) {
 		t.Skipf("scala-play-mini fixture not found at %s: %v", abs, serr)
 	}
 
-	idx := newTestIndexer(t, "scala-play-mini", nil)
+	idx := newTestIndexer(t, "scala-play-mini", nil, "")
 	doc, err := idx.Run(context.Background(), abs)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -811,7 +810,7 @@ func TestRustTokioMiniChannelRecvDynamic(t *testing.T) {
 		t.Skipf("rust-tokio-mini fixture not found at %s: %v", abs, serr)
 	}
 
-	idx := newTestIndexer(t, "rust-tokio-mini", nil)
+	idx := newTestIndexer(t, "rust-tokio-mini", nil, "")
 	doc, err := idx.Run(context.Background(), abs)
 	if err != nil {
 		t.Fatalf("Run: %v", err)

--- a/cmd/archigraph/module_single_unit_test.go
+++ b/cmd/archigraph/module_single_unit_test.go
@@ -50,7 +50,7 @@ func TestIndex_PlainRepoSingleModule(t *testing.T) {
 	writeFile(t, filepath.Join(dir, ".windsurf/skills/skill.ts"), "export const sk = 1\n")
 
 	col := &progress.SliceCollector{}
-	idx := newTestIndexer(t, "upvate-frontend", nil)
+	idx := newTestIndexer(t, "upvate-frontend", nil, "")
 	idx.publisher = col
 	idx.repoSlug = "upvate-frontend"
 
@@ -104,7 +104,7 @@ func TestIndex_MonorepoKeepsModules(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "packages/beta/index.ts"), "export const b = 1\n")
 
 	col := &progress.SliceCollector{}
-	idx := newTestIndexer(t, "polyrepo", nil)
+	idx := newTestIndexer(t, "polyrepo", nil, "")
 	idx.publisher = col
 	idx.repoSlug = "polyrepo"
 

--- a/cmd/archigraph/progress_instrumentation_test.go
+++ b/cmd/archigraph/progress_instrumentation_test.go
@@ -20,7 +20,7 @@ import (
 func TestIndexerProgress_FixtureRun(t *testing.T) {
 	col := &progress.SliceCollector{}
 
-	idx := newTestIndexer(t, "crossfile_go", nil)
+	idx := newTestIndexer(t, "crossfile_go", nil, "")
 	idx.publisher = col
 	idx.groupSlug = "testgroup"
 	idx.repoSlug = "crossfile_go"
@@ -148,7 +148,7 @@ func TestIndexerProgress_NoOpPublisher(t *testing.T) {
 // emitted when Pass 4 runs (i.e. PassGraphAlgo is NOT skipped).
 func TestIndexerProgress_AlgorithmEvents(t *testing.T) {
 	col := &progress.SliceCollector{}
-	idx := newTestIndexer(t, "crossfile_go", nil)
+	idx := newTestIndexer(t, "crossfile_go", nil, "")
 	idx.publisher = col
 
 	_, err := idx.Run(context.Background(), "testdata/crossfile_go")
@@ -173,7 +173,7 @@ func TestIndexerProgress_AlgorithmEvents(t *testing.T) {
 // emitted when PassGraphAlgo is skipped.
 func TestIndexerProgress_SkipAlgorithms(t *testing.T) {
 	col := &progress.SliceCollector{}
-	idx := newTestIndexer(t, "crossfile_go", []string{PassGraphAlgo})
+	idx := newTestIndexer(t, "crossfile_go", []string{PassGraphAlgo}, "")
 	idx.publisher = col
 
 	_, err := idx.Run(context.Background(), "testdata/crossfile_go")


### PR DESCRIPTION
## Summary

Refactors the race-prone "if os.Getenv == empty then t.Setenv" conditional guard in `newTestIndexer` (cmd/archigraph/index_test.go) to use an explicit `stateDir` parameter instead. Eliminates parallel-test races where two goroutines could both observe an empty env var and corrupt each other's state writes.

## Changes

- `newTestIndexer` signature: adds `stateDir string` parameter (defaults to `t.TempDir()`)
- `runIndexerOn` passes `""` to use default per-call
- `index_enrichment_test`: explicitly passes same `stateDir` to both indexer runs so resolutions seeded by run 1 are found by run 2
- Updated 12 call sites across 5 test files in cmd/archigraph

## Test Results

- `go test ./cmd/archigraph/... -count=1`: PASS
- `go fmt`, `go vet`, `go build`: all clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>