### PR TITLE
fix(extractor): migration prune covers SCOPE.Component emission path (#2603)

### DIFF
--- a/internal/extractors/cross/hierarchy/extractor.go
+++ b/internal/extractors/cross/hierarchy/extractor.go
@@ -27,6 +27,8 @@ package hierarchy
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -36,6 +38,34 @@ import (
 	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// emitMigrationEntitiesEnv mirrors the constant in
+// internal/extractors/python/extractor.go.  Both must stay in sync.
+const emitMigrationEntitiesEnv = "ARCHIGRAPH_EMIT_MIGRATION_ENTITIES"
+
+// isDjangoMigrationFile returns true for Python files that live inside a
+// Django migrations/ package (e.g. core/migrations/0019_*.py).  Mirrors the
+// same predicate in internal/extractors/python/extractor.go so the two prune
+// paths always agree.
+func isDjangoMigrationFile(path string) bool {
+	if !strings.HasSuffix(path, ".py") {
+		return false
+	}
+	dir := filepath.Dir(filepath.FromSlash(path))
+	return filepath.Base(dir) == "migrations"
+}
+
+// shouldSkipMigrationFile returns true when the given file is an
+// auto-generated Django migration AND the ARCHIGRAPH_EMIT_MIGRATION_ENTITIES
+// opt-in env var is NOT set.  When this returns true the hierarchy extractor
+// should emit no class entities for the file (issue #2603).
+func shouldSkipMigrationFile(path string) bool {
+	if !isDjangoMigrationFile(path) {
+		return false
+	}
+	v := os.Getenv(emitMigrationEntitiesEnv)
+	return v != "1" && v != "true"
+}
 
 func init() {
 	extractor.Register("_cross_hierarchy", &Extractor{})
@@ -758,6 +788,16 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		extractJTCSharp(source, file.Path, lang, res)
 		extractJTCInterface(source, file.Path, lang, res)
 	case "python":
+		// Issue #2603 — Django migration files are pruned by default.  The
+		// Python extractor already returns early for these files, but this
+		// cross-language pass runs independently (Pass 3) and was emitting a
+		// SCOPE.Component/class entity for every `class Migration(...):`
+		// declaration it found via pyClassRE.  Gate it behind the same env-var
+		// opt-in used by the Python extractor.
+		if shouldSkipMigrationFile(file.Path) {
+			span.SetAttributes(attribute.Bool("django_migration_pruned", true))
+			return nil, nil
+		}
 		extractPython(source, file.Path, res)
 	case "ruby":
 		extractRuby(source, file.Path, res)

--- a/internal/extractors/cross/hierarchy/extractor_test.go
+++ b/internal/extractors/cross/hierarchy/extractor_test.go
@@ -8,6 +8,60 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
+// migrationSrc is a minimal Django migration file body that matches pyClassRE.
+const migrationSrc = `from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    initial = True
+    dependencies = []
+    operations = [
+        migrations.CreateModel(
+            name='Device',
+            fields=[('id', models.AutoField(primary_key=True))],
+        ),
+    ]
+`
+
+// TestMigrationFile_NoSCOPEComponentEntity verifies that by default (no
+// ARCHIGRAPH_EMIT_MIGRATION_ENTITIES env var) the hierarchy extractor emits
+// zero entities for Django migration files (issue #2603).
+//
+// Before the fix the pyClassRE matched `class Migration(migrations.Migration):`
+// and emitted a SCOPE.Component/class entity named "Migration" — bypassing the
+// prune that the Python extractor performs via its early-return gate.
+func TestMigrationFile_NoSCOPEComponentEntity(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_MIGRATION_ENTITIES", "")
+
+	got := runExtract(t, "python", "core/migrations/0001_initial.py", migrationSrc)
+
+	if len(got) != 0 {
+		t.Errorf("default-off: hierarchy extractor emitted %d entities for migration file, want 0", len(got))
+		for _, e := range got {
+			t.Logf("  - name=%q kind=%q subtype=%q", e.Name, e.Kind, e.Subtype)
+		}
+	}
+}
+
+// TestMigrationFile_OptInEmitsComponent verifies that when
+// ARCHIGRAPH_EMIT_MIGRATION_ENTITIES=1 the hierarchy extractor DOES emit the
+// Migration class entity (opt-in path, symmetric with the Python extractor).
+func TestMigrationFile_OptInEmitsComponent(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_MIGRATION_ENTITIES", "1")
+
+	got := runExtract(t, "python", "core/migrations/0001_initial.py", migrationSrc)
+
+	hasMigration := false
+	for _, e := range got {
+		if e.Name == "Migration" && e.Kind == "SCOPE.Component" {
+			hasMigration = true
+			break
+		}
+	}
+	if !hasMigration {
+		t.Errorf("opt-in: hierarchy extractor did not emit Migration SCOPE.Component entity; got %v", entityNames(got))
+	}
+}
+
 func runExtract(t *testing.T, lang, path, source string) []types.EntityRecord {
 	t.Helper()
 	e := &Extractor{}


### PR DESCRIPTION
## Summary

- **Root cause**: The cross-language hierarchy extractor (`internal/extractors/cross/hierarchy/extractor.go`) was emitting `SCOPE.Component/class` entities for `class Migration(migrations.Migration):` declarations in Django migration files. This extractor runs in Pass 3 (completely independent of the Python extractor's early-return gate added in #2551/#2602), so the 101 `Migration` entities survived every rebuild.
- **Fix**: Gate the Python branch of `hierarchy.Extract()` with the same `isDjangoMigrationFile()` + `ARCHIGRAPH_EMIT_MIGRATION_ENTITIES` env-var opt-in used by the Python extractor. Returns `nil` immediately for migration files unless the flag is set.
- **Impact**: Iter-N+1 reindex of upvate should drop the count from 101 to 0.

## Identified emission path

`internal/extractors/cross/hierarchy/extractor.go:389` — `extractPython()` uses `pyClassRE` (`^class\s+(\w+)\s*\(([^)]+)\):`) which matched every `class Migration(migrations.Migration):` at line 7 of each Django migration file.

## Fix location

`internal/extractors/cross/hierarchy/extractor.go` — added `isDjangoMigrationFile()`, `shouldSkipMigrationFile()` helpers and a gate in `Extract()` before calling `extractPython()`.

## Test plan

- [x] `TestMigrationFile_NoSCOPEComponentEntity` — default-off: 0 entities emitted for `core/migrations/0001_initial.py`
- [x] `TestMigrationFile_OptInEmitsComponent` — opt-in (`ARCHIGRAPH_EMIT_MIGRATION_ENTITIES=1`): `Migration` SCOPE.Component entity is emitted
- [x] All existing hierarchy extractor tests pass (8 total)
- [x] `go build ./...` clean
- [x] `gofmt` clean
- [x] `go vet ./internal/extractors/cross/hierarchy/` clean
- [x] `go test ./internal/...` passes (pre-existing `internal/mcp` failure unrelated to this change — confirmed present on main before fix)

## Tech debt

The `isDjangoMigrationFile` predicate is now duplicated in two packages (`internal/extractors/python` and `internal/extractors/cross/hierarchy`). A future cleanup should extract it to a shared `internal/extractors/python/migrationutil` or `internal/fileutil` package so a single definition governs both prune paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)