### PR TITLE
fix(engine/tests): TESTS multi-hop now actually produces edges (#2570)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1042,7 +1042,24 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		}
 		reader := func(p string) []byte { return contentByPath[p] }
 
-		testsEdges := engine.ApplyTestsMultiHopViaHTTP(allPaths, reader, pass2Rels)
+		// #2570 — supplement pass2Rels with synthetic ROUTES_TO records
+		// derived from http_endpoint entities in pass3Records.  When the app
+		// separates router.register() and include(router.urls) into different
+		// files (upvate pattern), applyDjangoRouteComposition never fires in
+		// same-file mode and no composed ROUTES_TO land in pass2Rels.  The
+		// entities emitted by ApplyDjangoDRFRoutes carry path+source_handler
+		// properties that let us reconstruct equivalent ROUTES_TO records here.
+		endpointRoutesTo := engine.SynthesiseRoutesToFromEndpoints(
+			concatRecords(pass2Records, pass3Records),
+		)
+		routesForTests := pass2Rels
+		if len(endpointRoutesTo) > 0 {
+			routesForTests = make([]types.RelationshipRecord, len(pass2Rels)+len(endpointRoutesTo))
+			copy(routesForTests, pass2Rels)
+			copy(routesForTests[len(pass2Rels):], endpointRoutesTo)
+		}
+
+		testsEdges := engine.ApplyTestsMultiHopViaHTTP(allPaths, reader, routesForTests)
 		if len(testsEdges) > 0 {
 			fmt.Fprintf(os.Stderr, "archigraph: tests_multi_hop_http=%d edges\n", len(testsEdges))
 			pass2Rels = append(pass2Rels, testsEdges...)

--- a/internal/engine/tests_edges.go
+++ b/internal/engine/tests_edges.go
@@ -288,3 +288,74 @@ func enclosingPyTestFunc(src string, pos int) string {
 	}
 	return matches[len(matches)-1][1]
 }
+
+// ---------------------------------------------------------------------------
+// Synthetic ROUTES_TO from http_endpoint entities (#2570)
+// ---------------------------------------------------------------------------
+
+// SynthesiseRoutesToFromEndpoints builds synthetic ROUTES_TO RelationshipRecords
+// from http_endpoint entity records emitted by ApplyDjangoDRFRoutes and
+// ApplyDjangoNestedURLConf.  These entity records carry routing metadata in
+// their Properties map but do NOT produce standalone RelationshipRecord entries
+// — they live in pass3Records, not pass2Rels.
+//
+// Pass 2.8 (ApplyTestsMultiHopViaHTTP) needs ROUTES_TO in pass2Rels to build
+// its route index.  When the application separates router.register() calls and
+// include(router.urls) into different files (upvate pattern: routers.py +
+// urls.py), applyDjangoRouteComposition never fires in same-file mode and the
+// composed ROUTES_TO edges are never added to pass2Rels — leaving the route
+// index empty and producing zero TESTS edges.
+//
+// This function reconstructs synthetic ROUTES_TO records from two entity
+// property conventions:
+//
+//  1. drf_router_expanded entities: Kind==http_endpoint_synthesis,
+//     Properties["path"] = "/api/v1/schedule",
+//     Properties["source_handler"] = "SCOPE.Operation:ScheduleViewset.create"
+//     → emits http:<VERB>:<path> -ROUTES_TO-> SCOPE.Operation:<ViewSet.method>
+//
+//  2. urlconf_nested_include entities: Kind==http_endpoint_synthesis,
+//     Properties["path"] = "/api/v1/schedule",
+//     Properties["source_handler"] = "Controller:schedule_view"  (FBV)
+//     → emits http:ANY:<path> -ROUTES_TO-> Controller:<handler>
+//
+// Only entities where both "path" and "source_handler" are non-empty are
+// processed; catch-all (ANY-verb, no single handler) entities are skipped.
+//
+// The returned records are append-only and intended to be merged into
+// pass2Rels before calling ApplyTestsMultiHopViaHTTP.
+func SynthesiseRoutesToFromEndpoints(entityRecords []types.EntityRecord) []types.RelationshipRecord {
+	const httpEndpointKind = "http_endpoint_synthesis"
+	var out []types.RelationshipRecord
+	seen := map[string]bool{}
+	for _, e := range entityRecords {
+		if e.Kind != httpEndpointKind {
+			continue
+		}
+		path := e.Properties["path"]
+		handler := e.Properties["source_handler"]
+		if path == "" || handler == "" {
+			continue
+		}
+		verb := e.Properties["verb"]
+		if verb == "" {
+			verb = "ANY"
+		}
+		fromID := "http:" + strings.ToUpper(verb) + ":" + path
+		key := fromID + "|" + handler
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, types.RelationshipRecord{
+			FromID: fromID,
+			ToID:   handler,
+			Kind:   string(types.RelationshipKindRoutesTo),
+			Properties: map[string]string{
+				"pattern_type": "synthesised_from_endpoint",
+				"framework":    "django",
+			},
+		})
+	}
+	return out
+}

