### PR TITLE
feat(extractor/ts): dynamic dispatch CALLS edges via Record<K,Fn> maps

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -207,6 +207,10 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 	// so that callTarget can rewrite CALLS-to-hook-result edges.
 	x.hookVarToModule = x.buildHookVarToModule(root)
 
+	// Issue #2553 — build the dispatch-map registry before walk() so that
+	// callTarget can synthesise CALLS edges when it sees RESOLVERS[k](args).
+	x.dispatchMaps = x.buildDispatchMaps(root)
+
 	var extractErr error
 	func() {
 		defer func() {
@@ -340,6 +344,36 @@ type extractor struct {
 	// "ext:<module>" rather than the bare local-variable name, which
 	// would otherwise be unresolvable and land in bug-extractor.
 	hookVarToModule map[string]string
+
+	// dispatchMaps — Issue #2553. Built once per file in buildDispatchMaps
+	// (called from Extract before walk). Maps variable names that hold a
+	// Record<string, Fn>-style dispatch table to their registry entries.
+	//
+	//   const RESOLVERS: Record<string, Handler> = { a: fnA, b: fnB };
+	//
+	// → dispatchMaps["RESOLVERS"] = &dispatchMapInfo{
+	//       handlers: ["fnA", "fnB"],
+	//       byKey:    {"a": "fnA", "b": "fnB"},
+	//   }
+	//
+	// When callTarget encounters RESOLVERS[k](args) with a non-literal
+	// index it emits one synthetic CALLS edge per handler entry, each
+	// tagged Properties["via"]="dynamic_dispatch_map". When the index IS
+	// a string literal it resolves only to the matching handler via byKey
+	// (same as plain static dispatch). dispatchMaps is nil when no
+	// dispatch-map variable is found in the file (fast-path).
+	dispatchMaps map[string]*dispatchMapInfo
+}
+
+// dispatchMapInfo records the handlers registered in a Record<string, Fn>
+// dispatch map. Used by buildDispatchMaps and dispatchMapCallEdges (issue #2553).
+type dispatchMapInfo struct {
+	// handlers is the ordered list of handler identifiers (the VALUES from
+	// the object literal). Used for dynamic-index fan-out.
+	handlers []string
+	// byKey maps each literal property key to its handler identifier. Used
+	// for literal-index direct resolution (e.g. RESOLVERS['create_deficiency']).
+	byKey map[string]string
 }
 
 // emitDestructureDetailEnabled reports whether const_destructure /
@@ -1781,6 +1815,20 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 	seen := make(map[string]bool, len(calls))
 	rels := make([]types.RelationshipRecord, 0, len(calls))
 	for _, call := range calls {
+		// Issue #2553 — dynamic dispatch map: RESOLVERS[k](args).
+		// Check for subscript_expression as the function child BEFORE
+		// calling callTarget (which returns "" for subscript callee shapes
+		// and would cause us to skip the call entirely).
+		if dynRels := x.dispatchMapCallEdges(call, callerName); len(dynRels) > 0 {
+			for _, dr := range dynRels {
+				if !seen[dr.ToID] {
+					seen[dr.ToID] = true
+					rels = append(rels, dr)
+				}
+			}
+			continue
+		}
+
 		target := x.callTarget(call, frame)
 		if target == "" || target == "require" {
 			continue
@@ -1810,6 +1858,93 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 			}
 		}
 		rels = append(rels, rel)
+	}
+	return rels
+}
+
+// dispatchMapCallEdges detects `MAPVAR[key](args)` call patterns where MAPVAR
+// is a known dispatch map (tracked in x.dispatchMaps) and emits synthetic CALLS
+// edges. Returns nil when the call is not a dispatch-map invocation.
+//
+// Two sub-cases:
+//
+//  1. Dynamic index — `RESOLVERS[k](args)` where k is an identifier or other
+//     non-literal expression: synthesise one CALLS edge per registered handler
+//     in the dispatch map, tagged Properties["via"]="dynamic_dispatch_map".
+//
+//  2. Literal string index — `RESOLVERS['create_deficiency'](args)`: resolve
+//     directly to the single matching handler when it exists in the map, tagged
+//     Properties["via"]="dynamic_dispatch_map". This is structurally equivalent
+//     to a plain CALLS edge but still carries the traceability tag so reviewers
+//     know it came through the map. If the literal key is not found in the
+//     registered handlers the method returns nil (let the default path handle
+//     it or drop it).
+//
+// Issue #2553.
+func (x *extractor) dispatchMapCallEdges(call *sitter.Node, callerName string) []types.RelationshipRecord {
+	if x.dispatchMaps == nil || call == nil {
+		return nil
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "subscript_expression" {
+		return nil
+	}
+	// subscript_expression children: object, "[", index, "]"
+	// tree-sitter: object is child 0, index is child 2.
+	if fn.ChildCount() < 3 {
+		return nil
+	}
+	objNode := fn.Child(0)
+	indexNode := fn.Child(2)
+	if objNode == nil || indexNode == nil {
+		return nil
+	}
+	if objNode.Type() != "identifier" {
+		return nil
+	}
+	mapName := x.nodeText(objNode)
+	info, ok := x.dispatchMaps[mapName]
+	if !ok || info == nil || len(info.handlers) == 0 {
+		return nil
+	}
+
+	const viaProp = "dynamic_dispatch_map"
+
+	// Literal string index — resolve to single handler via byKey.
+	if indexNode.Type() == "string" {
+		// Extract the string content (strip surrounding quotes).
+		key := x.nodeText(indexNode)
+		key = strings.Trim(key, `"'`+"`")
+		if h, found := info.byKey[key]; found {
+			if h == callerName {
+				return nil // self-call drop
+			}
+			return []types.RelationshipRecord{{
+				ToID: h,
+				Kind: "CALLS",
+				Properties: map[string]string{
+					"via": viaProp,
+				},
+			}}
+		}
+		// Literal key not found in the registered handler map — fall
+		// through to the default path (return nil).
+		return nil
+	}
+
+	// Dynamic index — synthesise one edge per handler.
+	rels := make([]types.RelationshipRecord, 0, len(info.handlers))
+	for _, h := range info.handlers {
+		if h == callerName {
+			continue // skip self-recursion
+		}
+		rels = append(rels, types.RelationshipRecord{
+			ToID: h,
+			Kind: "CALLS",
+			Properties: map[string]string{
+				"via": viaProp,
+			},
+		})
 	}
 	return rels
 }
@@ -2096,6 +2231,133 @@ func (x *extractor) buildHookVarToModule(root *sitter.Node) map[string]string {
 		count := int(n.ChildCount())
 		for i := count - 1; i >= 0; i-- {
 			stack = append(stack, n.Child(i))
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// buildDispatchMaps scans the file AST for top-level variable declarations of
+// the form:
+//
+//	const RESOLVERS: Record<string, Fn> = { key1: handlerA, key2: handlerB }
+//	const RESOLVERS = { key1: handlerA, key2: handlerB }
+//
+// and returns a map from the variable identifier to the list of handler
+// identifiers declared as values in the object literal. Only declarations
+// at module scope (outside any function body) are considered, because
+// dispatch-map patterns are structural, not transient locals.
+//
+// Detection heuristics (either is sufficient to classify as a dispatch map):
+//  1. The declarator carries a TypeScript type annotation whose leading text
+//     is "Record<" (type annotation present on the "type" field of the
+//     variable_declarator node).
+//  2. The RHS is an object literal whose values are ALL identifier references
+//     (not function literals, not primitives). This matches the common
+//     pattern where handlers are declared elsewhere and assembled into a map.
+//
+// Issue #2553 — surfaced by core-mobile's offline-sync subsystem where
+// syncEngine.ts dispatches through syncResolvers via RESOLVERS[action.kind](args).
+func (x *extractor) buildDispatchMaps(root *sitter.Node) map[string]*dispatchMapInfo {
+	if root == nil {
+		return nil
+	}
+	result := make(map[string]*dispatchMapInfo)
+	// Only scan top-level statements (direct children of program root).
+	for i := 0; i < int(root.ChildCount()); i++ {
+		stmt := root.Child(i)
+		if stmt == nil {
+			continue
+		}
+		// Unwrap export_statement wrapper: `export const RESOLVERS = {...}`
+		target := stmt
+		if stmt.Type() == "export_statement" {
+			for j := 0; j < int(stmt.ChildCount()); j++ {
+				ch := stmt.Child(j)
+				if ch != nil && (ch.Type() == "lexical_declaration" || ch.Type() == "variable_declaration") {
+					target = ch
+					break
+				}
+			}
+		}
+		if target.Type() != "lexical_declaration" && target.Type() != "variable_declaration" {
+			continue
+		}
+		for j := 0; j < int(target.ChildCount()); j++ {
+			decl := target.Child(j)
+			if decl == nil || decl.Type() != "variable_declarator" {
+				continue
+			}
+			nameNode := decl.ChildByFieldName("name")
+			if nameNode == nil || nameNode.Type() != "identifier" {
+				continue
+			}
+			varName := x.nodeText(nameNode)
+			if varName == "" {
+				continue
+			}
+			valueNode := decl.ChildByFieldName("value")
+			if valueNode == nil || valueNode.Type() != "object" {
+				continue
+			}
+			// Check for Record<...> type annotation on the declarator.
+			hasRecordAnnotation := false
+			if typeNode := decl.ChildByFieldName("type"); typeNode != nil {
+				typeText := x.nodeText(typeNode)
+				if strings.Contains(typeText, "Record<") {
+					hasRecordAnnotation = true
+				}
+			}
+			// Collect key→handler pairs from the object literal.
+			var handlers []string
+			byKey := make(map[string]string)
+			allIdentifiers := true
+			for k := 0; k < int(valueNode.ChildCount()); k++ {
+				pair := valueNode.Child(k)
+				if pair == nil {
+					continue
+				}
+				if pair.Type() != "pair" {
+					// Skip punctuation nodes ({, }, ,).
+					continue
+				}
+				keyNode := pair.ChildByFieldName("key")
+				valNode := pair.ChildByFieldName("value")
+				if valNode == nil {
+					allIdentifiers = false
+					continue
+				}
+				if valNode.Type() == "identifier" {
+					handler := x.nodeText(valNode)
+					handlers = append(handlers, handler)
+					// Record the key→handler mapping for literal-index resolution.
+					// property_identifier keys need no quote-stripping; string keys do.
+					if keyNode != nil {
+						keyText := x.nodeText(keyNode)
+						keyText = strings.Trim(keyText, `"'`+"`")
+						byKey[keyText] = handler
+					}
+				} else {
+					// Value is a function literal or something else — not
+					// a pure reference map. Still count the entry for
+					// Record-annotated maps; otherwise disqualify.
+					allIdentifiers = false
+				}
+			}
+			if len(handlers) == 0 {
+				continue
+			}
+			// Accept when the type annotation is Record<...> OR when all
+			// values are plain identifier references (high-confidence
+			// heuristic for dispatch-map shape without explicit typing).
+			if hasRecordAnnotation || allIdentifiers {
+				result[varName] = &dispatchMapInfo{
+					handlers: handlers,
+					byKey:    byKey,
+				}
+			}
 		}
 	}
 	if len(result) == 0 {

--- a/internal/extractors/javascript/issue2553_record_dispatch_test.go
+++ b/internal/extractors/javascript/issue2553_record_dispatch_test.go
@@ -1,0 +1,237 @@
+// Package javascript — unit tests for issue #2553.
+//
+// Verifies that const X: Record<string, Fn> = { a: fnA, b: fnB }; X[k]()
+// dispatch patterns produce synthetic CALLS edges from the dispatch site to
+// each registered handler, tagged with Properties["via"]="dynamic_dispatch_map".
+//
+// Two positive cases and one negative (literal-key) case are covered.
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// parseTSDispatch parses source with the TypeScript grammar.
+func parseTSDispatch(t *testing.T, src []byte) *sitter.Tree {
+	t.Helper()
+	p := sitter.NewParser()
+	p.SetLanguage(tstypescript.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, src)
+	if err != nil {
+		t.Fatalf("parseTSDispatch: %v", err)
+	}
+	return tree
+}
+
+// extractTSDispatch is a local helper that runs the typescript extractor on
+// the given source and returns the entity slice.
+func extractTSDispatch(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	content := []byte(src)
+	tree := parseTSDispatch(t, content)
+	ext, ok := extreg.Get("typescript")
+	if !ok {
+		t.Fatalf("typescript extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     "syncEngine.ts",
+		Content:  content,
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+// hasDispatchCallEdge returns true when entity named fromName has a CALLS
+// relationship to toID with Properties["via"]="dynamic_dispatch_map".
+func hasDispatchCallEdge(ents []types.EntityRecord, fromName, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != fromName {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "CALLS" && r.ToID == toID &&
+				r.Properties != nil && r.Properties["via"] == "dynamic_dispatch_map" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasPlainCallEdge returns true when entity named fromName has a CALLS edge
+// to toID WITHOUT the dynamic_dispatch_map via property.
+func hasPlainCallEdge(ents []types.EntityRecord, fromName, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != fromName {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "CALLS" && r.ToID == toID {
+				if r.Properties == nil || r.Properties["via"] == "" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// countDispatchCallEdges returns the number of CALLS edges on fromName that
+// carry Properties["via"]="dynamic_dispatch_map".
+func countDispatchCallEdges(ents []types.EntityRecord, fromName string) int {
+	for i := range ents {
+		if ents[i].Name != fromName {
+			continue
+		}
+		n := 0
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "CALLS" && r.Properties != nil && r.Properties["via"] == "dynamic_dispatch_map" {
+				n++
+			}
+		}
+		return n
+	}
+	return 0
+}
+
+// TestTSExtractor_RecordDispatch_EmitsCallsEdges verifies that a dynamic
+// dispatch through a Record<string, Fn> map produces one synthetic CALLS
+// edge per registered handler, tagged with via="dynamic_dispatch_map".
+//
+// Fixture mirrors the syncEngine.ts / syncResolvers.ts pattern from the
+// core-mobile offline-sync subsystem (issue #2553).
+func TestTSExtractor_RecordDispatch_EmitsCallsEdges(t *testing.T) {
+	src := `
+import type { SyncAction } from './types';
+
+function fnA(action: SyncAction): void {}
+function fnB(action: SyncAction): void {}
+
+const RESOLVERS: Record<string, (action: SyncAction) => void> = {
+  create_deficiency: fnA,
+  update_deficiency: fnB,
+};
+
+function processSyncQueue(action: SyncAction): void {
+  RESOLVERS[action.kind](action);
+}
+`
+	ents := extractTSDispatch(t, src)
+
+	// The dispatcher must have synthetic CALLS edges to both handlers.
+	if !hasDispatchCallEdge(ents, "processSyncQueue", "fnA") {
+		t.Errorf("expected synthetic CALLS edge processSyncQueue→fnA (dynamic_dispatch_map), got: %v", relSummary(ents, "processSyncQueue"))
+	}
+	if !hasDispatchCallEdge(ents, "processSyncQueue", "fnB") {
+		t.Errorf("expected synthetic CALLS edge processSyncQueue→fnB (dynamic_dispatch_map), got: %v", relSummary(ents, "processSyncQueue"))
+	}
+
+	// Both edges must be tagged.
+	n := countDispatchCallEdges(ents, "processSyncQueue")
+	if n != 2 {
+		t.Errorf("expected 2 dynamic_dispatch_map CALLS edges from processSyncQueue, got %d", n)
+	}
+}
+
+// TestTSExtractor_RecordDispatch_NoTypeAnnotation verifies that the heuristic
+// also fires when there is no explicit Record<> annotation but all values in
+// the object literal are plain identifier references.
+func TestTSExtractor_RecordDispatch_NoTypeAnnotation(t *testing.T) {
+	src := `
+function handlerCreate() {}
+function handlerDelete() {}
+
+const ACTIONS = {
+  create: handlerCreate,
+  delete: handlerDelete,
+};
+
+function run(kind) {
+  ACTIONS[kind]();
+}
+`
+	ents := extractTSDispatch(t, src)
+
+	if !hasDispatchCallEdge(ents, "run", "handlerCreate") {
+		t.Errorf("expected synthetic CALLS edge run→handlerCreate, got: %v", relSummary(ents, "run"))
+	}
+	if !hasDispatchCallEdge(ents, "run", "handlerDelete") {
+		t.Errorf("expected synthetic CALLS edge run→handlerDelete, got: %v", relSummary(ents, "run"))
+	}
+}
+
+// TestTSExtractor_NoDynamicEdgesForLiteralAccess verifies that a literal-key
+// subscript call RESOLVERS['create_deficiency']() resolves directly to the
+// single matching handler rather than fanning out to all handlers. The edge
+// must still carry via="dynamic_dispatch_map" for traceability.
+func TestTSExtractor_NoDynamicEdgesForLiteralAccess(t *testing.T) {
+	src := `
+function fnA(action: any): void {}
+function fnB(action: any): void {}
+
+const RESOLVERS: Record<string, (action: any) => void> = {
+  create_deficiency: fnA,
+  update_deficiency: fnB,
+};
+
+function callSpecific(action: any): void {
+  RESOLVERS['create_deficiency'](action);
+}
+`
+	ents := extractTSDispatch(t, src)
+
+	// Only fnA should be targeted (the literal-key match).
+	if !hasDispatchCallEdge(ents, "callSpecific", "fnA") {
+		t.Errorf("expected CALLS edge callSpecific→fnA for literal key, got: %v", relSummary(ents, "callSpecific"))
+	}
+	// fnB must NOT receive a CALLS edge from the literal lookup.
+	if hasDispatchCallEdge(ents, "callSpecific", "fnB") {
+		t.Errorf("did not expect CALLS edge callSpecific→fnB for literal key")
+	}
+	// Exactly one dynamic_dispatch_map edge from callSpecific.
+	n := countDispatchCallEdges(ents, "callSpecific")
+	if n != 1 {
+		t.Errorf("expected exactly 1 dynamic_dispatch_map CALLS edge from callSpecific, got %d", n)
+	}
+}
+
+// relSummary returns a compact string of the relationships on a named entity
+// for use in test failure messages.
+func relSummary(ents []types.EntityRecord, name string) string {
+	for i := range ents {
+		if ents[i].Name != name {
+			continue
+		}
+		var parts []string
+		for _, r := range ents[i].Relationships {
+			via := ""
+			if r.Properties != nil && r.Properties["via"] != "" {
+				via = "[via=" + r.Properties["via"] + "]"
+			}
+			parts = append(parts, r.Kind+"→"+r.ToID+via)
+		}
+		if len(parts) == 0 {
+			return "(no relationships)"
+		}
+		result := ""
+		for j, p := range parts {
+			if j > 0 {
+				result += ", "
+			}
+			result += p
+		}
+		return result
+	}
+	return "(entity not found)"
+}


### PR DESCRIPTION
## Summary

- Detect `const X: Record<string, Fn> = { a: fnA, b: fnB }; X[k](args)` dispatch map patterns in the JS/TS extractor
- Emit synthetic CALLS edges from the dispatch site to each registered handler, tagged `Properties["via"]="dynamic_dispatch_map"` for traceability
- Two heuristics for detection: explicit `Record<...>` type annotation OR all values being plain identifier references

## Details

**Pattern detection** (`buildDispatchMaps`, `extractor.go:2265`): Scans top-level variable declarations for object literals whose values are identifier references and/or carry a `Record<` type annotation. Populates `extractor.dispatchMaps` with `{varName → *dispatchMapInfo{handlers, byKey}}`.

**Call synthesis** (`dispatchMapCallEdges`, `extractor.go:1855`): Called from `extractCallRelationships` before `callTarget`. When the callee is a `subscript_expression` on a known dispatch-map variable:
- Dynamic index (`X[k]()`): fan out to all registered handlers
- Literal string index (`X['key']()`): resolve to single matching handler via `byKey` map

**Motivating case**: core-mobile's offline-sync subsystem — `syncEngine.ts` dispatches to `syncResolvers.ts` handlers via `syncResolvers[action.kind](action)`. Previously this orchestrator was structurally invisible in the graph.

## Test plan

- [x] `TestTSExtractor_RecordDispatch_EmitsCallsEdges` — dynamic `[k]` index fans out to all handlers with `via=dynamic_dispatch_map`
- [x] `TestTSExtractor_RecordDispatch_NoTypeAnnotation` — heuristic fires without explicit `Record<>` annotation when all values are identifiers
- [x] `TestTSExtractor_NoDynamicEdgesForLiteralAccess` — literal `['key']` index resolves only to the matching handler, not all handlers
- [x] Full `./internal/extractors/javascript/...` test suite passes (no regressions)
- [x] `gofmt`, `go vet ./...`, `go build ./...` all clean

Closes #2553

🤖 Generated with [Claude Code](https://claude.com/claude-code)