### PR TITLE
feat(engine/python): Serializer/Signal/FilterSet → Model cross-refs (#2578)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -967,6 +967,34 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		}
 		pass3Records = append(pass3Records, signalEnts...)
 		pass2Rels = append(pass2Rels, signalRels...)
+
+		// Pass 2.6g — Serializer.Meta.model → Model REFERENCES edges (#2578).
+		// DRF Serializer subclasses whose inner Meta class declares `model = X`
+		// emit a REFERENCES edge so that graph queries for a Model X also surface
+		// its serializers.
+		serializerModelRels := runSerializerMetaModelEdges(classified)
+		if len(serializerModelRels) > 0 {
+			fmt.Fprintf(os.Stderr, "archigraph: serializer_meta_model_edges=%d\n", len(serializerModelRels))
+		}
+		pass2Rels = append(pass2Rels, serializerModelRels...)
+
+		// Pass 2.6h — @receiver(sender=Model) → Model HANDLES_SIGNAL edges (#2578).
+		// Explicit-sender @receiver decorators link the handler function to the
+		// Model class so queries for a Model also surface its signal handlers.
+		receiverSenderRels := runReceiverSenderEdges(classified)
+		if len(receiverSenderRels) > 0 {
+			fmt.Fprintf(os.Stderr, "archigraph: receiver_sender_edges=%d\n", len(receiverSenderRels))
+		}
+		pass2Rels = append(pass2Rels, receiverSenderRels...)
+
+		// Pass 2.6i — FilterSet.Meta.model → Model REFERENCES edges (#2578).
+		// django_filter FilterSet subclasses with Meta.model = X emit a REFERENCES
+		// edge so that queries for a Model also return its filter classes.
+		filterSetModelRels := runFilterSetMetaModelEdges(classified)
+		if len(filterSetModelRels) > 0 {
+			fmt.Fprintf(os.Stderr, "archigraph: filterset_meta_model_edges=%d\n", len(filterSetModelRels))
+		}
+		pass2Rels = append(pass2Rels, filterSetModelRels...)
 	}
 
 	// Pass 2.6 — Java JAX-RS / Spring MVC annotation route composition.
@@ -2614,6 +2642,66 @@ func runDjangoCBVRoutes(classified []classifiedFile) []types.EntityRecord {
 		return contentByPath[relPath]
 	}
 	return engine.ApplyDjangoCBVRoutes(pyPaths, reader)
+}
+
+// runSerializerMetaModelEdges emits REFERENCES edges from DRF Serializer
+// classes to the Model class named in their inner Meta.model = X declaration
+// (#2578). Repo-wide Python pass.
+func runSerializerMetaModelEdges(classified []classifiedFile) []types.RelationshipRecord {
+	if len(classified) == 0 {
+		return nil
+	}
+	contentByPath := make(map[string][]byte, len(classified))
+	var pyPaths []string
+	for _, cf := range classified {
+		if cf.language != "python" {
+			continue
+		}
+		contentByPath[cf.relPath] = cf.content
+		pyPaths = append(pyPaths, cf.relPath)
+	}
+	reader := func(relPath string) []byte { return contentByPath[relPath] }
+	return engine.ApplySerializerMetaModelEdges(pyPaths, reader)
+}
+
+// runReceiverSenderEdges emits HANDLES_SIGNAL edges from @receiver(…,
+// sender=Model) handler functions to the named Model class (#2578).
+// Repo-wide Python pass.
+func runReceiverSenderEdges(classified []classifiedFile) []types.RelationshipRecord {
+	if len(classified) == 0 {
+		return nil
+	}
+	contentByPath := make(map[string][]byte, len(classified))
+	var pyPaths []string
+	for _, cf := range classified {
+		if cf.language != "python" {
+			continue
+		}
+		contentByPath[cf.relPath] = cf.content
+		pyPaths = append(pyPaths, cf.relPath)
+	}
+	reader := func(relPath string) []byte { return contentByPath[relPath] }
+	return engine.ApplyReceiverSenderEdges(pyPaths, reader)
+}
+
+// runFilterSetMetaModelEdges emits REFERENCES edges from django_filter
+// FilterSet classes to the Model class named in their inner Meta.model = X
+// declaration (#2578). Repo-wide Python pass.
+func runFilterSetMetaModelEdges(classified []classifiedFile) []types.RelationshipRecord {
+	if len(classified) == 0 {
+		return nil
+	}
+	contentByPath := make(map[string][]byte, len(classified))
+	var pyPaths []string
+	for _, cf := range classified {
+		if cf.language != "python" {
+			continue
+		}
+		contentByPath[cf.relPath] = cf.content
+		pyPaths = append(pyPaths, cf.relPath)
+	}
+	reader := func(relPath string) []byte { return contentByPath[relPath] }
+	return engine.ApplyFilterSetMetaModelEdges(pyPaths, reader)
 }
 
 // stampEntityIDs computes the deterministic graph entity ID for every

