### PR TITLE
feat(extractor/ts): Zustand single-property selector binding CALLS edges

### DIFF
--- a/internal/extractors/javascript/destructure_bindings.go
+++ b/internal/extractors/javascript/destructure_bindings.go
@@ -46,6 +46,12 @@ import (
 // edges resolved through the destructure-binding table.
 const PropViaDestructuredBinding = "destructured_binding"
 
+// PropViaZustandSelector is the Properties["via"] value stamped on CALLS edges
+// resolved through a single-property arrow-selector binding (issue #2632):
+//
+//	const softLogout = useAuthStore(s => s.softLogout);
+const PropViaZustandSelector = "zustand_selector"
+
 // destructureBinding describes one local binding introduced by an object-pattern
 // destructuring statement.
 type destructureBinding struct {
@@ -127,13 +133,43 @@ func (x *extractor) buildDestructureBindings(scope *sitter.Node) map[string]*des
 // scanDestructureDeclarator processes a single variable_declarator node.
 // If the LHS is an object_pattern and the RHS matches a known source pattern,
 // it registers one destructureBinding per property in the object pattern.
+//
+// This also handles the single-property selector form (issue #2632):
+//
+//	const softLogout = useAuthStore(s => s.softLogout);
+//	softLogout();  ← needs CALLS edge
+//
+// When the LHS is a plain identifier and the RHS is a Zustand hook call whose
+// first argument is a simple member-expression arrow (s => s.action or s => s?.action),
+// one binding is registered: localName → actionName via=zustand_selector.
 func (x *extractor) scanDestructureDeclarator(decl *sitter.Node, out map[string]*destructureBinding) {
 	nameNode := decl.ChildByFieldName("name")
-	if nameNode == nil || nameNode.Type() != "object_pattern" {
+	if nameNode == nil {
 		return
 	}
 	valueNode := decl.ChildByFieldName("value")
 	if valueNode == nil {
+		return
+	}
+
+	// ── Single-property selector form (issue #2632) ──────────────────────────
+	// const softLogout = useAuthStore(s => s.softLogout);
+	if nameNode.Type() == "identifier" {
+		if actionName := x.parseSelectorArrowFn(valueNode); actionName != "" {
+			localName := x.nodeText(nameNode)
+			if localName != "" {
+				out[localName] = &destructureBinding{
+					localName:    localName,
+					sourceTarget: actionName,
+					via:          PropViaZustandSelector,
+				}
+				return
+			}
+		}
+	}
+
+	// ── Object-pattern destructuring form (issue #2625) ──────────────────────
+	if nameNode.Type() != "object_pattern" {
 		return
 	}
 
@@ -267,6 +303,99 @@ func (x *extractor) classifyDestructureRHS(value *sitter.Node) (via, calleeBase 
 	}
 
 	return "", ""
+}
+
+// parseSelectorArrowFn detects the single-property Zustand selector pattern (issue #2632):
+//
+//	useAuthStore(s => s.softLogout)          → "softLogout"
+//	useAuthStore((s) => s.softLogout)        → "softLogout"  (parenthesised param)
+//	useAuthStore(state => state.softLogout)  → "softLogout"  (any param name)
+//	useAuthStore(s => s?.softLogout)         → "softLogout"  (optional chain)
+//
+// Derived-value selectors like useAuthStore(s => Boolean(s.user)) return "" so
+// no spurious CALLS edge is emitted for non-callable selected values.
+//
+// Returns the action name on success or "" when the node does not match.
+func (x *extractor) parseSelectorArrowFn(value *sitter.Node) string {
+	if value == nil || value.Type() != "call_expression" {
+		return ""
+	}
+	// Callee must be a Zustand hook (useXxxStore).
+	fnNode := value.ChildByFieldName("function")
+	if fnNode == nil {
+		return ""
+	}
+	callee := x.calleeLeafName(fnNode)
+	if !isZustandHookName(callee) {
+		return ""
+	}
+	// First argument must be an arrow_function.
+	argsNode := value.ChildByFieldName("arguments")
+	if argsNode == nil {
+		return ""
+	}
+	// Find the first non-punctuation child of the arguments node.
+	var arrowNode *sitter.Node
+	for i := 0; i < int(argsNode.ChildCount()); i++ {
+		child := argsNode.Child(i)
+		if child == nil {
+			continue
+		}
+		t := child.Type()
+		if t == "(" || t == ")" || t == "," {
+			continue
+		}
+		arrowNode = child
+		break
+	}
+	if arrowNode == nil || arrowNode.Type() != "arrow_function" {
+		return ""
+	}
+	// Arrow body must be a simple member_expression (s.action) or
+	// optional member_expression (s?.action).  Anything else (call, binary,
+	// sequence, etc.) is a derived value — skip it.
+	bodyNode := arrowNode.ChildByFieldName("body")
+	if bodyNode == nil {
+		return ""
+	}
+	if bodyNode.Type() != "member_expression" && bodyNode.Type() != "optional_chain" {
+		return ""
+	}
+
+	// For optional_chain (s?.x) the grammar nests differently; normalise by
+	// accepting either member_expression or optional_chain and extracting the
+	// rightmost property identifier.
+	var propNode *sitter.Node
+	switch bodyNode.Type() {
+	case "member_expression":
+		// Verify that the object side is the arrow param — prevents chained
+		// access like s.nested.action from being treated as a single action.
+		objNode := bodyNode.ChildByFieldName("object")
+		if objNode == nil {
+			return ""
+		}
+		// Allow only a bare identifier (the selector parameter).
+		if objNode.Type() != "identifier" {
+			return ""
+		}
+		propNode = bodyNode.ChildByFieldName("property")
+	case "optional_chain":
+		// tree-sitter-javascript encodes `s?.x` as:
+		//   optional_chain → member_expression{object=s, property=x}
+		// or in some versions as a flat optional chain node. Walk children to
+		// find the trailing property_identifier.
+		for i := int(bodyNode.ChildCount()) - 1; i >= 0; i-- {
+			child := bodyNode.Child(i)
+			if child != nil && (child.Type() == "property_identifier" || child.Type() == "identifier") {
+				propNode = child
+				break
+			}
+		}
+	}
+	if propNode == nil {
+		return ""
+	}
+	return x.nodeText(propNode)
 }
 
 // calleeLeafName extracts the trailing identifier name from a function expression node.

--- a/internal/extractors/javascript/issue2632_zustand_selector_test.go
+++ b/internal/extractors/javascript/issue2632_zustand_selector_test.go
@@ -1,0 +1,227 @@
+// Package javascript_test — issue #2632: CALLS edges via single-property Zustand selector.
+//
+// PR #2629 handled `const { softLogout } = useAuthStore()` (object-pattern destructuring).
+// This file covers the more common arrow-selector form:
+//
+//	const softLogout = useAuthStore(s => s.softLogout);
+//	softLogout();  ← must produce CALLS edge
+//
+// Five test cases:
+//   - Basic:        s => s.action
+//   - Parenthesised: (s) => s.action
+//   - Any param name: state => state.action
+//   - Optional chain: s => s?.action
+//   - Negative: derived value (s => Boolean(s.user)) — no spurious edge
+package javascript_test
+
+import (
+	"testing"
+)
+
+// TestTSExtractor_ZustandSingleSelector_EmitsCallsEdge verifies the basic form:
+//
+//	const softLogout = useAuthStore(s => s.softLogout);
+//	softLogout();
+//
+// Must emit CALLS → softLogout with Properties["via"] = "zustand_selector".
+func TestTSExtractor_ZustandSingleSelector_EmitsCallsEdge(t *testing.T) {
+	src := `
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+  softLogout: () => set({ token: null }),
+}));
+
+export const handleLogout = () => {
+  const softLogout = useAuthStore(s => s.softLogout);
+  softLogout();
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	e := findByNameRel(ents, "handleLogout")
+	if e == nil {
+		t.Fatal("expected entity 'handleLogout' to be emitted")
+	}
+
+	found := false
+	for _, r := range e.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "softLogout" {
+			if r.Properties != nil && r.Properties["via"] == "zustand_selector" {
+				found = true
+				break
+			}
+			t.Logf("CALLS handleLogout→softLogout found but via=%q (want zustand_selector); props=%v",
+				r.Properties["via"], r.Properties)
+		}
+	}
+	if !found {
+		t.Logf("handleLogout relationships:")
+		for _, r := range e.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Errorf("expected CALLS handleLogout→softLogout with via=zustand_selector; not found")
+	}
+}
+
+// TestTSExtractor_ZustandSelectorParenthesized verifies the parenthesised-param form:
+//
+//	const softLogout = useAuthStore((s) => s.softLogout);
+//	softLogout();
+func TestTSExtractor_ZustandSelectorParenthesized(t *testing.T) {
+	src := `
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+  softLogout: () => set({ token: null }),
+}));
+
+export const handleLogout = () => {
+  const softLogout = useAuthStore((s) => s.softLogout);
+  softLogout();
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	e := findByNameRel(ents, "handleLogout")
+	if e == nil {
+		t.Fatal("expected entity 'handleLogout' to be emitted")
+	}
+
+	found := false
+	for _, r := range e.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "softLogout" &&
+			r.Properties != nil && r.Properties["via"] == "zustand_selector" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Logf("handleLogout relationships:")
+		for _, r := range e.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Errorf("expected CALLS handleLogout→softLogout with via=zustand_selector (parenthesised param); not found")
+	}
+}
+
+// TestTSExtractor_ZustandSelectorStateName verifies that any parameter name works:
+//
+//	const softLogout = useAuthStore(state => state.softLogout);
+//	softLogout();
+func TestTSExtractor_ZustandSelectorStateName(t *testing.T) {
+	src := `
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+  softLogout: () => set({ token: null }),
+}));
+
+export const handleLogout = () => {
+  const softLogout = useAuthStore(state => state.softLogout);
+  softLogout();
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	e := findByNameRel(ents, "handleLogout")
+	if e == nil {
+		t.Fatal("expected entity 'handleLogout' to be emitted")
+	}
+
+	found := false
+	for _, r := range e.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "softLogout" &&
+			r.Properties != nil && r.Properties["via"] == "zustand_selector" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Logf("handleLogout relationships:")
+		for _, r := range e.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Errorf("expected CALLS handleLogout→softLogout with via=zustand_selector (state param name); not found")
+	}
+}
+
+// TestTSExtractor_ZustandSelectorOptionalChain verifies optional-chain selector:
+//
+//	const softLogout = useAuthStore(s => s?.softLogout);
+//	softLogout();
+func TestTSExtractor_ZustandSelectorOptionalChain(t *testing.T) {
+	src := `
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+  softLogout: () => set({ token: null }),
+}));
+
+export const handleLogout = () => {
+  const softLogout = useAuthStore(s => s?.softLogout);
+  softLogout();
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	e := findByNameRel(ents, "handleLogout")
+	if e == nil {
+		t.Fatal("expected entity 'handleLogout' to be emitted")
+	}
+
+	found := false
+	for _, r := range e.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "softLogout" &&
+			r.Properties != nil && r.Properties["via"] == "zustand_selector" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Logf("handleLogout relationships:")
+		for _, r := range e.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Errorf("expected CALLS handleLogout→softLogout with via=zustand_selector (optional chain); not found")
+	}
+}
+
+// TestTSExtractor_ZustandSelectorDerivedValue_NoSpuriousEdge verifies the negative case:
+// a derived-value selector must NOT produce a CALLS edge for the local variable.
+//
+//	const isAuthed = useAuthStore(s => Boolean(s.user));
+//	isAuthed && doX();   ← isAuthed() is never called
+func TestTSExtractor_ZustandSelectorDerivedValue_NoSpuriousEdge(t *testing.T) {
+	src := `
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+  user: null,
+}));
+
+function doX() {}
+
+export function Guard() {
+  const isAuthed = useAuthStore(s => Boolean(s.user));
+  isAuthed && doX();
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	e := findByNameRel(ents, "Guard")
+	if e == nil {
+		t.Fatal("expected entity 'Guard' to be emitted")
+	}
+
+	for _, r := range e.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "isAuthed" {
+			t.Errorf("unexpected CALLS Guard→isAuthed: derived-value selector should not produce action CALLS edge; props=%v", r.Properties)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Extends `destructure_bindings.go` to detect the single-property arrow-selector Zustand pattern: `const softLogout = useAuthStore(s => s.softLogout)`
- Adds `parseSelectorArrowFn` helper that matches arrow bodies that are plain `member_expression` or `optional_chain` (skips derived-value selectors like `s => Boolean(s.user)`)
- Adds `PropViaZustandSelector = "zustand_selector"` constant to distinguish from the object-pattern destructuring form
- PR #2629 handled `const { x } = useStore()` — this PR closes the more common sibling pattern

## Test plan

- [ ] `TestTSExtractor_ZustandSingleSelector_EmitsCallsEdge` — `s => s.action` basic form
- [ ] `TestTSExtractor_ZustandSelectorParenthesized` — `(s) => s.action` parenthesised param
- [ ] `TestTSExtractor_ZustandSelectorStateName` — `state => state.action` any param name
- [ ] `TestTSExtractor_ZustandSelectorOptionalChain` — `s => s?.action` optional chain
- [ ] `TestTSExtractor_ZustandSelectorDerivedValue_NoSpuriousEdge` — `s => Boolean(s.user)` no edge
- [ ] All pre-existing `TestTSExtractor_Destructured*` tests from #2629 still pass
- [ ] `go vet ./...` and `go build ./...` clean

Closes #2632

🤖 Generated with [Claude Code](https://claude.com/claude-code)