### PR TITLE
fix(test): remove hardcoded developer fixture paths #2540

### DIFF
--- a/cmd/archigraph/issue820_test.go
+++ b/cmd/archigraph/issue820_test.go
@@ -1,14 +1,48 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+// findClientFixture searches for a client fixture directory.
+// Checks environment variable ARCHIGRAPH_FIXTURES first, then common developer paths.
+// Returns "" if not found.
+func findClientFixture(fixtureName string) string {
+	// Check environment variable first.
+	if env := os.Getenv("ARCHIGRAPH_FIXTURES"); env != "" {
+		path := filepath.Join(env, fixtureName)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	// Check common developer paths.
+	home, _ := os.UserHomeDir()
+	candidates := []string{
+		filepath.Join(home, "private/archigraph-fixtures", fixtureName),
+		filepath.Join(home, "Documents/Projects/archigraph-fixtures", fixtureName),
+		"/tmp/archigraph-fixtures/" + fixtureName,
+	}
+
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	return ""
+}
 
 // TestIssue820_FixtureD_OrphanRate checks that the orphan rate on
 // fixture-d stays at or below the pre-regression baseline (~9.1%).
 // It exercises the CONTAINS-edge fix for Lombok/Panache synthesized entities.
 func TestIssue820_FixtureD_OrphanRate(t *testing.T) {
-	fixtureDir := "/Users/jorgecajas/private/archigraph-fixtures/client-fixture-d"
+	fixtureDir := findClientFixture("client-fixture-d")
+	if fixtureDir == "" {
+		t.Skip("client-fixture-d not found (set ARCHIGRAPH_FIXTURES env var)")
+	}
 	doc := runIndexerOn(t, fixtureDir, "client-fixture-d", nil)
 
 	// Count orphans (entities with zero inbound edges).
@@ -50,7 +84,10 @@ func TestIssue820_FixtureD_OrphanRate(t *testing.T) {
 
 // TestIssue820_FixtureF_OrphanRate checks orphan rate on fixture-f.
 func TestIssue820_FixtureF_OrphanRate(t *testing.T) {
-	fixtureDir := "/Users/jorgecajas/private/archigraph-fixtures/client-fixture-f"
+	fixtureDir := findClientFixture("client-fixture-f")
+	if fixtureDir == "" {
+		t.Skip("client-fixture-f not found (set ARCHIGRAPH_FIXTURES env var)")
+	}
 	doc := runIndexerOn(t, fixtureDir, "client-fixture-f", nil)
 
 	inbound := make(map[string]int, len(doc.Entities))

--- a/internal/extractors/javascript/class_arrow_measure_test.go
+++ b/internal/extractors/javascript/class_arrow_measure_test.go
@@ -22,11 +22,39 @@ import (
 	"github.com/cajasmota/archigraph/internal/extractors/javascript"
 )
 
+// findClientFixture searches for a client fixture directory.
+// Checks environment variable ARCHIGRAPH_FIXTURES first, then common developer paths.
+// Returns "" if not found.
+func findClientFixture(fixtureName string) string {
+	// Check environment variable first.
+	if env := os.Getenv("ARCHIGRAPH_FIXTURES"); env != "" {
+		path := filepath.Join(env, fixtureName)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	// Check common developer paths.
+	home, _ := os.UserHomeDir()
+	candidates := []string{
+		filepath.Join(home, "private/archigraph-fixtures", fixtureName),
+		filepath.Join(home, "Documents/Projects/archigraph-fixtures", fixtureName),
+		"/tmp/archigraph-fixtures/" + fixtureName,
+	}
+
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	return ""
+}
+
 func TestClassArrow_Measurement(t *testing.T) {
 	if os.Getenv("ARCHIGRAPH_771_MEASURE") != "1" {
 		t.Skip("set ARCHIGRAPH_771_MEASURE=1 to run #771 corpus measurement")
 	}
-	home, _ := os.UserHomeDir()
 	cases := []struct {
 		fixture string
 		root    string
@@ -34,11 +62,11 @@ func TestClassArrow_Measurement(t *testing.T) {
 	}{
 		// fixture-e: AngularJS-style service classes with class-field arrows;
 		// expect at least 5 new SCOPE.Operation entities (actual: 51 found).
-		{"client-fixture-e", filepath.Join(home, "private/archigraph-fixtures/client-fixture-e"), 5},
+		{"client-fixture-e", findClientFixture("client-fixture-e"), 5},
 		// fixture-b and fixture-c: React/functional code — no class-field
 		// arrows in practice; minWant=0 so measurement reports without failing.
-		{"client-fixture-b", filepath.Join(home, "private/archigraph-fixtures/client-fixture-b"), 0},
-		{"client-fixture-c", filepath.Join(home, "private/archigraph-fixtures/client-fixture-c"), 0},
+		{"client-fixture-b", findClientFixture("client-fixture-b"), 0},
+		{"client-fixture-c", findClientFixture("client-fixture-c"), 0},
 	}
 
 	ext := javascript.New()


### PR DESCRIPTION
Closes #2540

PR #2519 (#2515) cleaned internal/engine but missed two test files with hardcoded `/Users/jorgecajas/private/archigraph-fixtures/` paths.

## Changes

Both files now use env-var-overridable fixture lookup helpers:

1. **cmd/archigraph/issue820_test.go** (client-fixture-d/f):
   - Added `findClientFixture()` helper that checks ARCHIGRAPH_FIXTURES env var
   - Tests skip cleanly when fixtures unavailable

2. **internal/extractors/javascript/class_arrow_measure_test.go** (client-fixture-e/b/c):
   - Added identical `findClientFixture()` helper
   - Tests skip cleanly when fixtures unavailable

## Verification

- Tests pass when fixtures are present (developer machine)
- Tests skip with clear message when fixtures absent
- `grep -rn '/Users/.*private' --include='*_test.go' internal/ cmd/` is now empty
- All pre-commit gates pass (gofmt, go vet, go build)