### PR TITLE
fix(engine/python): djangoReceiverRe captures stacked decorators

### DIFF
--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -33,6 +33,7 @@ var (
 	djangoCBVClassRe      = regexp.MustCompile(`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*(?:View|Mixin|APIView|ViewSet)[^)]*)\)\s*:`)
 	djangoCBVMethodRe     = regexp.MustCompile(`(?m)^\s{4,}def\s+(get|post|put|patch|delete|head|options|trace)\s*\(\s*self`)
 	djangoReceiverRe      = regexp.MustCompile(`(?m)@receiver\s*\(\s*([\w.]+)(?:\s*,\s*sender\s*=\s*(\w+))?[^)]*\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+	djangoReceiverOnlyRe  = regexp.MustCompile(`(?m)@receiver\s*\(\s*([\w.]+)(?:\s*,\s*sender\s*=\s*(\w+))?[^)]*\)`)
 	djangoAdminRegRe      = regexp.MustCompile(`(?m)admin\.site\.register\s*\(\s*(\w+)(?:\s*,\s*(\w+))?\s*\)`)
 	djangoAdminDecorRe    = regexp.MustCompile(`(?m)@admin\.register\s*\(\s*(\w+)\s*\)\s*\n\s*class\s+(\w+)\s*\(`)
 	djangoDRFSerializerRe = regexp.MustCompile(
@@ -131,26 +132,111 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	// of a HANDLES_SIGNAL edge — not a new entity.  This avoids the
 	// Service:<ModelName> phantom orphans introduced by the old YAML pattern
 	// (issue #1374 item 3).
-	for _, idx := range allMatchesIndex(djangoReceiverRe, source) {
-		signalType := source[idx[2]:idx[3]]
-		handlerName := source[idx[6]:idx[7]]
-		line := lineOf(source, idx[0])
-		props := map[string]string{"framework": "django", "pattern_type": "signal", "signal_type": signalType}
-		var senderModel string
-		if idx[4] != -1 {
-			senderModel = source[idx[4]:idx[5]]
-			props["sender"] = senderModel
+	//
+	// #2599: Walk upward from each `def` to collect ALL stacked @receiver decorators,
+	// emitting one HANDLES_SIGNAL edge per @receiver (one per sender).
+
+	// Find all @receiver decorators in the file (without requiring a def to follow).
+	receiverMatches := allMatchesIndex(djangoReceiverOnlyRe, source)
+
+	// Find all function definitions in the file.
+	defRe := regexp.MustCompile(`(?m)^\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+	defMatches := allMatchesIndex(defRe, source)
+
+	// Track handler functions we've already emitted (to avoid duplicates).
+	handledFuncs := map[string]bool{}
+
+	// For each function, collect its associated @receiver decorators.
+	for _, defIdx := range defMatches {
+		defStart := defIdx[0]
+		handlerName := source[defIdx[2]:defIdx[3]]
+
+		// Skip if we've already emitted this handler.
+		if handledFuncs[handlerName] {
+			continue
 		}
-		ent := entity(handlerName, "SCOPE.Operation", "function", file.Path, line, props)
-		// Emit HANDLES_SIGNAL → sender model so the handler is connected to
-		// the existing model entity instead of leaving it as an orphan.
-		if senderModel != "" {
-			ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
-				ToID:       djangoModelRef(senderModel),
-				Kind:       string(types.RelationshipKindHandlesSignal),
-				Properties: map[string]string{"signal_type": signalType, "framework": "django"},
-			})
+
+		// Collect all @receiver decorators that immediately precede this def.
+		var decorators []struct {
+			signalType  string
+			senderModel string
+			line        int
 		}
+
+		// Walk backward through decorators to find those immediately before def.
+		nextCheckPos := defStart
+		for i := len(receiverMatches) - 1; i >= 0; i-- {
+			rIdx := receiverMatches[i]
+			rStart := rIdx[0]
+			rEnd := rIdx[1]
+
+			// Only consider receivers that come before the next check position.
+			if rStart >= nextCheckPos {
+				continue
+			}
+
+			// Check if there's only whitespace/comments between @receiver and next pos.
+			between := source[rEnd:nextCheckPos]
+			if !isOnlyWhitespaceAndComments(between) {
+				break // Reached a non-contiguous decorator; stop walking backward.
+			}
+
+			signalType := source[rIdx[2]:rIdx[3]]
+			var senderModel string
+			if rIdx[4] != -1 {
+				senderModel = source[rIdx[4]:rIdx[5]]
+			}
+			rLine := lineOf(source, rStart)
+
+			decorators = append(decorators, struct {
+				signalType  string
+				senderModel string
+				line        int
+			}{signalType, senderModel, rLine})
+
+			// Update position to check next decorator is immediately before current one.
+			nextCheckPos = rStart
+		}
+
+		// If no receivers found, skip this function.
+		if len(decorators) == 0 {
+			continue
+		}
+
+		// Reverse the decorators since we collected them backward.
+		for i, j := 0, len(decorators)-1; i < j; i, j = i+1, j-1 {
+			decorators[i], decorators[j] = decorators[j], decorators[i]
+		}
+
+		handledFuncs[handlerName] = true
+
+		// Use the first (highest) decorator's line for the entity.
+		entityLine := decorators[0].line
+
+		// Build properties: include signal_type and sender from first receiver (for backward compatibility).
+		props := map[string]string{"framework": "django", "pattern_type": "signal"}
+		if len(decorators) > 0 {
+			props["signal_type"] = decorators[0].signalType
+			if decorators[0].senderModel != "" {
+				props["sender"] = decorators[0].senderModel
+			}
+		}
+
+		// Emit one entity per distinct handler function.
+		// We'll aggregate all HANDLES_SIGNAL edges onto it.
+		ent := entity(handlerName, "SCOPE.Operation", "function", file.Path, entityLine, props)
+
+		// Add one HANDLES_SIGNAL edge per @receiver decorator.
+		for _, decorator := range decorators {
+			if decorator.senderModel != "" {
+				ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+					ToID:       djangoModelRef(decorator.senderModel),
+					Kind:       string(types.RelationshipKindHandlesSignal),
+					Properties: map[string]string{"signal_type": decorator.signalType, "framework": "django"},
+				})
+			}
+		}
+
 		out = append(out, ent)
 	}
 
