### PR TITLE
feat(engine/python): @action + custom urlpatterns endpoint synthesis

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -943,6 +943,18 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		}
 		pass3Records = append(pass3Records, adminEntities...)
 
+		// Pass 2.6e-vs — DRF ViewSet.as_view({dict}) route synthesis (#2614).
+		// Handles the explicit method-map mounting pattern that appears outside
+		// router.register() — e.g. the upvate notification routes where
+		// NotificationViewSet.as_view({'get': 'list', 'delete': 'delete_all'})
+		// is pre-bound to a variable and then wired into urlpatterns. Covers
+		// both the pre-bound-variable form and the inline as_view({}) form.
+		vsAsViewEntities := runDjangoViewSetAsViewRoutes(classified)
+		if len(vsAsViewEntities) > 0 {
+			fmt.Fprintf(os.Stderr, "archigraph: drf_viewset_asview_routes=%d entities\n", len(vsAsViewEntities))
+		}
+		pass3Records = append(pass3Records, vsAsViewEntities...)
+
 		// Pass 2.6e — Celery cross-file dispatch edges (#1617). The per-file
 		// scheduled-job pass only links `task.delay()` call sites that share a
 		// file with the @shared_task definition. This repo-wide pass resolves
@@ -2642,6 +2654,30 @@ func runDjangoCBVRoutes(classified []classifiedFile) []types.EntityRecord {
 		return contentByPath[relPath]
 	}
 	return engine.ApplyDjangoCBVRoutes(pyPaths, reader)
+}
+
+// runDjangoViewSetAsViewRoutes runs the DRF ViewSet.as_view({dict}) route
+// expansion pass (#2614). Handles the explicit method-map pattern where a
+// ViewSet is mounted outside of a router.register() call via either a
+// pre-bound variable (_name = VS.as_view({'get': 'list'})) or an inline
+// call inside path("...", VS.as_view({'post': 'create'})).
+func runDjangoViewSetAsViewRoutes(classified []classifiedFile) []types.EntityRecord {
+	if len(classified) == 0 {
+		return nil
+	}
+	contentByPath := make(map[string][]byte, len(classified))
+	var pyPaths []string
+	for _, cf := range classified {
+		if cf.language != "python" {
+			continue
+		}
+		contentByPath[cf.relPath] = cf.content
+		pyPaths = append(pyPaths, cf.relPath)
+	}
+	reader := func(relPath string) []byte {
+		return contentByPath[relPath]
+	}
+	return engine.ApplyDjangoViewSetAsViewRoutes(pyPaths, reader)
 }
 
 // runSerializerMetaModelEdges emits REFERENCES edges from DRF Serializer

--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -1954,6 +1954,218 @@ func ApplyDjangoCBVRoutes(
 	return out
 }
 