--- a/internal/engine/django_model_cross_refs.go
+++ b/internal/engine/django_model_cross_refs.go
@@ -1,0 +1,360 @@
+// django_model_cross_refs.go — Serializer/Signal/FilterSet → Model cross-ref edges.
+//
+// Issue #2578 — MCP graph misses serializer/signal/filter cross-references
+// when looking up "where is Model X referenced?".  Bench iter 2 q11 surfaced
+// the gap: querying GroupDeviceSettings references returned zero results for
+// ReadGroupDeviceSettingsSerializer (declared Meta.model = GroupDeviceSettings)
+// and for the @receiver(post_save, sender=GroupDeviceSettings) handler in
+// replicate_to_datalake.py.
+//
+// This file adds three REPO-WIDE synthesis passes (they walk every Python file
+// to resolve cross-file class names):
+//
+//	ApplySerializerMetaModelEdges
+//	  — DRF Serializer subclasses (any class whose name ends in "Serializer",
+//	    or whose bases include a Serializer suffix) with an inner
+//	    `class Meta: model = SomeModel` declaration emit a REFERENCES edge
+//	    from the Serializer class to the Model class.
+//
+//	ApplyReceiverSenderEdges
+//	  — @receiver(post_save, sender=Model) (and pre_save / post_delete etc.)
+//	    decorators emit a LISTENS_FOR edge from the decorated handler function
+//	    to the named Model class.
+//
+//	ApplyFilterSetMetaModelEdges
+//	  — django_filter FilterSet subclasses with an inner
+//	    `class Meta: model = SomeModel` emit a REFERENCES edge from the
+//	    FilterSet class to the Model class.
+//
+// Architecture mirrors the peer engine passes (django_signal_pubsub_edges.go,
+// orm_field_edges.go): each function is APPEND-ONLY — it never modifies or
+// removes existing entities or edges, so it cannot regress surrounding passes.
+//
+// All three passes are called from index.go Pass 2.6 alongside the Celery and
+// custom-signal pub/sub passes.
+//
+// Refs #2578.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// serializerMetaModelRe matches an inner Meta class with a model = SomeName
+// assignment inside a Python class body.  We look for it scoped to two levels
+// of indentation so that nested-class false positives (e.g. a NestedSerializer
+// inside a parent body) are handled correctly by the enclosing-class scanner.
+//
+// Group 1 = the model class name (bare identifier, may be qualified like
+// "accounts.User" — in that case we take the last segment only).
+var serializerMetaModelRe = regexp.MustCompile(
+	`(?m)^\s{4,}class\s+Meta\s*(?:\([^)]*\))?\s*:\s*\n(?:[^\n]*\n)*?\s+model\s*=\s*([A-Z]\w*)`,
+)
+
+// filterSetMetaModelRe is functionally identical to serializerMetaModelRe; we
+// keep them separate for clarity and independent testing.
+var filterSetMetaModelRe = regexp.MustCompile(
+	`(?m)^\s{4,}class\s+Meta\s*(?:\([^)]*\))?\s*:\s*\n(?:[^\n]*\n)*?\s+model\s*=\s*([A-Z]\w*)`,
+)
+
+// outerClassRe extracts every top-level class definition in a Python file.
+// Group 1 = class name, Group 2 = base-class list (may be empty).
+var outerClassRe = regexp.MustCompile(
+	`(?m)^class\s+(\w+)\s*(?:\(([^)]*)\))?\s*:`,
+)
+
+// receiverSenderLineRe matches a single @receiver(…, sender=SomeClass…) line.
+// Group 1 = sender class name.
+var receiverSenderLineRe = regexp.MustCompile(
+	`(?m)^[ \t]*@receiver\s*\([^)]*\bsender\s*=\s*([A-Z]\w*)[^)]*\)`,
+)
+
+// receiverDefRe matches the def (or async def) that terminates a decorator
+// block.  Group 1 = function name.
+var receiverDefRe = regexp.MustCompile(
+	`(?m)^[ \t]*(?:async\s+)?def\s+(\w+)\s*\(`,
+)
+
+// ---------------------------------------------------------------------------
+// ApplySerializerMetaModelEdges
+// ---------------------------------------------------------------------------
+
+// ApplySerializerMetaModelEdges walks every Python file in the repo and emits
+// a REFERENCES edge from each DRF Serializer class to the Model class named in
+// its inner `class Meta: model = <Model>` declaration.
+//
+// A class is treated as a Serializer candidate when its name ends in
+// "Serializer" OR when its base-class list contains a name ending in
+// "Serializer".  This matches the conventions used in upvate_core and the
+// majority of DRF codebases.
+//
+// pyPaths:    repo-relative paths of every Python file.
+// fileReader: returns the source bytes for a repo-relative path.
+func ApplySerializerMetaModelEdges(
+	pyPaths []string,
+	fileReader NestedURLConfFileReader,
+) []types.RelationshipRecord {
+	if fileReader == nil {
+		return nil
+	}
+
+	var out []types.RelationshipRecord
+	seen := map[string]bool{}
+
+	for _, p := range pyPaths {
+		content := fileReader(p)
+		if len(content) == 0 {
+			continue
+		}
+		s := string(content)
+		// Quick bail-out: if the file has neither "Serializer" nor a Meta class
+		// there is nothing to do.
+		if !strings.Contains(s, "Serializer") || !strings.Contains(s, "class Meta") {
+			continue
+		}
+
+		// For each top-level class in the file, check whether it is a
+		// Serializer and whether it declares Meta.model.
+		classMatches := outerClassRe.FindAllStringSubmatchIndex(s, -1)
+		for ci, cm := range classMatches {
+			className := s[cm[2]:cm[3]]
+			var bases string
+			if cm[4] >= 0 {
+				bases = s[cm[4]:cm[5]]
+			}
+
+			isSerializer := strings.HasSuffix(className, "Serializer") ||
+				serializerInBases(bases)
+			if !isSerializer {
+				continue
+			}
+
+			// Determine the extent of this class body: from after the colon to
+			// the start of the next top-level class (or end of file).
+			bodyStart := cm[1] // byte after the class header line ends
+			bodyEnd := len(s)
+			if ci+1 < len(classMatches) {
+				bodyEnd = classMatches[ci+1][0]
+			}
+			body := s[bodyStart:bodyEnd]
+
+			// Look for `class Meta: … model = SomeModel` inside the body.
+			mm := serializerMetaModelRe.FindStringSubmatch(body)
+			if mm == nil {
+				continue
+			}
+			modelName := mm[1]
+
+			key := p + "|Serializer:" + className + "|Model:" + modelName
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			out = append(out, types.RelationshipRecord{
+				FromID: "Class:" + className,
+				ToID:   "Class:" + modelName,
+				Kind:   string(types.RelationshipKindReferences),
+				Properties: map[string]string{
+					"framework":    "drf",
+					"pattern_type": "serializer_meta_model",
+					"via":          "Meta.model",
+				},
+			})
+		}
+	}
+	return out
+}
+
+// serializerInBases returns true when the bases string (the raw content
+// between the parentheses in `class Foo(bases...)`) contains at least one
+// name ending in "Serializer".
+func serializerInBases(bases string) bool {
+	for _, part := range strings.Split(bases, ",") {
+		t := strings.TrimSpace(part)
+		// Strip any module prefix: "serializers.ModelSerializer" → "ModelSerializer"
+		if dot := strings.LastIndexByte(t, '.'); dot >= 0 {
+			t = t[dot+1:]
+		}
+		if strings.HasSuffix(t, "Serializer") {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// ApplyReceiverSenderEdges
+// ---------------------------------------------------------------------------
+
+// ApplyReceiverSenderEdges walks every Python file and emits a HANDLES_SIGNAL
+// edge from each @receiver(…, sender=Model) handler function to the named
+// Model class.
+//
+// Only receivers that supply an explicit `sender=<ClassName>` kwarg are
+// matched; bare `@receiver(post_save)` handlers (which receive ALL models) are
+// intentionally skipped because they don't name a specific model.
+//
+// Multiple stacked @receiver decorators on the same def (upvate_core pattern:
+// one @receiver per model) each produce a separate HANDLES_SIGNAL edge.
+//
+// Implementation: we find every @receiver line that carries a sender= arg,
+// then scan forward from that position to find the first `def` — that is the
+// handler function.  This two-scan strategy handles both the single-decorator
+// and the stacked-decorator cases correctly.
+func ApplyReceiverSenderEdges(
+	pyPaths []string,
+	fileReader NestedURLConfFileReader,
+) []types.RelationshipRecord {
+	if fileReader == nil {
+		return nil
+	}
+
+	var out []types.RelationshipRecord
+	seen := map[string]bool{}
+
+	for _, p := range pyPaths {
+		content := fileReader(p)
+		if len(content) == 0 {
+			continue
+		}
+		s := string(content)
+		if !strings.Contains(s, "@receiver") || !strings.Contains(s, "sender=") {
+			continue
+		}
+
+		// Find all @receiver(…sender=X…) lines and their byte offsets.
+		for _, idx := range receiverSenderLineRe.FindAllStringSubmatchIndex(s, -1) {
+			senderModel := s[idx[2]:idx[3]]
+			// Scan forward from the end of this decorator line to find the
+			// first `def` (skipping any intervening decorators).
+			rest := s[idx[1]:]
+			dm := receiverDefRe.FindStringSubmatchIndex(rest)
+			if dm == nil {
+				continue
+			}
+			handlerFunc := rest[dm[2]:dm[3]]
+
+			key := p + "|" + handlerFunc + "|" + senderModel
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			out = append(out, types.RelationshipRecord{
+				FromID: "Function:" + handlerFunc,
+				ToID:   "Class:" + senderModel,
+				Kind:   string(types.RelationshipKindHandlesSignal),
+				Properties: map[string]string{
+					"framework":    "django_signals",
+					"pattern_type": "receiver_sender_model",
+					"via":          "@receiver(sender=)",
+				},
+			})
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// ApplyFilterSetMetaModelEdges
+// ---------------------------------------------------------------------------
+
+// ApplyFilterSetMetaModelEdges walks every Python file and emits a REFERENCES
+// edge from each django_filter FilterSet subclass to the Model class named in
+// its inner `class Meta: model = <Model>` declaration.
+//
+// A class is treated as a FilterSet candidate when its name ends in "Filter"
+// OR when its base-class list contains a name ending in "FilterSet".
+func ApplyFilterSetMetaModelEdges(
+	pyPaths []string,
+	fileReader NestedURLConfFileReader,
+) []types.RelationshipRecord {
+	if fileReader == nil {
+		return nil
+	}
+
+	var out []types.RelationshipRecord
+	seen := map[string]bool{}
+
+	for _, p := range pyPaths {
+		content := fileReader(p)
+		if len(content) == 0 {
+			continue
+		}
+		s := string(content)
+		if (!strings.Contains(s, "Filter") && !strings.Contains(s, "FilterSet")) ||
+			!strings.Contains(s, "class Meta") {
+			continue
+		}
+
+		classMatches := outerClassRe.FindAllStringSubmatchIndex(s, -1)
+		for ci, cm := range classMatches {
+			className := s[cm[2]:cm[3]]
+			var bases string
+			if cm[4] >= 0 {
+				bases = s[cm[4]:cm[5]]
+			}
+
+			isFilterSet := strings.HasSuffix(className, "Filter") ||
+				strings.HasSuffix(className, "FilterSet") ||
+				filterSetInBases(bases)
+			if !isFilterSet {
+				continue
+			}
+
+			bodyStart := cm[1]
+			bodyEnd := len(s)
+			if ci+1 < len(classMatches) {
+				bodyEnd = classMatches[ci+1][0]
+			}
+			body := s[bodyStart:bodyEnd]
+
+			mm := filterSetMetaModelRe.FindStringSubmatch(body)
+			if mm == nil {
+				continue
+			}
+			modelName := mm[1]
+
+			key := p + "|FilterSet:" + className + "|Model:" + modelName
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			out = append(out, types.RelationshipRecord{
+				FromID: "Class:" + className,
+				ToID:   "Class:" + modelName,
+				Kind:   string(types.RelationshipKindReferences),
+				Properties: map[string]string{
+					"framework":    "django_filter",
+					"pattern_type": "filterset_meta_model",
+					"via":          "Meta.model",
+				},
+			})
+		}
+	}
+	return out
+}
+
+// filterSetInBases returns true when the bases string contains a name ending
+// in "FilterSet".
+func filterSetInBases(bases string) bool {
+	for _, part := range strings.Split(bases, ",") {
+		t := strings.TrimSpace(part)
+		if dot := strings.LastIndexByte(t, '.'); dot >= 0 {
+			t = t[dot+1:]
+		}
+		if strings.HasSuffix(t, "FilterSet") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/django_model_cross_refs_test.go
+++ b/internal/engine/django_model_cross_refs_test.go
@@ -1,0 +1,312 @@
+// Tests for the #2578 Serializer/Signal/FilterSet → Model cross-ref passes.
+package engine
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func fileMapReader2578(files map[string]string) NestedURLConfFileReader {
+	return func(relPath string) []byte {
+		if s, ok := files[relPath]; ok {
+			return []byte(s)
+		}
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestPyExtractor_SerializerMetaModel_EmitsReferences
+// ---------------------------------------------------------------------------
+
+func TestPyExtractor_SerializerMetaModel_EmitsReferences(t *testing.T) {
+	files := map[string]string{
+		"core/serializers/group_device_settings_serializer.py": `from rest_framework import serializers
+from core.models import GroupDeviceSettings
+
+class ReadGroupDeviceSettingsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GroupDeviceSettings
+        fields = "__all__"
+
+class WriteGroupDeviceSettingsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GroupDeviceSettings
+        fields = ["id", "name"]
+`,
+		"core/serializers/device_serializer.py": `from rest_framework import serializers
+from core.models import Device
+
+class DeviceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Device
+        fields = ["id", "serial_number"]
+`,
+		// Non-serializer file — should produce zero edges.
+		"core/views/dashboard.py": `def dashboard(request):
+    pass
+`,
+	}
+
+	paths := []string{
+		"core/serializers/group_device_settings_serializer.py",
+		"core/serializers/device_serializer.py",
+		"core/views/dashboard.py",
+	}
+	reader := fileMapReader2578(files)
+
+	rels := ApplySerializerMetaModelEdges(paths, reader)
+
+	// Expect 3 REFERENCES edges: 2 from the first file + 1 from the second.
+	refs := relsOfKind(rels, "REFERENCES")
+	if len(refs) != 3 {
+		t.Fatalf("expected 3 REFERENCES edges, got %d: %v", len(refs), refs)
+	}
+
+	// Verify each edge targets the correct model.
+	wantEdges := map[string]string{
+		"Class:ReadGroupDeviceSettingsSerializer":  "Class:GroupDeviceSettings",
+		"Class:WriteGroupDeviceSettingsSerializer": "Class:GroupDeviceSettings",
+		"Class:DeviceSerializer":                   "Class:Device",
+	}
+	for _, r := range refs {
+		want, ok := wantEdges[r.FromID]
+		if !ok {
+			t.Errorf("unexpected FromID %q in REFERENCES edge %v", r.FromID, r)
+			continue
+		}
+		if r.ToID != want {
+			t.Errorf("edge from %q: want ToID %q got %q", r.FromID, want, r.ToID)
+		}
+		if r.Properties["pattern_type"] != "serializer_meta_model" {
+			t.Errorf("edge from %q: want pattern_type serializer_meta_model, got %q",
+				r.FromID, r.Properties["pattern_type"])
+		}
+		if r.Properties["framework"] != "drf" {
+			t.Errorf("edge from %q: want framework drf, got %q",
+				r.FromID, r.Properties["framework"])
+		}
+	}
+}
+
+func TestPyExtractor_SerializerMetaModel_NilReader(t *testing.T) {
+	rels := ApplySerializerMetaModelEdges([]string{"a.py"}, nil)
+	if len(rels) != 0 {
+		t.Fatalf("expected nil reader to return zero edges, got %d", len(rels))
+	}
+}
+
+func TestPyExtractor_SerializerMetaModel_NoSerializerFiles(t *testing.T) {
+	files := map[string]string{
+		"core/models/group.py": `from django.db import models
+
+class Group(models.Model):
+    name = models.CharField(max_length=255)
+    class Meta:
+        db_table = "groups"
+`,
+	}
+	rels := ApplySerializerMetaModelEdges([]string{"core/models/group.py"}, fileMapReader2578(files))
+	if len(rels) != 0 {
+		t.Fatalf("expected 0 edges for non-serializer file, got %d: %v", len(rels), rels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestPyExtractor_ReceiverDecorator_EmitsListensFor
+// ---------------------------------------------------------------------------
+
+func TestPyExtractor_ReceiverDecorator_EmitsListensFor(t *testing.T) {
+	// upvate_core pattern: multiple stacked @receiver decorators on one def.
+	files := map[string]string{
+		"core/signals/replicate_to_datalake.py": `from django.db.models.signals import post_save
+from django.dispatch import receiver
+from core.models import Group, Client, Device, GroupDeviceSettings
+
+@receiver(post_save, sender=Group)
+@receiver(post_save, sender=Client)
+@receiver(post_save, sender=Device)
+@receiver(post_save, sender=GroupDeviceSettings)
+def replicate_signal(sender, instance, created, **kwargs):
+    pass
+`,
+		// Single-sender receiver.
+		"core/signals/notify.py": `from django.db.models.signals import post_delete
+from django.dispatch import receiver
+from core.models import Contract
+
+@receiver(post_delete, sender=Contract)
+def on_contract_deleted(sender, instance, **kwargs):
+    pass
+`,
+	}
+
+	paths := []string{
+		"core/signals/replicate_to_datalake.py",
+		"core/signals/notify.py",
+	}
+	reader := fileMapReader2578(files)
+
+	rels := ApplyReceiverSenderEdges(paths, reader)
+
+	// Expect 4 edges from the first file + 1 from the second = 5 total.
+	handlesSignal := relsOfKind(rels, "HANDLES_SIGNAL")
+	if len(handlesSignal) != 5 {
+		t.Fatalf("expected 5 HANDLES_SIGNAL edges, got %d: %v", len(handlesSignal), rels)
+	}
+
+	// Confirm GroupDeviceSettings is among the targets.
+	found := false
+	for _, r := range handlesSignal {
+		if r.ToID == "Class:GroupDeviceSettings" {
+			found = true
+			if r.FromID != "Function:replicate_signal" {
+				t.Errorf("GroupDeviceSettings listener: want FromID Function:replicate_signal, got %q", r.FromID)
+			}
+			if r.Properties["pattern_type"] != "receiver_sender_model" {
+				t.Errorf("GroupDeviceSettings listener: want pattern_type receiver_sender_model, got %q",
+					r.Properties["pattern_type"])
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a HANDLES_SIGNAL edge targeting Class:GroupDeviceSettings, not found")
+	}
+
+	// Confirm Contract delete handler.
+	foundContract := false
+	for _, r := range handlesSignal {
+		if r.ToID == "Class:Contract" && r.FromID == "Function:on_contract_deleted" {
+			foundContract = true
+		}
+	}
+	if !foundContract {
+		t.Error("expected HANDLES_SIGNAL from on_contract_deleted to Class:Contract, not found")
+	}
+}
+
+func TestPyExtractor_ReceiverDecorator_BareReceiverSkipped(t *testing.T) {
+	// A bare @receiver(post_save) without sender= must NOT produce an edge.
+	files := map[string]string{
+		"core/signals/generic.py": `from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+@receiver(post_save)
+def catch_all(sender, instance, **kwargs):
+    pass
+`,
+	}
+	rels := ApplyReceiverSenderEdges([]string{"core/signals/generic.py"}, fileMapReader2578(files))
+	if len(rels) != 0 {
+		t.Fatalf("expected 0 edges for bare @receiver without sender=, got %d: %v", len(rels), rels)
+	}
+}
+
+func TestPyExtractor_ReceiverDecorator_NilReader(t *testing.T) {
+	rels := ApplyReceiverSenderEdges([]string{"a.py"}, nil)
+	if len(rels) != 0 {
+		t.Fatalf("expected nil reader to return zero edges, got %d", len(rels))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestPyExtractor_FilterSetMetaModel_EmitsReferences
+// ---------------------------------------------------------------------------
+
+func TestPyExtractor_FilterSetMetaModel_EmitsReferences(t *testing.T) {
+	files := map[string]string{
+		"core/filters/device_filters.py": `import django_filters
+from core.models import Device
+
+class DeviceFilter(django_filters.FilterSet):
+    class Meta:
+        model = Device
+        fields = []
+`,
+		"core/filters/building_filters.py": `import django_filters
+from core.models import Building
+
+class BuildingFilter(django_filters.FilterSet):
+    class Meta:
+        model = Building
+        fields = ["id", "name"]
+
+class BuildingActiveFilter(django_filters.FilterSet):
+    class Meta:
+        model = Building
+        fields = ["is_active"]
+`,
+		// A non-filter file — must produce zero edges.
+		"core/models/device.py": `from django.db import models
+
+class Device(models.Model):
+    serial_number = models.CharField(max_length=100)
+    class Meta:
+        db_table = "devices"
+`,
+	}
+
+	paths := []string{
+		"core/filters/device_filters.py",
+		"core/filters/building_filters.py",
+		"core/models/device.py",
+	}
+	reader := fileMapReader2578(files)
+
+	rels := ApplyFilterSetMetaModelEdges(paths, reader)
+
+	refs := relsOfKind(rels, "REFERENCES")
+	if len(refs) != 3 {
+		t.Fatalf("expected 3 REFERENCES edges, got %d: %v", len(refs), refs)
+	}
+
+	wantEdges := map[string]string{
+		"Class:DeviceFilter":         "Class:Device",
+		"Class:BuildingFilter":       "Class:Building",
+		"Class:BuildingActiveFilter": "Class:Building",
+	}
+	for _, r := range refs {
+		want, ok := wantEdges[r.FromID]
+		if !ok {
+			t.Errorf("unexpected FromID %q in REFERENCES edge %v", r.FromID, r)
+			continue
+		}
+		if r.ToID != want {
+			t.Errorf("edge from %q: want ToID %q got %q", r.FromID, want, r.ToID)
+		}
+		if r.Properties["pattern_type"] != "filterset_meta_model" {
+			t.Errorf("edge from %q: want pattern_type filterset_meta_model, got %q",
+				r.FromID, r.Properties["pattern_type"])
+		}
+		if r.Properties["framework"] != "django_filter" {
+			t.Errorf("edge from %q: want framework django_filter, got %q",
+				r.FromID, r.Properties["framework"])
+		}
+	}
+}
+
+func TestPyExtractor_FilterSetMetaModel_NilReader(t *testing.T) {
+	rels := ApplyFilterSetMetaModelEdges([]string{"a.py"}, nil)
+	if len(rels) != 0 {
+		t.Fatalf("expected nil reader to return zero edges, got %d", len(rels))
+	}
+}
+
+func TestPyExtractor_FilterSetMetaModel_NonFilterFile(t *testing.T) {
+	files := map[string]string{
+		"core/models/group.py": `from django.db import models
+
+class Group(models.Model):
+    name = models.CharField(max_length=255)
+    class Meta:
+        db_table = "core_group"
+`,
+	}
+	rels := ApplyFilterSetMetaModelEdges([]string{"core/models/group.py"}, fileMapReader2578(files))
+	if len(rels) != 0 {
+		t.Fatalf("expected 0 edges for non-filter model file, got %d: %v", len(rels), rels)
+	}
+}


### PR DESCRIPTION
## Summary

- **ApplySerializerMetaModelEdges** (`internal/engine/django_model_cross_refs.go:114`): DRF Serializer subclasses with `class Meta: model = X` emit `REFERENCES` → Model, so querying for e.g. `GroupDeviceSettings` now surfaces `ReadGroupDeviceSettingsSerializer`.
- **ApplyReceiverSenderEdges** (`internal/engine/django_model_cross_refs.go:186`): `@receiver(post_save, sender=Model)` decorators emit `HANDLES_SIGNAL` → Model, including the stacked multi-sender pattern in `replicate_to_datalake.py`.
- **ApplyFilterSetMetaModelEdges** (`internal/engine/django_model_cross_refs.go:257`): django_filter `FilterSet` subclasses with `Meta.model = X` emit `REFERENCES` → Model.
- All three passes wired into `cmd/archigraph/index.go` as Passes 2.6g/h/i.
- 9 new tests in `internal/engine/django_model_cross_refs_test.go`.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/engine/... ./cmd/archigraph/...` — clean
- [x] `go test ./internal/engine/...` — all pass (13s)
- [x] `go test ./internal/extractors/python/...` — all pass
- [x] `TestPyExtractor_SerializerMetaModel_EmitsReferences` — 3 REFERENCES edges
- [x] `TestPyExtractor_ReceiverDecorator_EmitsListensFor` — 5 HANDLES_SIGNAL edges (stacked decorators)
- [x] `TestPyExtractor_FilterSetMetaModel_EmitsReferences` — 3 REFERENCES edges

Closes #2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)