### PR TITLE
feat(install): cross-platform Windsurf MCP registration (#2618)

### DIFF
--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -244,9 +244,18 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Step 3: MCP registration
+	// Register in every detected Claude config dir and in any Windsurf
+	// config paths whose parent directory already exists (i.e. Windsurf is
+	// installed). Windsurf paths that have no parent dir are silently skipped.
 	// ─────────────────────────────────────────────────────────────────────────
 	var registeredPaths []string
-	for _, cfgPath := range claudeDirs {
+
+	// Collect all target paths: Claude dirs first, then Windsurf.
+	allMCPTargets := make([]string, len(claudeDirs))
+	copy(allMCPTargets, claudeDirs)
+	allMCPTargets = append(allMCPTargets, mcpreg.DetectWindsurfPaths()...)
+
+	for _, cfgPath := range allMCPTargets {
 		if opts.DryRun {
 			registeredPaths = append(registeredPaths, cfgPath)
 			continue

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -50,8 +50,9 @@ type Entry struct {
 type Tool string
 
 const (
-	ClaudeCode Tool = "claude-code"
-	Windsurf   Tool = "windsurf"
+	ClaudeCode        Tool = "claude-code"
+	Windsurf          Tool = "windsurf"
+	WindsurfJetBrains Tool = "windsurf-jetbrains"
 )
 
 // SettingsPath returns the absolute path to the settings file for a tool.
@@ -67,9 +68,47 @@ func SettingsPath(tool Tool) (string, error) {
 		// This is the file Claude Code reads for mcpServers entries.
 		return filepath.Join(home, ".claude.json"), nil
 	case Windsurf:
+		// Windsurf desktop app: ~/.codeium/windsurf/mcp_config.json
 		return filepath.Join(home, ".codeium", "windsurf", "mcp_config.json"), nil
+	case WindsurfJetBrains:
+		// Windsurf JetBrains plugin: ~/.codeium/mcp_config.json
+		return filepath.Join(home, ".codeium", "mcp_config.json"), nil
 	}
 	return "", fmt.Errorf("unknown tool: %s", tool)
+}
+
+// DetectWindsurfPaths returns the Windsurf config paths that should be
+// registered. Only paths whose parent directory already exists are returned —
+// if Windsurf is not installed the list will be empty and the caller can skip
+// registration silently.
+//
+// Two paths are considered:
+//   - ~/.codeium/windsurf/mcp_config.json  (Windsurf desktop app)
+//   - ~/.codeium/mcp_config.json           (Windsurf JetBrains plugin)
+//
+// For each path: if the config file itself exists it is always included. If
+// the file does not exist but its parent directory does, the caller will
+// create the file (Windsurf is installed but the MCP config hasn't been
+// written yet). If neither the file nor the parent directory exists the
+// path is omitted.
+func DetectWindsurfPaths() []string {
+	var out []string
+	for _, tool := range []Tool{Windsurf, WindsurfJetBrains} {
+		p, err := SettingsPath(tool)
+		if err != nil {
+			continue
+		}
+		// Include if the config file exists OR if its parent dir exists
+		// (meaning Windsurf is installed but hasn't written an MCP config yet).
+		if _, err := os.Stat(p); err == nil {
+			out = append(out, p)
+			continue
+		}
+		if _, err := os.Stat(filepath.Dir(p)); err == nil {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // DetectClaudeConfigDirs returns the list of ~/.claude.json paths to

--- a/internal/install/mcpreg/mcpreg_test.go
+++ b/internal/install/mcpreg/mcpreg_test.go
@@ -214,3 +214,197 @@ func TestUnregisterPath(t *testing.T) {
 		t.Fatalf("archigraph entry still present after Unregister: %s", b)
 	}
 }
+
+// ── Windsurf tests ────────────────────────────────────────────────────────────
+
+// TestInstallRegistersWindsurfDesktop: fakeHome with the Windsurf desktop
+// parent dir present → DetectWindsurfPaths includes the desktop path and
+// RegisterPath populates the archigraph entry.
+func TestInstallRegistersWindsurfDesktop(t *testing.T) {
+	home := withHome(t)
+
+	// Simulate Windsurf desktop app installed: create the parent dir.
+	desktopDir := filepath.Join(home, ".codeium", "windsurf")
+	if err := os.MkdirAll(desktopDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := DetectWindsurfPaths()
+	desktopConfig := filepath.Join(desktopDir, "mcp_config.json")
+
+	found := false
+	for _, p := range paths {
+		if p == desktopConfig {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("DetectWindsurfPaths did not return desktop path %s; got %v", desktopConfig, paths)
+	}
+
+	// Register and verify the entry is correct.
+	if _, err := RegisterPath(desktopConfig, "/usr/local/bin/archigraph"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(desktopConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		McpServers map[string]Entry `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	got := doc.McpServers[ServerName]
+	if got.Command != "/usr/local/bin/archigraph" {
+		t.Fatalf("desktop: command = %q, want /usr/local/bin/archigraph", got.Command)
+	}
+	if len(got.Args) != 1 || got.Args[0] != "mcp-bridge" {
+		t.Fatalf("desktop: args = %v, want [mcp-bridge]", got.Args)
+	}
+	if got.Type != "stdio" {
+		t.Fatalf("desktop: type = %q, want stdio", got.Type)
+	}
+}
+
+// TestInstallRegistersWindsurfJetBrains: fakeHome with the JetBrains plugin
+// parent dir present → DetectWindsurfPaths includes the JetBrains path and
+// RegisterPath populates the archigraph entry.
+func TestInstallRegistersWindsurfJetBrains(t *testing.T) {
+	home := withHome(t)
+
+	// Simulate Windsurf JetBrains plugin installed: create ~/.codeium/ only
+	// (NOT the windsurf/ subdir, so the desktop path must NOT appear).
+	codeiumDir := filepath.Join(home, ".codeium")
+	if err := os.MkdirAll(codeiumDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := DetectWindsurfPaths()
+	jbConfig := filepath.Join(codeiumDir, "mcp_config.json")
+
+	found := false
+	for _, p := range paths {
+		if p == jbConfig {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("DetectWindsurfPaths did not return JetBrains path %s; got %v", jbConfig, paths)
+	}
+
+	// The desktop path must NOT appear (windsurf/ subdir does not exist).
+	desktopConfig := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+	for _, p := range paths {
+		if p == desktopConfig {
+			t.Fatalf("DetectWindsurfPaths included desktop path %s but windsurf/ dir does not exist", p)
+		}
+	}
+
+	// Register and verify the entry is correct.
+	if _, err := RegisterPath(jbConfig, "/usr/local/bin/archigraph"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(jbConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		McpServers map[string]Entry `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	got := doc.McpServers[ServerName]
+	if got.Command != "/usr/local/bin/archigraph" {
+		t.Fatalf("jetbrains: command = %q, want /usr/local/bin/archigraph", got.Command)
+	}
+}
+
+// TestInstallSkipsAbsentWindsurf: fakeHome without .codeium dir →
+// DetectWindsurfPaths returns an empty slice and no writes occur.
+func TestInstallSkipsAbsentWindsurf(t *testing.T) {
+	withHome(t)
+	// No .codeium directory created — Windsurf is not installed.
+
+	paths := DetectWindsurfPaths()
+	if len(paths) != 0 {
+		t.Fatalf("expected no Windsurf paths when .codeium absent, got %v", paths)
+	}
+}
+
+// TestWindsurfJetBrainsPath verifies the canonical path for WindsurfJetBrains.
+func TestWindsurfJetBrainsPath(t *testing.T) {
+	home := withHome(t)
+	p, err := SettingsPath(WindsurfJetBrains)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".codeium", "mcp_config.json")
+	if p != want {
+		t.Fatalf("WindsurfJetBrains path: got %s, want %s", p, want)
+	}
+	// Confirm no hardcoded slash separators or /Users/ prefixes.
+	if filepath.IsAbs(p) && filepath.Dir(p) == "/" {
+		t.Fatalf("path looks hardcoded: %s", p)
+	}
+}
+
+// TestInstall_CrossPlatformPaths asserts that all tool paths are constructed
+// via filepath.Join (no string-concatenated '/' separators) by verifying
+// each path is rooted under the fake home dir and that filepath.Rel succeeds
+// without traversal (i.e. no ".." components at the start).
+func TestInstall_CrossPlatformPaths(t *testing.T) {
+	home := withHome(t)
+
+	for _, tool := range []Tool{ClaudeCode, Windsurf, WindsurfJetBrains} {
+		p, err := SettingsPath(tool)
+		if err != nil {
+			t.Fatalf("SettingsPath(%s): %v", tool, err)
+		}
+		// filepath.Rel must succeed and must not start with ".." (which would
+		// indicate the path escapes the home directory).
+		rel, err := filepath.Rel(home, p)
+		if err != nil {
+			t.Errorf("tool %s: filepath.Rel(%s, %s) failed: %v", tool, home, p, err)
+			continue
+		}
+		// A path under home either equals home (".") or starts with a
+		// path component — it must NOT start with "..".
+		parts := filepath.SplitList(rel)
+		_ = parts
+		if len(rel) >= 2 && rel[:2] == ".." {
+			t.Errorf("tool %s: path %s escapes home %s (rel=%s)", tool, p, home, rel)
+		}
+	}
+}
+
+// TestWindsurfRegistrationUpdatesPath verifies that re-running RegisterPath
+// with a new binary path updates the command field (--force reinstall case).
+func TestWindsurfRegistrationUpdatesPath(t *testing.T) {
+	home := withHome(t)
+
+	desktopDir := filepath.Join(home, ".codeium", "windsurf")
+	if err := os.MkdirAll(desktopDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(desktopDir, "mcp_config.json")
+
+	if _, err := RegisterPath(cfgPath, "/old/archigraph"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RegisterPath(cfgPath, "/new/archigraph"); err != nil {
+		t.Fatal(err)
+	}
+
+	b, _ := os.ReadFile(cfgPath)
+	var doc struct {
+		McpServers map[string]Entry `json:"mcpServers"`
+	}
+	_ = json.Unmarshal(b, &doc)
+	got := doc.McpServers[ServerName]
+	if got.Command != "/new/archigraph" {
+		t.Fatalf("Windsurf desktop: command not updated on re-register: %q", got.Command)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `WindsurfJetBrains` tool constant + path (`~/.codeium/mcp_config.json`) to `mcpreg` alongside the existing `Windsurf` desktop path (`~/.codeium/windsurf/mcp_config.json`)
- Adds `DetectWindsurfPaths()`: only includes a config path when its parent directory exists (Windsurf actually installed), silently skips absent hosts
- Extends `RunCopy` step 3 to append detected Windsurf paths to the MCP registration targets; they are recorded in `state.MCP.RegisteredPaths` so `RunUninstall` deregisters them automatically (no uninstall code changes needed)
- All paths use `filepath.Join(home, ...)` with `home` from `os.UserHomeDir()` — no hardcoded `/Users/`, no `$HOME` reads, no literal `/` separators in path construction

## Test plan

- [x] `TestInstallRegistersWindsurfDesktop` — fakeHome with `~/.codeium/windsurf/` present → path included, entry written with correct command/args/type
- [x] `TestInstallRegistersWindsurfJetBrains` — fakeHome with `~/.codeium/` only → JetBrains path included, desktop path absent
- [x] `TestInstallSkipsAbsentWindsurf` — fakeHome without `.codeium/` → empty list, no writes
- [x] `TestInstall_CrossPlatformPaths` — all 3 tool paths start under fake home, no `..` escapes
- [x] `TestWindsurfRegistrationUpdatesPath` — re-registering with new binary path updates the `command` field
- [x] `TestWindsurfJetBrainsPath` — canonical path for the new `WindsurfJetBrains` tool constant
- [x] All 16 `mcpreg` tests pass; all 7 `internal/install/...` + `cmd/archigraph/...` packages pass

## Closes

Closes #2618

🤖 Generated with [Claude Code](https://claude.com/claude-code)