### PR TITLE
fix(mcp): frequency-rank find_callers fires on real data (#2591)

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -282,12 +282,21 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 			callers = append(callers, c)
 		}
 
-		// #2577: count CALLS edges per source entity to rank callers by frequency.
-		// Build a map: entity ID (unprefixed) -> count of CALLS edges to target.
-		callFrequency := make(map[string]int)
+		// #2577/#2591: rank callers by call frequency (descending).
+		//
+		// Frequency is the sum of edge weights for CALLS edges pointing from
+		// each source to target. edge.weight is 1.0 per raw edge, OR the
+		// numeric value of Properties["count"] when the extractor deduplicates
+		// multiple call sites into a single edge with a count property.
+		//
+		// Summing weights (not counting raw edges) means both representation
+		// styles are handled uniformly:
+		//   - Extractor emits N duplicate CALLS edges → each weight=1 → sum=N
+		//   - Extractor emits 1 CALLS edge with Properties["count"]="N" → weight=N → sum=N
+		callFrequency := make(map[string]float64)
 		for _, e := range adj.in[target] {
 			if e.kind == "CALLS" {
-				callFrequency[e.target]++
+				callFrequency[e.target] += e.weight
 			}
 		}
 

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -1347,3 +1347,62 @@ func TestFindCallers_TieBreakAlphabetical(t *testing.T) {
 		t.Errorf("expected second caller=FuncB, got %v", second["name"])
 	}
 }
+
+// TestFindCallersIntegration_FrequencyRankedOnRealHandler exercises the full
+// MCP handler end-to-end (#2591). It verifies that when extractors emit ONE
+// CALLS edge per (caller, callee) pair with a Properties["count"] encoding the
+// call-site frequency (the real-world pattern), the MCP response honours that
+// frequency rather than falling back to alphabetical order.
+//
+// Fixture: A×1 call, B×3 calls, C×2 calls → expected order [B, C, A].
+// Each caller has exactly ONE relationship record but with "count" in Properties.
+// This matches how JS/Python extractors represent multi-site callers on upvate data.
+func TestFindCallersIntegration_FrequencyRankedOnRealHandler(t *testing.T) {
+	// One CALLS edge per caller, with Properties["count"] encoding frequency.
+	entities := []graph.Entity{
+		{ID: "ent-a", Name: "FuncA", Kind: "Function", SourceFile: "a.js", StartLine: 1},
+		{ID: "ent-b", Name: "FuncB", Kind: "Function", SourceFile: "b.js", StartLine: 1},
+		{ID: "ent-c", Name: "FuncC", Kind: "Function", SourceFile: "c.js", StartLine: 1},
+		{ID: "ent-t", Name: "callApi", Kind: "Function", SourceFile: "api.js", StartLine: 1},
+	}
+	rels := []graph.Relationship{
+		// A calls callApi 1 time (single edge, count=1)
+		{FromID: "ent-a", ToID: "ent-t", Kind: "CALLS", Properties: map[string]string{"count": "1"}},
+		// B calls callApi 3 times (single edge, count=3) — should rank first
+		{FromID: "ent-b", ToID: "ent-t", Kind: "CALLS", Properties: map[string]string{"count": "3"}},
+		// C calls callApi 2 times (single edge, count=2) — should rank second
+		{FromID: "ent-c", ToID: "ent-t", Kind: "CALLS", Properties: map[string]string{"count": "2"}},
+	}
+	doc := minDoc(entities, rels)
+	srv := newTestServer(t, doc)
+
+	// Call THROUGH handleFindCallers (the real MCP entry point), not the
+	// structured seam directly — this is what #2591 identified as broken.
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "ent-t",
+		"depth":     float64(1),
+	})
+
+	callers, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array, got %T", out["callers"])
+	}
+	if len(callers) != 3 {
+		t.Fatalf("expected 3 callers, got %d: %v", len(callers), callers)
+	}
+
+	// Expected order by count desc: B(3), C(2), A(1).
+	names := make([]string, len(callers))
+	for i, c := range callers {
+		names[i] = c.(map[string]any)["name"].(string)
+	}
+	if names[0] != "FuncB" {
+		t.Errorf("rank 1: expected FuncB (count=3), got %q; full order=%v", names[0], names)
+	}
+	if names[1] != "FuncC" {
+		t.Errorf("rank 2: expected FuncC (count=2), got %q; full order=%v", names[1], names)
+	}
+	if names[2] != "FuncA" {
+		t.Errorf("rank 3: expected FuncA (count=1), got %q; full order=%v", names[2], names)
+	}
+}

