### PR TITLE
fix(mcp): expose full tool surface + default to single group when cwd unresolvable

### DIFF
--- a/internal/mcp/cwd_gate_test.go
+++ b/internal/mcp/cwd_gate_test.go
@@ -1,14 +1,15 @@
 package mcp
 
-// cwd_gate_test.go — unit tests for the tools/list cwd-gate (#1769).
+// cwd_gate_test.go — unit tests for the tools/list cwd-gate (#1769, #2620).
 //
 // Test matrix:
-//   - No registered groups      → only sentinel.
-//   - cwd outside all groups    → only sentinel.
-//   - cwd inside one group      → full list (minus sentinel).
-//   - cwd inside multiple groups (ambiguous) → full list.
-//   - cwd inside group with 0 repos (empty group) → only sentinel + hint.
-//   - archigraph_status call from no-match cwd → expected guidance text.
+//   - No registered groups                                  → only sentinel.
+//   - cwd outside all groups, single group registered       → full list (singleton fallback #2620).
+//   - cwd outside all groups, multiple groups registered    → full list (tools error per-call #2620).
+//   - cwd inside one group                                  → full list (minus sentinel).
+//   - cwd inside multiple groups (ambiguous)                → full list.
+//   - cwd inside group with 0 repos (empty group)           → only sentinel + hint.
+//   - archigraph_status call from no-match cwd              → expected guidance text.
 
 import (
 	"encoding/json"
@@ -69,19 +70,29 @@ func TestListToolsForCWD_NoGroups(t *testing.T) {
 	}
 }
 
