### PR TITLE
feat(extractor/ts): CALLS edges through React Query hook config object

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -1810,6 +1810,144 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 			}
 		}
 		rels = append(rels, rel)
+		// Issue #2554 — React Query / TanStack Query hook calls pass inline
+		// arrow functions as queryFn / mutationFn / onSuccess / etc. The
+		// extractor recognized the outer hook call but didn't follow into
+		// those arrow bodies — so the chain useFoo → svc.foo → callApi was
+		// broken. When the callee is a React hook (matches /^use[A-Z]/),
+		// traverse the config object's callback values and emit CALLS edges
+		// from the outer hook site to anything called inside.
+		if isReactHookCallee(x, call) {
+			hookRels := x.extractReactQueryHookCalls(call, callerName, frame, seen)
+			rels = append(rels, hookRels...)
+		}
+	}
+	return rels
+}
+
+// reactQueryConfigKeys is the set of React Query / TanStack Query config object
+// property keys whose values are callbacks (arrow functions or function
+// expressions). When the extractor encounters a call to a React hook
+// (callee matching /^use[A-Z]/) with an object-literal argument containing
+// one of these keys, it traverses the callback body to emit CALLS edges
+// from the outer hook call site. Issue #2554.
+var reactQueryConfigKeys = map[string]bool{
+	"queryFn":         true,
+	"mutationFn":      true,
+	"onSuccess":       true,
+	"onError":         true,
+	"onSettled":       true,
+	"select":          true,
+	"enabled":         true,
+	"initialData":     true,
+	"placeholderData": true,
+	"onMutate":        true,
+}
+
+// isReactHookCallee returns true when the call_expression's callee name
+// matches the React hook naming convention: starts with "use" followed by
+// an uppercase letter (e.g. useQuery, useMutation, useInspections).
+func isReactHookCallee(x *extractor, call *sitter.Node) bool {
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return false
+	}
+	var leaf string
+	switch fn.Type() {
+	case "identifier":
+		leaf = x.nodeText(fn)
+	case "member_expression":
+		if prop := fn.ChildByFieldName("property"); prop != nil {
+			leaf = x.nodeText(prop)
+		}
+	}
+	return len(leaf) > 3 && strings.HasPrefix(leaf, "use") && leaf[3] >= 'A' && leaf[3] <= 'Z'
+}
+
+// extractReactQueryHookCalls looks into the arguments of a React hook call_expression
+// for any object-literal with React Query config keys (queryFn, mutationFn, etc.).
+// For each such key whose value is an arrow_function or function_expression,
+// it emits CALLS edges from callerName to every call inside the callback body,
+// marking them with Properties["via"]="react_query_hook". Issue #2554.
+func (x *extractor) extractReactQueryHookCalls(call *sitter.Node, callerName string, frame *classBindings, seen map[string]bool) []types.RelationshipRecord {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return nil
+	}
+	var rels []types.RelationshipRecord
+	// Walk argument list for object expressions.
+	for i := 0; i < int(args.ChildCount()); i++ {
+		arg := args.Child(i)
+		if arg == nil {
+			continue
+		}
+		nodeType := arg.Type()
+		if nodeType != "object" && nodeType != "object_expression" {
+			continue
+		}
+		// Scan object properties for React Query config keys.
+		for j := 0; j < int(arg.ChildCount()); j++ {
+			prop := arg.Child(j)
+			if prop == nil {
+				continue
+			}
+			propType := prop.Type()
+			if propType != "pair" && propType != "property" && propType != "method_definition" {
+				continue
+			}
+			keyNode := prop.ChildByFieldName("key")
+			if keyNode == nil {
+				continue
+			}
+			key := x.nodeText(keyNode)
+			if !reactQueryConfigKeys[key] {
+				continue
+			}
+			// Found a React Query config key. Get the value node.
+			valNode := prop.ChildByFieldName("value")
+			if valNode == nil {
+				continue
+			}
+			// Unwrap parenthesized expressions.
+			if valNode.Type() == "parenthesized_expression" && valNode.ChildCount() > 0 {
+				valNode = valNode.Child(1)
+			}
+			// Only traverse arrow_function and function_expression values.
+			var callbackBody *sitter.Node
+			switch valNode.Type() {
+			case "arrow_function":
+				callbackBody = valNode.ChildByFieldName("body")
+			case "function", "function_expression":
+				callbackBody = valNode.ChildByFieldName("body")
+			default:
+				continue
+			}
+			if callbackBody == nil {
+				continue
+			}
+			// Extract all calls inside the callback body.
+			innerCalls := findAllNodes(callbackBody, "call_expression", "new_expression")
+			for _, ic := range innerCalls {
+				target := x.callTarget(ic, frame)
+				if target == "" || target == "require" {
+					continue
+				}
+				if !strings.Contains(target, ":") && target == callerName {
+					continue
+				}
+				if seen[target] {
+					continue
+				}
+				seen[target] = true
+				rels = append(rels, types.RelationshipRecord{
+					ToID: target,
+					Kind: "CALLS",
+					Properties: map[string]string{
+						"via": "react_query_hook",
+					},
+				})
+			}
+		}
 	}
 	return rels
 }