--- a/internal/engine/tests_edges_test.go
+++ b/internal/engine/tests_edges_test.go
@@ -273,6 +273,179 @@ func TestApplyTestsMultiHop_EmptyRoutes(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// TestSynthesiseRoutesToFromEndpoints (#2570)
+//
+// Verifies that SynthesiseRoutesToFromEndpoints converts http_endpoint entities
+// (emitted by ApplyDjangoDRFRoutes) into ROUTES_TO RelationshipRecords that
+// buildRoutesToIndex can consume, enabling Pass 2.8 to produce TESTS edges
+// on repositories like upvate that keep router.register() and include() in
+// separate files.
+// ---------------------------------------------------------------------------
+
+func TestSynthesiseRoutesToFromEndpoints_DRFPattern(t *testing.T) {
+	// Simulate entities from ApplyDjangoDRFRoutes for a ScheduleViewset.
+	entities := []types.EntityRecord{
+		{
+			Kind: "http_endpoint_synthesis",
+			Properties: map[string]string{
+				"verb":            "POST",
+				"path":            "/api/v1/schedule",
+				"source_handler":  "SCOPE.Operation:ScheduleViewset.create",
+				"drf_view_method": "ScheduleViewset.create",
+				"pattern_type":    "drf_router_expanded",
+				"framework":       "django",
+			},
+		},
+		{
+			Kind: "http_endpoint_synthesis",
+			Properties: map[string]string{
+				"verb":            "GET",
+				"path":            "/api/v1/schedule",
+				"source_handler":  "SCOPE.Operation:ScheduleViewset.list",
+				"drf_view_method": "ScheduleViewset.list",
+				"pattern_type":    "drf_router_expanded",
+				"framework":       "django",
+			},
+		},
+		// ANY catch-all — no source_handler; must be skipped.
+		{
+			Kind: "http_endpoint_synthesis",
+			Properties: map[string]string{
+				"verb":         "ANY",
+				"path":         "/api/v1/schedule/{id}",
+				"pattern_type": "drf_router_expanded",
+				"framework":    "django",
+			},
+		},
+		// Non-endpoint entity — must be ignored.
+		{
+			Kind: "SCOPE.Operation",
+			Properties: map[string]string{
+				"path": "/api/v1/schedule",
+			},
+		},
+	}
+
+	rels := SynthesiseRoutesToFromEndpoints(entities)
+
+	if len(rels) != 2 {
+		t.Fatalf("expected 2 ROUTES_TO records (POST + GET), got %d: %+v", len(rels), rels)
+	}
+	for _, r := range rels {
+		if r.Kind != "ROUTES_TO" {
+			t.Errorf("expected Kind=ROUTES_TO, got %q", r.Kind)
+		}
+	}
+
+	// Verify the POST record.
+	var foundPost bool
+	for _, r := range rels {
+		if r.FromID == "http:POST:/api/v1/schedule" && r.ToID == "SCOPE.Operation:ScheduleViewset.create" {
+			foundPost = true
+		}
+	}
+	if !foundPost {
+		t.Errorf("expected POST ROUTES_TO for ScheduleViewset.create; got %+v", rels)
+	}
+}
+
+// TestSynthesiseRoutesToFromEndpoints_Dedup verifies that duplicate (fromID, toID)
+// pairs are deduplicated even when the same endpoint entity appears twice
+// (e.g. from both pass2Records and pass3Records being merged via concatRecords).
+func TestSynthesiseRoutesToFromEndpoints_Dedup(t *testing.T) {
+	e := types.EntityRecord{
+		Kind: "http_endpoint_synthesis",
+		Properties: map[string]string{
+			"verb":           "POST",
+			"path":           "/api/v1/import",
+			"source_handler": "SCOPE.Operation:ImportViewSet.create",
+			"pattern_type":   "drf_router_expanded",
+		},
+	}
+	rels := SynthesiseRoutesToFromEndpoints([]types.EntityRecord{e, e, e})
+	if len(rels) != 1 {
+		t.Errorf("expected exactly 1 deduplicated ROUTES_TO record, got %d: %+v", len(rels), rels)
+	}
+}
+
+// TestSynthesiseRoutesToFromEndpoints_EmptyInput ensures the function is a
+// no-op when given an empty or nil slice.
+func TestSynthesiseRoutesToFromEndpoints_EmptyInput(t *testing.T) {
+	if rels := SynthesiseRoutesToFromEndpoints(nil); len(rels) != 0 {
+		t.Errorf("nil input must return empty; got %d records", len(rels))
+	}
+	if rels := SynthesiseRoutesToFromEndpoints([]types.EntityRecord{}); len(rels) != 0 {
+		t.Errorf("empty input must return empty; got %d records", len(rels))
+	}
+}
+
+// TestMultiHop_UpvatePattern is an integration-style test that simulates the
+// full Pass 2.8 flow for a repository like upvate: router.register() and
+// include() in separate files, so pass2Rels has zero ROUTES_TO but
+// pass3Records contains http_endpoint entities from ApplyDjangoDRFRoutes.
+//
+// The test verifies that when SynthesiseRoutesToFromEndpoints output is merged
+// into the routesToRels argument, ApplyTestsMultiHopViaHTTP produces TESTS
+// edges for a Django TestCase class method calling self.client.post(...).
+func TestMultiHop_UpvatePattern(t *testing.T) {
+	// Simulate the http_endpoint entity emitted by ApplyDjangoDRFRoutes.
+	drfEndpointEntities := []types.EntityRecord{
+		{
+			Kind: "http_endpoint_synthesis",
+			Properties: map[string]string{
+				"verb":            "POST",
+				"path":            "/api/v1/import",
+				"source_handler":  "SCOPE.Operation:ImportViewSet.create",
+				"drf_view_method": "ImportViewSet.create",
+				"pattern_type":    "drf_router_expanded",
+				"framework":       "django",
+			},
+		},
+	}
+
+	// Simulate a Django TestCase test method calling self.client.post('/api/v1/import').
+	const upvateTestSrc = `import io
+from rest_framework.test import APIClient, APITestCase
+
+class ImportCSVTest(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_import_csv_returns_200(self):
+        response = self.client.post('/api/v1/import', data={}, format='json')
+        self.assertEqual(response.status_code, 200)
+`
+
+	paths := []string{"core/tests/test_schedule_import.py"}
+	content := map[string][]byte{
+		"core/tests/test_schedule_import.py": []byte(upvateTestSrc),
+	}
+	reader := func(p string) []byte { return content[p] }
+
+	// Simulate what index.go Pass 2.8 now does: synthesise ROUTES_TO from
+	// endpoint entities and merge with pass2Rels (empty for upvate pattern).
+	synthesised := SynthesiseRoutesToFromEndpoints(drfEndpointEntities)
+	if len(synthesised) == 0 {
+		t.Fatal("SynthesiseRoutesToFromEndpoints returned empty — test setup is wrong")
+	}
+
+	edges := ApplyTestsMultiHopViaHTTP(paths, reader, synthesised)
+
+	var found bool
+	for _, e := range edges {
+		if e.ToID == "SCOPE.Operation:ImportViewSet.create" &&
+			e.Properties["test_function"] == "test_import_csv_returns_200" &&
+			e.Properties["via"] == "http_router" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected TESTS edge from test_import_csv_returns_200 to ImportViewSet.create; got %+v", edges)
+	}
+}
+
 // TestTestsEdges_PathPrefixFallback verifies that a test calling a detail URL
 // (/api/v1/foo/42) is matched against the collection route (/api/v1/foo) when
 // no exact entry exists in the ROUTES_TO index.


### PR DESCRIPTION
Closes #2570

Bench iter 2 confirmed PR #2559 wiring landed but TESTS coverage stayed at 0.16% — no edges produced on real upvate data.

## Root cause (hypothesis 2 confirmed)
`pass2Rels` contains ZERO ROUTES_TO for upvate because:
- YAML rules emit `Route:<bare>` → `View:<ViewSet>` per-file from core/routers.py
- `suppressGlobalDRFOrphans` deletes those edges (they're meant to be composed-prefix replacements)
- Composed replacement only fires when `include(router.urls)` + `router.register()` are in the SAME file — upvate splits them
- `ApplyDjangoDRFRoutes` + `ApplyDjangoNestedURLConf` emit `http_endpoint_synthesis` entities into `pass3Records` but those are entities NOT RelationshipRecord, so `buildRoutesToIndex` never sees them

## Fix
- `engine/tests_edges.go:293-358` — new `SynthesiseRoutesToFromEndpoints` converts http_endpoint_synthesis entities into synthetic ROUTES_TO records
- `cmd/archigraph/index.go:1043-1058` — Pass 2.8 calls SynthesiseRoutesToFromEndpoints on concatRecords(pass2, pass3) before ApplyTestsMultiHopViaHTTP

## Tests (4 new, all pass)
- TestSynthesiseRoutesToFromEndpoints_DRFPattern
- TestSynthesiseRoutesToFromEndpoints_Dedup
- TestSynthesiseRoutesToFromEndpoints_EmptyInput
- TestMultiHop_UpvatePattern (integration — Django TestCase pattern)

## Tech debt
ApplyDjangoNestedURLConf doesn't set source_handler for DRF router.register routes — followup needed for endpoints registered via urlconf_nested_include without drf_router_expanded companion.