-// TestListToolsForCWD_CWDOutsideAllGroups — cwd under /tmp, group registered elsewhere → sentinel.
-func TestListToolsForCWD_CWDOutsideAllGroups(t *testing.T) {
+// TestListToolsForCWD_CWDOutsideAllGroups_SingleGroup — #2620: cwd outside
+// the registered repo but exactly one group registered → singleton fallback
+// returns the FULL tool list (not sentinel). The fix makes the bridge usable
+// from hosts (Windsurf JetBrains) that launch with an unrelated cwd.
+func TestListToolsForCWD_CWDOutsideAllGroups_SingleGroup(t *testing.T) {
 	repoDir := t.TempDir()
 	srv := makeTestServer(t, map[string]map[string]string{
 		"mygroup": {"myrepo": repoDir},
 	})
 
+	// cwd is outside the registered repo, but singleton fallback should apply.
 	entries, err := srv.ListToolsForCWD("/tmp/unrelated-project")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !isSentinelOnly(entries) {
-		t.Fatalf("expected only sentinel tool for unrelated cwd, got %v", toolNames(entries))
+	// Fix #2620: singleton group → full list, not sentinel.
+	if isSentinelOnly(entries) {
+		t.Fatalf("expected full tool list via singleton fallback, got sentinel only (#2620)")
+	}
+	for _, e := range entries {
+		if e.Name == sentinelToolName {
+			t.Errorf("sentinel must not appear in full tool list when singleton fallback applies")
+		}
 	}
 }
 
@@ -167,9 +178,11 @@ func TestListToolsForCWD_EmptyGroup(t *testing.T) {
 	}
 }
 
-// TestListToolsForCWD_Ambiguous — cwd matches multiple groups → full list.
-func TestListToolsForCWD_Ambiguous(t *testing.T) {
-	// Create a shared parent dir so two groups' repos are ancestors of cwd.
+// TestListToolsForCWD_MultipleGroups_UnmatchedCWD_FullList — #2620: when cwd
+// matches no registered repo and multiple groups are registered, return the
+// FULL tool catalog (not sentinel). Each tool that requires a group will error
+// at call-time with a helpful "specify group=" message.
+func TestListToolsForCWD_MultipleGroups_UnmatchedCWD_FullList(t *testing.T) {
 	parentDir := t.TempDir()
 	repoA := filepath.Join(parentDir, "repoA")
 	repoB := filepath.Join(parentDir, "repoB")
@@ -185,22 +198,47 @@ func TestListToolsForCWD_Ambiguous(t *testing.T) {
 		"groupB": {"repoB": repoB},
 	})
 
-	// cwd is parentDir which is NOT under either repo → no match, returns sentinel.
-	// To create a true ambiguous scenario we'd need one cwd under both repos,
-	// which requires nested repos (parent is ancestor of both).
-	// Test the no-match case instead (parentDir is not under any repo).
+	// parentDir is NOT under either repo — multiple groups registered.
+	// Fix #2620: should return full tool list, NOT sentinel.
 	entries, err := srv.ListToolsForCWD(parentDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// parentDir is not under repoA or repoB — it's the parent, so no match.
-	// Multiple groups registered → sentinel (can't do singleton fallback).
-	if !isSentinelOnly(entries) {
-		t.Logf("tools: %v", toolNames(entries))
-		// Ambiguous → full list is also acceptable; only sentinel is wrong here
-		// if we get the full list for a known-unregistered cwd.
-		// Re-check: parentDir is NOT under repoA or repoB, so it should be sentinel.
-		t.Fatalf("expected sentinel for cwd outside all groups with multiple groups, got %d tools", len(entries))
+	if isSentinelOnly(entries) {
+		t.Fatalf("expected full tool list for multi-group unmatched cwd (#2620), got sentinel only")
+	}
+	// Sentinel must NOT appear in the full list.
+	for _, e := range entries {
+		if e.Name == sentinelToolName {
+			t.Errorf("sentinel must not appear in full tool list for multi-group unmatched cwd")
+		}
+	}
+}
+
+// TestListToolsForCWD_SingleGroup_RootCwd_FullList — #2620: bridge launched
+// with cwd=/ (Windsurf JetBrains) and exactly one group registered → full
+// tool list via singleton fallback.
+func TestListToolsForCWD_SingleGroup_RootCwd_FullList(t *testing.T) {
+	repoDir := t.TempDir()
+	srv := makeTestServer(t, map[string]map[string]string{
+		"upvate": {"upvate_core": repoDir},
+	})
+
+	entries, err := srv.ListToolsForCWD("/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isSentinelOnly(entries) {
+		t.Fatalf("expected full tool list for single-group singleton fallback with cwd=/ (#2620), got sentinel only")
+	}
+	// Sentinel must NOT appear.
+	for _, e := range entries {
+		if e.Name == sentinelToolName {
+			t.Errorf("sentinel must not appear in full tool list for singleton fallback")
+		}
+	}
+	if len(entries) < 5 {
+		t.Errorf("full list suspiciously small: %d tools", len(entries))
 	}
 }
 

--- a/internal/mcp/routing_test.go
+++ b/internal/mcp/routing_test.go
@@ -475,3 +475,75 @@ func TestHasGitDirInTree_WalksUp(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveGroup_SingleGroup_RootCwd_ReturnsThatGroup — #2620: when exactly
+// one group is registered and cwd=/ (or any unmatched path), resolveGroup
+// returns that group via the singleton fallback (Source="singleton").
+// Note: ResolveCWD returns Source="none" for non-project cwd; the singleton
+// behaviour for tool-listing is implemented in ListToolsForCWD.
+func TestResolveGroup_SingleGroup_RootCwd_ReturnsThatGroup(t *testing.T) {
+	tmp := t.TempDir()
+	repoPath := filepath.Join(tmp, "upvate_core")
+	if err := mkdirp(repoPath); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	reg := &Registry{
+		Groups: map[string]RegistryGroup{
+			"upvate": {
+				Repos: map[string]RegistryRepo{
+					"upvate-core": {Path: repoPath},
+				},
+			},
+		},
+	}
+	st := NewState(reg)
+
+	// resolveGroup uses the singleton fallback when cwd doesn't match.
+	g, src, err := resolveGroup(st, "", "/")
+	if err != nil {
+		t.Fatalf("resolveGroup(cwd=/): unexpected error: %v", err)
+	}
+	if g != "upvate" {
+		t.Errorf("resolveGroup(cwd=/): want Group=upvate, got %q", g)
+	}
+	if src != "singleton" {
+		t.Errorf("resolveGroup(cwd=/): want Source=singleton, got %q", src)
+	}
+}
+
+// TestResolveGroup_MultipleGroups_RootCwd_AmbiguousError — #2620: when multiple
+// groups are registered and cwd=/ (unmatched), resolveGroup returns an ambiguous
+// error listing all registered groups. The ListToolsForCWD layer handles
+// returning the full catalog (not sentinel) for this case.
+func TestResolveGroup_MultipleGroups_RootCwd_AmbiguousError(t *testing.T) {
+	tmp := t.TempDir()
+	repoA := filepath.Join(tmp, "repoA")
+	repoB := filepath.Join(tmp, "repoB")
+	if err := mkdirp(repoA); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := mkdirp(repoB); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	reg := &Registry{
+		Groups: map[string]RegistryGroup{
+			"groupA": {Repos: map[string]RegistryRepo{"repoA": {Path: repoA}}},
+			"groupB": {Repos: map[string]RegistryRepo{"repoB": {Path: repoB}}},
+		},
+	}
+	st := NewState(reg)
+
+	// resolveGroup with no explicit group and unmatched cwd → ambiguous error
+	// listing registered groups.
+	_, _, err := resolveGroup(st, "", "/")
+	if err == nil {
+		t.Fatal("resolveGroup(multi-group, cwd=/): expected ambiguous error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ambiguous group") {
+		t.Errorf("resolveGroup(multi-group, cwd=/): error should mention 'ambiguous group': %v", err)
+	}
+	// Error should list the registered group names.
+	if !strings.Contains(err.Error(), "groupA") || !strings.Contains(err.Error(), "groupB") {
+		t.Errorf("resolveGroup(multi-group, cwd=/): error should list registered groups: %v", err)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -238,17 +238,42 @@ func (s *Server) ListToolsForCWD(cwd string) ([]MCPToolEntry, error) {
 	}
 
 	// Three paths that lead to the sentinel:
-	//   1. No group covers cwd (group == "" and not ambiguous).
-	//   2. No groups are registered at all.
-	//   3. Group resolved but has 0 repos (empty group, needs rebuild).
-	noMatch := group == "" && len(candidates) == 0 && len(s.State.registry.Groups) > 0
+	//   1. No groups are registered at all.
+	//   2. Group resolved but has 0 repos (empty group, needs rebuild).
+	//   3. No group covers cwd AND multiple groups registered AND none is singleton.
+	//      (Sentinel here would be unhelpful — handled below.)
 	unregistered := len(s.State.registry.Groups) == 0
 
-	if noMatch || unregistered || groupEmpty {
+	// cwd is outside ALL registered group paths (group == "" and not ambiguous).
+	noDirectMatch := group == "" && len(candidates) == 0 && len(s.State.registry.Groups) > 0
+
+	if noDirectMatch {
+		// #2620: Singleton-group fallback — when exactly one group is registered,
+		// use it as the implicit default regardless of cwd. This makes the bridge
+		// usable from hosts (Windsurf JetBrains, Codex) that launch with cwd=/
+		// or any directory that is not under a registered repo path.
+		if len(s.State.registry.Groups) == 1 {
+			for gname, grp := range s.State.registry.Groups {
+				group = gname
+				if len(grp.Repos) == 0 {
+					groupEmpty = true
+				}
+				break
+			}
+		} else {
+			// Multiple groups registered and cwd is unmatched: return the full tool
+			// catalog anyway. Each tool that requires a group will error at call time
+			// with a "specify group= (registered groups: ...)" message. Downgrading
+			// to sentinel here makes the bridge completely unusable (#2620).
+			return s.fullToolList()
+		}
+	}
+
+	if unregistered || groupEmpty {
 		return s.sentinelToolList(cwd, group, groupEmpty), nil
 	}
 
-	// Ambiguous or unambiguous match: return the full catalog.
+	// Ambiguous or unambiguous match (including singleton fallback): return the full catalog.
 	return s.fullToolList()
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `ListToolsForCWD` called `groupFromRegistryWithCandidates` directly and fell through to the sentinel (1-tool) path when cwd didn't match any registered repo. It bypassed the singleton-group fallback that `resolveGroup` already implements.
- **Fix 1 (single group)**: When exactly 1 group is registered and cwd is unmatched, apply the singleton fallback — return the full tool catalog. This covers the Windsurf JetBrains cwd=/ case.
- **Fix 2 (multiple groups)**: When 2+ groups are registered and cwd is unmatched, also return the full catalog. Tools that require a group will error at call time with "specify group= (registered groups: foo, bar)" — which is actionable — instead of a 1-tool sentinel which is not.

## Test plan

- [x] `TestListToolsForCWD_SingleGroup_RootCwd_FullList` — single group + cwd=/ → full list
- [x] `TestListToolsForCWD_CWDOutsideAllGroups_SingleGroup` — single group + unrelated cwd → full list (was: sentinel)
- [x] `TestListToolsForCWD_MultipleGroups_UnmatchedCWD_FullList` — multi-group + unmatched cwd → full list (was: sentinel)
- [x] `TestResolveGroup_SingleGroup_RootCwd_ReturnsThatGroup` — resolveGroup singleton fallback for cwd=/
- [x] `TestResolveGroup_MultipleGroups_RootCwd_AmbiguousError` — resolveGroup ambiguous error lists all groups
- [x] All existing ListToolsForCWD / routing tests pass
- [x] Pre-existing schema contract failure (`archigraph_persona_event` depth arg) is unrelated and pre-dates this branch

Closes #2620

🤖 Generated with [Claude Code](https://claude.com/claude-code)