@@ -306,6 +392,19 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil
+}
+
+// isOnlyWhitespaceAndComments returns true if text contains only whitespace and
+// Python comments (lines starting with #). Used to detect if @receiver decorators
+// immediately precede a def.
+func isOnlyWhitespaceAndComments(text string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			return false
+		}
+	}
+	return true
 }
 
 // djangoModelRef returns the structural reference ID used as the ToID for

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -502,6 +502,75 @@ def replicate_invoice(sender, instance, **kwargs):
 	}
 }
 
+// TestDjango_SignalReceiver_StackedDecorators verifies that multiple stacked
+// @receiver decorators on a single function are ALL captured, emitting one
+// HANDLES_SIGNAL edge per @receiver (per sender model).
+// Fixes #2599: upvate's replicate_to_datalake.py has 11 @receiver decorators
+// on one function; the old regex only captured the last one per file.
+func TestDjango_SignalReceiver_StackedDecorators(t *testing.T) {
+	src := `@receiver(post_save, sender=Contract)
+@receiver(post_delete, sender=Contract)
+@receiver(post_save, sender=Invoice)
+@receiver(post_delete, sender=Invoice)
+@receiver(post_save, sender=Payment)
+def replicate_to_datalake(sender, instance, **kwargs):
+    pass
+`
+	ents := extract(t, "python_django", src)
+
+	// Must have exactly one handler entity (not 5).
+	var handler *extractResult
+	handlerCount := 0
+	for i := range ents {
+		if ents[i].Name == "replicate_to_datalake" && ents[i].Props["pattern_type"] == "signal" {
+			handler = &ents[i]
+			handlerCount++
+		}
+	}
+	if handlerCount != 1 {
+		t.Fatalf("expected 1 handler entity for stacked @receiver, got %d", handlerCount)
+	}
+	if handler == nil {
+		t.Fatal("expected entity named 'replicate_to_datalake'")
+	}
+
+	// Must have exactly 5 HANDLES_SIGNAL edges (one per @receiver).
+	handleCount := 0
+	for _, r := range handler.Rels {
+		if r.Kind == "HANDLES_SIGNAL" {
+			handleCount++
+		}
+	}
+	if handleCount != 5 {
+		t.Fatalf("expected 5 HANDLES_SIGNAL edges for 5 stacked @receiver decorators, got %d", handleCount)
+	}
+
+	// Verify all senders are represented.
+	senderSet := make(map[string]bool)
+	for _, r := range handler.Rels {
+		if r.Kind == "HANDLES_SIGNAL" {
+			senderSet[r.ToID] = true
+		}
+	}
+	expectedSenders := map[string]bool{
+		"Class:Contract": true,
+		"Class:Invoice":  true,
+		"Class:Payment":  true,
+	}
+	for expected := range expectedSenders {
+		if !senderSet[expected] {
+			t.Errorf("expected HANDLES_SIGNAL edge to %s, not found in rels: %+v", expected, handler.Rels)
+		}
+	}
+
+	// No phantom model entities.
+	for _, e := range ents {
+		if e.Name == "Contract" || e.Name == "Invoice" || e.Name == "Payment" {
+			t.Fatalf("phantom entity emitted for model %q", e.Name)
+		}
+	}
+}
+
 // ---- #1411: duplicate-kind node regression tests ----
 
 // TestDjango_ViewSet_SingleNode verifies that a DRF ViewSet class is emitted


### PR DESCRIPTION
## Summary
- Fixes #2599: upvate's replicate_to_datalake.py with 11 stacked @receiver decorators on one function now correctly emits 11 edges instead of 1
- Added djangoReceiverOnlyRe regex to match @receiver decorators without requiring def to follow
- Modified signal receiver extraction to walk upward from each def and collect all contiguous stacked decorators
- Each @receiver now generates its own HANDLES_SIGNAL edge (one per sender model)

## Test plan
- TestDjango_SignalReceiver: single decorator still works
- TestDjango_SignalReceiver_HandlesSignalEdge: handler entity + edge validation
- TestDjango_SignalReceiver_NoSender: decorators without sender still work
- TestDjango_SignalReceiver_StackedDecorators: 5 stacked decorators → 5 edges (NEW)
- All 139 existing tests still pass
- gofmt, go vet, go build all clean

Generated with Claude Code