### PR TITLE
fix(daemon/mcp): case-insensitive cwd→group resolution on macOS/Windows

### DIFF
--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -138,15 +139,77 @@ func groupFromRegistryWithCandidates(s *State, cwd string) (string, []string) {
 
 // pathContains reports whether ancestor is an ancestor (or equal to) child.
 // Both paths must already be absolute + clean.
+// On macOS and Windows, the comparison is case-insensitive to handle
+// case-insensitive filesystems (APFS, HFS+, NTFS). On other systems,
+// the comparison is case-sensitive.
 func pathContains(ancestor, child string) bool {
-	if ancestor == child {
-		return true
+	// Normalize both paths: realpath to resolve symlinks and make them comparable.
+	// On macOS, /var -> /private/var, so we must resolve both sides consistently.
+	// If EvalSymlinks succeeds for at least one, use the resolved path; otherwise
+	// fall back to the original. This ensures both sides use the same symlink
+	// canonicalization (or neither do).
+	ancestorNorm := ancestor
+	childNorm := child
+	ancestorResolved := true
+	childResolved := true
+
+	if resolved, err := filepath.EvalSymlinks(ancestor); err == nil {
+		ancestorNorm = resolved
+	} else {
+		ancestorResolved = false
 	}
+	if resolved, err := filepath.EvalSymlinks(child); err == nil {
+		childNorm = resolved
+	} else {
+		childResolved = false
+	}
+
+	// If only one resolved, try to normalize the unresolved one to the same symlink base.
+	// This handles cases where ancestor exists but child doesn't (yet) — we can still
+	// do string comparison once we strip common symlinks.
+	if ancestorResolved && !childResolved {
+		// Try to resolve the parent of child iteratively until we get a resolved path
+		// or run out of parents. This works around "directory doesn't exist yet" cases.
+		cur := child
+		for {
+			parent := filepath.Dir(cur)
+			if parent == cur {
+				break
+			}
+			if resolved, err := filepath.EvalSymlinks(parent); err == nil {
+				childNorm = filepath.Join(resolved, filepath.Base(cur))
+				break
+			}
+			cur = parent
+		}
+	}
+
+	// On case-insensitive filesystems (macOS, Windows), use EqualFold.
+	// On case-sensitive filesystems (Linux, etc.), use exact equality.
+	caseInsensitive := runtime.GOOS == "darwin" || runtime.GOOS == "windows"
+
+	// Check exact equality.
+	if caseInsensitive {
+		if strings.EqualFold(ancestorNorm, childNorm) {
+			return true
+		}
+	} else {
+		if ancestorNorm == childNorm {
+			return true
+		}
+	}
+
+	// Check prefix: ancestor + separator is a prefix of child + separator.
 	sep := string(os.PathSeparator)
-	if !strings.HasSuffix(ancestor, sep) {
-		ancestor += sep
+	if !strings.HasSuffix(ancestorNorm, sep) {
+		ancestorNorm += sep
 	}
-	return strings.HasPrefix(child+sep, ancestor)
+	childWithSep := childNorm + sep
+
+	if caseInsensitive {
+		return strings.HasPrefix(strings.ToLower(childWithSep), strings.ToLower(ancestorNorm))
+	}
+	return strings.HasPrefix(childWithSep, ancestorNorm)
 }
 
 // groupFromCWD walks dir upward looking for .archigraph/group.json which

--- a/internal/mcp/routing_test.go
+++ b/internal/mcp/routing_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -227,4 +228,113 @@ func TestResolveGroup_AmbiguousCWDIncludesCandidates(t *testing.T) {
 
 func mkdirp(p string) error {
 	return osMkdirAll(p, 0o755)
+}
+
+// TestPathContains_CaseInsensitiveOnMacOSWindows verifies that pathContains
+// performs case-insensitive matching on macOS (darwin) and Windows, and
+// case-sensitive matching on Linux and other systems. This addresses issue #2543:
+// shell-reported cwd may differ in casing from the indexed manifest path on
+// case-insensitive filesystems (APFS, HFS+, NTFS).
+func TestPathContains_CaseInsensitiveOnMacOSWindows(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		t.Skipf("case-insensitive test only applies on darwin/windows; skipping on %s", runtime.GOOS)
+	}
+
+	cases := []struct {
+		name     string
+		ancestor string
+		child    string
+		want     bool
+	}{
+		{
+			name:     "exact match same casing",
+			ancestor: "/Users/test/UpVate/upvate_core",
+			child:    "/Users/test/UpVate/upvate_core/src",
+			want:     true,
+		},
+		{
+			name:     "lowercase child cwd vs uppercase ancestor manifest",
+			ancestor: "/Users/test/UpVate/upvate_core",
+			child:    "/Users/test/upvate/upvate_core/src",
+			want:     true,
+		},
+		{
+			name:     "exact equality with different casing",
+			ancestor: "/Users/test/UpVate/upvate_core",
+			child:    "/Users/test/upvate/upvate_core",
+			want:     true,
+		},
+		{
+			name:     "nested path with different casing",
+			ancestor: "/Users/test/MyRepo",
+			child:    "/Users/test/MYREPO/src/pkg",
+			want:     true,
+		},
+		{
+			name:     "unrelated path even with overlapping string",
+			ancestor: "/Users/test/repo",
+			child:    "/Users/test/repository",
+			want:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pathContains(tc.ancestor, tc.child)
+			if got != tc.want {
+				t.Errorf("pathContains(%q, %q): want %v, got %v", tc.ancestor, tc.child, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestGroupFromRegistryWithCandidates_CaseInsensitive verifies that the registry
+// cwd-to-group matcher handles case-insensitive paths on macOS/Windows (issue #2543).
+// It tests that when the registered repo path differs in casing from the cwd,
+// the match still succeeds on case-insensitive filesystems.
+func TestGroupFromRegistryWithCandidates_CaseInsensitive(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		t.Skipf("case-insensitive test only applies on darwin/windows; skipping on %s", runtime.GOOS)
+	}
+
+	tmp := t.TempDir()
+
+	// Register repo with uppercase path.
+	upperRepoPath := filepath.Join(tmp, "UpVate", "upvate_core")
+	if err := mkdirp(upperRepoPath); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Register a second repo in a different group to force groupFromRegistryWithCandidates
+	// to make a real decision (not singleton fallback).
+	otherRepoPath := filepath.Join(tmp, "other")
+	if err := mkdirp(otherRepoPath); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	reg := &Registry{
+		Groups: map[string]RegistryGroup{
+			"upvate": {
+				Repos: map[string]RegistryRepo{
+					"upvate-core": {Path: upperRepoPath},
+				},
+			},
+			"other-group": {
+				Repos: map[string]RegistryRepo{
+					"other": {Path: otherRepoPath},
+				},
+			},
+		},
+	}
+	st := NewState(reg)
+
+	// Use cwd with lowercase path — on a case-insensitive filesystem, this is the
+	// same directory as the registered upperRepoPath, so the match should succeed.
+	lowerRepoPath := filepath.Join(tmp, "upvate", "upvate_core")
+	cwd := filepath.Join(lowerRepoPath, "src", "views")
+
+	g, candidates := groupFromRegistryWithCandidates(st, cwd)
+	if g != "upvate" {
+		t.Errorf("groupFromRegistryWithCandidates: want group=upvate, got %s (candidates: %v)", g, candidates)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes issue #2543: shell-reported cwd may differ in casing from the indexed manifest path on case-insensitive filesystems (APFS, HFS+, NTFS). The fix enables case-insensitive path matching on macOS and Windows while preserving case-sensitive behavior on Linux and other systems.

## Changes

- Updated `pathContains()` function to perform case-insensitive string comparison on darwin/windows
- Added symlink normalization via `filepath.EvalSymlinks` with fallback for non-existent paths
- Preserves case-sensitive matching on linux and other systems via `runtime.GOOS` guard
- Added comprehensive test coverage for case-insensitive matching scenarios

## Test plan

- [x] `go test ./internal/mcp/ -run "Test(ResolveGroup|PathContains|GroupFromRegistry)" -count=1` — all pass
- [x] `gofmt -l internal/mcp/routing.go` — empty output
- [x] `go vet ./internal/mcp/...` — clean
- [x] `go build ./...` — clean

🤖 Generated with Claude Code