### PR TITLE
feat(engine/tests): multi-hop TESTS propagation via HTTP router (#2549)

### DIFF
--- a/internal/engine/tests_edges.go
+++ b/internal/engine/tests_edges.go
@@ -1,0 +1,290 @@
+// TESTS edge multi-hop propagation via HTTP router registration — #2549.
+//
+// # Problem
+//
+// Django REST Framework tests call the API through the Django test client:
+//
+//	self.client.post('/api/v1/schedule/import', data, format='json')
+//
+// The existing testmap extractor (internal/extractors/cross/testmap) detects
+// the test function and emits a TESTS edge, but only to the HTTP-client method
+// call object itself ("self.client.post").  The production ViewSet method
+// (e.g. ScheduleViewset.import_csv) never receives a TESTS edge — it is
+// invisible to coverage queries.
+//
+// The root cause is that the extractor works file-by-file and has no access to
+// the routing graph that links `/api/v1/schedule/import` → the ViewSet. Only
+// 14 of 8,564 production entities on upvate had ANY incoming TESTS edge (0.16%
+// coverage) as a result.
+//
+// # Fix
+//
+// ApplyTestsMultiHopViaHTTP is a repo-wide, append-only pass that runs AFTER
+// the per-file extractor passes have completed.  It needs two inputs:
+//
+//  1. The full set of classified file paths + content, so it can scan test
+//     files for HTTP client call patterns.
+//  2. The ROUTES_TO relationships already collected from the DRF router /
+//     URL-conf passes, so it can follow endpoint → ViewSet without re-parsing
+//     urlconfs.
+//
+// For each HTTP client call found in a test function body the pass:
+//
+//  1. Extracts the URL path literal from the call.
+//  2. Normalises the path (strips trailing slash, lowercases) and looks it up
+//     in the ROUTES_TO index (keyed by normalised path suffix).
+//  3. When a matching ROUTES_TO edge is found, reads the ViewSet ToID from
+//     that edge as the production target.
+//  4. Synthesises a TESTS relationship from the enclosing test function → the
+//     ViewSet entity, tagged with Properties["via"]="http_router" for
+//     traceability.
+//
+// The pass is append-only: it never modifies or removes any entity or
+// relationship. It returns only the newly synthesised TESTS edges; the caller
+// appends them to the pass-3 relationship set.
+//
+// Refs #2549.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Regex patterns
+// ---------------------------------------------------------------------------
+
+// testClientHTTPCallRe matches Django REST / requests-style HTTP client calls
+// inside test function bodies.  Patterns covered:
+//
+//	self.client.post('/path', ...)
+//	self.client.get('/path')
+//	client.post('/path', ...)
+//	requests.get('/path', ...)
+//	self.client.patch('/path', ...)
+//
+// Group 1 = HTTP verb (get|post|put|patch|delete).
+// Group 2 = URL path literal (single or double quoted).
+var testClientHTTPCallRe = regexp.MustCompile(
+	`\b(?:self\.client|client|requests|httpx)\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*["']([^"'\n\r]+)["']`,
+)
+
+// pyTestFuncRe re-matches test function headers to locate the enclosing test
+// function of a call site. Using a lightweight version here rather than
+// importing the testmap internal type.
+var pyTestFuncForEdgeRe = regexp.MustCompile(
+	`(?m)^(?:[ \t]*)(?:async\s+)?def\s+(test_\w+)\s*\(`,
+)
+
+// isTestFilePath returns true when the path looks like a Python test file by
+// naming convention. Mirrors the pytest frameworkEntry filename hints.
+func isTestFilePath(p string) bool {
+	base := p
+	if idx := strings.LastIndexByte(p, '/'); idx >= 0 {
+		base = p[idx+1:]
+	}
+	lower := strings.ToLower(base)
+	return strings.HasPrefix(lower, "test_") && strings.HasSuffix(lower, ".py") ||
+		strings.HasSuffix(lower, "_test.py")
+}
+
+// ---------------------------------------------------------------------------
+// Path normalisation
+// ---------------------------------------------------------------------------
+
+// normaliseHTTPPath strips a trailing slash, collapses multiple slashes, and
+// lower-cases the path so that '/api/v1/Foo/' and '/api/v1/foo' match the same
+// ROUTES_TO entry.
+func normaliseHTTPPath(raw string) string {
+	p := strings.ToLower(raw)
+	// Collapse repeated slashes.
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	p = strings.TrimRight(p, "/")
+	if p == "" {
+		p = "/"
+	}
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// ROUTES_TO index
+// ---------------------------------------------------------------------------
+
+// buildRoutesToIndex indexes the ROUTES_TO relationships by the normalised
+// path suffix that is embedded in the FromID.
+//
+// FromID convention used by the DRF router + URL-conf passes:
+//
+//	"Route:/api/v1/users"    (from ApplyDjangoNestedURLConf / ApplyDjangoDRFRoutes)
+//	"http:POST:/api/v1/foo"  (from http_endpoint_synthesis)
+//
+// For each, we record normalisedPath → ToID so the caller can do a
+// O(1) lookup from a test URL path to the downstream ViewSet/handler entity.
+//
+// A single path may be served by multiple ViewSets (e.g. list vs detail) but
+// in practice the ROUTES_TO index maps one URL prefix per ViewSet class; we
+// store all matching ToIDs and emit one TESTS edge per.
+func buildRoutesToIndex(rels []types.RelationshipRecord) map[string][]string {
+	idx := make(map[string][]string)
+	for _, r := range rels {
+		if r.Kind != string(types.RelationshipKindRoutesTo) {
+			continue
+		}
+		// Extract path from FromID.
+		var rawPath string
+		switch {
+		case strings.HasPrefix(r.FromID, "Route:"):
+			rawPath = r.FromID[len("Route:"):]
+		case strings.HasPrefix(r.FromID, "http:"):
+			// "http:POST:/api/v1/foo" → extract path after the second colon.
+			parts := strings.SplitN(r.FromID, ":", 3)
+			if len(parts) == 3 {
+				rawPath = parts[2]
+			}
+		}
+		if rawPath == "" {
+			continue
+		}
+		norm := normaliseHTTPPath(rawPath)
+		idx[norm] = append(idx[norm], r.ToID)
+	}
+	return idx
+}
+
+// ---------------------------------------------------------------------------
+// Main pass
+// ---------------------------------------------------------------------------
+
+// ApplyTestsMultiHopViaHTTP synthesises TESTS edges from test functions to
+// ViewSet / handler entities by following HTTP client call sites through the
+// ROUTES_TO graph index.
+//
+// Parameters:
+//
+//	paths      — repo-relative paths of every file in the index.
+//	fileReader — returns the raw source bytes for a repo-relative path.
+//	routesToRels — the full set of ROUTES_TO relationships already collected
+//	               by the URL-conf / DRF passes.  May include other edge kinds;
+//	               the function filters by Kind=="ROUTES_TO".
+//
+// Returns only the newly synthesised TESTS RelationshipRecords. The caller is
+// responsible for appending these to its accumulated relationship slice.
+func ApplyTestsMultiHopViaHTTP(
+	paths []string,
+	fileReader NestedURLConfFileReader,
+	routesToRels []types.RelationshipRecord,
+) []types.RelationshipRecord {
+	if fileReader == nil || len(routesToRels) == 0 {
+		return nil
+	}
+
+	// Build the path → ViewSet(s) lookup from ROUTES_TO edges.
+	routeIdx := buildRoutesToIndex(routesToRels)
+	if len(routeIdx) == 0 {
+		return nil
+	}
+
+	var out []types.RelationshipRecord
+	seen := map[string]bool{} // deduplicate (testFunc, toID) pairs
+
+	for _, p := range paths {
+		if !isTestFilePath(p) {
+			continue
+		}
+		content := fileReader(p)
+		if len(content) == 0 {
+			continue
+		}
+		src := string(content)
+
+		// Quick bail-out: file must contain an HTTP client call pattern.
+		if !strings.Contains(src, ".client.") && !strings.Contains(src, "requests.") &&
+			!strings.Contains(src, "httpx.") {
+			continue
+		}
+
+		// Find every HTTP client call site in this test file.
+		for _, callIdx := range testClientHTTPCallRe.FindAllStringSubmatchIndex(src, -1) {
+			if len(callIdx) < 6 {
+				continue
+			}
+			// callIdx[4]:callIdx[5] = URL path literal (group 2).
+			rawPath := src[callIdx[4]:callIdx[5]]
+			if rawPath == "" {
+				continue
+			}
+
+			norm := normaliseHTTPPath(rawPath)
+
+			// Try to find a matching ROUTES_TO target via prefix matching.
+			// The test URL may include query params or be a detail URL
+			// (/api/v1/users/42) while the route is registered for the
+			// collection (/api/v1/users).  We attempt exact match first, then
+			// walk up the path hierarchy stripping the last segment.
+			var viewSetIDs []string
+			candidate := norm
+			for candidate != "" && candidate != "/" {
+				if ids, ok := routeIdx[candidate]; ok {
+					viewSetIDs = ids
+					break
+				}
+				// Strip the last path segment.
+				idx := strings.LastIndexByte(candidate, '/')
+				if idx <= 0 {
+					break
+				}
+				candidate = candidate[:idx]
+			}
+			if len(viewSetIDs) == 0 {
+				continue
+			}
+
+			// Determine enclosing test function at call site position.
+			callPos := callIdx[0]
+			testFunc := enclosingPyTestFunc(src, callPos)
+			if testFunc == "" {
+				continue
+			}
+
+			// Emit one TESTS edge per matching ViewSet.
+			for _, toID := range viewSetIDs {
+				key := p + "|" + testFunc + "|" + toID
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				out = append(out, types.RelationshipRecord{
+					FromID: "SCOPE.Operation:" + testFunc,
+					ToID:   toID,
+					Kind:   "TESTS",
+					Properties: map[string]string{
+						"via":           "http_router",
+						"http_path":     rawPath,
+						"test_file":     p,
+						"test_function": testFunc,
+						"pattern_type":  "tests_multi_hop_http_router",
+						"confidence":    "high",
+					},
+				})
+			}
+		}
+	}
+	return out
+}
+
+// enclosingPyTestFunc returns the name of the innermost test_ function whose
+// header appears before pos in src.  Returns "" when no enclosing test
+// function can be identified.
+func enclosingPyTestFunc(src string, pos int) string {
+	sub := src[:pos]
+	matches := pyTestFuncForEdgeRe.FindAllStringSubmatch(sub, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[len(matches)-1][1]
+}

--- a/internal/engine/tests_edges_test.go
+++ b/internal/engine/tests_edges_test.go
@@ -1,0 +1,304 @@
+// Tests for ApplyTestsMultiHopViaHTTP — #2549.
+//
+// Verifies that the multi-hop TESTS propagation pass synthesises TESTS edges
+// from test functions through HTTP client call sites → ROUTES_TO → ViewSet
+// method, and that it does NOT synthesise spurious edges when no matching
+// route exists.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// testFooViewsSrc is a minimal views.py that defines FooView.create. In a
+// real index this file would be processed by the DRF extractor and generate
+// a ViewSet entity; here we only need the ROUTES_TO relationship below.
+const testFooViewsSrc = `from rest_framework.viewsets import ModelViewSet
+
+class FooView(ModelViewSet):
+    """A simple viewset."""
+
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+`
+
+// testFooTestSrc is the Django REST test file that exercises FooView via the
+// test client at the registered URL prefix /api/v1/foo.
+const testFooTestSrc = `import pytest
+from rest_framework.test import APITestCase
+
+class TestFooCreate(APITestCase):
+    def test_create_foo(self):
+        response = self.client.post('/api/v1/foo', {'name': 'bar'}, format='json')
+        self.assertEqual(response.status_code, 201)
+
+    def test_list_foo(self):
+        response = self.client.get('/api/v1/foo')
+        self.assertEqual(response.status_code, 200)
+`
+
+// routesToFoo is a minimal ROUTES_TO relationship emitted by the DRF router
+// pass.  FromID uses the "Route:" prefix convention; ToID is the ViewSet stub
+// in "View:" prefix convention.
+var routesToFoo = []types.RelationshipRecord{
+	{
+		FromID: "Route:/api/v1/foo",
+		ToID:   "View:FooView",
+		Kind:   "ROUTES_TO",
+		Properties: map[string]string{
+			"pattern_type": "ast_driven",
+		},
+	},
+}
+
+// ---------------------------------------------------------------------------
+// TestTestsEdges_MultiHopViaHttpClient
+//
+// Happy-path: test file calls self.client.post('/api/v1/foo'), ROUTES_TO
+// maps /api/v1/foo → View:FooView.  Expect at least one TESTS edge from the
+// enclosing test function to View:FooView tagged with via=http_router.
+// ---------------------------------------------------------------------------
+
+func TestTestsEdges_MultiHopViaHttpClient(t *testing.T) {
+	paths := []string{
+		"app/views.py",
+		"app/tests/test_foo.py",
+	}
+	content := map[string][]byte{
+		"app/views.py":          []byte(testFooViewsSrc),
+		"app/tests/test_foo.py": []byte(testFooTestSrc),
+	}
+	reader := func(p string) []byte { return content[p] }
+
+	edges := ApplyTestsMultiHopViaHTTP(paths, reader, routesToFoo)
+
+	if len(edges) == 0 {
+		t.Fatal("expected at least one synthesised TESTS edge, got none")
+	}
+
+	// Verify at least one edge targets View:FooView with the right metadata.
+	var found bool
+	for _, e := range edges {
+		if e.Kind != "TESTS" {
+			t.Errorf("unexpected edge Kind %q (want TESTS)", e.Kind)
+			continue
+		}
+		if e.ToID != "View:FooView" {
+			continue
+		}
+		if e.Properties["via"] != "http_router" {
+			t.Errorf("expected via=http_router, got %q", e.Properties["via"])
+		}
+		if e.Properties["pattern_type"] != "tests_multi_hop_http_router" {
+			t.Errorf("expected pattern_type=tests_multi_hop_http_router, got %q", e.Properties["pattern_type"])
+		}
+		if e.Properties["confidence"] != "high" {
+			t.Errorf("expected confidence=high, got %q", e.Properties["confidence"])
+		}
+		found = true
+	}
+
+	if !found {
+		t.Errorf("no TESTS edge targeting View:FooView found; edges emitted: %+v", edges)
+	}
+
+	// Verify that both test functions (POST and GET) each contributed an edge.
+	testFuncs := map[string]bool{}
+	for _, e := range edges {
+		if e.ToID == "View:FooView" {
+			testFuncs[e.Properties["test_function"]] = true
+		}
+	}
+	if !testFuncs["test_create_foo"] {
+		t.Errorf("expected TESTS edge from test_create_foo, got test_funcs=%v", testFuncs)
+	}
+	if !testFuncs["test_list_foo"] {
+		t.Errorf("expected TESTS edge from test_list_foo, got test_funcs=%v", testFuncs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTestsEdges_NoHopWhenRouteAbsent
+//
+// Negative case: test calls a path for which NO ROUTES_TO edge exists.
+// The pass must emit zero edges (no phantom nodes, no dangling refs).
+// ---------------------------------------------------------------------------
+
+const testBarTestSrc = `import pytest
+from rest_framework.test import APITestCase
+
+class TestBarEndpoints(APITestCase):
+    def test_call_unknown_endpoint(self):
+        # /api/v1/nonexistent has no registered viewset.
+        response = self.client.post('/api/v1/nonexistent', {})
+        self.assertEqual(response.status_code, 404)
+`
+
+func TestTestsEdges_NoHopWhenRouteAbsent(t *testing.T) {
+	paths := []string{
+		"app/tests/test_bar.py",
+	}
+	content := map[string][]byte{
+		"app/tests/test_bar.py": []byte(testBarTestSrc),
+	}
+	reader := func(p string) []byte { return content[p] }
+
+	// routesToFoo maps /api/v1/foo, NOT /api/v1/nonexistent.
+	edges := ApplyTestsMultiHopViaHTTP(paths, reader, routesToFoo)
+
+	if len(edges) != 0 {
+		t.Errorf("expected 0 synthesised edges when route is absent, got %d: %+v", len(edges), edges)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Additional unit tests for helpers
+// ---------------------------------------------------------------------------
+
+func TestNormaliseHTTPPath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"/api/v1/foo/", "/api/v1/foo"},
+		{"/api/v1/foo", "/api/v1/foo"},
+		{"//api//v1//foo//", "/api/v1/foo"},
+		{"/", "/"},
+		{"", "/"},
+		{"/API/V1/Foo", "/api/v1/foo"},
+	}
+	for _, tc := range cases {
+		got := normaliseHTTPPath(tc.in)
+		if got != tc.want {
+			t.Errorf("normaliseHTTPPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestIsTestFilePath(t *testing.T) {
+	yes := []string{
+		"tests/test_foo.py",
+		"app/tests/test_schedule_import.py",
+		"foo_test.py",
+		"bar_test.py",
+	}
+	no := []string{
+		"views.py",
+		"models.py",
+		"urls.py",
+		"test_results.json",
+	}
+	for _, p := range yes {
+		if !isTestFilePath(p) {
+			t.Errorf("isTestFilePath(%q) = false, want true", p)
+		}
+	}
+	for _, p := range no {
+		if isTestFilePath(p) {
+			t.Errorf("isTestFilePath(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestBuildRoutesToIndex(t *testing.T) {
+	rels := []types.RelationshipRecord{
+		{Kind: "ROUTES_TO", FromID: "Route:/api/v1/users", ToID: "View:UserViewSet"},
+		{Kind: "ROUTES_TO", FromID: "Route:/api/v1/orders/", ToID: "View:OrderViewSet"},
+		{Kind: "CALLS", FromID: "Foo", ToID: "Bar"}, // must be ignored
+		{Kind: "ROUTES_TO", FromID: "http:POST:/api/v1/items", ToID: "View:ItemViewSet"},
+	}
+	idx := buildRoutesToIndex(rels)
+
+	if ids, ok := idx["/api/v1/users"]; !ok || len(ids) == 0 || ids[0] != "View:UserViewSet" {
+		t.Errorf("Route: prefix not indexed correctly; got %v", idx)
+	}
+	// Trailing-slash path is normalised.
+	if ids, ok := idx["/api/v1/orders"]; !ok || len(ids) == 0 || ids[0] != "View:OrderViewSet" {
+		t.Errorf("trailing-slash path not normalised; got %v", idx)
+	}
+	// http: prefix extraction.
+	if ids, ok := idx["/api/v1/items"]; !ok || len(ids) == 0 || ids[0] != "View:ItemViewSet" {
+		t.Errorf("http: prefix not indexed correctly; got %v", idx)
+	}
+	// CALLS edge must not appear.
+	if _, ok := idx["Bar"]; ok {
+		t.Errorf("non-ROUTES_TO edge was indexed")
+	}
+}
+
+func TestEnclosingPyTestFunc(t *testing.T) {
+	src := `import pytest
+
+class FooTest:
+    def test_alpha(self):
+        self.client.post('/foo')
+        self.client.get('/bar')
+
+    def test_beta(self):
+        self.client.delete('/baz')
+`
+	// Position inside test_alpha body (after "self.client.post('/foo')").
+	posAlpha := len("import pytest\n\nclass FooTest:\n    def test_alpha(self):\n        self.client.post('/foo')\n")
+	got := enclosingPyTestFunc(src, posAlpha-1)
+	if got != "test_alpha" {
+		t.Errorf("enclosingPyTestFunc for posAlpha=%d: got %q, want test_alpha", posAlpha, got)
+	}
+
+	// Position inside test_beta body.
+	posBeta := len(src) - len("        self.client.delete('/baz')\n") - 5
+	got = enclosingPyTestFunc(src, posBeta)
+	if got != "test_beta" {
+		t.Errorf("enclosingPyTestFunc for posBeta=%d: got %q, want test_beta", posBeta, got)
+	}
+}
+
+func TestApplyTestsMultiHop_NilFileReader(t *testing.T) {
+	edges := ApplyTestsMultiHopViaHTTP([]string{"test_foo.py"}, nil, routesToFoo)
+	if len(edges) != 0 {
+		t.Errorf("nil reader must return empty; got %d edges", len(edges))
+	}
+}
+
+func TestApplyTestsMultiHop_EmptyRoutes(t *testing.T) {
+	reader := func(p string) []byte { return []byte(testFooTestSrc) }
+	edges := ApplyTestsMultiHopViaHTTP([]string{"app/tests/test_foo.py"}, reader, nil)
+	if len(edges) != 0 {
+		t.Errorf("empty routes must return empty; got %d edges", len(edges))
+	}
+}
+
+// TestTestsEdges_PathPrefixFallback verifies that a test calling a detail URL
+// (/api/v1/foo/42) is matched against the collection route (/api/v1/foo) when
+// no exact entry exists in the ROUTES_TO index.
+func TestTestsEdges_PathPrefixFallback(t *testing.T) {
+	detailTestSrc := `from rest_framework.test import APITestCase
+
+class TestFooDetail(APITestCase):
+    def test_retrieve_foo(self):
+        response = self.client.get('/api/v1/foo/42')
+        self.assertEqual(response.status_code, 200)
+`
+	paths := []string{"app/tests/test_detail.py"}
+	content := map[string][]byte{
+		"app/tests/test_detail.py": []byte(detailTestSrc),
+	}
+	reader := func(p string) []byte { return content[p] }
+
+	edges := ApplyTestsMultiHopViaHTTP(paths, reader, routesToFoo)
+
+	var found bool
+	for _, e := range edges {
+		if e.ToID == "View:FooView" && e.Properties["test_function"] == "test_retrieve_foo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected TESTS edge via prefix fallback /api/v1/foo for detail URL /api/v1/foo/42; got %+v", edges)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ApplyTestsMultiHopViaHTTP` in `internal/engine/tests_edges.go` — a repo-wide, append-only pass that synthesises TESTS edges from Django REST test functions through HTTP client call sites → ROUTES_TO → ViewSet methods
- Fixes the root cause of 0.16% TESTS-edge coverage on upvate-core: the per-file testmap extractor only saw `self.client.post(...)` as a call target, never following the route to the actual ViewSet handler
- Edges are tagged `Properties["via"]="http_router"` and `pattern_type="tests_multi_hop_http_router"` for traceability

## Test plan

- [x] `TestTestsEdges_MultiHopViaHttpClient` — fixture: test file calls `self.client.post('/api/v1/foo')` + `self.client.get('/api/v1/foo')`, ROUTES_TO maps `/api/v1/foo` → `View:FooView`; verifies TESTS edges synthesised to `View:FooView` from both test functions
- [x] `TestTestsEdges_NoHopWhenRouteAbsent` — test calls `/api/v1/nonexistent` with no matching ROUTES_TO entry; verifies zero edges emitted (no phantom nodes)
- [x] `TestTestsEdges_PathPrefixFallback` — detail URL `/api/v1/foo/42` resolves to collection route `/api/v1/foo` via hierarchical path stripping
- [x] Unit tests for helpers: `TestNormaliseHTTPPath`, `TestIsTestFilePath`, `TestBuildRoutesToIndex`, `TestEnclosingPyTestFunc`
- [x] `go vet`, `go build`, `go test ./internal/engine/... -count=1` all pass

Closes #2549

🤖 Generated with [Claude Code](https://claude.com/claude-code)