+// ---------------------------------------------------------------------------
+// DRF ViewSet.as_view({method_map}) routes — Issue #2614
+// ---------------------------------------------------------------------------
+//
+// Problem: DRF ViewSets can be mounted without a router via the explicit
+// method-map form:
+//
+//	_list = NotificationViewSet.as_view({'get': 'list', 'delete': 'delete_all'})
+//	urlpatterns = [
+//	    path("notifications/", _list, name="notifications-list"),
+//	]
+//
+// Or inline:
+//
+//	path("notifications/", NotificationViewSet.as_view({'get': 'list'}))
+//
+// ApplyDjangoDRFRoutes only processes files that contain router.register()
+// calls — it never sees the urlpatterns lines above. ApplyDjangoCBVRoutes
+// uses cbvAsViewRe which requires as_view() with NO arguments and thus
+// misses the dict form. ApplyDjangoNestedURLConf emits a single ANY entity
+// for the path but cannot derive the per-verb signal from the method map.
+//
+// Fix: scan every Django URL file and router file for the two patterns and
+// emit per-verb http_endpoint synthetics with source_handler set to the
+// ViewSet action method. Refs #2614.
+
+// drfViewSetAsViewAssignRe matches variable assignment of the form:
+//
+//	_name = ViewSet.as_view({'get': 'list', 'delete': 'delete_all'})
+//	_name = views.ViewSet.as_view({"get": "list"})
+//
+// Captures group 1 = variable name, group 2 = ViewSet class name (last
+// segment of dotted path), group 3 = the raw dict body inside { }.
+var drfViewSetAsViewAssignRe = regexp.MustCompile(
+	`(\w+)\s*=\s*(?:[\w.]+\.)?(\w+)\s*\.\s*as_view\s*\(\s*\{([^}]+)\}`)
+
+// drfViewSetAsViewInlineRe matches a path() call with an inline as_view({dict}):
+//
+//	path("notifications/", NotificationViewSet.as_view({'get': 'list'}))
+//
+// Captures group 1 = route pattern, group 2 = ViewSet class name (last
+// segment), group 3 = raw dict body.
+var drfViewSetAsViewInlineRe = regexp.MustCompile(
+	`(?:re_)?path\s*\(\s*r?["']([^"']*)["']\s*,\s*(?:[\w.]+\.)?(\w+)\s*\.\s*as_view\s*\(\s*\{([^}]+)\}`)
+
+// drfViewSetAsViewPathVarRe matches a path() whose handler is a bare
+// identifier (the variable assigned by drfViewSetAsViewAssignRe):
+//
+//	path("notifications/", _notification_list, name="...")
+//
+// Captures group 1 = route pattern, group 2 = handler variable name.
+var drfViewSetAsViewPathVarRe = regexp.MustCompile(
+	`(?:re_)?path\s*\(\s*r?["']([^"']*)["']\s*,\s*(_\w+)`)
+
+// drfMethodMapKVRe extracts key-value pairs from a Python dict literal of
+// the form 'verb': 'action' or "verb": "action".
+var drfMethodMapKVRe = regexp.MustCompile(
+	`["'](\w+)['"]\s*:\s*["'](\w+)["']`)
+
+// parseViewSetMethodMap parses the raw body of a {verb: action, ...} dict
+// from a ViewSet.as_view() call and returns the map of uppercase HTTP verb
+// → ViewSet action name.
+func parseViewSetMethodMap(body string) map[string]string {
+	out := map[string]string{}
+	for _, m := range drfMethodMapKVRe.FindAllStringSubmatch(body, -1) {
+		verb := strings.ToUpper(m[1])
+		action := m[2]
+		out[verb] = action
+	}
+	return out
+}
+
+// ApplyDjangoViewSetAsViewRoutes handles the DRF ViewSet.as_view({dict})
+// mounting pattern that appears outside of router.register() — either as a
+// pre-bound variable reused in urlpatterns, or as an inline as_view() call
+// directly inside a path(). For each such binding it emits one per-verb
+// http_endpoint synthetic carrying source_handler and, when the binding is
+// reached via a parent include() chain, the url_prefix property.
+//
+// parentFiles: repo-relative Python file paths.
+// fileReader:  resolves a repo-relative path to raw bytes.
+func ApplyDjangoViewSetAsViewRoutes(
+	parentFiles []string,
+	fileReader NestedURLConfFileReader,
+) []types.EntityRecord {
+	if fileReader == nil {
+		return nil
+	}
+
+	var out []types.EntityRecord
+	seen := map[string]bool{}
+
+	for _, relPath := range parentFiles {
+		if !isDjangoURLFile(relPath) && !isDjangoRoutersFile(relPath) {
+			continue
+		}
+		content := fileReader(relPath)
+		if len(content) == 0 {
+			continue
+		}
+		src := string(content)
+
+		// Step 1 — collect variable assignments:
+		//   _notification_list = views.NotificationViewSet.as_view({'get': 'list'})
+		// Map: varName → {HTTP_VERB: action_name, ViewSet: className}
+		type varBinding struct {
+			viewSetName string
+			methodMap   map[string]string
+		}
+		varBindings := map[string]varBinding{}
+		for _, m := range drfViewSetAsViewAssignRe.FindAllStringSubmatch(src, -1) {
+			varName := m[1]
+			viewSetName := m[2]
+			dictBody := m[3]
+			methodMap := parseViewSetMethodMap(dictBody)
+			if len(methodMap) > 0 {
+				varBindings[varName] = varBinding{viewSetName: viewSetName, methodMap: methodMap}
+			}
+		}
+
+		// Determine parent include() prefixes for prefix composition.
+		parentPrefixes := findParentIncludePrefixes(relPath, parentFiles, fileReader)
+		if len(parentPrefixes) == 0 {
+			parentPrefixes = []string{""}
+		}
+
+		// Also apply local path("prefix", include(routerVar.urls)) prefixes.
+		flat := flattenParenthesised(src)
+		localRouterPrefixes := buildLocalRouterPrefixes(flat)
+		// For router files, the local prefix is on the router var; for url
+		// files with explicit urlpatterns, there's typically no router var.
+		// Apply the first available local prefix as a general URL mount prefix.
+		var localMount string
+		for _, p := range localRouterPrefixes {
+			localMount = p
+			break
+		}
+		if localMount != "" && len(parentPrefixes) == 1 && parentPrefixes[0] == "" {
+			parentPrefixes = []string{localMount}
+		}
+
+		emitForBinding := func(rawPattern, viewSetName string, methodMap map[string]string) {
+			for _, pp := range parentPrefixes {
+				composed := joinDjangoRoutePaths(pp, rawPattern)
+				canonical := canonicalDjango(composed)
+				if canonical == "" || canonical == "/" {
+					continue
+				}
+				urlPrefix := ""
+				if pp != "" {
+					urlPrefix = "/" + strings.Trim(pp, "/")
+				}
+				for httpVerb, actionName := range methodMap {
+					id := httproutes.SyntheticID(httpVerb, canonical)
+					if seen[id] {
+						continue
+					}
+					seen[id] = true
+					qualifiedHandler := viewSetName + "." + actionName
+					props := map[string]string{
+						"verb":           httpVerb,
+						"path":           canonical,
+						"framework":      "django",
+						"pattern_type":   "drf_viewset_asview_route",
+						"drf_view_class": viewSetName,
+						"source_handler": "SCOPE.Operation:" + qualifiedHandler,
+					}
+					if urlPrefix != "" {
+						props["url_prefix"] = urlPrefix
+					}
+					out = append(out, types.EntityRecord{
+						ID:                 id,
+						Name:               id,
+						Kind:               httpEndpointKind,
+						SourceFile:         relPath,
+						Language:           "python",
+						Properties:         props,
+						EnrichmentRequired: false,
+						EnrichmentStatus:   types.StatusPending,
+						QualityScore:       0.8,
+					})
+				}
+			}
+		}
+
+		// Step 2a — inline as_view({dict}) directly inside path():
+		//   path("notifications/", NotificationViewSet.as_view({'get': 'list'}))
+		for _, m := range drfViewSetAsViewInlineRe.FindAllStringSubmatch(flat, -1) {
+			rawPattern := m[1]
+			viewSetName := m[2]
+			dictBody := m[3]
+			methodMap := parseViewSetMethodMap(dictBody)
+			if len(methodMap) > 0 {
+				emitForBinding(rawPattern, viewSetName, methodMap)
+			}
+		}
+
+		// Step 2b — pre-bound variable referenced in path():
+		//   path("notifications/", _notification_list, ...)
+		if len(varBindings) > 0 {
+			for _, m := range drfViewSetAsViewPathVarRe.FindAllStringSubmatch(flat, -1) {
+				rawPattern := m[1]
+				varName := m[2]
+				if binding, ok := varBindings[varName]; ok {
+					emitForBinding(rawPattern, binding.viewSetName, binding.methodMap)
+				}
+			}
+		}
+	}
+	return out
+}
+
 // emitCBVMethodEntities emits synthetic SCOPE.Operation entities for each
 // HTTP handler method that the CBV exposes via inheritance but does NOT
 // explicitly define. Mirrors emitViewSetMethodEntities from #783.

