### PR TITLE
feat(feedback): Phase 1 MVP — archigraph feedback anonymized quality report

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback-report.yml
+++ b/.github/ISSUE_TEMPLATE/feedback-report.yml
@@ -1,0 +1,90 @@
+name: Feedback Report (archigraph feedback)
+description: >
+  Auto-generated quality report from the `archigraph feedback` skill.
+  Covers extractor coverage, orphan rate, resolution disposition, and framework
+  recognition. All identifiers are hashed; file paths are scrubbed.
+labels: ["feedback", "needs-triage"]
+body:
+  - type: checkboxes
+    id: anonymization
+    attributes:
+      label: Anonymization verification
+      description: >
+        Please confirm you have reviewed the report for any un-scrubbed content before
+        submitting. The `archigraph feedback` command scrubs all identifiers and paths,
+        but a final human review is the last line of defence.
+      options:
+        - label: >
+            I have verified this report contains no real source code,
+            file paths, or identifier names (all entity names look like ent_a3f7 or op_92c1;
+            all paths look like <go>/<seg-1>/<seg-2>.go).
+          required: true
+        - label: >
+            I generated this report with `archigraph feedback` v0.9+
+          required: false
+
+  - type: textarea
+    id: report
+    attributes:
+      label: Feedback report
+      description: >
+        Paste the full contents of your `.md` file here.
+        The report was written to `~/.archigraph/feedback/<group>-<timestamp>.md`.
+      render: markdown
+      placeholder: |
+        # archigraph feedback report
+
+        Generated: ...
+        archigraph version: ...
+        Group profile: ...
+        Confidence: ...
+
+        ## 1. Extractor Coverage
+        ...
+
+  - type: textarea
+    id: fixture
+    attributes:
+      label: Fixture tarball (optional, Phase 2)
+      description: >
+        If you generated a fixture tarball (Phase 2+), attach it here.
+        The tarball contains only synthetic code — no real source files.
+        Drag and drop the `.tar.gz` file into this field.
+      placeholder: Drag and drop the .tar.gz file here (optional)
+
+  - type: input
+    id: version
+    attributes:
+      label: archigraph version
+      description: >
+        Shown in the report header as "archigraph version: vN.M.K".
+      placeholder: "v1.2.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Impact
+      description: Which area does this report primarily indicate a problem in?
+      options:
+        - Extractor gap (entities missing for a language or kind)
+        - Resolver bug (edges missing or wrong disposition)
+        - Framework support (framework not recognized or incorrectly tagged)
+        - Docgen quality (incoherent or stub prose sections)
+        - Cross-stack linkage (frontend/backend edges not connected)
+        - Performance (indexing unusually slow for this group size)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context (optional)
+      description: >
+        Anything else that might help — e.g. the tech stack used, whether this is a
+        monorepo, whether the codebase uses unusual language features, or what the
+        expected vs actual behaviour was. Do NOT include source code or real file paths.
+      placeholder: >
+        e.g. "The codebase uses JAX-RS for REST endpoints; orphan rate on Endpoint kind is 81%."

