### PR TITLE
feat(extractor/ts): dynamic URL template normalization (#2615)

### DIFF
--- a/internal/extractors/cross/httpclient/extractor.go
+++ b/internal/extractors/cross/httpclient/extractor.go
@@ -32,6 +32,20 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
+// jsTemplateInterpolationRE matches a single ${...} expression inside a
+// template literal. Used by normalizeTemplateURL to replace each interpolation
+// with the {*} wildcard sentinel so that dynamic paths (e.g. `/users/${id}`)
+// round-trip through normalizePathForIndex the same way as server-side route
+// parameters like `/users/{pk}` or `/users/<int:id>`.
+var jsTemplateInterpolationRE = regexp.MustCompile(`\$\{[^}]*\}`)
+
+// normalizeTemplateURL replaces every ${...} interpolation in a template-literal
+// URL with the canonical wildcard sentinel {*}. Static URLs (no interpolations)
+// are returned unchanged.
+func normalizeTemplateURL(url string) string {
+	return jsTemplateInterpolationRE.ReplaceAllString(url, "{*}")
+}
+
 func init() {
 	extractor.Register("_cross_httpclient", &Extractor{})
 }
@@ -59,14 +73,26 @@ type call struct {
 // Note: RE2 (Go's regexp engine) limits repetition counts to 1000 max.
 var jsFetchDoubleRE = regexp.MustCompile(`(?m)\bfetch\s*\(\s*"([^"\s]{1,500})"`)
 var jsFetchSingleRE = regexp.MustCompile(`(?m)\bfetch\s*\(\s*'([^'\s]{1,500})'`)
-var jsFetchBacktickRE = regexp.MustCompile("(?m)\\bfetch\\s*\\(\\s*`([^`\\s]{1,500})`")
 
-// axios.METHOD('url') — separate patterns for single and double quotes.
+// jsFetchBacktickRE matches fetch(`...`) including template literals with
+// ${...} interpolations. The interpolation content is allowed to be empty or
+// non-backtick so the regex captures the full raw template string; callers
+// pass the captured group through normalizeTemplateURL to replace each ${...}
+// with the {*} wildcard sentinel (#2615).
+var jsFetchBacktickRE = regexp.MustCompile("(?m)\\bfetch\\s*\\(\\s*`([^`]{1,500})`")
+
+// axios.METHOD('url') — separate patterns for single, double, and backtick quotes.
 var jsAxiosDoubleRE = regexp.MustCompile(
 	`(?im)\baxios\.(get|post|put|patch|delete|head|options|request)\s*\(\s*"([^"\s]{1,500})"`,
 )
 var jsAxiosSingleRE = regexp.MustCompile(
 	`(?im)\baxios\.(get|post|put|patch|delete|head|options|request)\s*\(\s*'([^'\s]{1,500})'`,
+)
+
+// jsAxiosBacktickRE matches axios.METHOD(`url`) with optional ${...} interpolations.
+// Captured group 2 is passed through normalizeTemplateURL (#2615).
+var jsAxiosBacktickRE = regexp.MustCompile(
+	"(?im)\\baxios\\.(get|post|put|patch|delete|head|options|request)\\s*\\(\\s*`([^`]{1,500})`",
 )
 
 // Python: requests.METHOD('url') / httpx.METHOD('url')
@@ -231,8 +257,9 @@ func extractJS(source string) []call {
 	for _, m := range jsFetchSingleRE.FindAllStringSubmatch(source, -1) {
 		out = append(out, call{url: m[1]})
 	}
+	// Backtick template literals: normalize ${...} interpolations to {*} (#2615).
 	for _, m := range jsFetchBacktickRE.FindAllStringSubmatch(source, -1) {
-		out = append(out, call{url: m[1]})
+		out = append(out, call{url: normalizeTemplateURL(m[1])})
 	}
 
 	// axios double-quote: groups [full, method, url]
@@ -245,6 +272,12 @@ func extractJS(source string) []call {
 	for _, m := range jsAxiosSingleRE.FindAllStringSubmatch(source, -1) {
 		if len(m) >= 3 {
 			out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+		}
+	}
+	// axios backtick template literals: normalize ${...} interpolations to {*} (#2615).
+	for _, m := range jsAxiosBacktickRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			out = append(out, call{url: normalizeTemplateURL(m[2]), method: strings.ToUpper(m[1])})
 		}
 	}
 

--- a/internal/extractors/cross/httpclient/extractor_test.go
+++ b/internal/extractors/cross/httpclient/extractor_test.go
@@ -129,6 +129,55 @@ func TestJS_NoHTTPCalls(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// #2615 — template-literal URL normalization
+// ---------------------------------------------------------------------------
+
+// TestTSExtractor_TemplateString_NormalizedToWildcard verifies that a single
+// ${...} interpolation in a backtick template literal is replaced with the
+// {*} wildcard sentinel so the client path can match the server route
+// /users/{pk} or /users/<int:id> via normalizePathForIndex.
+func TestTSExtractor_TemplateString_NormalizedToWildcard(t *testing.T) {
+	src := "fetch(`/users/${id}`)"
+	apis := apiEntities(runExtract(t, "typescript", src))
+	if len(apis) != 1 {
+		t.Fatalf("expected 1 API entity, got %d", len(apis))
+	}
+	want := "/users/{*}"
+	if apis[0].Name != want {
+		t.Errorf("url = %q, want %q", apis[0].Name, want)
+	}
+}
+
+// TestTSExtractor_NestedTemplateString_AllPlaceholdersReplaced verifies that
+// every ${...} expression in a multi-segment template literal is independently
+// replaced with {*}, covering paths like /users/${id}/posts/${postId}.
+func TestTSExtractor_NestedTemplateString_AllPlaceholdersReplaced(t *testing.T) {
+	src := "fetch(`/users/${id}/posts/${postId}`)"
+	apis := apiEntities(runExtract(t, "typescript", src))
+	if len(apis) != 1 {
+		t.Fatalf("expected 1 API entity, got %d", len(apis))
+	}
+	want := "/users/{*}/posts/{*}"
+	if apis[0].Name != want {
+		t.Errorf("url = %q, want %q", apis[0].Name, want)
+	}
+}
+
+// TestTSExtractor_StaticString_Unchanged is a negative regression test: a
+// plain string argument with no interpolations must be emitted verbatim.
+func TestTSExtractor_StaticString_Unchanged(t *testing.T) {
+	src := `fetch('/foo')`
+	apis := apiEntities(runExtract(t, "typescript", src))
+	if len(apis) != 1 {
+		t.Fatalf("expected 1 API entity, got %d", len(apis))
+	}
+	want := "/foo"
+	if apis[0].Name != want {
+		t.Errorf("url = %q, want %q", apis[0].Name, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Python: requests / httpx
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Template literals like `callApi(\`/users/\${id}\`)` were silently extracted with the raw `${id}` placeholder, so they never matched server-side routes like `/users/{pk}` or `/users/<int:id>` during cross-repo link resolution.
- Added `normalizeTemplateURL` in `internal/extractors/cross/httpclient/extractor.go` — replaces every `${...}` interpolation with the `{*}` wildcard sentinel used by `normalizePathForIndex` on the server side.
- Extended the backtick regex for `fetch` to allow `${...}` content inside the backtick string, and added a new `jsAxiosBacktickRE` for `axios.METHOD(\`url\`)` with template expressions.

Closes #2615

## Test plan

- [x] `TestTSExtractor_TemplateString_NormalizedToWildcard` — `fetch(\`/users/${id}\`)` → entity path `/users/{*}`
- [x] `TestTSExtractor_NestedTemplateString_AllPlaceholdersReplaced` — `fetch(\`/users/${id}/posts/${postId}\`)` → `/users/{*}/posts/{*}`
- [x] `TestTSExtractor_StaticString_Unchanged` — `fetch('/foo')` still emits `/foo` (regression guard)
- [x] Full `./internal/extractors/cross/httpclient/...` suite green
- [x] Full `./internal/extractors/javascript/...` suite green
- [x] `gofmt`, `go vet`, `go build ./...` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)