### PR TITLE
fix(testmap): migrate other framework filenameHints → pathHints

### DIFF
--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -1504,3 +1504,23 @@ func TestPytest_TestsDirMatchesAnyPath(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Regression: #2606 — filenameHints must not contain path patterns
+// ---------------------------------------------------------------------------
+
+// TestAllFrameworks_NoPathPatternsInFilenameHints asserts that all framework
+// entries have basenames only in filenameHints and no forward-slash patterns
+// (those belong in pathHints). This prevents silent match failures due to
+// matchesAnyFilename only checking the basename against the full path.
+func TestAllFrameworks_NoPathPatternsInFilenameHints(t *testing.T) {
+	for _, fe := range frameworkOrder {
+		for _, re := range fe.filenameHints {
+			pattern := re.String()
+			if strings.Contains(pattern, "/") {
+				t.Errorf("framework %q has path pattern in filenameHints: %q (move to pathHints)",
+					fe.name, pattern)
+			}
+		}
+	}
+}

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -572,8 +572,10 @@ var frameworkOrder = []frameworkEntry{
 		importHints: []string{"cypress", "cy.", "@cypress/"},
 		filenameHints: []*regexp.Regexp{
 			regexp.MustCompile(`\.cy\.(?:ts|tsx|js|jsx)$`),
-			regexp.MustCompile(`cypress/e2e/`),
-			regexp.MustCompile(`cypress/integration/`),
+		},
+		pathHints: []*regexp.Regexp{
+			regexp.MustCompile(`/cypress/e2e/`),
+			regexp.MustCompile(`/cypress/integration/`),
 		},
 		detect: detectJest,
 	},


### PR DESCRIPTION
## Summary
- Moved `cypress/e2e/` and `cypress/integration/` path patterns from `filenameHints` to `pathHints`
- `matchesAnyFilename` only checks basenames; path patterns were silently not matching
- Added regression test `TestAllFrameworks_NoPathPatternsInFilenameHints`

## Test plan
- [x] All existing testmap tests pass (51 tests)
- [x] New regression test verifies no framework has path patterns in `filenameHints`
- [x] `gofmt`, `go vet`, `go build`, and full test suite pass

Closes #2606

🤖 Generated with Claude Code