### PR TITLE
feat(extractor/js): synthesize baseUrl fallback for bare imports (#2576)

### DIFF
--- a/internal/extractors/javascript/aliases.go
+++ b/internal/extractors/javascript/aliases.go
@@ -105,8 +105,18 @@ type aliasEntry struct {
 // AliasMap is the per-repository merged alias table. Lookups are
 // resolved by iterating entries longest-prefix first so `@/components`
 // wins over `@` when both are declared.
+//
+// BaseURL (#2576): when tsconfig has a baseUrl but no paths{} declarations,
+// BaseURL holds the repo-relative base directory (e.g. "src"). Callers
+// that need filesystem-validated resolution can check BaseURL after a
+// ResolveAll miss to resolve bare imports relative to that directory.
 type AliasMap struct {
 	entries []aliasEntry
+	// BaseURL is the repo-relative path of tsconfig compilerOptions.baseUrl
+	// when the tsconfig has no paths{} entries. Empty when paths{} are
+	// declared (paths take precedence and the baseUrl-only fallback is not
+	// needed) or when no tsconfig is present.
+	BaseURL string
 }
 
 // Resolve returns the repo-relative POSIX path the import specifier
@@ -244,14 +254,55 @@ func LoadAliasMap(repoRoot string) AliasMap {
 		return AliasMap{}
 	}
 	var entries []aliasEntry
-	entries = append(entries, parseTsconfigPaths(repoRoot)...)
+	tsEntries := parseTsconfigPaths(repoRoot)
+	entries = append(entries, tsEntries...)
 	entries = append(entries, parseViteAliases(repoRoot)...)
 	entries = append(entries, parseWebpackAliases(repoRoot)...)
 	entries = append(entries, parseMetroAliases(repoRoot)...)
 	entries = append(entries, parseBabelAliases(repoRoot)...)
 	// Sort by descending prefix length so longest match wins.
 	sortByPrefixLen(entries)
-	return AliasMap{entries: dedupAliasEntries(entries)}
+
+	// Synthetic baseUrl fallback (#2576): when tsconfig has baseUrl but no
+	// paths{} declarations, record BaseURL on the map so callers can resolve
+	// bare imports relative to baseUrl with an on-disk existence check.
+	// This is intentionally NOT added to entries so that npm package imports
+	// that happen to share a name (e.g. "react") are not misclassified when
+	// no matching file exists under baseUrl.
+	var baseURL string
+	if len(tsEntries) == 0 {
+		baseURL = parseTsconfigBaseURL(repoRoot)
+	}
+
+	return AliasMap{entries: dedupAliasEntries(entries), BaseURL: baseURL}
+}
+
+// parseTsconfigBaseURL reads the tsconfig.json / jsconfig.json at configDir
+// and returns the repo-relative baseUrl value, or "" when none is set or
+// the file cannot be parsed. Used by LoadAliasMap to populate AliasMap.BaseURL
+// when no paths{} entries are present.
+func parseTsconfigBaseURL(configDir string) string {
+	for _, name := range []string{"tsconfig.json", "jsconfig.json"} {
+		configPath := filepath.Join(configDir, name)
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			continue
+		}
+		cleaned := stripJSONComments(data)
+		var raw struct {
+			CompilerOptions struct {
+				BaseURL string `json:"baseUrl"`
+			} `json:"compilerOptions"`
+		}
+		if err := json.Unmarshal(cleaned, &raw); err != nil {
+			continue
+		}
+		bu := strings.TrimPrefix(strings.TrimPrefix(raw.CompilerOptions.BaseURL, "./"), "/")
+		if bu != "" && bu != "." {
+			return bu
+		}
+	}
+	return ""
 }
 
 // loadSubdirAliasMap parses configs found under a specific subdirectory
@@ -535,6 +586,7 @@ func parseTsconfigPathsBytesWithDir(data []byte, configDir string, depth int) []
 		}
 		out = append(out, entry)
 	}
+
 	return out
 }
 

--- a/internal/extractors/javascript/imports.go
+++ b/internal/extractors/javascript/imports.go
@@ -240,6 +240,17 @@ func (x *extractor) collectFromImportStatement(n *sitter.Node, out *[]importBind
 			// external-synth (external-unknown) — honest disposition and
 			// keeps RN/Expo bug-extractor counts off the floor.
 			aliasResolved = exists
+		} else if x.aliases.BaseURL != "" && x.repoRoot != "" {
+			// Synthetic baseUrl fallback (#2576): when tsconfig has baseUrl
+			// but no paths{}, resolve bare imports relative to baseUrl only
+			// when the candidate file actually exists on disk. npm package
+			// imports (e.g. "react") that have no matching file under baseUrl
+			// are left unresolved here and fall through to external treatment.
+			candidate := x.aliases.BaseURL + "/" + source
+			if found := firstExistingJSPath(x.repoRoot, candidate); found != "" {
+				resolved = found
+				aliasResolved = true
+			}
 		}
 	}
 	dotted := source // default: npm spec verbatim (slashes become dots below)

