### PR TITLE
feat(extractor/ts): dispatch maps with inline arrows + exported objects (#2565)

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -2452,6 +2452,7 @@ func (x *extractor) buildDispatchMaps(root *sitter.Node) map[string]*dispatchMap
 			var handlers []string
 			byKey := make(map[string]string)
 			allIdentifiers := true
+			hasInlineArrows := false
 			for k := 0; k < int(valueNode.ChildCount()); k++ {
 				pair := valueNode.Child(k)
 				if pair == nil {
@@ -2477,8 +2478,27 @@ func (x *extractor) buildDispatchMaps(root *sitter.Node) map[string]*dispatchMap
 						keyText = strings.Trim(keyText, `"'`+"`")
 						byKey[keyText] = handler
 					}
+				} else if valNode.Type() == "arrow_function" || valNode.Type() == "function_expression" {
+					// Gap (1) — inline arrow/function handler: `{ foo: () => svc.foo() }`.
+					// Extract the call targets from the function body so that
+					// X[k]() fans out to the actual callee rather than a synthetic name.
+					// Issue #2565.
+					innerTargets := x.callTargetsInFunctionNode(valNode)
+					if len(innerTargets) > 0 {
+						handlers = append(handlers, innerTargets...)
+						hasInlineArrows = true
+						if keyNode != nil {
+							keyText := x.nodeText(keyNode)
+							keyText = strings.Trim(keyText, `"'`+"`")
+							// For literal-key resolution, map the key to the first
+							// (and most common) inner call target.
+							byKey[keyText] = innerTargets[0]
+						}
+					}
+					// Inline function value — not a pure identifier reference map.
+					allIdentifiers = false
 				} else {
-					// Value is a function literal or something else — not
+					// Value is something else (primitive, object, etc.) — not
 					// a pure reference map. Still count the entry for
 					// Record-annotated maps; otherwise disqualify.
 					allIdentifiers = false
@@ -2489,8 +2509,10 @@ func (x *extractor) buildDispatchMaps(root *sitter.Node) map[string]*dispatchMap
 			}
 			// Accept when the type annotation is Record<...> OR when all
 			// values are plain identifier references (high-confidence
-			// heuristic for dispatch-map shape without explicit typing).
-			if hasRecordAnnotation || allIdentifiers {
+			// heuristic for dispatch-map shape without explicit typing) OR
+			// when at least one inline arrow handler was resolved (Gap (1),
+			// issue #2565).
+			if hasRecordAnnotation || allIdentifiers || hasInlineArrows {
 				result[varName] = &dispatchMapInfo{
 					handlers: handlers,
 					byKey:    byKey,
@@ -2502,6 +2524,54 @@ func (x *extractor) buildDispatchMaps(root *sitter.Node) map[string]*dispatchMap
 		return nil
 	}
 	return result
+}
+
+// callTargetsInFunctionNode extracts the callee names of top-level
+// call_expressions found in the body of an arrow_function or
+// function_expression node. Used by buildDispatchMaps to resolve inline
+// arrow handlers (Gap (1), issue #2565).
+//
+// Only direct call targets (identifier or member_expression property) are
+// returned; nested call chains are not traversed to avoid over-approximation.
+// Deduplication is applied so each target appears at most once.
+func (x *extractor) callTargetsInFunctionNode(fn *sitter.Node) []string {
+	if fn == nil {
+		return nil
+	}
+	// arrow_function: body is the "body" field — either a statement_block or
+	// a single expression (parenthesized_expression, call_expression, etc.).
+	// function_expression: body is always a statement_block.
+	body := fn.ChildByFieldName("body")
+	if body == nil {
+		return nil
+	}
+	calls := findAllNodes(body, "call_expression")
+	if len(calls) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(calls))
+	var targets []string
+	for _, call := range calls {
+		callee := call.ChildByFieldName("function")
+		if callee == nil {
+			continue
+		}
+		var name string
+		switch callee.Type() {
+		case "identifier", "type_identifier", "property_identifier":
+			name = x.nodeText(callee)
+		case "member_expression":
+			if prop := callee.ChildByFieldName("property"); prop != nil {
+				name = x.nodeText(prop)
+			}
+		}
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		targets = append(targets, name)
+	}
+	return targets
 }
 
 // isComponentName returns true when name starts with an ASCII uppercase

--- a/internal/extractors/javascript/issue2565_dispatch_gaps_test.go
+++ b/internal/extractors/javascript/issue2565_dispatch_gaps_test.go
@@ -1,0 +1,144 @@
+// Package javascript — unit tests for issue #2565.
+//
+// Verifies two dispatch-map gaps not covered by #2553:
+//
+//	(1) Inline arrow handlers: `const X = { foo: () => svc.foo() }; X[k]()`
+//	    should emit CALLS from the dispatch site to svc.foo (the inner callee).
+//
+//	(2) Exported object (intra-file): `export const X = { foo: handler }; X[k]()`
+//	    should emit CALLS from the dispatch site to handler (same as non-exported).
+//
+// Cross-file imports (gap (3)) are deferred.
+package javascript_test
+
+import (
+	"testing"
+)
+
+// TestTSExtractor_RecordDispatch_InlineArrows verifies that a dispatch map
+// whose values are inline arrow functions (not identifier references) still
+// produces synthetic CALLS edges from the dispatch site to the callees inside
+// each arrow body. Issue #2565 gap (1).
+func TestTSExtractor_RecordDispatch_InlineArrows(t *testing.T) {
+	src := `
+import { svc } from './svc';
+
+const HANDLERS = {
+  foo: () => svc.foo(),
+  bar: () => svc.bar(),
+};
+
+function dispatch(key: string): void {
+  HANDLERS[key]();
+}
+`
+	ents := extractTSDispatch(t, src)
+
+	// The dispatcher must have synthetic CALLS edges to both inline callees.
+	if !hasDispatchCallEdge(ents, "dispatch", "foo") {
+		t.Errorf("expected synthetic CALLS edge dispatch→foo (dynamic_dispatch_map), got: %v", relSummary(ents, "dispatch"))
+	}
+	if !hasDispatchCallEdge(ents, "dispatch", "bar") {
+		t.Errorf("expected synthetic CALLS edge dispatch→bar (dynamic_dispatch_map), got: %v", relSummary(ents, "dispatch"))
+	}
+
+	n := countDispatchCallEdges(ents, "dispatch")
+	if n != 2 {
+		t.Errorf("expected 2 dynamic_dispatch_map CALLS edges from dispatch, got %d", n)
+	}
+}
+
+// TestTSExtractor_RecordDispatch_InlineArrows_LiteralKey verifies that a
+// literal-key subscript call resolves to the single matching inline-arrow
+// callee rather than fanning out to all handlers. Issue #2565 gap (1).
+func TestTSExtractor_RecordDispatch_InlineArrows_LiteralKey(t *testing.T) {
+	src := `
+import { svc } from './svc';
+
+const HANDLERS = {
+  foo: () => svc.foo(),
+  bar: () => svc.bar(),
+};
+
+function callFoo(): void {
+  HANDLERS['foo']();
+}
+`
+	ents := extractTSDispatch(t, src)
+
+	// Only foo's inner callee should be targeted.
+	if !hasDispatchCallEdge(ents, "callFoo", "foo") {
+		t.Errorf("expected CALLS edge callFoo→foo for literal key, got: %v", relSummary(ents, "callFoo"))
+	}
+	// bar's callee must NOT receive an edge.
+	if hasDispatchCallEdge(ents, "callFoo", "bar") {
+		t.Errorf("did not expect CALLS edge callFoo→bar for literal key 'foo'")
+	}
+	n := countDispatchCallEdges(ents, "callFoo")
+	if n != 1 {
+		t.Errorf("expected exactly 1 dynamic_dispatch_map CALLS edge from callFoo, got %d", n)
+	}
+}
+
+// TestTSExtractor_RecordDispatch_ExportedObject verifies that an exported
+// const object literal is treated the same as a non-exported one — the
+// dispatch CALLS edges are emitted when the object is used intra-file.
+// Issue #2565 gap (2).
+func TestTSExtractor_RecordDispatch_ExportedObject(t *testing.T) {
+	src := `
+function handlerA(): void {}
+function handlerB(): void {}
+
+export const ACTIONS = {
+  create: handlerA,
+  delete: handlerB,
+};
+
+function run(kind: string): void {
+  ACTIONS[kind]();
+}
+`
+	ents := extractTSDispatch(t, src)
+
+	if !hasDispatchCallEdge(ents, "run", "handlerA") {
+		t.Errorf("expected synthetic CALLS edge run→handlerA (dynamic_dispatch_map), got: %v", relSummary(ents, "run"))
+	}
+	if !hasDispatchCallEdge(ents, "run", "handlerB") {
+		t.Errorf("expected synthetic CALLS edge run→handlerB (dynamic_dispatch_map), got: %v", relSummary(ents, "run"))
+	}
+	n := countDispatchCallEdges(ents, "run")
+	if n != 2 {
+		t.Errorf("expected 2 dynamic_dispatch_map CALLS edges from run, got %d", n)
+	}
+}
+
+// TestTSExtractor_RecordDispatch_ExportedObject_LiteralKey verifies that a
+// literal-key subscript access on an exported const object resolves to the
+// single matching handler. Issue #2565 gap (2).
+func TestTSExtractor_RecordDispatch_ExportedObject_LiteralKey(t *testing.T) {
+	src := `
+function handlerA(): void {}
+function handlerB(): void {}
+
+export const ACTIONS = {
+  create: handlerA,
+  delete: handlerB,
+};
+
+function runCreate(): void {
+  ACTIONS['create']();
+}
+`
+	ents := extractTSDispatch(t, src)
+
+	if !hasDispatchCallEdge(ents, "runCreate", "handlerA") {
+		t.Errorf("expected CALLS edge runCreate→handlerA for literal key, got: %v", relSummary(ents, "runCreate"))
+	}
+	if hasDispatchCallEdge(ents, "runCreate", "handlerB") {
+		t.Errorf("did not expect CALLS edge runCreate→handlerB for literal key 'create'")
+	}
+	n := countDispatchCallEdges(ents, "runCreate")
+	if n != 1 {
+		t.Errorf("expected exactly 1 dynamic_dispatch_map CALLS edge from runCreate, got %d", n)
+	}
+}


### PR DESCRIPTION
## Summary

- **Gap (1) — inline arrow handlers**: `const X = { foo: () => svc.foo() }; X[k]()` now emits `CALLS` from the dispatch site to inner callees (`foo`, `bar`). New `callTargetsInFunctionNode` helper traverses `arrow_function`/`function_expression` bodies via `findAllNodes` and extracts callee names. A `hasInlineArrows` flag in `buildDispatchMaps` ensures these maps are registered even without a `Record<>` annotation.
- **Gap (2) — exported objects (intra-file)**: `export const X = { foo: handler }; X[k]()` was already handled by the existing `export_statement` unwrap path from #2553. Two new tests confirm and lock this behaviour.
- **Gap (3) — cross-file imports**: deferred (too large for this pass).

## Changed files

- `internal/extractors/javascript/extractor.go` — `buildDispatchMaps` extended + `callTargetsInFunctionNode` helper added (~73 lines)
- `internal/extractors/javascript/issue2565_dispatch_gaps_test.go` — 4 new tests (2 per gap, dynamic + literal-key variants each)

## Test plan

- [ ] `go test ./internal/extractors/javascript/... -run TestTSExtractor_RecordDispatch_InlineArrows` — passes
- [ ] `go test ./internal/extractors/javascript/... -run TestTSExtractor_RecordDispatch_ExportedObject` — passes
- [ ] `go test ./internal/extractors/javascript/...` (full package) — all pass
- [ ] `go vet ./internal/extractors/javascript/...` — clean
- [ ] `go fmt` — applied

Closes #2565

🤖 Generated with [Claude Code](https://claude.com/claude-code)