--- a/internal/cli/feedback.go
+++ b/internal/cli/feedback.go
@@ -1,0 +1,248 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/feedback"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+	"github.com/cajasmota/archigraph/internal/version"
+)
+
+// newFeedbackCmd returns the cobra command for `archigraph feedback`.
+//
+// The command generates a privacy-preserving markdown quality report from the
+// local graph (fully offline — no network calls). The report covers extractor
+// coverage, orphan rate, resolution disposition, and framework recognition.
+// All entity names are replaced with per-report ephemeral 4-hex hashes.
+// File paths are replaced with depth-preserved structural templates.
+func newFeedbackCmd() *cobra.Command {
+	var (
+		groupFlag string
+		outFlag   string
+		yesFlag   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "feedback",
+		Short: "Generate an anonymized quality report for sharing with archigraph maintainers",
+		Long: `Generate a privacy-preserving markdown report covering:
+  - Extractor coverage (entity kinds, source-window completeness, annotation coverage)
+  - Orphan rate by entity kind
+  - Resolution disposition vector
+  - Framework recognition
+
+Anonymization guarantees:
+  - Entity names replaced with per-report ephemeral 4-hex hashes (salt never persisted)
+  - File paths replaced with depth-preserved structural templates
+  - Per-kind stats suppressed when N < 10
+  - Report suppressed entirely when total entities < 50
+
+The report is written to a local file only. No network calls. No telemetry.
+The user decides whether to paste it into a GitHub issue.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFeedback(cmd, groupFlag, outFlag, yesFlag)
+		},
+	}
+
+	cmd.Flags().StringVar(&groupFlag, "group", "", "group name (default: inferred from current directory)")
+	cmd.Flags().StringVar(&outFlag, "out", "", "output path (default: ~/.archigraph/feedback/<group>-<timestamp>.md)")
+	cmd.Flags().BoolVar(&yesFlag, "yes", false, "skip confirmation prompt (for CI / scripting)")
+	return cmd
+}
+
+// runFeedback is the implementation of `archigraph feedback`.
+func runFeedback(cmd *cobra.Command, groupName, outPath string, yes bool) error {
+	w := cmd.OutOrStdout()
+
+	// 1. Resolve group name.
+	if groupName == "" {
+		resolved, err := inferGroupFromCWD()
+		if err != nil {
+			return fmt.Errorf("could not infer group from current directory: %w\nUse --group <name> to specify a group explicitly.", err)
+		}
+		groupName = resolved
+	}
+
+	// 2. Load group config to discover repos.
+	reg, err := registry.Load()
+	if err != nil {
+		return fmt.Errorf("feedback: load registry: %w", err)
+	}
+	var groupRef *registry.GroupRef
+	for i := range reg.Groups {
+		if reg.Groups[i].Name == groupName {
+			groupRef = &reg.Groups[i]
+			break
+		}
+	}
+	if groupRef == nil {
+		return fmt.Errorf("feedback: group %q not found in registry (run `archigraph list` to see available groups)", groupName)
+	}
+
+	cfg, err := registry.LoadGroupConfig(groupRef.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("feedback: load group config: %w", err)
+	}
+
+	// 3. Resolve output path.
+	if outPath == "" {
+		ts := time.Now().UTC().Format("20060102T150405")
+		home, err := registry.HomeDir()
+		if err != nil {
+			return fmt.Errorf("feedback: resolve home dir: %w", err)
+		}
+		outDir := filepath.Join(home, "feedback")
+		if err := os.MkdirAll(outDir, 0o755); err != nil {
+			return fmt.Errorf("feedback: create output dir: %w", err)
+		}
+		outPath = filepath.Join(outDir, groupName+"-"+ts+".md")
+	}
+
+	// 4. Show confirmation prompt (skipped with --yes).
+	totalEntities, totalRels, nRepos := quickGroupStats(cfg.Repos)
+	if !yes {
+		fmt.Fprintf(w, "archigraph feedback — anonymized quality report\n")
+		fmt.Fprintf(w, "Group: %s (%d repos, ~%d entities, ~%d relationships)\n\n",
+			groupName, nRepos, totalEntities, totalRels)
+		fmt.Fprintf(w, "What will be collected:\n")
+		fmt.Fprintf(w, "  + Extractor coverage stats (no source text)\n")
+		fmt.Fprintf(w, "  + Orphan rates by entity kind\n")
+		fmt.Fprintf(w, "  + Resolution disposition vector\n")
+		fmt.Fprintf(w, "  + Framework detector hit counts\n\n")
+		fmt.Fprintf(w, "What will NOT be collected:\n")
+		fmt.Fprintf(w, "  - Source code\n")
+		fmt.Fprintf(w, "  - File paths (depth structure only, segments replaced)\n")
+		fmt.Fprintf(w, "  - Identifier names (4-hex hashes, per-report ephemeral salt)\n")
+		fmt.Fprintf(w, "  - Any network calls (fully offline)\n\n")
+		fmt.Fprintf(w, "Report will be written to: %s\n\n", outPath)
+		fmt.Fprintf(w, "Proceed? [y/N] ")
+
+		// Read confirmation.
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+		if answer != "y" && answer != "yes" {
+			fmt.Fprintln(w, "Cancelled.")
+			return nil
+		}
+	}
+
+	// 5. Load graphs for all repos.
+	var docs []*graph.Document
+	for _, repo := range cfg.Repos {
+		stateDir := daemon.StateDirForRepo(repo.Path)
+		doc, err := graph.LoadGraphFromDir(stateDir)
+		if err != nil {
+			// Non-fatal: log and skip repos with missing graphs.
+			fmt.Fprintf(w, "warning: skipping repo %s (graph not found: %v)\n", repo.Slug, err)
+			continue
+		}
+		docs = append(docs, doc)
+	}
+
+	if len(docs) == 0 {
+		return fmt.Errorf("feedback: no indexed graphs found for group %q — run `archigraph index` first", groupName)
+	}
+
+	// 6. Generate report.
+	fmt.Fprintln(w, "Generating report...")
+	report, err := feedback.Generate(context.Background(), docs, feedback.Opts{
+		GroupName: groupName,
+		Version:   version.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("feedback: generate: %w", err)
+	}
+
+	// 7. Write to file.
+	f, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("feedback: create output file: %w", err)
+	}
+	defer f.Close()
+
+	if err := feedback.Render(f, report); err != nil {
+		return fmt.Errorf("feedback: render: %w", err)
+	}
+
+	if report.IsSuppressed() {
+		fmt.Fprintf(w, "\nReport suppressed: group has fewer than 50 entities (got %d).\n", report.TotalEntities)
+		fmt.Fprintf(w, "Index a larger group and re-run `archigraph feedback`.\n")
+		fmt.Fprintf(w, "Suppression notice written to: %s\n", outPath)
+		return nil
+	}
+
+	fmt.Fprintf(w, "\nReport written to: %s\n", outPath)
+	passing := 0
+	for i := range report.SanityResults {
+		if report.SanityResults[i].Passed {
+			passing++
+		}
+	}
+	fmt.Fprintf(w, "Confidence: %d%% (%d/%d sanity checks passed)\n",
+		report.Confidence, passing, len(report.SanityResults))
+	fmt.Fprintf(w, "\nVerify the report by opening the .md file and scanning for any unhashed paths or\n")
+	fmt.Fprintf(w, "identifiers before sharing. Then file a GitHub issue using the template at:\n")
+	fmt.Fprintf(w, "  https://github.com/cajasmota/archigraph/issues/new?template=feedback-report.yml\n")
+	return nil
+}
+
+// inferGroupFromCWD attempts to find a registered group whose repos include
+// the current working directory (or a parent directory thereof).
+func inferGroupFromCWD() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	reg, err := registry.Load()
+	if err != nil {
+		return "", err
+	}
+	for _, g := range reg.Groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		for _, repo := range cfg.Repos {
+			if repo.Path == "" {
+				continue
+			}
+			abs, err := filepath.Abs(repo.Path)
+			if err != nil {
+				continue
+			}
+			// Match if cwd is the repo path or a subdirectory thereof.
+			rel, err := filepath.Rel(abs, cwd)
+			if err == nil && !strings.HasPrefix(rel, "..") {
+				return g.Name, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no registered group contains directory %s", cwd)
+}
+
+// quickGroupStats reads graph-stats.json for each repo to get fast approximate
+// totals for the confirmation prompt. Falls back to zeroes on error.
+func quickGroupStats(repos []registry.Repo) (totalEntities, totalRels, nRepos int) {
+	nRepos = len(repos)
+	for _, repo := range repos {
+		stateDir := daemon.StateDirForRepo(repo.Path)
+		doc, err := graph.LoadGraphFromDir(stateDir)
+		if err != nil {
+			continue
+		}
+		totalEntities += len(doc.Entities)
+		totalRels += len(doc.Relationships)
+	}
+	return
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -70,6 +70,7 @@ func newRoot() *cobra.Command {
 		newInstallHooksCmd(),
 		newBenchCaptureCmd(),
 		newPersonasCmd(),
+		newFeedbackCmd(),
 		newHelpCmd(),
 	)
 

--- a/internal/feedback/anonymize.go
+++ b/internal/feedback/anonymize.go
@@ -1,0 +1,151 @@
+// Package feedback implements the anonymized quality-report skill (issue #2544).
+// It computes structural metrics from a loaded graph, anonymizes all identifiers
+// and paths with an ephemeral per-report salt, and renders a markdown report.
+package feedback
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// kindFamily maps entity Kind strings to the short prefix used in hashed names.
+// Any kind not listed falls back to "ent_".
+var kindFamily = map[string]string{
+	"function":                 "op_",
+	"method":                   "op_",
+	"operation":                "op_",
+	"class":                    "ent_",
+	"struct":                   "ent_",
+	"interface":                "ent_",
+	"model":                    "ent_",
+	"module":                   "mod_",
+	"http_endpoint":            "ep_",
+	"http_endpoint_definition": "ep_",
+	"http_endpoint_call":       "ep_",
+	"endpoint":                 "ep_",
+	"variable":                 "var_",
+	"constant":                 "var_",
+	"field":                    "var_",
+}
+
+// unusualExts maps file extensions that might narrow a project's identity to
+// language-family bucket labels. Extensions not listed are preserved as-is.
+var unusualExts = map[string]string{
+	".clj":    "<jvm-lang>",
+	".cljs":   "<jvm-lang>",
+	".cljc":   "<jvm-lang>",
+	".ex":     "<beam-lang>",
+	".exs":    "<beam-lang>",
+	".erl":    "<beam-lang>",
+	".hrl":    "<beam-lang>",
+	".hs":     "<ml-lang>",
+	".lhs":    "<ml-lang>",
+	".ml":     "<ml-lang>",
+	".mli":    "<ml-lang>",
+	".fs":     "<ml-lang>",
+	".fsi":    "<ml-lang>",
+	".fsx":    "<ml-lang>",
+	".elm":    "<ml-lang>",
+	".scala":  "<jvm-lang>",
+	".groovy": "<jvm-lang>",
+	".kt":     "<jvm-lang>",
+	".kts":    "<jvm-lang>",
+	".lua":    "<scripting-lang>",
+	".nim":    "<systems-lang>",
+	".zig":    "<systems-lang>",
+	".cr":     "<scripting-lang>",
+	".jl":     "<ml-lang>",
+	".r":      "<ml-lang>",
+	".R":      "<ml-lang>",
+	".m":      "<matlab-lang>",
+	".swift":  "<apple-lang>",
+	".dart":   "<flutter-lang>",
+}
+
+// NameHash returns a short anonymized identifier for name using the given salt.
+// The format is "<kind-prefix><4-hex>", e.g. "ent_a3f7" or "op_92c1".
+// kind is the entity Kind string from graph.Entity.Kind.
+func NameHash(name string, kind string, salt []byte) string {
+	prefix := kindFamily[strings.ToLower(kind)]
+	if prefix == "" {
+		prefix = "ent_"
+	}
+	h := sha256.New()
+	h.Write(salt)
+	h.Write([]byte(":"))
+	h.Write([]byte(name))
+	sum := h.Sum(nil)
+	return prefix + hex.EncodeToString(sum[:2])
+}
+
+// PathScrub transforms a file path into a depth-preserved structural template.
+// Rules:
+//   - Split on "/" (filepath.ToSlash normalises OS separators).
+//   - Replace each directory segment with "<seg-N>" (1-indexed from the leftmost segment).
+//   - The filename's extension is preserved (or bucketed for unusual extensions).
+//   - The first segment is replaced with the extension label: "<ext>" e.g. "<go>".
+//   - If the total depth (number of segments) exceeds 5 the tail is replaced with "<...>".
+//     The cap applies before extension bucketing so the structure is always ≤6 tokens.
+//
+// Example:
+//
+//	src/main/java/com/example/UserController.java → <java>/<seg-1>/<seg-2>/<seg-3>/<seg-4>.java
+func PathScrub(p string) string {
+	p = filepath.ToSlash(p)
+	segs := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	if len(segs) == 0 {
+		return p
+	}
+
+	// Pull the filename and extension off the last segment.
+	last := segs[len(segs)-1]
+	ext := filepath.Ext(last)
+	dirSegs := segs[:len(segs)-1]
+
+	// Bucket unusual extensions.
+	bucketedExt := ext
+	if bucket, ok := unusualExts[strings.ToLower(ext)]; ok {
+		bucketedExt = bucket
+	}
+
+	// Build the prefix token from the extension family label.
+	var extLabel string
+	if ext == "" {
+		extLabel = "<file>"
+	} else {
+		// e.g. ".go" → "<go>", ".ts" → "<ts>"
+		raw := strings.TrimPrefix(strings.ToLower(ext), ".")
+		if bucket, ok := unusualExts[ext]; ok {
+			extLabel = bucket
+		} else {
+			extLabel = "<" + raw + ">"
+		}
+	}
+
+	// Cap depth: dirs beyond 4 are folded into "<...>".
+	// Total path after scrub: extLabel / seg-1 / … / seg-N[capped] . ext
+	const maxDirSegs = 4
+	truncated := false
+	if len(dirSegs) > maxDirSegs {
+		dirSegs = dirSegs[:maxDirSegs]
+		truncated = true
+	}
+
+	parts := make([]string, 0, len(dirSegs)+2)
+	parts = append(parts, extLabel)
+	for i := range dirSegs {
+		parts = append(parts, fmt.Sprintf("<seg-%d>", i+1))
+	}
+	if truncated {
+		parts = append(parts, "<...>")
+	}
+
+	result := strings.Join(parts, "/")
+	if bucketedExt != "" {
+		result += bucketedExt
+	}
+	return result
+}

--- a/internal/feedback/anonymize_test.go
+++ b/internal/feedback/anonymize_test.go
@@ -1,0 +1,134 @@
+package feedback
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNameHash_BasicFormat(t *testing.T) {
+	salt := []byte("testsalt123")
+	h := NameHash("UserController", "class", salt)
+	if !strings.HasPrefix(h, "ent_") {
+		t.Errorf("expected ent_ prefix for class kind, got %q", h)
+	}
+	if len(h) != 8 { // "ent_" (4) + 4 hex chars (4)
+		t.Errorf("expected length 8, got %d: %q", len(h), h)
+	}
+}
+
+func TestNameHash_KindPrefixes(t *testing.T) {
+	salt := []byte("salt")
+	cases := []struct {
+		kind   string
+		prefix string
+	}{
+		{"function", "op_"},
+		{"method", "op_"},
+		{"class", "ent_"},
+		{"struct", "ent_"},
+		{"interface", "ent_"},
+		{"module", "mod_"},
+		{"http_endpoint", "ep_"},
+		{"variable", "var_"},
+		{"unknown_kind", "ent_"}, // fallback
+	}
+	for _, tc := range cases {
+		h := NameHash("SomeName", tc.kind, salt)
+		if !strings.HasPrefix(h, tc.prefix) {
+			t.Errorf("kind=%q: expected prefix %q, got %q", tc.kind, tc.prefix, h)
+		}
+	}
+}
+
+func TestNameHash_SaltDifferentiates(t *testing.T) {
+	name := "UserService"
+	kind := "class"
+	h1 := NameHash(name, kind, []byte("salt-a"))
+	h2 := NameHash(name, kind, []byte("salt-b"))
+	if h1 == h2 {
+		t.Errorf("different salts should produce different hashes, both got %q", h1)
+	}
+}
+
+func TestNameHash_SaltMakesStable(t *testing.T) {
+	salt := []byte("stable-salt")
+	h1 := NameHash("getUsers", "function", salt)
+	h2 := NameHash("getUsers", "function", salt)
+	if h1 != h2 {
+		t.Errorf("same salt should produce same hash: %q vs %q", h1, h2)
+	}
+}
+
+func TestNameHash_OnlyHexInSuffix(t *testing.T) {
+	salt := []byte("hexcheck")
+	h := NameHash("AnyName", "class", salt)
+	suffix := strings.TrimPrefix(h, "ent_")
+	for _, ch := range suffix {
+		if !strings.ContainsRune("0123456789abcdef", ch) {
+			t.Errorf("non-hex char %q in hash suffix %q", ch, suffix)
+		}
+	}
+}
+
+func TestPathScrub_BasicGo(t *testing.T) {
+	got := PathScrub("internal/graph/load.go")
+	if !strings.HasPrefix(got, "<go>/") {
+		t.Errorf("expected <go>/ prefix, got %q", got)
+	}
+	if !strings.HasSuffix(got, ".go") {
+		t.Errorf("expected .go suffix, got %q", got)
+	}
+}
+
+func TestPathScrub_DeepPath(t *testing.T) {
+	// depth 6 dirs + filename: should cap at 4 dir segments + <...>
+	got := PathScrub("a/b/c/d/e/f/file.ts")
+	if !strings.Contains(got, "<...>") {
+		t.Errorf("expected <...> for depth > 5, got %q", got)
+	}
+}
+
+func TestPathScrub_ShallowPath(t *testing.T) {
+	got := PathScrub("src/main.py")
+	if !strings.HasPrefix(got, "<py>/") {
+		t.Errorf("expected <py>/ prefix, got %q", got)
+	}
+	if strings.Contains(got, "<...>") {
+		t.Errorf("shallow path should not have <...>, got %q", got)
+	}
+}
+
+func TestPathScrub_UnusualExt_Clojure(t *testing.T) {
+	got := PathScrub("src/core/main.clj")
+	if !strings.Contains(got, "<jvm-lang>") {
+		t.Errorf("expected <jvm-lang> bucket for .clj, got %q", got)
+	}
+}
+
+func TestPathScrub_UnusualExt_Elixir(t *testing.T) {
+	got := PathScrub("lib/app/router.ex")
+	if !strings.Contains(got, "<beam-lang>") {
+		t.Errorf("expected <beam-lang> bucket for .ex, got %q", got)
+	}
+}
+
+func TestPathScrub_NoRealSegments(t *testing.T) {
+	got := PathScrub("a/b/c/MyController.java")
+	// Should not contain "a", "b", "c", or "MyController"
+	for _, bad := range []string{"a/", "/b/", "/c/", "MyController"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("scrubbed path %q still contains raw segment %q", got, bad)
+		}
+	}
+}
+
+func TestPathScrub_PreservesSegCount(t *testing.T) {
+	// 2 dirs + filename = 3 parts total
+	got := PathScrub("src/utils/helper.go")
+	// Expected: <go>/<seg-1>/<seg-2>.go — 3 slash-separated parts including the last
+	parts := strings.Split(got, "/")
+	// <go> + <seg-1> + <seg-2>.go = 3
+	if len(parts) != 3 {
+		t.Errorf("expected 3 parts, got %d: %q", len(parts), got)
+	}
+}

--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -1,0 +1,251 @@
+package feedback
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Render writes the markdown feedback report to w. Section order is stable.
+// If r.IsSuppressed() is true it emits only the suppression notice.
+func Render(w io.Writer, r *Report) error {
+	if r.IsSuppressed() {
+		fmt.Fprintf(w, "# archigraph feedback report — suppressed\n\n")
+		fmt.Fprintf(w, "Generated: %s\n", r.GeneratedAt.Format(time.RFC3339))
+		fmt.Fprintf(w, "Group: %s\n\n", r.GroupName)
+		fmt.Fprintf(w, "> **Report suppressed**: total entities = %d (minimum %d required).\n", r.TotalEntities, minEntitiesForReport)
+		fmt.Fprintf(w, ">\n")
+		fmt.Fprintf(w, "> Small codebases produce statistically unreliable metrics and are more\n")
+		fmt.Fprintf(w, "> fingerprinting-prone. Index a larger group and re-run `archigraph feedback`.\n")
+		return nil
+	}
+
+	// Header
+	fmt.Fprintf(w, "# archigraph feedback report\n\n")
+	fmt.Fprintf(w, "Generated: %s\n", r.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(w, "archigraph version: %s\n", r.Version)
+	langList := strings.Join(r.Languages, ", ")
+	if langList == "" {
+		langList = "(unknown)"
+	}
+	fmt.Fprintf(w, "Group profile: %d language(s) (%s), %s entities, %s relationships\n",
+		len(r.Languages), langList,
+		rangeLabel(r.TotalEntities), rangeLabel(r.TotalRelationships))
+	fmt.Fprintf(w, "Confidence: %d%% (%d/%d sanity checks passed)\n\n",
+		r.Confidence, countPassed(r.SanityResults), len(r.SanityResults))
+
+	// Section 1 — Extractor Coverage
+	fmt.Fprintf(w, "## 1. Extractor Coverage\n\n")
+	fmt.Fprintf(w, "### Entities by language\n\n")
+	if len(r.EntitiesByLanguage) == 0 {
+		fmt.Fprintf(w, "_No language with >= 10 entities found._\n\n")
+	} else {
+		langs := sortedStringIntKeys(r.EntitiesByLanguage)
+		fmt.Fprintf(w, "| Language | Entity count (range) |\n|---|---|\n")
+		for _, lang := range langs {
+			fmt.Fprintf(w, "| %s | %s |\n", lang, countRangeLabel(r.EntitiesByLanguage[lang]))
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	fmt.Fprintf(w, "### Entity kind distribution\n\n")
+	if len(r.EntityKindDist) == 0 {
+		fmt.Fprintf(w, "_No kind x language combination with >= 10 entities._\n\n")
+	} else {
+		fmt.Fprintf(w, "| Kind | Language | Count (range) |\n|---|---|---|\n")
+		rows := make([]EntityKindLang, len(r.EntityKindDist))
+		copy(rows, r.EntityKindDist)
+		sort.Slice(rows, func(i, j int) bool {
+			if rows[i].Language != rows[j].Language {
+				return rows[i].Language < rows[j].Language
+			}
+			return rows[i].Kind < rows[j].Kind
+		})
+		for _, row := range rows {
+			fmt.Fprintf(w, "| %s | %s | %s |\n", row.Kind, row.Language, countRangeLabel(row.Count))
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	fmt.Fprintf(w, "### Source-window completeness\n\n")
+	fmt.Fprintf(w, "Entities with valid start/end line: **%.1f%%** (%d of %d)\n\n",
+		r.SourceWindow.PctComplete,
+		r.SourceWindow.TotalWithWindow,
+		r.SourceWindow.TotalEntities)
+
+	fmt.Fprintf(w, "### Annotation coverage\n\n")
+	if r.AnnotationCoverage.Total > 0 {
+		fmt.Fprintf(w, "Framework-annotated entities: **%.1f%%** (%d of %d)\n\n",
+			r.AnnotationCoverage.PctAnnotated,
+			r.AnnotationCoverage.TotalAnnotated,
+			r.AnnotationCoverage.Total)
+	} else {
+		fmt.Fprintf(w, "_No entities with annotation data._\n\n")
+	}
+
+	fmt.Fprintf(w, "### Field extraction rate\n\n")
+	if r.FieldExtractionRate.ClassTotal > 0 {
+		fmt.Fprintf(w, "Class/Model entities with zero fields: **%.1f%%** (%d total class-like entities)\n\n",
+			r.FieldExtractionRate.ZeroFieldsPct,
+			r.FieldExtractionRate.ClassTotal)
+	} else {
+		fmt.Fprintf(w, "_No class or model entities found._\n\n")
+	}
+
+	// Section 2 — Orphan Rate
+	fmt.Fprintf(w, "## 2. Orphan Rate\n\n")
+	fmt.Fprintf(w, "An entity is orphan when it has no outgoing semantic edges (CONTAINS/DECLARES excluded).\n\n")
+	if len(r.OrphanByKind) == 0 {
+		fmt.Fprintf(w, "_No entity kind with >= 10 entities found._\n\n")
+	} else {
+		fmt.Fprintf(w, "| Kind | Total | Orphan | Orphan %% |\n|---|---|---|---|\n")
+		kinds := sortedKindStatsKeys(r.OrphanByKind)
+		for _, kind := range kinds {
+			ks := r.OrphanByKind[kind]
+			fmt.Fprintf(w, "| %s | %d | %d | %.1f%% |\n", kind, ks.Total, ks.OrphanCount, ks.OrphanPct)
+		}
+		fmt.Fprintf(w, "\n")
+
+		// Highlight high-orphan kinds.
+		fmt.Fprintf(w, "**High-orphan kinds** (> 30%%):\n\n")
+		any := false
+		for _, kind := range kinds {
+			ks := r.OrphanByKind[kind]
+			if ks.OrphanPct > 30.0 {
+				fmt.Fprintf(w, "- `%s`: %.1f%% orphan rate\n", kind, ks.OrphanPct)
+				any = true
+			}
+		}
+		if !any {
+			fmt.Fprintf(w, "_None — all kinds with >= 10 entities have orphan rate <= 30%%._\n")
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	// Section 3 — Resolution Disposition
+	fmt.Fprintf(w, "## 3. Resolution Disposition\n\n")
+	if r.ResolutionTotal == 0 {
+		fmt.Fprintf(w, "_No relationship resolution data available (no `resolution` property found on edges)._\n\n")
+	} else {
+		rv := r.Resolution
+		fmt.Fprintf(w, "| Disposition | Percentage |\n|---|---|\n")
+		fmt.Fprintf(w, "| resolved | %.2f%% |\n", rv.ResolvedPct)
+		fmt.Fprintf(w, "| external-known | %.2f%% |\n", rv.ExternalKnownPct)
+		fmt.Fprintf(w, "| external-unknown | %.2f%% |\n", rv.ExternalUnknownPct)
+		fmt.Fprintf(w, "| bug-extractor | %.2f%% |\n", rv.BugExtractorPct)
+		fmt.Fprintf(w, "| bug-resolver | %.2f%% |\n", rv.BugResolverPct)
+		fmt.Fprintf(w, "| dynamic | %.2f%% |\n\n", rv.DynamicPct)
+		fmt.Fprintf(w, "_Total edges examined: %s_\n\n", countRangeLabel(r.ResolutionTotal))
+	}
+
+	// Section 4 — Framework Recognition
+	fmt.Fprintf(w, "## 4. Framework Recognition\n\n")
+	fmt.Fprintf(w, "### Detector hits\n\n")
+	if len(r.FrameworkHits) == 0 {
+		fmt.Fprintf(w, "_No framework with >= 10 tagged entities. This may indicate the framework detector did not fire, or this is a vanilla codebase._\n\n")
+	} else {
+		fmt.Fprintf(w, "| Framework | Entities tagged (range) |\n|---|---|\n")
+		fws := sortedStringIntKeys(r.FrameworkHits)
+		for _, fw := range fws {
+			fmt.Fprintf(w, "| %s | %s |\n", fw, countRangeLabel(r.FrameworkHits[fw]))
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	// Section 5 — Cross-Stack Flows (Phase 1 placeholder)
+	fmt.Fprintf(w, "## 5. Cross-Stack Flows\n\n")
+	fmt.Fprintf(w, "_(not in Phase 1)_\n\n")
+
+	// Section 6 — Docgen Quality (Phase 1 placeholder)
+	fmt.Fprintf(w, "## 6. Docgen Quality\n\n")
+	fmt.Fprintf(w, "_(not in Phase 1)_\n\n")
+
+	// Section 7 — Sanity Check Details
+	fmt.Fprintf(w, "## 7. Sanity Check Details\n\n")
+	fmt.Fprintf(w, "| Check | Result | Note |\n|---|---|---|\n")
+	for _, sr := range r.SanityResults {
+		status := "PASS"
+		if !sr.Passed {
+			status = "FAIL"
+		}
+		note := sr.Note
+		if note == "" {
+			note = "-"
+		}
+		fmt.Fprintf(w, "| `%s` | %s | %s |\n", sr.Name, status, note)
+	}
+	fmt.Fprintf(w, "\n")
+
+	// Footer
+	fmt.Fprintf(w, "---\n\n")
+	fmt.Fprintf(w, "_This report was generated by `archigraph feedback`. No source code, file paths,_\n")
+	fmt.Fprintf(w, "_or identifier names are included. Entity names are replaced with per-report_\n")
+	fmt.Fprintf(w, "_ephemeral 4-hex hashes. Entity counts are shown as ranges. Salt: ephemeral,_\n")
+	fmt.Fprintf(w, "_not persisted, not logged._\n")
+	return nil
+}
+
+// countPassed counts how many sanity results passed.
+func countPassed(results []SanityResult) int {
+	n := 0
+	for _, r := range results {
+		if r.Passed {
+			n++
+		}
+	}
+	return n
+}
+
+// rangeLabel returns a "X-Y" bucket label for a raw count (used in the header).
+func rangeLabel(n int) string {
+	switch {
+	case n < 50:
+		return "< 50"
+	case n < 1000:
+		return fmt.Sprintf("%d-%d", roundDown(n, 100), roundDown(n, 100)+100)
+	case n < 10000:
+		return fmt.Sprintf("%d-%d", roundDown(n, 500), roundDown(n, 500)+500)
+	default:
+		return fmt.Sprintf("%d-%d", roundDown(n, 1000), roundDown(n, 1000)+1000)
+	}
+}
+
+// countRangeLabel returns a range label for per-kind counts in tables.
+func countRangeLabel(n int) string {
+	switch {
+	case n <= 5:
+		return "1-5"
+	case n <= 20:
+		return "6-20"
+	case n <= 100:
+		return "21-100"
+	default:
+		return "100+"
+	}
+}
+
+func roundDown(n, step int) int {
+	return (n / step) * step
+}
+
+// sortedStringIntKeys returns sorted keys of a map[string]int.
+func sortedStringIntKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sortedKindStatsKeys returns sorted keys of a map[string]KindStats.
+func sortedKindStatsKeys(m map[string]KindStats) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -1,0 +1,398 @@
+package feedback
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// minEntitiesForReport is the hard floor below which the report is suppressed
+// to avoid statistically unreliable metrics and fingerprinting risk.
+const minEntitiesForReport = 50
+
+// Opts controls report generation behaviour.
+type Opts struct {
+	// GroupName is the archigraph group name — used in the report header.
+	GroupName string
+	// Version is the archigraph binary version string — used in the header.
+	Version string
+}
+
+// KindStats holds per-entity-kind orphan metrics.
+type KindStats struct {
+	Total       int
+	OrphanCount int
+	OrphanPct   float64
+}
+
+// ResolutionVector holds the disposition breakdown for graph relationships.
+type ResolutionVector struct {
+	ResolvedPct        float64
+	ExternalKnownPct   float64
+	ExternalUnknownPct float64
+	BugExtractorPct    float64
+	BugResolverPct     float64
+	DynamicPct         float64
+}
+
+// EntityKindLang is one row in the entity kind × language table.
+type EntityKindLang struct {
+	Kind     string
+	Language string
+	Count    int
+}
+
+// SourceWindowStats captures completeness of start/end line coverage.
+type SourceWindowStats struct {
+	TotalWithWindow int
+	TotalEntities   int
+	PctComplete     float64
+}
+
+// Report is the fully computed, anonymized feedback report.
+type Report struct {
+	// Meta
+	GeneratedAt time.Time
+	GroupName   string
+	Version     string
+
+	// Summary counts — used in the header profile line.
+	TotalEntities      int
+	TotalRelationships int
+	Languages          []string
+
+	// Section 1 — Extractor Coverage
+	EntitiesByLanguage map[string]int    // lang → count (suppressed when < 10)
+	EntityKindDist     []EntityKindLang  // kind × lang rows (suppressed when < 10)
+	SourceWindow       SourceWindowStats // source-window completeness
+	AnnotationCoverage struct {
+		TotalAnnotated int
+		Total          int
+		PctAnnotated   float64
+	}
+	FieldExtractionRate struct {
+		ClassTotal    int
+		ZeroFieldsPct float64
+	}
+
+	// Section 2 — Orphan Rate
+	OrphanByKind map[string]KindStats // kind → orphan stats (kinds with N < 10 suppressed)
+
+	// Section 3 — Resolution Disposition
+	Resolution      ResolutionVector
+	ResolutionTotal int // total edges examined
+
+	// Section 4 — Framework Recognition
+	FrameworkHits          map[string]int // framework → entity count
+	FrameworkFilesDetected int            // number of files with known-framework signals
+
+	// Sanity + Confidence
+	SanityResults []SanityResult
+	Confidence    int // percentage 0–100
+
+	// suppressed is true when TotalEntities < minEntitiesForReport.
+	suppressed bool
+}
+
+// Generate loads the graphs for the given repos, computes anonymized metrics,
+// and returns a Report. The salt is generated ephemerally inside this function
+// and is never persisted or logged.
+//
+// docs is a slice of already-loaded graph.Document values (one per repo in the
+// group). Pass them in from the caller so this package stays free of daemon RPC
+// logic.
+func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, error) {
+	// Generate per-report ephemeral salt. Never stored, never logged.
+	salt := make([]byte, 32)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("feedback.Generate: generate salt: %w", err)
+	}
+
+	r := &Report{
+		GeneratedAt:        time.Now().UTC(),
+		GroupName:          opts.GroupName,
+		Version:            opts.Version,
+		EntitiesByLanguage: make(map[string]int),
+		OrphanByKind:       make(map[string]KindStats),
+		FrameworkHits:      make(map[string]int),
+	}
+
+	// Merge all docs into aggregate structures.
+	// We collect raw (un-suppressed) counts first, then suppress after.
+	kindTotals := make(map[string]int)                // kind → total
+	kindOrphans := make(map[string]int)               // kind → orphan count
+	kindLangCounts := make(map[string]map[string]int) // kind → lang → count
+
+	// To detect orphans: an entity is orphan when its only outgoing edges are
+	// CONTAINS / DECLARES, or it has no outgoing edges at all.
+	// We track outgoing semantic edges per entity ID.
+	type edgeSummary struct {
+		semanticOut int // edges that are not CONTAINS/DECLARES
+	}
+	entityEdges := make(map[string]*edgeSummary)
+
+	// Index of entity ID → kind for the orphan lookup pass.
+	entityKind := make(map[string]string)
+	entityLang := make(map[string]string)
+
+	// Resolution disposition counters.
+	var (
+		resResolved        int
+		resExternalKnown   int
+		resExternalUnknown int
+		resBugExtractor    int
+		resBugResolver     int
+		resDynamic         int
+	)
+
+	annotated := 0
+	totalAnnotated := 0
+	classCount := 0
+	classZeroFields := 0
+
+	for _, doc := range docs {
+		if doc == nil {
+			continue
+		}
+		r.TotalEntities += len(doc.Entities)
+		r.TotalRelationships += len(doc.Relationships)
+
+		for i := range doc.Entities {
+			e := &doc.Entities[i]
+			lang := strings.ToLower(e.Language)
+			kind := e.Kind
+
+			if lang != "" {
+				r.EntitiesByLanguage[lang]++
+			}
+			kindTotals[kind]++
+			if kindLangCounts[kind] == nil {
+				kindLangCounts[kind] = make(map[string]int)
+			}
+			if lang != "" {
+				kindLangCounts[kind][lang]++
+			}
+
+			entityKind[e.ID] = kind
+			entityLang[e.ID] = lang
+
+			// Initialise edge summary so even no-edge entities appear.
+			if _, ok := entityEdges[e.ID]; !ok {
+				entityEdges[e.ID] = &edgeSummary{}
+			}
+
+			// Source-window completeness: start_line > 0 AND end_line > start_line.
+			if e.StartLine > 0 && e.EndLine > e.StartLine {
+				r.SourceWindow.TotalWithWindow++
+			}
+
+			// Annotation coverage.
+			totalAnnotated++
+			if e.Properties["framework"] != "" {
+				annotated++
+				r.FrameworkHits[e.Properties["framework"]]++
+			}
+
+			// Field extraction for Class/Model kinds.
+			if kind == "class" || kind == "struct" || kind == "model" {
+				classCount++
+				// Fields are typically emitted as child entities; we use
+				// Properties["field_count"] when available.
+				if e.Properties["field_count"] == "0" || e.Properties["field_count"] == "" {
+					classZeroFields++
+				}
+			}
+		}
+
+		// Count framework-file signals from Properties["framework"] presence on ANY entity.
+		frameworkFilesSeen := make(map[string]bool)
+		for i := range doc.Entities {
+			e := &doc.Entities[i]
+			if src := e.SourceFile; src != "" && e.Properties["framework"] != "" {
+				frameworkFilesSeen[src] = true
+			}
+		}
+		r.FrameworkFilesDetected += len(frameworkFilesSeen)
+
+		// Process relationships.
+		for i := range doc.Relationships {
+			rel := &doc.Relationships[i]
+
+			// Semantic edge tracking for orphan detection.
+			if !isStructuralEdge(rel.Kind) {
+				if es, ok := entityEdges[rel.FromID]; ok {
+					es.semanticOut++
+				}
+			}
+
+			// Resolution disposition from Properties["resolution"] (PR #2503).
+			switch rel.Properties["resolution"] {
+			case "resolved":
+				resResolved++
+			case "external_known":
+				resExternalKnown++
+			case "external_unknown":
+				resExternalUnknown++
+			case "bug_extractor":
+				resBugExtractor++
+			case "bug_resolver":
+				resBugResolver++
+			case "dynamic":
+				resDynamic++
+			}
+		}
+	}
+
+	// Compute orphan counts per kind.
+	for id, es := range entityEdges {
+		if es.semanticOut == 0 {
+			kind := entityKind[id]
+			kindOrphans[kind]++
+		}
+	}
+
+	// Build OrphanByKind (suppress kinds with N < 10).
+	for kind, total := range kindTotals {
+		if total < 10 {
+			continue
+		}
+		orphans := kindOrphans[kind]
+		pct := 0.0
+		if total > 0 {
+			pct = 100.0 * float64(orphans) / float64(total)
+		}
+		r.OrphanByKind[kind] = KindStats{
+			Total:       total,
+			OrphanCount: orphans,
+			OrphanPct:   pct,
+		}
+	}
+
+	// Build EntityKindDist (suppress rows where kind+lang count < 10).
+	for kind, langMap := range kindLangCounts {
+		for lang, count := range langMap {
+			if count < 10 {
+				continue
+			}
+			// Anonymize: we do NOT hash the kind or language — those are
+			// structural labels, not user identifiers.
+			r.EntityKindDist = append(r.EntityKindDist, EntityKindLang{
+				Kind:     kind,
+				Language: lang,
+				Count:    bucketCount(count),
+			})
+		}
+	}
+
+	// Suppress per-language counts < 10.
+	for lang, count := range r.EntitiesByLanguage {
+		if count < 10 {
+			delete(r.EntitiesByLanguage, lang)
+		}
+	}
+
+	// Build language list (sorted by count desc for the header).
+	r.Languages = sortedLanguages(r.EntitiesByLanguage)
+
+	// Source-window completeness.
+	r.SourceWindow.TotalEntities = r.TotalEntities
+	if r.TotalEntities > 0 {
+		r.SourceWindow.PctComplete = 100.0 * float64(r.SourceWindow.TotalWithWindow) / float64(r.TotalEntities)
+	}
+
+	// Annotation coverage.
+	r.AnnotationCoverage.Total = totalAnnotated
+	r.AnnotationCoverage.TotalAnnotated = annotated
+	if totalAnnotated > 0 {
+		r.AnnotationCoverage.PctAnnotated = 100.0 * float64(annotated) / float64(totalAnnotated)
+	}
+
+	// Field extraction rate.
+	r.FieldExtractionRate.ClassTotal = classCount
+	if classCount > 0 {
+		r.FieldExtractionRate.ZeroFieldsPct = 100.0 * float64(classZeroFields) / float64(classCount)
+	}
+
+	// Resolution disposition vector.
+	total := resResolved + resExternalKnown + resExternalUnknown + resBugExtractor + resBugResolver + resDynamic
+	r.ResolutionTotal = total
+	if total > 0 {
+		tf := float64(total)
+		r.Resolution = ResolutionVector{
+			ResolvedPct:        100.0 * float64(resResolved) / tf,
+			ExternalKnownPct:   100.0 * float64(resExternalKnown) / tf,
+			ExternalUnknownPct: 100.0 * float64(resExternalUnknown) / tf,
+			BugExtractorPct:    100.0 * float64(resBugExtractor) / tf,
+			BugResolverPct:     100.0 * float64(resBugResolver) / tf,
+			DynamicPct:         100.0 * float64(resDynamic) / tf,
+		}
+	}
+
+	// Suppress report if too few entities.
+	if r.TotalEntities < minEntitiesForReport {
+		r.suppressed = true
+	}
+
+	// Framework hits: suppress entries with count < 10.
+	for fw, count := range r.FrameworkHits {
+		if count < 10 {
+			delete(r.FrameworkHits, fw)
+		}
+	}
+
+	// Run sanity checks.
+	r.SanityResults, r.Confidence = runSanityChecks(r)
+
+	return r, nil
+}
+
+// IsSuppressed reports whether the report was suppressed due to insufficient data.
+func (r *Report) IsSuppressed() bool { return r.suppressed }
+
+// isStructuralEdge returns true for CONTAINS / DECLARES edge kinds that represent
+// containment rather than semantic connectivity.
+func isStructuralEdge(kind string) bool {
+	return kind == "CONTAINS" || kind == "DECLARES"
+}
+
+// bucketCount maps a raw count to a privacy-preserving range bucket.
+// Instead of exact numbers, the report shows ranges to prevent fingerprinting.
+func bucketCount(n int) int {
+	switch {
+	case n <= 5:
+		return 3 // centre of 1-5
+	case n <= 20:
+		return 13 // centre of 6-20
+	case n <= 100:
+		return 60 // centre of 21-100
+	default:
+		return 200 // 100+
+	}
+}
+
+// sortedLanguages returns language names sorted by entity count descending.
+func sortedLanguages(m map[string]int) []string {
+	type lc struct {
+		lang  string
+		count int
+	}
+	rows := make([]lc, 0, len(m))
+	for l, c := range m {
+		rows = append(rows, lc{l, c})
+	}
+	// Simple insertion sort (small N).
+	for i := 1; i < len(rows); i++ {
+		for j := i; j > 0 && rows[j].count > rows[j-1].count; j-- {
+			rows[j], rows[j-1] = rows[j-1], rows[j]
+		}
+	}
+	langs := make([]string, len(rows))
+	for i, r := range rows {
+		langs[i] = r.lang
+	}
+	return langs
+}

--- a/internal/feedback/report_test.go
+++ b/internal/feedback/report_test.go
@@ -1,0 +1,318 @@
+package feedback
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// makeEntity is a test helper that builds a minimal graph.Entity.
+func makeEntity(id, name, kind, lang, srcFile string, startLine, endLine int) graph.Entity {
+	return graph.Entity{
+		ID:         id,
+		Name:       name,
+		Kind:       kind,
+		Language:   lang,
+		SourceFile: srcFile,
+		StartLine:  startLine,
+		EndLine:    endLine,
+		Properties: map[string]string{},
+	}
+}
+
+// makeDoc builds a minimal graph.Document from a slice of entities.
+func makeDoc(entities []graph.Entity, rels []graph.Relationship) *graph.Document {
+	return &graph.Document{
+		Entities:      entities,
+		Relationships: rels,
+		Stats: graph.Stats{
+			Entities:      len(entities),
+			Relationships: len(rels),
+		},
+	}
+}
+
+// repeat produces n copies of e with unique IDs.
+func repeat(e graph.Entity, n int) []graph.Entity {
+	out := make([]graph.Entity, n)
+	for i := range out {
+		out[i] = e
+		out[i].ID = e.ID + string(rune('a'+i%26)) + strings.Repeat("x", i/26)
+	}
+	return out
+}
+
+func TestGenerate_SuppressedWhenTooFewEntities(t *testing.T) {
+	// 10 entities — below the 50 minimum.
+	entities := repeat(makeEntity("e1", "MyFunc", "function", "go", "main.go", 1, 10), 10)
+	doc := makeDoc(entities, nil)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "test-group"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !r.IsSuppressed() {
+		t.Error("expected report to be suppressed for < 50 entities")
+	}
+}
+
+func TestGenerate_NotSuppressedAtThreshold(t *testing.T) {
+	entities := repeat(makeEntity("e1", "MyFunc", "function", "go", "main.go", 1, 10), 50)
+	doc := makeDoc(entities, nil)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "test-group"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.IsSuppressed() {
+		t.Error("expected report to NOT be suppressed at exactly 50 entities")
+	}
+}
+
+func TestGenerate_LanguageCountsSuppressed(t *testing.T) {
+	// 5 Go entities + 50 Python entities. Go should be suppressed (< 10).
+	var entities []graph.Entity
+	entities = append(entities, repeat(makeEntity("g1", "GoFunc", "function", "go", "main.go", 1, 5), 5)...)
+	entities = append(entities, repeat(makeEntity("p1", "PyFunc", "function", "python", "main.py", 1, 5), 50)...)
+	doc := makeDoc(entities, nil)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if _, ok := r.EntitiesByLanguage["go"]; ok {
+		t.Error("go with only 5 entities should be suppressed (< 10)")
+	}
+	if _, ok := r.EntitiesByLanguage["python"]; !ok {
+		t.Error("python with 50 entities should be present")
+	}
+}
+
+func TestGenerate_OrphanRateComputed(t *testing.T) {
+	// 20 function entities, no outgoing semantic edges → all orphan.
+	entities := repeat(makeEntity("f1", "DoWork", "function", "go", "a.go", 1, 10), 20)
+	doc := makeDoc(entities, nil)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ks, ok := r.OrphanByKind["function"]
+	if !ok {
+		t.Fatal("expected OrphanByKind[function]")
+	}
+	if ks.OrphanCount != 20 {
+		t.Errorf("expected 20 orphans, got %d", ks.OrphanCount)
+	}
+	if ks.OrphanPct != 100.0 {
+		t.Errorf("expected 100%% orphan rate, got %.1f%%", ks.OrphanPct)
+	}
+}
+
+func TestGenerate_SemanticEdgeReducesOrphanRate(t *testing.T) {
+	entities := repeat(makeEntity("f1", "Caller", "function", "go", "a.go", 1, 10), 20)
+	// Give the first entity a semantic CALLS edge.
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "f1a", ToID: "f1b", Kind: "CALLS"},
+	}
+	doc := makeDoc(entities, rels)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ks, ok := r.OrphanByKind["function"]
+	if !ok {
+		t.Fatal("expected OrphanByKind[function]")
+	}
+	// f1a has a CALLS edge so it is not an orphan; 19 are orphans.
+	if ks.OrphanCount != 19 {
+		t.Errorf("expected 19 orphans (1 has CALLS edge), got %d", ks.OrphanCount)
+	}
+}
+
+func TestGenerate_ContainsDeclaresDontReduceOrphan(t *testing.T) {
+	entities := repeat(makeEntity("e1", "Thing", "class", "java", "A.java", 1, 20), 15)
+	// CONTAINS and DECLARES edges should NOT count as semantic.
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "e1b", Kind: "CONTAINS"},
+		{ID: "r2", FromID: "e1c", ToID: "e1d", Kind: "DECLARES"},
+	}
+	doc := makeDoc(entities, rels)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ks := r.OrphanByKind["class"]
+	// All 15 are still orphans (CONTAINS/DECLARES don't reduce orphan count).
+	if ks.OrphanCount != 15 {
+		t.Errorf("expected 15 orphans (CONTAINS/DECLARES excluded), got %d", ks.OrphanCount)
+	}
+}
+
+func TestGenerate_ResolutionDisposition(t *testing.T) {
+	entities := repeat(makeEntity("e1", "X", "function", "go", "x.go", 1, 5), 50)
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "e1b", Kind: "CALLS", Properties: map[string]string{"resolution": "resolved"}},
+		{ID: "r2", FromID: "e1c", ToID: "e1d", Kind: "CALLS", Properties: map[string]string{"resolution": "bug_extractor"}},
+		{ID: "r3", FromID: "e1e", ToID: "e1f", Kind: "CALLS", Properties: map[string]string{"resolution": "external_known"}},
+		{ID: "r4", FromID: "e1g", ToID: "e1h", Kind: "CALLS", Properties: map[string]string{"resolution": "dynamic"}},
+	}
+	doc := makeDoc(entities, rels)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.ResolutionTotal != 4 {
+		t.Errorf("expected ResolutionTotal=4, got %d", r.ResolutionTotal)
+	}
+	if r.Resolution.ResolvedPct != 25.0 {
+		t.Errorf("expected resolved 25%%, got %.1f%%", r.Resolution.ResolvedPct)
+	}
+}
+
+func TestGenerate_SourceWindowCompleteness(t *testing.T) {
+	entities := []graph.Entity{
+		makeEntity("e1", "Good", "function", "go", "a.go", 5, 15), // valid window
+		makeEntity("e2", "Bad", "function", "go", "a.go", 0, 0),   // no window
+		makeEntity("e3", "Bad2", "function", "go", "a.go", 5, 5),  // equal lines
+	}
+	// Need at least 50 total — pad with valid-window entities.
+	for i := 3; i < 50; i++ {
+		e := makeEntity("pad", "Fn", "function", "go", "a.go", 1, 10)
+		e.ID = fmt.Sprintf("pad%d", i)
+		entities = append(entities, e)
+	}
+	doc := makeDoc(entities, nil)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.SourceWindow.TotalEntities != 50 {
+		t.Errorf("expected 50 total entities, got %d", r.SourceWindow.TotalEntities)
+	}
+	// 1 good from the first three + 47 good from padding = 48 with valid windows.
+	if r.SourceWindow.TotalWithWindow != 48 {
+		t.Errorf("expected 48 entities with valid window, got %d", r.SourceWindow.TotalWithWindow)
+	}
+}
+
+func TestGenerate_MultipleDocsAggregated(t *testing.T) {
+	entities1 := repeat(makeEntity("e1", "GoFunc", "function", "go", "a.go", 1, 5), 30)
+	entities2 := repeat(makeEntity("e2", "PyFunc", "function", "python", "b.py", 1, 5), 30)
+	doc1 := makeDoc(entities1, nil)
+	doc2 := makeDoc(entities2, nil)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc1, doc2}, Opts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.TotalEntities != 60 {
+		t.Errorf("expected 60 total entities, got %d", r.TotalEntities)
+	}
+	if r.IsSuppressed() {
+		t.Error("expected report to NOT be suppressed with 60 entities")
+	}
+}
+
+func TestRender_SuppressedReport(t *testing.T) {
+	r := &Report{
+		TotalEntities: 10,
+		GeneratedAt:   mustParseTime("2026-05-27T00:00:00Z"),
+		GroupName:     "tiny-group",
+		suppressed:    true,
+	}
+	var sb strings.Builder
+	if err := Render(&sb, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := sb.String()
+	if !strings.Contains(out, "suppressed") {
+		t.Error("suppressed report should contain the word 'suppressed'")
+	}
+	if strings.Contains(out, "## 1.") {
+		t.Error("suppressed report should not contain section headers")
+	}
+}
+
+func TestRender_FullReport(t *testing.T) {
+	r := &Report{
+		TotalEntities:      100,
+		TotalRelationships: 200,
+		GeneratedAt:        mustParseTime("2026-05-27T00:00:00Z"),
+		GroupName:          "test-group",
+		Version:            "v1.0.0",
+		Languages:          []string{"go", "typescript"},
+		EntitiesByLanguage: map[string]int{"go": 80, "typescript": 20},
+		EntityKindDist:     []EntityKindLang{{Kind: "function", Language: "go", Count: 50}},
+		SourceWindow:       SourceWindowStats{TotalWithWindow: 90, TotalEntities: 100, PctComplete: 90.0},
+		OrphanByKind:       map[string]KindStats{"function": {Total: 80, OrphanCount: 16, OrphanPct: 20.0}},
+		Resolution: ResolutionVector{
+			ResolvedPct:        70.0,
+			ExternalKnownPct:   10.0,
+			ExternalUnknownPct: 10.0,
+			BugExtractorPct:    5.0,
+			BugResolverPct:     4.0,
+			DynamicPct:         1.0,
+		},
+		ResolutionTotal: 200,
+		FrameworkHits:   map[string]int{"gin": 15},
+		SanityResults:   []SanityResult{{Name: "minimum-entity-count", Passed: true}},
+		Confidence:      100,
+	}
+	r.AnnotationCoverage.Total = 100
+	r.AnnotationCoverage.TotalAnnotated = 15
+	r.AnnotationCoverage.PctAnnotated = 15.0
+
+	var sb strings.Builder
+	if err := Render(&sb, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := sb.String()
+
+	// Check all sections present.
+	for _, section := range []string{
+		"## 1. Extractor Coverage",
+		"## 2. Orphan Rate",
+		"## 3. Resolution Disposition",
+		"## 4. Framework Recognition",
+		"## 5. Cross-Stack Flows",
+		"## 6. Docgen Quality",
+		"## 7. Sanity Check Details",
+	} {
+		if !strings.Contains(out, section) {
+			t.Errorf("expected section %q in output", section)
+		}
+	}
+
+	// Phase 1 placeholders.
+	if !strings.Contains(out, "(not in Phase 1)") {
+		t.Error("expected Phase 1 placeholder text for cross-stack and docgen sections")
+	}
+
+	// Footer privacy note.
+	if !strings.Contains(out, "ephemeral") {
+		t.Error("expected privacy footer mentioning ephemeral salt")
+	}
+
+	// Framework hits.
+	if !strings.Contains(out, "gin") {
+		t.Error("expected framework 'gin' in output")
+	}
+}
+
+// mustParseTime parses an RFC3339 time for use in tests.
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/internal/feedback/sanity.go
+++ b/internal/feedback/sanity.go
@@ -1,0 +1,113 @@
+package feedback
+
+import (
+	"fmt"
+	"math"
+)
+
+// SanityResult is the outcome of a single sanity check.
+type SanityResult struct {
+	Name   string
+	Passed bool
+	Note   string
+}
+
+// runSanityChecks evaluates the loaded metrics against the defined sanity checks
+// and returns a slice of results plus a confidence score (passed/total as 0–100).
+func runSanityChecks(r *Report) ([]SanityResult, int) {
+	var results []SanityResult
+
+	// 1. Entity count > 0 for each indexed language.
+	for lang, count := range r.EntitiesByLanguage {
+		passed := count > 0
+		note := ""
+		if !passed {
+			note = fmt.Sprintf("language %q has 0 entities", lang)
+		}
+		results = append(results, SanityResult{
+			Name:   fmt.Sprintf("entity-count-nonzero[%s]", lang),
+			Passed: passed,
+			Note:   note,
+		})
+	}
+
+	// 2. Orphan rate < 100% for all kinds with N >= 10.
+	for kind, ks := range r.OrphanByKind {
+		if ks.Total < 10 {
+			continue
+		}
+		passed := ks.OrphanPct < 100.0
+		note := ""
+		if !passed {
+			note = fmt.Sprintf("kind %q has 100%% orphan rate (%d/%d)", kind, ks.OrphanCount, ks.Total)
+		}
+		results = append(results, SanityResult{
+			Name:   fmt.Sprintf("orphan-rate-not-100pct[%s]", kind),
+			Passed: passed,
+			Note:   note,
+		})
+	}
+
+	// 3. Resolution vector sums to 100% ± 0.1%.
+	if r.ResolutionTotal > 0 {
+		sum := r.Resolution.ResolvedPct +
+			r.Resolution.ExternalKnownPct +
+			r.Resolution.ExternalUnknownPct +
+			r.Resolution.BugExtractorPct +
+			r.Resolution.BugResolverPct +
+			r.Resolution.DynamicPct
+		passed := math.Abs(sum-100.0) <= 0.1
+		note := ""
+		if !passed {
+			note = fmt.Sprintf("resolution vector sums to %.3f%% (expected 100.0%% ± 0.1%%)", sum)
+		}
+		results = append(results, SanityResult{
+			Name:   "resolution-vector-sums-to-100pct",
+			Passed: passed,
+			Note:   note,
+		})
+	}
+
+	// 4. Framework hits >= 1 if known-framework files were detected.
+	if r.FrameworkFilesDetected > 0 {
+		total := 0
+		for _, count := range r.FrameworkHits {
+			total += count
+		}
+		passed := total >= 1
+		note := ""
+		if !passed {
+			note = fmt.Sprintf("%d known-framework files detected but framework_detector_hits = 0", r.FrameworkFilesDetected)
+		}
+		results = append(results, SanityResult{
+			Name:   "framework-hits-if-detected",
+			Passed: passed,
+			Note:   note,
+		})
+	}
+
+	// 5. Total entities >= 50.
+	passed := r.TotalEntities >= minEntitiesForReport
+	note := ""
+	if !passed {
+		note = fmt.Sprintf("total entities = %d (minimum %d required for reliable report)", r.TotalEntities, minEntitiesForReport)
+	}
+	results = append(results, SanityResult{
+		Name:   "minimum-entity-count",
+		Passed: passed,
+		Note:   note,
+	})
+
+	// Compute confidence.
+	passing := 0
+	for _, res := range results {
+		if res.Passed {
+			passing++
+		}
+	}
+	confidence := 0
+	if len(results) > 0 {
+		confidence = int(math.Round(100.0 * float64(passing) / float64(len(results))))
+	}
+	return results, confidence
+}

--- a/internal/feedback/sanity_test.go
+++ b/internal/feedback/sanity_test.go
@@ -1,0 +1,164 @@
+package feedback
+
+import (
+	"testing"
+)
+
+func TestRunSanityChecks_AllPass(t *testing.T) {
+	r := &Report{
+		TotalEntities: 100,
+		EntitiesByLanguage: map[string]int{
+			"go": 100,
+		},
+		OrphanByKind: map[string]KindStats{
+			"function": {Total: 50, OrphanCount: 10, OrphanPct: 20.0},
+		},
+		Resolution: ResolutionVector{
+			ResolvedPct:        70.0,
+			ExternalKnownPct:   10.0,
+			ExternalUnknownPct: 10.0,
+			BugExtractorPct:    5.0,
+			BugResolverPct:     4.0,
+			DynamicPct:         1.0,
+		},
+		ResolutionTotal:        100,
+		FrameworkFilesDetected: 5,
+		FrameworkHits:          map[string]int{"spring": 20},
+	}
+
+	results, confidence := runSanityChecks(r)
+	if confidence < 80 {
+		t.Errorf("expected high confidence, got %d%%", confidence)
+	}
+	for _, res := range results {
+		if !res.Passed {
+			t.Errorf("expected check %q to pass, note: %s", res.Name, res.Note)
+		}
+	}
+}
+
+func TestRunSanityChecks_SuppressedByCount(t *testing.T) {
+	r := &Report{
+		TotalEntities:      30, // below minimum
+		EntitiesByLanguage: map[string]int{"go": 30},
+		OrphanByKind:       map[string]KindStats{},
+		ResolutionTotal:    0,
+		FrameworkHits:      map[string]int{},
+	}
+
+	results, confidence := runSanityChecks(r)
+	_ = confidence
+
+	// The minimum-entity-count check must fail.
+	found := false
+	for _, res := range results {
+		if res.Name == "minimum-entity-count" {
+			if res.Passed {
+				t.Errorf("minimum-entity-count should FAIL for %d entities", r.TotalEntities)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("minimum-entity-count check not found in results")
+	}
+}
+
+func TestRunSanityChecks_OrphanRate100Pct(t *testing.T) {
+	r := &Report{
+		TotalEntities:      200,
+		EntitiesByLanguage: map[string]int{"java": 200},
+		OrphanByKind: map[string]KindStats{
+			"endpoint": {Total: 50, OrphanCount: 50, OrphanPct: 100.0},
+		},
+		ResolutionTotal: 0,
+		FrameworkHits:   map[string]int{},
+	}
+
+	results, _ := runSanityChecks(r)
+	found := false
+	for _, res := range results {
+		if res.Name == "orphan-rate-not-100pct[endpoint]" {
+			if res.Passed {
+				t.Error("orphan-rate check should FAIL for 100% orphan rate")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("orphan-rate-not-100pct[endpoint] not found in results")
+	}
+}
+
+func TestRunSanityChecks_ResolutionVectorOff(t *testing.T) {
+	r := &Report{
+		TotalEntities:      200,
+		EntitiesByLanguage: map[string]int{"python": 200},
+		OrphanByKind:       map[string]KindStats{},
+		Resolution: ResolutionVector{
+			ResolvedPct:        50.0,
+			ExternalKnownPct:   10.0,
+			ExternalUnknownPct: 10.0,
+			BugExtractorPct:    10.0,
+			BugResolverPct:     5.0,
+			DynamicPct:         0.0, // sum = 85, not 100
+		},
+		ResolutionTotal: 100,
+		FrameworkHits:   map[string]int{},
+	}
+
+	results, _ := runSanityChecks(r)
+	found := false
+	for _, res := range results {
+		if res.Name == "resolution-vector-sums-to-100pct" {
+			if res.Passed {
+				t.Error("resolution vector check should FAIL when sum != 100")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("resolution-vector-sums-to-100pct not found in results")
+	}
+}
+
+func TestRunSanityChecks_FrameworkFilesNoHits(t *testing.T) {
+	r := &Report{
+		TotalEntities:          200,
+		EntitiesByLanguage:     map[string]int{"java": 200},
+		OrphanByKind:           map[string]KindStats{},
+		ResolutionTotal:        0,
+		FrameworkFilesDetected: 10,
+		FrameworkHits:          map[string]int{}, // 0 hits despite framework files
+	}
+
+	results, _ := runSanityChecks(r)
+	found := false
+	for _, res := range results {
+		if res.Name == "framework-hits-if-detected" {
+			if res.Passed {
+				t.Error("framework-hits check should FAIL when files detected but hits = 0")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("framework-hits-if-detected not found in results")
+	}
+}
+
+func TestRunSanityChecks_ConfidenceFormula(t *testing.T) {
+	// 1 passing check out of 1 total = 100%
+	r := &Report{
+		TotalEntities:      100,
+		EntitiesByLanguage: map[string]int{},
+		OrphanByKind:       map[string]KindStats{},
+		ResolutionTotal:    0,
+		FrameworkHits:      map[string]int{},
+	}
+
+	_, confidence := runSanityChecks(r)
+	if confidence != 100 {
+		t.Errorf("expected 100%% confidence when only check is minimum-entity-count passing, got %d%%", confidence)
+	}
+}

--- a/skills/archigraph-feedback/SKILL.md
+++ b/skills/archigraph-feedback/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: archigraph-feedback
+description: >
+  Generate a privacy-preserving anonymized quality report for sharing with archigraph
+  maintainers. Covers extractor coverage, orphan rate, resolution disposition, and
+  framework recognition. All identifiers are hashed; file paths are scrubbed. Fully
+  offline — no network calls, no telemetry, no auto-issue-creation.
+when-to-use: >
+  User asks to "file feedback", "generate a feedback report", "report an archigraph
+  quality issue", "share extraction quality data", or invokes /archigraph-feedback
+  explicitly. Also useful when a user notices that specific entity kinds are missing,
+  orphan rates are unexpectedly high, or framework annotations are not being detected.
+---
+
+# archigraph-feedback
+
+Generate an anonymized quality report that you can share with archigraph maintainers
+to help improve extractor coverage, resolver accuracy, and framework support — without
+revealing any source code, file paths, or identifier names.
+
+## Privacy promise
+
+The report contains:
+- **Entity name hashes**: per-report ephemeral salt (from `crypto/rand`), 4-hex output
+  (e.g. `ent_a3f7`, `op_92c1`). Salt is never persisted and never logged.
+- **Path templates**: `<go>/<seg-1>/<seg-2>.go` — depth preserved, all segments replaced.
+- **Count ranges**: exact entity counts are bucketed (1-5, 6-20, 21-100, 100+).
+- **Structural labels only**: kind names (`function`, `class`), language names, and
+  framework annotation names (`@GetMapping`, `@Inject`) are not hashed — they are
+  public framework vocabulary and essential for maintainers to diagnose issues.
+
+The report does **not** contain:
+- Source code (zero lines of code).
+- Real file paths (depth + extension only).
+- Real identifier names (hashed to 4 hex).
+- Any network requests (fully offline).
+- Any automatic issue creation (you decide whether to share).
+
+## How to run
+
+```
+archigraph feedback [--group <name>] [--out <path>] [--yes]
+```
+
+**Flags:**
+- `--group <name>` — which group to analyse (default: inferred from your current directory).
+- `--out <path>` — where to write the report (default: `~/.archigraph/feedback/<group>-<timestamp>.md`).
+- `--yes` — skip the confirmation prompt (useful for CI or scripting).
+
+**Example:**
+```
+archigraph feedback --group my-service
+```
+
+The CLI will show you what will (and will not) be collected, then ask for confirmation
+before generating the report.
+
+## How to verify the report before sharing
+
+1. Open the generated `.md` file in any text editor or markdown viewer.
+2. Check that **no real source code** appears anywhere. The report should contain only
+   markdown tables, percentage statistics, and hash-like identifiers (e.g. `ent_a3f7`).
+3. Check that **no real file paths** appear. All paths should look like `<go>/<seg-1>/<seg-2>.go`.
+4. Check that **no real class or function names** appear. All entity references should
+   be in the form `<kind-prefix>_<4-hex>` (e.g. `op_92c1`, `ent_b61d`).
+5. Framework annotation names like `@GetMapping` or `@Inject` **are** allowed — they are
+   public framework vocabulary and help maintainers understand which framework rules fired.
+
+If you spot any real identifier or path that was not scrubbed, **do not share the report**
+and file an issue at https://github.com/cajasmota/archigraph/issues describing the leak.
+
+## How to file the GitHub issue
+
+Once you have verified the report:
+
+1. Go to https://github.com/cajasmota/archigraph/issues/new?template=feedback-report.yml
+2. Check the anonymization-verification box confirming you have reviewed the report.
+3. Paste the full contents of the `.md` file into the **Feedback report** field.
+4. Fill in the **archigraph version** (shown in the report header).
+5. Select the **Impact** category that best describes your issue.
+6. Submit the issue.
+
+Maintainers will triage the report using the confidence score, the orphan-rate table,
+and the resolution disposition vector to identify the most likely extractor or resolver gap.
+
+## What the report covers (Phase 1)
+
+| Section | Contents |
+|---|---|
+| 1. Extractor Coverage | Entity counts by language, kind distribution, source-window completeness, annotation coverage, field extraction rate |
+| 2. Orphan Rate | Per-kind orphan rate (entities with no semantic outgoing edges) |
+| 3. Resolution Disposition | Breakdown of edge resolution outcomes (resolved, external-known, bug-extractor, …) |
+| 4. Framework Recognition | Framework detector hit counts per recognized framework |
+| 5. Cross-Stack Flows | _(Phase 2)_ |
+| 6. Docgen Quality | _(Phase 2)_ |
+| 7. Sanity Check Details | Which automated checks passed / failed, and why |
+
+## Confidence score
+
+The report header includes a **Confidence** percentage, computed as the fraction of
+automated sanity checks that passed:
+
+- Entity count > 0 for each indexed language
+- Orphan rate < 100% for all kinds with N >= 10
+- Resolution vector sums to 100% ± 0.1%
+- Framework hits >= 1 if known-framework files were detected
+- Total entities >= 50 (else the report is suppressed entirely)
+
+A low confidence score (e.g. 40%) may indicate a partial index or an unusual
+environment. The report may still contain useful signals — confidence is a triage
+aid for maintainers, not a quality gate.
+
+## Minimum codebase size
+
+The report requires at least **50 indexed entities**. Below that threshold, metrics
+are statistically unreliable and small-sample combinations could fingerprint the
+codebase. The CLI will emit a suppression notice instead of a full report.
+
+## Phase 2 (not yet available)
+
+Phase 2 will add:
+- Failure pattern section (AST node-type patterns for top-5 failures)
+- Expected vs actual edge tables
+- Synthetic fixture tarball generation
+- Docgen quality section
+- Cross-stack flow section


### PR DESCRIPTION
## Summary

- Implements `archigraph feedback` CLI subcommand (issue #2544 Phase 1 MVP)
- Adds `internal/feedback` package with `Generate()`, `Render()`, and sanity checks
- Anonymization: ephemeral per-report `crypto/rand` salt, 4-hex name hashing, depth-preserved path scrubbing with extension-family bucketing, N<10 suppression, total < 50 suppression
- Adds `skills/archigraph-feedback/SKILL.md` user-facing wrapper
- Adds `.github/ISSUE_TEMPLATE/feedback-report.yml` issue template

Closes #2544

## Test plan

- [x] `go test ./internal/feedback/... -count=1` — 29 tests, all PASS
- [x] `go test ./cmd/archigraph/... -count=1` — no regressions (61s)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l` — empty (no unformatted files)
- [ ] Manual: `archigraph feedback --group <name>` on a real indexed group (requires local daemon)

## Anonymization helpers

- `NameHash(name, kind string, salt []byte) string` — `<kind-prefix>_<4-hex>` via SHA-256(salt:name)[:2]
- `PathScrub(p string) string` — depth-preserved `<ext>/<seg-1>/.../<seg-N>.ext`, cap at 4 dir segs, unusual ext bucketing

## Tech debt surfaced

- `FrameworkFilesDetected` is inferred from `Properties["framework"]` presence per entity rather than a dedicated per-file property — may over/under-count on some extractors.
- The `field_count` property heuristic relies on a property not all extractors emit; zero-field class detection will silently over-count where the property is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)