--- a/internal/engine/django_drf_actions_test.go
+++ b/internal/engine/django_drf_actions_test.go
@@ -2189,3 +2189,257 @@ class ChildViewSet(ModelViewSet):
 		"http:GET:/parents/{pk}/children/{pk}",
 	})
 }
+
+// ---------------------------------------------------------------------------
+// Issue #2614 — ViewSet.as_view({dict}) route synthesis tests
+// ---------------------------------------------------------------------------
+
+// TestDRF_ActionDecorator_EmitsEndpoint verifies that a ViewSet with an
+// @action decorator whose url_path contains a slash (e.g. "notes/create")
+// is correctly emitted under the full composed path
+// /<prefix>/{pk}/notes/create when detail=True. This is the upvate
+// ContractViewSet pattern where custom sub-resource actions are mounted as
+// nested URL segments rather than flat paths.
+func TestDRF_ActionDecorator_EmitsEndpoint(t *testing.T) {
+	files := fileMap{
+		"core/routers.py": `
+from rest_framework import routers
+from core.views import ContractViewSet
+
+router = routers.DefaultRouter()
+router.register(r"contracts", ContractViewSet)
+
+urlpatterns = [
+    path("", include(router.urls)),
+]
+`,
+		"upvate_core/urls.py": `
+from django.urls import path, include
+urlpatterns = [
+    path("api/v1/", include("core.routers")),
+]
+`,
+		"core/views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+
+class ContractViewSet(ModelViewSet):
+    @action(
+        methods=["post"],
+        detail=False,
+        url_path="notes/create",
+    )
+    def create_note(self, request):
+        pass
+
+    @action(
+        methods=["delete"],
+        detail=True,
+        url_path="notes/delete",
+    )
+    def delete_note(self, request, pk, *args, **kwargs):
+        pass
+`,
+	}
+
+	pyPaths := []string{"upvate_core/urls.py", "core/routers.py", "core/views.py"}
+	got := ApplyDjangoDRFRoutes(pyPaths, files.reader)
+
+	// detail=False → collection route (no {pk})
+	assertHasAllIDs(t, got, []string{
+		"http:POST:/api/v1/contracts/notes/create",
+	})
+	// detail=True → detail route with {pk}
+	assertHasAllIDs(t, got, []string{
+		"http:DELETE:/api/v1/contracts/{pk}/notes/delete",
+	})
+}
+
+// TestDRF_ActionDetailFalse_EmitsCollectionPath verifies that
+// @action(detail=False) decorators on a ViewSet emit the action at the
+// collection path (without a {pk} segment). Tests multiple HTTP verbs and
+// url_path values to cover the common upvate patterns (permissions,
+// s3_attachment, import viewsets).
+func TestDRF_ActionDetailFalse_EmitsCollectionPath(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import PermissionViewSet
+
+router = routers.DefaultRouter()
+router.register(r"permissions", PermissionViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+
+class PermissionViewSet(ModelViewSet):
+    @action(methods=["put"], detail=False, url_path="bulk_update_permissions")
+    def bulk_update_permissions(self, request):
+        pass
+
+    @action(methods=["get"], detail=True, url_path="scope_permissions")
+    def scope_permissions(self, request, pk=None):
+        pass
+
+    @action(methods=["put"], detail=True, url_path="assign_scope_permissions")
+    def assign_scope_permissions(self, request, pk=None):
+        pass
+`,
+	}
+
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// detail=False → collection path (no {pk})
+	assertHasAllIDs(t, got, []string{
+		"http:PUT:/permissions/bulk_update_permissions",
+	})
+	// detail=True → detail path with {pk}
+	assertHasAllIDs(t, got, []string{
+		"http:GET:/permissions/{pk}/scope_permissions",
+		"http:PUT:/permissions/{pk}/assign_scope_permissions",
+	})
+	// detail=False action must NOT have {pk} in the path
+	assertHasNoneIDs(t, got, []string{
+		"http:PUT:/permissions/{pk}/bulk_update_permissions",
+	})
+}
+
+// TestDjango_CustomPathOutsideRouter_EmitsEndpoint is the primary regression
+// test for #2614 pattern (b): a DRF ViewSet mounted outside router.register()
+// via the explicit method-map form ViewSet.as_view({'verb': 'action'}).
+//
+// This covers the upvate notification routing pattern where:
+//
+//	_notification_list = views.NotificationViewSet.as_view({
+//	    'get': 'list', 'delete': 'delete_all'})
+//	urlpatterns = [
+//	    path("notifications/", _notification_list),
+//	    path("notifications/<int:pk>/", _notification_detail),
+//	]
+func TestDjango_CustomPathOutsideRouter_EmitsEndpoint(t *testing.T) {
+	files := fileMap{
+		"upvate_core/urls.py": `
+from django.urls import path, include
+urlpatterns = [
+    path("api/v1/", include("core.routers")),
+]
+`,
+		"core/routers.py": `
+from django.urls import path, include
+from rest_framework import routers
+from core import views
+
+router = routers.DefaultRouter()
+router.register(r"contracts", views.ContractViewSet)
+
+_notification_list = views.NotificationViewSet.as_view({
+    'get': 'list',
+    'delete': 'delete_all',
+})
+_notification_detail = views.NotificationViewSet.as_view({
+    'patch': 'partial_update',
+    'delete': 'destroy',
+})
+_notification_mark_all_read = views.NotificationViewSet.as_view({
+    'post': 'mark_all_read',
+})
+
+urlpatterns = [
+    path("", include(router.urls)),
+    path("notifications/", _notification_list, name="notifications-list"),
+    path("notifications/mark-all-read/", _notification_mark_all_read, name="notifications-mark-all-read"),
+    path("notifications/<int:pk>/", _notification_detail, name="notifications-detail"),
+]
+`,
+	}
+
+	pyPaths := []string{"upvate_core/urls.py", "core/routers.py"}
+	got := ApplyDjangoViewSetAsViewRoutes(pyPaths, files.reader)
+
+	// Pre-bound variable form: _notification_list → GET + DELETE at collection path.
+	assertHasAllIDs(t, got, []string{
+		"http:GET:/api/v1/notifications",
+		"http:DELETE:/api/v1/notifications",
+	})
+	// _notification_mark_all_read → POST at mark-all-read path.
+	assertHasAllIDs(t, got, []string{
+		"http:POST:/api/v1/notifications/mark-all-read",
+	})
+	// _notification_detail → PATCH + DELETE at detail path.
+	assertHasAllIDs(t, got, []string{
+		"http:PATCH:/api/v1/notifications/{pk}",
+		"http:DELETE:/api/v1/notifications/{pk}",
+	})
+}
+
+// TestDjango_ViewSetAsView_InlineDict verifies that an inline
+// ViewSet.as_view({'get': 'list'}) call directly inside a path() (no
+// pre-bound variable) is also handled.
+func TestDjango_ViewSetAsView_InlineDict(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path
+from views import ItemViewSet
+
+urlpatterns = [
+    path("items/", ItemViewSet.as_view({'get': 'list', 'post': 'create'})),
+    path("items/<int:pk>/", ItemViewSet.as_view({'get': 'retrieve', 'delete': 'destroy'})),
+]
+`,
+	}
+
+	got := ApplyDjangoViewSetAsViewRoutes([]string{"urls.py"}, files.reader)
+
+	assertHasAllIDs(t, got, []string{
+		"http:GET:/items",
+		"http:POST:/items",
+		"http:GET:/items/{pk}",
+		"http:DELETE:/items/{pk}",
+	})
+}
+
+// TestDjango_ViewSetAsView_SourceHandlerSet verifies that the
+// source_handler property on each emitted entity points to the correct
+// ViewSet action method name, enabling the Phase-2 resolver to emit
+// IMPLEMENTS edges.
+func TestDjango_ViewSetAsView_SourceHandlerSet(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path
+from views import NotificationViewSet
+
+_list = NotificationViewSet.as_view({'get': 'list', 'delete': 'delete_all'})
+
+urlpatterns = [
+    path("notifications/", _list),
+]
+`,
+	}
+
+	got := ApplyDjangoViewSetAsViewRoutes([]string{"urls.py"}, files.reader)
+
+	wantHandlers := map[string]string{
+		"http:GET:/notifications":    "SCOPE.Operation:NotificationViewSet.list",
+		"http:DELETE:/notifications": "SCOPE.Operation:NotificationViewSet.delete_all",
+	}
+
+	foundCount := 0
+	for _, r := range got {
+		if r.Kind != httpEndpointKind {
+			continue
+		}
+		wantHandler, ok := wantHandlers[r.ID]
+		if !ok {
+			continue
+		}
+		foundCount++
+		gotHandler := r.Properties["source_handler"]
+		if gotHandler != wantHandler {
+			t.Errorf("entity %q: source_handler=%q want %q", r.ID, gotHandler, wantHandler)
+		}
+	}
+	if foundCount != 2 {
+		t.Errorf("expected 2 matching entities, found %d", foundCount)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ApplyDjangoViewSetAsViewRoutes` (pass 2.6e-vs) to handle DRF ViewSets mounted via `ViewSet.as_view({'http_verb': 'action_name'})` outside of `router.register()` — the upvate notification pattern
- Handles both pre-bound variable form (`_name = VS.as_view({...}); path(..., _name)`) and inline form (`path(..., VS.as_view({...}))`)
- Each binding emits per-verb `http_endpoint` entities with `source_handler = "SCOPE.Operation:ViewSet.action"` and parent `url_prefix` for cross-repo linker
- Wires the new pass as pass 2.6e-vs in `cmd/archigraph/index.go`

## Pattern locations (file:line)

- `internal/engine/django_drf_actions.go:1958` — `ApplyDjangoViewSetAsViewRoutes` function + `drfViewSetAsViewAssignRe` / `drfViewSetAsViewInlineRe` / `drfViewSetAsViewPathVarRe` regexes
- `internal/engine/django_drf_actions.go:1910` — `drfViewSetAsViewAssignRe` regex
- `cmd/archigraph/index.go:2647` — `runDjangoViewSetAsViewRoutes` + pipeline wiring

## Test plan

- [x] `TestDRF_ActionDecorator_EmitsEndpoint` — `@action` with `url_path` containing slash (e.g. `notes/create`)
- [x] `TestDRF_ActionDetailFalse_EmitsCollectionPath` — `@action(detail=False)` emits collection path; `detail=True` emits `{pk}` path
- [x] `TestDjango_CustomPathOutsideRouter_EmitsEndpoint` — pre-bound variable `_notification_list = VS.as_view({...})` in urlpatterns
- [x] `TestDjango_ViewSetAsView_InlineDict` — inline `VS.as_view({...})` in `path()`
- [x] `TestDjango_ViewSetAsView_SourceHandlerSet` — `source_handler` points to correct action method
- [x] All pre-existing engine tests pass (`go test ./internal/engine/` green)
- [x] `go build ./...` clean; `go vet ./...` clean; `gofmt` no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)