### PR TITLE
fix(test): plug crossfile_go leak in fb_default_test and verify_1620_test

### DIFF
--- a/cmd/archigraph/fb_default_test.go
+++ b/cmd/archigraph/fb_default_test.go
@@ -14,6 +14,7 @@ import (
 // TestIndex_FBOnlyByDefault verifies that Index() writes graph.fb by default
 // without graph.json (ADR-0016 flip-day, issue #808).
 func TestIndex_FBOnlyByDefault(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
 	tmp := t.TempDir()
 	outPath := filepath.Join(tmp, "graph.json")
 
@@ -50,6 +51,7 @@ func TestIndex_FBOnlyByDefault(t *testing.T) {
 // TestIndex_ExportJSON verifies that Index() with WithExportJSON(true)
 // writes both graph.fb and graph.json.
 func TestIndex_ExportJSON(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
 	tmp := t.TempDir()
 	outPath := filepath.Join(tmp, "graph.json")
 
@@ -74,6 +76,7 @@ func TestIndex_ExportJSON(t *testing.T) {
 // still results in a valid graph.fb being written (the no-op doesn't break
 // the existing write path).
 func TestIndex_ExportFBDeprecatedNoOp(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
 	tmp := t.TempDir()
 	outPath := filepath.Join(tmp, "graph.json")
 
@@ -92,6 +95,7 @@ func TestIndex_ExportFBDeprecatedNoOp(t *testing.T) {
 // TestFBRoundTrip_LoadGraphFromDir verifies that a graph written by Index()
 // can be loaded back via graph.LoadGraphFromDir and has matching entity count.
 func TestFBRoundTrip_LoadGraphFromDir(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
 	tmp := t.TempDir()
 	outPath := filepath.Join(tmp, "graph.json")
 

--- a/cmd/archigraph/verify_1620_test.go
+++ b/cmd/archigraph/verify_1620_test.go
@@ -18,6 +18,7 @@ import (
 //	ARCHIGRAPH_VERIFY_REPO=/path/to/upvate_core go test ./cmd/archigraph/ \
 //	  -run TestVerify1620Pipeline -v -count=1 -timeout=20m
 func TestVerify1620Pipeline(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
 	repo := os.Getenv("ARCHIGRAPH_VERIFY_REPO")
 	if repo == "" {
 		t.Skip("set ARCHIGRAPH_VERIFY_REPO to a real repo to run the #1620 e2e verification")


### PR DESCRIPTION
## Summary
Fixes the TestMain leak detector false positive on `crossfile_go` tests. The fb_default_test and TestVerify1620Pipeline tests were calling Index() without isolating ARCHIGRAPH_DAEMON_ROOT, causing writes to the real ~/.archigraph/store/.

## Diagnosis: Real Leak
- Issue was real, not a detector false positive
- Tests called Index() which invokes daemon.StateDirForRepo() and daemon.GraphPathForRepo()
- Without ARCHIGRAPH_DAEMON_ROOT set, these functions use the real home directory
- Detected entry: `crossfile_go-<hash>` (repo tag based naming)

## Fix
Added `t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())` to the start of:
- TestIndex_FBOnlyByDefault (fb_default_test.go:17)
- TestIndex_ExportJSON (fb_default_test.go:54)
- TestIndex_ExportFBDeprecatedNoOp (fb_default_test.go:79)
- TestFBRoundTrip_LoadGraphFromDir (fb_default_test.go:98)
- TestVerify1620Pipeline (verify_1620_test.go:21)

## Test Verification
- Pre-fix: Store count 55 → 56 after running tests (1 new entry leaked)
- Post-fix: Store count remains at 0 (clean); full test suite passes without leak-detector warnings
- All pre-commit gates pass: gofmt, go vet, go build, go test ./cmd/archigraph/... -count=1

Closes #2528