--- a/internal/mcp/traversal.go
+++ b/internal/mcp/traversal.go
@@ -52,6 +52,12 @@ func (a *adjacency) Incoming(id string) []edge {
 // Called ONCE per reload (cached on LoadedRepo.Adjacency, #1656). Handlers
 // must NOT call this per-query — they pay an O(R)=117k scan plus thousands
 // of allocations every time. Use repo.Adjacency instead.
+//
+// Edge weight: defaults to 1.0 but reads Properties["count"] or
+// Properties["weight"] when present. Extractors that deduplicate call sites
+// into a single CALLS edge with a numeric "count" property (e.g. "30" for a
+// file that calls a function 30 times) will have their frequency honoured by
+// any consumer that sums edge.weight instead of counting raw edges (#2591).
 func buildAdjacency(doc *graph.Document, repo string) *adjacency {
 	a := &adjacency{
 		out: make(map[string][]edge, len(doc.Entities)),
@@ -59,11 +65,29 @@ func buildAdjacency(doc *graph.Document, repo string) *adjacency {
 	}
 	for i := range doc.Relationships {
 		r := &doc.Relationships[i]
-		w := 1.0
+		w := edgeWeight(r)
 		a.out[r.FromID] = append(a.out[r.FromID], edge{target: r.ToID, kind: r.Kind, weight: w, relIdx: i})
 		a.in[r.ToID] = append(a.in[r.ToID], edge{target: r.FromID, kind: r.Kind, weight: w, relIdx: i})
 	}
 	return a
+}
+
+// edgeWeight returns the numeric weight for a relationship edge. It reads
+// Properties["count"] first (call-site count emitted by extractors that
+// deduplicate edges), then Properties["weight"] (module-aggregate weight),
+// falling back to 1.0. Values <= 0 are treated as 1.0.
+func edgeWeight(r *graph.Relationship) float64 {
+	for _, key := range []string{"count", "weight"} {
+		if r.Properties == nil {
+			break
+		}
+		if v, ok := r.Properties[key]; ok && v != "" {
+			if n, err := strconv.ParseFloat(v, 64); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+	return 1.0
 }
 
 // stepEdge is a single STEP_IN_PROCESS edge entry stored in StepAdj.


### PR DESCRIPTION
## Summary

- **Root cause**: PR #2582 added frequency sort by counting raw adjacency edges per caller. The unit tests used multiple duplicate `CALLS` relationship records to simulate call count. Real JS/Python extractors emit **one** CALLS edge per (caller, callee) pair with `Properties[\"count\"]` encoding call-site frequency — so all real callers had frequency=1 and the sort fell back to alphabetical.
- **Fix**: `buildAdjacency` now calls `edgeWeight()` which reads `Properties[\"count\"]` / `Properties[\"weight\"]` from each relationship. `findCallersStructured` sums `edge.weight` instead of counting raw edges — both extractor styles (duplicate edges OR single edge with count property) now produce correct frequency ranking.
- **Code paths affected**: one path (`findCallersStructured` in `flow_tools.go`, shared by `handleFindCallers` and `handleNeighbors` direction=in); the fix is in `traversal.go`'s `buildAdjacency` which is the single build point for all adjacency consumers.

## Test plan

- [ ] `TestFindCallersIntegration_FrequencyRankedOnRealHandler` — new integration test goes through `handleFindCallers` with single deduplicated edges + `Properties[\"count\"]`; asserts B(3) > C(2) > A(1)
- [ ] All existing `TestFindCallers_*` tests pass (including `TestFindCallers_RankedByFrequency` which uses duplicate edge records — still works since each raw edge has weight=1)
- [ ] `go test ./internal/mcp/... -run TestFindCallers` passes

Closes #2591

🤖 Generated with [Claude Code](https://claude.com/claude-code)