--- a/internal/extractors/javascript/tsconfig_paths_test.go
+++ b/internal/extractors/javascript/tsconfig_paths_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -216,6 +217,179 @@ func TestTSExtractor_TsconfigAbsent_NoChange(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected IMPORTS edge for './utils' (or resolved form); got %v", paths)
+	}
+}
+
+// TestTSExtractor_TsconfigBaseUrlOnly_ResolvesBareImport verifies that when
+// tsconfig has only baseUrl (no paths{}), a bare import that resolves to an
+// existing file under baseUrl is resolved to that file's repo-relative path.
+//
+// Fixture layout:
+//
+//	<tmpdir>/
+//	  tsconfig.json        — baseUrl: "./src" (no paths)
+//	  src/shared/Foo.ts    — target file
+//	  src/main.ts          — source file under test
+func TestTSExtractor_TsconfigBaseUrlOnly_ResolvesBareImport(t *testing.T) {
+	resetAliasMapCache()
+	dir := t.TempDir()
+
+	writeTsconfigAliasFile(t, dir, `{
+		"compilerOptions": {
+			"baseUrl": "./src"
+		}
+	}`)
+
+	sharedDir := filepath.Join(dir, "src", "shared")
+	if err := os.MkdirAll(sharedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writePlainFile(t, sharedDir, "Foo.ts", `export class Foo {}`)
+
+	// AliasMap.BaseURL should be populated and Resolve should not hit the path.
+	m := LoadAliasMap(dir)
+	if m.BaseURL != "src" {
+		t.Errorf("expected AliasMap.BaseURL == %q, got %q", "src", m.BaseURL)
+	}
+	if got := m.Resolve("shared/Foo"); got != "" {
+		t.Errorf("Resolve via alias table should miss for baseUrl-only tsconfig; got %q", got)
+	}
+
+	// End-to-end extraction: 'shared/Foo' must resolve to src/shared/Foo.ts.
+	src := []byte(`import { Foo } from 'shared/Foo';`)
+	tree := parseTSForAlias(t, src)
+	entities := extractWithRepo(t, dir, "src/main.ts", src, tree)
+
+	paths := importsEdgePaths2572(entities)
+	if len(paths) == 0 {
+		t.Fatal("no IMPORTS edges emitted")
+	}
+	if !paths["shared/Foo"] {
+		t.Errorf("expected IMPORTS edge with import_path 'shared/Foo'; got: %v", paths)
+	}
+	// The resolved file path must appear in the edges (either as a
+	// repo-relative file path or as a dotted-module ToID) confirming that the
+	// baseUrl fallback resolved the import to a project-internal target.
+	// When aliasResolved=true the ToID is "<dotted>.<importedName>" so we
+	// look for any path containing "src" and "shared" and "Foo".
+	found := false
+	for p := range paths {
+		if (strings.Contains(p, "src") && strings.Contains(p, "shared") && strings.Contains(p, "Foo")) ||
+			p == "src/shared/Foo.ts" || p == "src/shared/Foo" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a resolved edge pointing to src/shared/Foo*; got: %v", paths)
+	}
+}
+
+// TestTSExtractor_TsconfigBaseUrlOnly_FallsThroughForExternal verifies that
+// when tsconfig has only baseUrl and a bare import like 'react' has no
+// corresponding file under baseUrl, the import is treated as an external npm
+// spec (not misclassified as a project-internal import).
+//
+// Fixture layout:
+//
+//	<tmpdir>/
+//	  tsconfig.json  — baseUrl: "./src" (no paths)
+//	  src/main.ts    — source file under test
+//	  (no src/react file — react is npm-only)
+func TestTSExtractor_TsconfigBaseUrlOnly_FallsThroughForExternal(t *testing.T) {
+	resetAliasMapCache()
+	dir := t.TempDir()
+
+	writeTsconfigAliasFile(t, dir, `{
+		"compilerOptions": {
+			"baseUrl": "./src"
+		}
+	}`)
+
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// No src/react file — react is an npm package.
+	src := []byte(`import React from 'react';`)
+	tree := parseTSForAlias(t, src)
+	entities := extractWithRepo(t, dir, "src/main.ts", src, tree)
+
+	paths := importsEdgePaths2572(entities)
+	if len(paths) == 0 {
+		t.Fatal("no IMPORTS edges emitted; 'react' must still produce an IMPORTS edge")
+	}
+	// The import_path must be the raw 'react' spec.
+	if !paths["react"] {
+		t.Errorf("expected IMPORTS edge with import_path 'react'; got: %v", paths)
+	}
+	// No resolved-path form (src/react*) should appear — that would indicate
+	// the baseUrl wildcard incorrectly swallowed an external npm import.
+	for p := range paths {
+		if strings.HasPrefix(p, "src/react") || strings.HasPrefix(p, "src.react") {
+			t.Errorf("'react' must not resolve via baseUrl; got spurious edge: %q", p)
+		}
+	}
+}
+
+// TestTSExtractor_TsconfigBaseUrlAndPaths_PathsWins verifies that when
+// tsconfig has both baseUrl and paths{}, the explicit paths{} entries take
+// precedence over the baseUrl wildcard fallback and AliasMap.BaseURL is
+// empty (the fallback is not needed when paths are present).
+//
+// Fixture layout:
+//
+//	<tmpdir>/
+//	  tsconfig.json               — baseUrl: ".", paths: {"@/*": ["src/*"]}
+//	  src/components/Btn.ts       — paths alias target
+//	  src/shared/Foo.ts           — would match baseUrl but paths takes precedence
+//	  src/App.ts                  — source file under test
+func TestTSExtractor_TsconfigBaseUrlAndPaths_PathsWins(t *testing.T) {
+	resetAliasMapCache()
+	dir := t.TempDir()
+
+	writeTsconfigAliasFile(t, dir, `{
+		"compilerOptions": {
+			"baseUrl": ".",
+			"paths": {
+				"@/*": ["src/*"]
+			}
+		}
+	}`)
+
+	// Create both target directories.
+	compDir := filepath.Join(dir, "src", "components")
+	if err := os.MkdirAll(compDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writePlainFile(t, compDir, "Btn.ts", `export function Btn() {}`)
+
+	sharedDir := filepath.Join(dir, "src", "shared")
+	if err := os.MkdirAll(sharedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writePlainFile(t, sharedDir, "Foo.ts", `export class Foo {}`)
+
+	// AliasMap.BaseURL must be empty when paths{} are present.
+	m := LoadAliasMap(dir)
+	if m.BaseURL != "" {
+		t.Errorf("expected AliasMap.BaseURL == %q when paths are declared, got %q", "", m.BaseURL)
+	}
+
+	// The @/* alias must resolve correctly via paths{}.
+	if got := m.Resolve("@/components/Btn"); got != "src/components/Btn" {
+		t.Errorf("Resolve(@/components/Btn) = %q, want %q", got, "src/components/Btn")
+	}
+
+	// End-to-end: @/components/Btn import uses paths alias, not baseUrl.
+	src := []byte(`import { Btn } from '@/components/Btn';`)
+	tree := parseTSForAlias(t, src)
+	entities := extractWithRepo(t, dir, "src/App.ts", src, tree)
+
+	paths := importsEdgePaths2572(entities)
+	if !paths["@/components/Btn"] {
+		t.Errorf("expected IMPORTS edge with import_path '@/components/Btn'; got: %v", paths)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `AliasMap.BaseURL` field populated from tsconfig `compilerOptions.baseUrl` when no `paths{}` entries are present
- In `collectFromImportStatement`, after an alias-table miss, resolves bare imports relative to `BaseURL` **only when the candidate file exists on disk** — npm packages (e.g. `react`) that have no file under baseUrl fall through to external treatment unchanged
- Backward compatible: when `paths{}` are declared, `BaseURL` is empty and the new code path is never reached

## Test plan

- [ ] `TestTSExtractor_TsconfigBaseUrlOnly_ResolvesBareImport` — `baseUrl: "./src"`, no paths; `import { Foo } from 'shared/Foo'` resolves to `src/shared/Foo.ts` (PASS)
- [ ] `TestTSExtractor_TsconfigBaseUrlOnly_FallsThroughForExternal` — same tsconfig; `import React from 'react'` stays as external, no `src/react*` edges (PASS)
- [ ] `TestTSExtractor_TsconfigBaseUrlAndPaths_PathsWins` — both `baseUrl` and `paths{}`; `AliasMap.BaseURL` is empty, paths entries resolve correctly (PASS)
- [ ] Full `go test ./internal/extractors/javascript/... -count=1` — all 40+ tests PASS

Closes #2576

🤖 Generated with [Claude Code](https://claude.com/claude-code)