### PR TITLE
fix(links/http): handle empty canonicalPath in consumer-side hits

### DIFF
--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -60,6 +60,7 @@ package links
 // import_pass, label_pass, and string_pass intact.
 
 import (
+	"log"
 	"regexp"
 	"sort"
 	"strings"
@@ -345,14 +346,32 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 	// so that placeholder names ({pk}, {param}, {id}, :id, etc.) from different
 	// extractors all collapse to the same bucket key {*}. The original
 	// canonicalPath is preserved on every hit object for identifier emission.
+	//
+	// #2558: When canonicalPath is empty, fall back to the parsed path from
+	// the hit.name to avoid silent skip. This handles consumer-side hits where
+	// canonicalPath may not be populated but the endpoint name carries the path.
 	byPath := map[string][]*httpEndpointHit{}
+	hitsProcessed := 0
+	hitsCanonicalEmpty := 0
 	for _, byRepo := range hits {
 		for _, perRepo := range byRepo {
 			for _, h := range perRepo {
-				if h.canonicalPath == "" {
+				hitsProcessed++
+				path := h.canonicalPath
+				if path == "" {
+					hitsCanonicalEmpty++
+					// Fallback: parse path from the canonical name if
+					// canonicalPath is empty. This mirrors the fallback
+					// logic above (lines 300-308) and ensures consumer
+					// hits without a populated path property still register.
+					if _, p, ok := parseHTTPName(h.name); ok {
+						path = p
+					}
+				}
+				if path == "" {
 					continue
 				}
-				key := normalizePathForIndex(h.canonicalPath)
+				key := normalizePathForIndex(path)
 				byPath[key] = append(byPath[key], h)
 
 				// #819 — also index under the prefix-stripped path when the
@@ -361,9 +380,9 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 				// API-version prefix (e.g. fetch('/buildings/') vs server at
 				// '/api/v1/buildings/') still find the producer via byPath.
 				// We only strip when h.urlPrefix is a valid path prefix of
-				// h.canonicalPath to avoid false-positive strip-downs.
-				if h.urlPrefix != "" && strings.HasPrefix(h.canonicalPath, h.urlPrefix) {
-					stripped := h.canonicalPath[len(h.urlPrefix):]
+				// the (possibly fallback) path to avoid false-positive strip-downs.
+				if h.urlPrefix != "" && strings.HasPrefix(path, h.urlPrefix) {
+					stripped := path[len(h.urlPrefix):]
 					if stripped == "" {
 						stripped = "/"
 					}
@@ -563,6 +582,15 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 	}
 	res.LinksAdded = added
 	res.Skipped = skipped
+
+	// Diagnostic logging: #2558 tracking of empty canonicalPath handling.
+	// These counters help identify if the fallback path resolution is covering
+	// consumer-side hits that would have been silently dropped in prior versions.
+	if hitsProcessed > 0 {
+		log.Printf("http_pass: hits_processed=%d, hits_canonical_empty=%d, links_registered=%d",
+			hitsProcessed, hitsCanonicalEmpty, len(fresh))
+	}
+
 	return res, nil
 }
 

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -1682,3 +1682,88 @@ func TestHTTPPass_CrossBucketConsumerCollision(t *testing.T) {
 		t.Errorf("#1445 regression: consumerA (http:GET:/roles) not linked to handler1 via prefix-strip; links=%+v", doc.Links)
 	}
 }
+
+// TestHTTPPass_HandlesEmptyCanonicalPath verifies that consumer-side hits with
+// empty canonicalPath (path property not populated) are still registered and
+// matched via the fallback path parsed from the hit.name. This addresses #2558:
+// previously such hits were silently dropped from the byPath index, causing
+// orphaned consumer synthetics and inflating the orphan-count metric.
+func TestHTTPPass_HandlesEmptyCanonicalPath(t *testing.T) {
+	root := fixtureRoot(t)
+	// Producer side: typical backend endpoint with full properties.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{
+				"id": "h1", "name": "ProductView", "kind": "Controller",
+				"source_file": "app/views.py",
+			},
+			{
+				"id": "ep1", "name": "http:GET:/products/{id}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/products/{id}",
+					"framework":    "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	// Consumer side: endpoint with EMPTY canonicalPath but valid name.
+	// This simulates a consumer hit where the path property was not populated
+	// during synthesis but the name still carries the full http:VERB:path form.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{
+				"id": "fn1", "name": "fetchProduct", "kind": "Function",
+				"source_file": "src/api.ts",
+			},
+			{
+				"id": "ep2", "name": "http:GET:/products/{id}", "kind": "http_endpoint_call",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "", // EMPTY: this is the #2558 case
+					"framework":     "fetch",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:fetchProduct",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("ghttp2558", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "ghttp2558-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hit *Link
+	for i, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			hit = &doc.Links[i]
+			break
+		}
+	}
+	// The fix: consumer hit with empty canonicalPath must still register and link.
+	if hit == nil {
+		t.Fatalf("#2558 regression: expected http-method link for consumer with empty canonicalPath, got none; links=%+v", doc.Links)
+	}
+	if hit.Source != "frontend::fn1" {
+		t.Errorf("source: want frontend::fn1 (resolved caller), got %s", hit.Source)
+	}
+	if hit.Target != "backend::h1" {
+		t.Errorf("target: want backend::h1 (resolved handler), got %s", hit.Target)
+	}
+	// Identifier should still use the path from the fallback, not empty.
+	if hit.Identifier == nil || !strings.Contains(*hit.Identifier, "/products/") {
+		t.Errorf("identifier should contain /products/; got %v", hit.Identifier)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2558

The cross-repo HTTP pass silently skipped consumer-side hits with empty `canonicalPath`, contributing to orphaned synthetics. This fix implements fallback path resolution and adds diagnostic counters.

## Changes

- **Fallback path resolution**: When a consumer hit has empty `canonicalPath`, parse the path from the canonical `name` (e.g., `http:GET:/products/{id}` → `/products/{id}`)
- **Prefix-strip fix**: Update URL prefix stripping to work with fallback path
- **Diagnostic counters**: Log hits_processed, hits_canonical_empty, links_registered at end of pass
- **Test**: TestHTTPPass_HandlesEmptyCanonicalPath verifies empty path handling

## Fix Details

File: `internal/links/http_pass.go`
- Line 359–368: Fallback path extraction in byPath loop
- Line 383–384: Use fallback path for prefix-strip check
- Line 589–593: Diagnostic logging

Test: `internal/links/http_pass_test.go`
- Lines 1687–1763: New test case

All existing tests pass.