--- a/internal/extractors/javascript/issue2554_react_query_test.go
+++ b/internal/extractors/javascript/issue2554_react_query_test.go
@@ -1,0 +1,136 @@
+// Package javascript_test — issue #2554: React Query hook bodies must emit
+// CALLS edges through inline arrow-function config values (queryFn, mutationFn,
+// onSuccess, onError, etc.).
+//
+// The outer hook call (e.g. useQuery / useMutation) is already recognized.
+// What was missing is following into the arrow-function values of the config
+// object to emit CALLS from the outer hook entity to inner service/API calls.
+package javascript_test
+
+import (
+	"testing"
+)
+
+// TestTSExtractor_ReactQueryHook_FollowsArrowBody verifies that a useQuery
+// call whose queryFn is an inline arrow function emits a CALLS edge from the
+// outer hook entity to the inner service call. Edge must carry
+// Properties["via"]="react_query_hook". Issue #2554.
+func TestTSExtractor_ReactQueryHook_FollowsArrowBody(t *testing.T) {
+	src := `
+import { useQuery } from "@tanstack/react-query";
+import { inspectionsService } from "./inspectionsService";
+
+const useInspections = () => useQuery({
+  queryKey: ['inspections'],
+  queryFn: () => inspectionsService.getAll(),
+});
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	// Outer hook entity must exist.
+	if findByNameRel(ents, "useInspections") == nil {
+		t.Fatal("expected entity 'useInspections' to be emitted")
+	}
+
+	// Must emit CALLS from useInspections to getAll (the inner service call).
+	if !hasRelEdge(ents, "useInspections", "CALLS", "getAll") {
+		// Dump edges for debugging.
+		e := findByNameRel(ents, "useInspections")
+		if e != nil {
+			t.Logf("useInspections relationships:")
+			for _, r := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+		t.Errorf("expected CALLS useInspections→getAll (via react_query_hook), not found")
+	}
+
+	// Verify via property is set.
+	e := findByNameRel(ents, "useInspections")
+	if e != nil {
+		found := false
+		for _, r := range e.Relationships {
+			if r.Kind == "CALLS" && r.ToID == "getAll" {
+				if r.Properties != nil && r.Properties["via"] == "react_query_hook" {
+					found = true
+				} else {
+					t.Errorf("CALLS useInspections→getAll missing Properties[via]=react_query_hook; got %v", r.Properties)
+				}
+			}
+		}
+		if !found {
+			// edge not found — already reported above
+		}
+	}
+}
+
+// TestTSExtractor_ReactMutation_FollowsArrowBody verifies that a useMutation
+// call whose mutationFn is an inline arrow function emits a CALLS edge from
+// the outer hook entity to the inner mutation call. Issue #2554.
+func TestTSExtractor_ReactMutation_FollowsArrowBody(t *testing.T) {
+	src := `
+import { useMutation } from "@tanstack/react-query";
+import { inspectionsService } from "./inspectionsService";
+
+const useCreateInspection = () => useMutation({
+  mutationFn: (data) => inspectionsService.create(data),
+  onSuccess: () => queryClient.invalidateQueries(['inspections']),
+  onError: (err) => console.error(err),
+});
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if findByNameRel(ents, "useCreateInspection") == nil {
+		t.Fatal("expected entity 'useCreateInspection' to be emitted")
+	}
+
+	// Must emit CALLS from useCreateInspection to create (mutationFn body).
+	if !hasRelEdge(ents, "useCreateInspection", "CALLS", "create") {
+		e := findByNameRel(ents, "useCreateInspection")
+		if e != nil {
+			t.Logf("useCreateInspection relationships:")
+			for _, r := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+		t.Errorf("expected CALLS useCreateInspection→create (via mutationFn), not found")
+	}
+
+	// Must also emit CALLS for onSuccess body (invalidateQueries).
+	if !hasRelEdge(ents, "useCreateInspection", "CALLS", "invalidateQueries") {
+		t.Errorf("expected CALLS useCreateInspection→invalidateQueries (via onSuccess), not found")
+	}
+}
+
+// TestTSExtractor_NonReactHookNotTraversed verifies that a plain non-hook
+// call expression (useState) with a non-React-Query argument does NOT trigger
+// the config-object traversal. Issue #2554 — the fix must not over-emit.
+func TestTSExtractor_NonReactHookNotTraversed(t *testing.T) {
+	src := `
+import { useState } from "react";
+
+const useCounter = () => {
+  const [count, setCount] = useState(0);
+  return { count, setCount };
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if findByNameRel(ents, "useCounter") == nil {
+		t.Fatal("expected entity 'useCounter' to be emitted")
+	}
+
+	// useState(0) has no object-literal config with React Query keys.
+	// No CALLS with via=react_query_hook should appear.
+	e := findByNameRel(ents, "useCounter")
+	if e != nil {
+		for _, r := range e.Relationships {
+			if r.Kind == "CALLS" && r.Properties != nil && r.Properties["via"] == "react_query_hook" {
+				t.Errorf("unexpected CALLS with via=react_query_hook on plain useState; got %s→%s", "useCounter", r.ToID)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes the broken `useHook → svc.method → callApi` CALLS chain for React Query / TanStack Query hooks
- When a callee matches `/^use[A-Z]/` and its first argument is an object literal containing React Query config keys (`queryFn`, `mutationFn`, `onSuccess`, `onError`, `onSettled`, `select`, `enabled`, etc.), the extractor now traverses the arrow-function values and emits CALLS edges from the outer hook entity to any calls inside
- Edges are marked with `Properties["via"]="react_query_hook"` for downstream filtering/debugging

**This is half-1 of #2554 (extractor fix only). The companion MCP-side scope-isolation fix is deferred to a follow-up PR after #2550 perf agent lands.**

## Test plan

- [x] `TestTSExtractor_ReactQueryHook_FollowsArrowBody` — `useQuery({ queryFn: () => svc.getAll() })` emits CALLS from outer hook to `getAll` with `via=react_query_hook`
- [x] `TestTSExtractor_ReactMutation_FollowsArrowBody` — `useMutation({ mutationFn, onSuccess, onError })` emits CALLS to inner service calls
- [x] `TestTSExtractor_NonReactHookNotTraversed` — `useState(0)` with no config-object does NOT trigger the traversal
- [x] Full existing test suite: `go test ./internal/extractors/javascript/... -count=1` PASS
- [x] `gofmt -l` empty, `go vet ./...` clean, `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)