### PR TITLE
fix(links/http): resolve duplicate-consumer orphans via multi-consumer linking

### DIFF
--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -631,16 +631,23 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 		for _, p := range producers {
 			producersByRepo[p.repo] = append(producersByRepo[p.repo], p)
 		}
-		// Group consumers by repo (first hit per repo — the deterministic
-		// ordering above means we keep the smallest stampedID per repo).
-		consumerRepos := map[string]*httpEndpointHit{}
+		// Group ALL consumers by repo — unlike the old single-consumer-per-repo
+		// deduplication, we now allow every distinct consumer entity (e.g.
+		// a legacy service file and a V2 service file that both call the same
+		// endpoint) to receive its own cross-repo link. The emitted map keyed
+		// by (source, target, method) prevents duplicate links when two
+		// consumers in the same repo happen to resolve to the same producer
+		// entity. (#2611)
+		consumersByRepo := map[string][]*httpEndpointHit{}
 		for _, h := range consumers {
-			if _, ok := consumerRepos[h.repo]; !ok {
-				consumerRepos[h.repo] = h
-			}
+			consumersByRepo[h.repo] = append(consumersByRepo[h.repo], h)
 		}
 
-		consumerRepoNames := sortedKeys(consumerRepos)
+		consumerRepoNames := make([]string, 0, len(consumersByRepo))
+		for r := range consumersByRepo {
+			consumerRepoNames = append(consumerRepoNames, r)
+		}
+		sort.Strings(consumerRepoNames)
 		producerRepoNames := make([]string, 0, len(producersByRepo))
 		for r := range producersByRepo {
 			producerRepoNames = append(producerRepoNames, r)
@@ -650,184 +657,185 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 		for _, cRepo := range consumerRepoNames {
 			for _, pRepo := range producerRepoNames {
 				intraRepo := cRepo == pRepo
-				c := consumerRepos[cRepo]
-				// Verb-aware producer selection (#747):
-				//   Tier 1 — producer with the SAME specific verb as the
-				//            consumer (exact_verb).
-				//   Tier 2 — producer with verb=ANY (any_fallback).
-				//   Tier 3 — none. We skip rather than fall through to a
-				//            different specific verb: DELETE/{id} must
-				//            never link to PATCH/{id} just because both
-				//            paths normalize the same.
-				// Producers within each tier are already sorted by
-				// less() above, so picking the first match is
-				// deterministic.
-				p, quality := pickProducerForConsumer(c, producersByRepo[pRepo])
+				for _, c := range consumersByRepo[cRepo] {
+					// Verb-aware producer selection (#747):
+					//   Tier 1 — producer with the SAME specific verb as the
+					//            consumer (exact_verb).
+					//   Tier 2 — producer with verb=ANY (any_fallback).
+					//   Tier 3 — none. We skip rather than fall through to a
+					//            different specific verb: DELETE/{id} must
+					//            never link to PATCH/{id} just because both
+					//            paths normalize the same.
+					// Producers within each tier are already sorted by
+					// less() above, so picking the first match is
+					// deterministic.
+					p, quality := pickProducerForConsumer(c, producersByRepo[pRepo])
 
-				// Prefix-injection retry (#2569): mirrors Tier 2 of
-				// resolveCallByPath in internal/engine/http_endpoint_match.go
-				// (#2557). When the standard byPath match missed AND the
-				// consumer path carries no API/version prefix of its own,
-				// retry by prepending each well-known prefix candidate to the
-				// consumer's normalized path and probing byPath. This handles
-				// the upvate pattern where the frontend extractor emits a raw
-				// path (e.g. `/searchBuildings`) while the backend mounts the
-				// route at `/api/v1/searchBuildings`.
-				//
-				// First match wins; edge is stamped with
-				// Properties["prefix_normalized"] (e.g. "api/v1") so the
-				// resolution is traceable in the graph.
-				var prefixNormalized string
-				if p == nil {
-					consumerPath := c.canonicalPath
-					if consumerPath == "" {
-						if _, parsed, ok := parseHTTPName(c.name); ok {
-							consumerPath = parsed
+					// Prefix-injection retry (#2569): mirrors Tier 2 of
+					// resolveCallByPath in internal/engine/http_endpoint_match.go
+					// (#2557). When the standard byPath match missed AND the
+					// consumer path carries no API/version prefix of its own,
+					// retry by prepending each well-known prefix candidate to the
+					// consumer's normalized path and probing byPath. This handles
+					// the upvate pattern where the frontend extractor emits a raw
+					// path (e.g. `/searchBuildings`) while the backend mounts the
+					// route at `/api/v1/searchBuildings`.
+					//
+					// First match wins; edge is stamped with
+					// Properties["prefix_normalized"] (e.g. "api/v1") so the
+					// resolution is traceable in the graph.
+					var prefixNormalized string
+					if p == nil {
+						consumerPath := c.canonicalPath
+						if consumerPath == "" {
+							if _, parsed, ok := parseHTTPName(c.name); ok {
+								consumerPath = parsed
+							}
 						}
-					}
-					normConsumerPath := normalizePathForIndex(consumerPath)
-					// Only attempt when the consumer path has no API/version
-					// prefix itself — a double-prefixed path would be invalid.
-					if _, hasPrefix := stripAPIPrefix(normConsumerPath); !hasPrefix && normConsumerPath != "" {
-						for _, pfx := range crossRepoPrefixCandidates {
-							prefixedKey := pfx + normConsumerPath
-							pfxCandidates := make([]*httpEndpointHit, 0)
-							for _, h := range byPath[prefixedKey] {
-								if h.repo == pRepo && h.side == sideProducer {
-									pfxCandidates = appendUnique(pfxCandidates, h)
+						normConsumerPath := normalizePathForIndex(consumerPath)
+						// Only attempt when the consumer path has no API/version
+						// prefix itself — a double-prefixed path would be invalid.
+						if _, hasPrefix := stripAPIPrefix(normConsumerPath); !hasPrefix && normConsumerPath != "" {
+							for _, pfx := range crossRepoPrefixCandidates {
+								prefixedKey := pfx + normConsumerPath
+								pfxCandidates := make([]*httpEndpointHit, 0)
+								for _, h := range byPath[prefixedKey] {
+									if h.repo == pRepo && h.side == sideProducer {
+										pfxCandidates = appendUnique(pfxCandidates, h)
+									}
+								}
+								if len(pfxCandidates) > 0 {
+									sort.SliceStable(pfxCandidates, func(i, j int) bool { return less(pfxCandidates[i], pfxCandidates[j]) })
+									p, quality = pickProducerForConsumer(c, pfxCandidates)
+									if p != nil {
+										prefixNormalized = strings.TrimPrefix(pfx, "/")
+										break
+									}
 								}
 							}
-							if len(pfxCandidates) > 0 {
-								sort.SliceStable(pfxCandidates, func(i, j int) bool { return less(pfxCandidates[i], pfxCandidates[j]) })
-								p, quality = pickProducerForConsumer(c, pfxCandidates)
-								if p != nil {
-									prefixNormalized = strings.TrimPrefix(pfx, "/")
+						}
+					}
+
+					// URL-pattern normalization retry (#2588): when both the standard
+					// byPath lookup AND the prefix-injection retry miss, attempt to
+					// match the consumer path against every producer in the target repo
+					// using normalizeURLPattern. This resolves the 374-candidate case
+					// where client emits /inspections/{id} and server emits
+					// /api/v1/inspections/<pk:int> — different param syntax only.
+					//
+					// When a normalized match is found, confidence is boosted to
+					// urlPatternNormConfidence (0.95) and Properties["normalization"]
+					// is set to "url_pattern" so the resolution is traceable.
+					var urlPatternNormAnnotation string
+					var urlPatternNormConfidenceVal float64
+					if p == nil {
+						consumerPath := c.canonicalPath
+						if consumerPath == "" {
+							if _, parsed, ok := parseHTTPName(c.name); ok {
+								consumerPath = parsed
+							}
+						}
+						if consumerPath != "" {
+							for _, candidate := range producersByRepo[pRepo] {
+								if !verbsCompatible(c.verb, candidate.verb) {
+									continue
+								}
+								producerPath := candidate.canonicalPath
+								if producerPath == "" {
+									if _, parsed, ok := parseHTTPName(candidate.name); ok {
+										producerPath = parsed
+									}
+								}
+								conf, ann := applyURLPatternNorm(consumerPath, producerPath)
+								if conf > 0 {
+									p = candidate
+									quality = matchQualityAnyFallback
+									urlPatternNormAnnotation = ann
+									urlPatternNormConfidenceVal = conf
 									break
 								}
 							}
 						}
 					}
-				}
 
-				// URL-pattern normalization retry (#2588): when both the standard
-				// byPath lookup AND the prefix-injection retry miss, attempt to
-				// match the consumer path against every producer in the target repo
-				// using normalizeURLPattern. This resolves the 374-candidate case
-				// where client emits /inspections/{id} and server emits
-				// /api/v1/inspections/<pk:int> — different param syntax only.
-				//
-				// When a normalized match is found, confidence is boosted to
-				// urlPatternNormConfidence (0.95) and Properties["normalization"]
-				// is set to "url_pattern" so the resolution is traceable.
-				var urlPatternNormAnnotation string
-				var urlPatternNormConfidenceVal float64
-				if p == nil {
-					consumerPath := c.canonicalPath
-					if consumerPath == "" {
-						if _, parsed, ok := parseHTTPName(c.name); ok {
-							consumerPath = parsed
+					if p == nil {
+						continue
+					}
+
+					// Source / target: consumer's caller → producer's handler.
+					// If either side hasn't resolved to a real entity, fall
+					// back to the synthetic stampedID so the link still
+					// points at something meaningful.
+					srcID := c.callerID
+					if srcID == "" {
+						srcID = c.stampedID
+					}
+					tgtID := p.handlerID
+					if tgtID == "" {
+						tgtID = p.stampedID
+					}
+					source := entityKey(c.repo, srcID)
+					target := entityKey(p.repo, tgtID)
+					// #2585 — intra-repo HTTP self-calls use MethodHTTPSelf so
+					// they are segregated from cross-repo CALLS links.
+					linkMethod := MethodHTTP
+					if intraRepo {
+						linkMethod = MethodHTTPSelf
+					}
+					id := MakeID(source, target, linkMethod)
+					if emitted[id] {
+						continue
+					}
+					emitted[id] = true
+					// #2571/#2573: mark this consumer as cross-repo-resolved for
+					// the per-pass counter. One consumer may link to multiple
+					// producer repos; we count it resolved once it has any link.
+					matchedConsumers[entityKey(c.repo, c.stampedID)] = true
+
+					ident := canonicalIdentifier(c, p)
+					ch := httpChannel
+					confidence := ScoreImport()
+					if urlPatternNormConfidenceVal > 0 {
+						confidence = urlPatternNormConfidenceVal
+					}
+					// Intra-repo self-calls use RelationRoutesTo; cross-repo uses RelationCalls.
+					relation := RelationCalls
+					if intraRepo {
+						relation = RelationRoutesTo
+					}
+					link := Link{
+						ID:           id,
+						Source:       source,
+						Target:       target,
+						Relation:     relation,
+						Method:       linkMethod,
+						Confidence:   confidence,
+						Channel:      &ch,
+						Identifier:   &ident,
+						DiscoveredAt: now,
+						SourceLocations: [][]string{
+							{c.sourceFile},
+							{p.sourceFile},
+						},
+						MatchQuality: quality,
+					}
+					if prefixNormalized != "" {
+						link.Properties = map[string]string{"prefix_normalized": prefixNormalized}
+					}
+					if urlPatternNormAnnotation != "" {
+						if link.Properties == nil {
+							link.Properties = map[string]string{}
 						}
+						link.Properties["normalization"] = urlPatternNormAnnotation
 					}
-					if consumerPath != "" {
-						for _, candidate := range producersByRepo[pRepo] {
-							if !verbsCompatible(c.verb, candidate.verb) {
-								continue
-							}
-							producerPath := candidate.canonicalPath
-							if producerPath == "" {
-								if _, parsed, ok := parseHTTPName(candidate.name); ok {
-									producerPath = parsed
-								}
-							}
-							conf, ann := applyURLPatternNorm(consumerPath, producerPath)
-							if conf > 0 {
-								p = candidate
-								quality = matchQualityAnyFallback
-								urlPatternNormAnnotation = ann
-								urlPatternNormConfidenceVal = conf
-								break
-							}
+					if intraRepo {
+						if link.Properties == nil {
+							link.Properties = map[string]string{}
 						}
+						link.Properties["intra_repo"] = "true"
 					}
-				}
-
-				if p == nil {
-					continue
-				}
-
-				// Source / target: consumer's caller → producer's handler.
-				// If either side hasn't resolved to a real entity, fall
-				// back to the synthetic stampedID so the link still
-				// points at something meaningful.
-				srcID := c.callerID
-				if srcID == "" {
-					srcID = c.stampedID
-				}
-				tgtID := p.handlerID
-				if tgtID == "" {
-					tgtID = p.stampedID
-				}
-				source := entityKey(c.repo, srcID)
-				target := entityKey(p.repo, tgtID)
-				// #2585 — intra-repo HTTP self-calls use MethodHTTPSelf so
-				// they are segregated from cross-repo CALLS links.
-				linkMethod := MethodHTTP
-				if intraRepo {
-					linkMethod = MethodHTTPSelf
-				}
-				id := MakeID(source, target, linkMethod)
-				if emitted[id] {
-					continue
-				}
-				emitted[id] = true
-				// #2571/#2573: mark this consumer as cross-repo-resolved for
-				// the per-pass counter. One consumer may link to multiple
-				// producer repos; we count it resolved once it has any link.
-				matchedConsumers[entityKey(c.repo, c.stampedID)] = true
-
-				ident := canonicalIdentifier(c, p)
-				ch := httpChannel
-				confidence := ScoreImport()
-				if urlPatternNormConfidenceVal > 0 {
-					confidence = urlPatternNormConfidenceVal
-				}
-				// Intra-repo self-calls use RelationRoutesTo; cross-repo uses RelationCalls.
-				relation := RelationCalls
-				if intraRepo {
-					relation = RelationRoutesTo
-				}
-				link := Link{
-					ID:           id,
-					Source:       source,
-					Target:       target,
-					Relation:     relation,
-					Method:       linkMethod,
-					Confidence:   confidence,
-					Channel:      &ch,
-					Identifier:   &ident,
-					DiscoveredAt: now,
-					SourceLocations: [][]string{
-						{c.sourceFile},
-						{p.sourceFile},
-					},
-					MatchQuality: quality,
-				}
-				if prefixNormalized != "" {
-					link.Properties = map[string]string{"prefix_normalized": prefixNormalized}
-				}
-				if urlPatternNormAnnotation != "" {
-					if link.Properties == nil {
-						link.Properties = map[string]string{}
-					}
-					link.Properties["normalization"] = urlPatternNormAnnotation
-				}
-				if intraRepo {
-					if link.Properties == nil {
-						link.Properties = map[string]string{}
-					}
-					link.Properties["intra_repo"] = "true"
-				}
-				fresh = append(fresh, link)
+					fresh = append(fresh, link)
+				} // end for _, c := range consumersByRepo[cRepo]
 			}
 		}
 	}

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -2310,3 +2310,188 @@ func TestHTTPPass_IntraRepoSelfCall_Resolved(t *testing.T) {
 		}
 	}
 }
+
+// TestHTTPPass_MultiConsumerSameEndpoint verifies that when two consumer entities
+// in the same repo share the same canonical path (e.g. a legacy service file and
+// a V2 service file both calling GET /users/{id}), the pass emits a cross-repo
+// CALLS link for EACH consumer, not just the first one (#2611).
+//
+// Before the fix: only the consumer with the lexicographically-smaller stampedID
+// was resolved; the other remained a permanent orphan.
+// After the fix: both consumers are resolved, producing two distinct links.
+func TestHTTPPass_MultiConsumerSameEndpoint(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "UserView", "kind": "Controller", "source_file": "app/views.py"},
+			{
+				"id": "ep1", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/users/{id}", "framework": "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	// Two frontend consumer entities for the SAME endpoint path, in different
+	// source files — simulating a legacy service and a V2 service.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "loadUserLegacy", "kind": "Function", "source_file": "src/api.js"},
+			{
+				"id": "ep2", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "src/api.js",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/users/{id}", "framework": "fetch",
+					"pattern_type": "http_endpoint_client_synthesis", "source_caller": "Function:loadUserLegacy",
+				},
+			},
+			{"id": "fn2", "name": "loadUserV2", "kind": "Function", "source_file": "src/apiV2.ts"},
+			{
+				"id": "ep3", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "src/apiV2.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/users/{id}", "framework": "fetch",
+					"pattern_type": "http_endpoint_client_synthesis", "source_caller": "Function:loadUserV2",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g2611", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g2611-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var httpLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			httpLinks = append(httpLinks, l)
+		}
+	}
+	// Both consumers must be resolved — two distinct links expected.
+	if len(httpLinks) != 2 {
+		t.Errorf("expected 2 http links (one per consumer), got %d: %+v", len(httpLinks), httpLinks)
+	}
+	// Both links must point to the same backend handler.
+	for _, l := range httpLinks {
+		if l.Target != "backend::h1" {
+			t.Errorf("expected target=backend::h1, got %s", l.Target)
+		}
+	}
+	// The two links must have distinct sources (fn1 and fn2).
+	sources := make([]string, 0, len(httpLinks))
+	for _, l := range httpLinks {
+		sources = append(sources, l.Source)
+	}
+	sort.Strings(sources)
+	wantSources := []string{"frontend::fn1", "frontend::fn2"}
+	sort.Strings(wantSources)
+	for i, s := range sources {
+		if s != wantSources[i] {
+			t.Errorf("sources[%d]: want %s, got %s", i, wantSources[i], s)
+		}
+	}
+}
+
+// TestHTTPPass_MultiConsumerBelowThreshold verifies that consumer entities with
+// paths that cannot match any producer (e.g. a truly novel path with no backend
+// definition) still remain orphans even after the multi-consumer fix. This pins
+// the negative path: lifting deduplication must not create spurious links.
+func TestHTTPPass_MultiConsumerBelowThreshold(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "UserView", "kind": "Controller", "source_file": "app/views.py"},
+			{
+				"id": "ep1", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/users/{id}", "framework": "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	// Two frontend consumers: one with a known path, one with a novel path
+	// that has no backend counterpart. Only the known path should be linked.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "loadUser", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep2", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/users/{id}", "framework": "fetch",
+					"pattern_type": "http_endpoint_client_synthesis", "source_caller": "Function:loadUser",
+				},
+			},
+			{"id": "fn2", "name": "loadOrphan", "kind": "Function", "source_file": "src/admin.ts"},
+			{
+				"id": "ep3", "name": "http:GET:/admin/secret-endpoint", "kind": "http_endpoint",
+				"source_file": "src/admin.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/admin/secret-endpoint", "framework": "fetch",
+					"pattern_type": "http_endpoint_client_synthesis", "source_caller": "Function:loadOrphan",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	res, err := RunAllPasses("g2611b", root, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g2611b-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var httpLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			httpLinks = append(httpLinks, l)
+		}
+	}
+	// Only the known-path consumer should be linked; the novel-path consumer stays orphan.
+	if len(httpLinks) != 1 {
+		t.Errorf("expected 1 http link (only the matchable consumer), got %d: %+v", len(httpLinks), httpLinks)
+	}
+	if len(httpLinks) > 0 && httpLinks[0].Source != "frontend::fn1" {
+		t.Errorf("expected source=frontend::fn1, got %s", httpLinks[0].Source)
+	}
+	// Find the HTTP pass result.
+	var httpPassResult *PassResult
+	for i, pr := range res.Results {
+		if pr.Pass == "http" {
+			httpPassResult = &res.Results[i]
+			break
+		}
+	}
+	if httpPassResult == nil {
+		t.Fatal("expected an http pass result")
+	}
+	// OrphanCalls should be 1 (the novel path consumer).
+	if httpPassResult.OrphanCalls != 1 {
+		t.Errorf("expected OrphanCalls=1, got %d", httpPassResult.OrphanCalls)
+	}
+	// CrossRepoResolved should be 1.
+	if httpPassResult.CrossRepoResolved != 1 {
+		t.Errorf("expected CrossRepoResolved=1, got %d", httpPassResult.CrossRepoResolved)
+	}
+	_ = strings.Contains("", "")
+}


### PR DESCRIPTION
## Summary

- **Root cause found**: `runHTTPPass` kept only ONE consumer per (repo, name-bucket) via a `map[string]*httpEndpointHit`. When two source files (e.g. legacy `checklistServices.js` and V2 `checklistServiceV2.js`) both emit a consumer synthetic for the same endpoint (`http:GET:/checklists`), only the first was linked. The second was a permanent orphan.
- **Fix**: Changed `consumerRepos map[string]*httpEndpointHit` → `consumersByRepo map[string][]*httpEndpointHit`. All consumers per repo in the same name-bucket now receive their own cross-repo CALLS link. Existing `emitted map[string]bool` prevents duplicate links when two consumers resolve to the same producer.
- **Sample analysis** (148 unresolved frontend calls, iter-4 baseline 83.6%):
  - 36 duplicate-name orphans → fixed by this PR
  - 24 dynamic `/{param}/` paths → deferred (runtime URL structure)
  - 17 camelCase RTK aliases → correct orphans (frontend-only abstractions)
  - 64 unindexed backend routes → extractor coverage gap (separate issue)
  - 7 other (verb-mismatch, query-in-path)

## Predicted impact

Current state (post iter-4 fixes): ~163/390 = 41.8% orphan rate.
After this fix: ~(163−36)/390 ≈ **32.6% orphan rate** (−9.2pp).

## Test plan

- [x] `TestHTTPPass_MultiConsumerSameEndpoint` — two consumers, same path, different source files → 2 distinct links emitted, both target the same backend handler
- [x] `TestHTTPPass_MultiConsumerBelowThreshold` — novel-path consumer stays orphan; `OrphanCalls=1`, `CrossRepoResolved=1` counters correct
- [x] `go test ./internal/links/... -count=1` — all 2312+ existing tests pass
- [x] `gofmt -l` clean, `go vet ./...` clean, `go build ./...` clean

## Tech debt

The 64 unindexed backend routes (dashboard views, admin endpoints, sync routes) require backend extractor coverage improvements — that is a separate issue beyond this pass's scope.

Refs #2547 / iter-4 bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)