### PR TITLE
fix(mcp/inspect): filter unresolved calls, always emit called_by, add metadata

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -72,9 +72,13 @@ Output: BM25-scored entities with BFS expansion. Tail trimmed below `min_score`.
 
 #### `archigraph_inspect`
 
-Key parameters: `entity_id` (required; accepts id, qname, or label), `verbose` (bool), `repo_filter[]`, `fields[]`.
+Key parameters: `entity_id` (required; accepts id, qname, or label), `verbose` (bool), `repo_filter[]`, `fields[]`, `include_unresolved` (bool, default `false`).
 
-Output: full entity record including all properties + attached findings. Also returns `calls[]` and `called_by[]` arrays with line-precise edges: each `calls` entry carries `{target, target_path, line, via}` where `line` is the line in the inspected entity's source where the call appears; each `called_by` entry carries `{source, source_path, line, context}` where `line` is the line in the caller's source and `context` is a ~40-char snippet around the call site.
+Output: full entity record including all properties + attached findings. Also returns:
+
+- `calls[]` — outbound CALLS edges with line-precise data. Each entry: `{target, target_path, line, via}`. Unresolved edges (where the target entity could not be found — empty `target_path` or bare repo prefix) are **filtered by default**. Pass `include_unresolved: true` to include them; unresolved entries carry an extra `"unresolved": true` field.
+- `called_by[]` — inbound CALLS edges (callers). Always present even when empty (`called_by: []`). Each entry: `{source, source_path, line, context}` where `context` is a ~40-char snippet of the call-site line.
+- `metadata` — index provenance block: `{indexed_ref, indexed_sha, indexed_at, age_seconds}`. Agents can use `age_seconds` to decide whether line numbers might be stale before calling `archigraph_get_source`.
 
 #### `archigraph_get_source`
 

--- a/internal/mcp/inspect_trio_2640_2641_2642_test.go
+++ b/internal/mcp/inspect_trio_2640_2641_2642_test.go
@@ -1,0 +1,209 @@
+package mcp
+
+// inspect_trio_2640_2641_2642_test.go — tests for three inspect improvements.
+//
+// #2640: calls[] filters unresolved edges by default; include_unresolved=true
+//        shows all with annotation.
+// #2641: called_by always present (empty array when no callers).
+// #2642: metadata block exposes indexed_ref/sha/at/age_seconds.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// callInspectWithArgs calls handleGetNode with arbitrary extra arguments.
+func callInspectWithArgs(t *testing.T, srv *Server, args map[string]any) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleGetNode(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetNode error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %v", res.Content)
+	}
+	return extractResultJSON(t, res)
+}
+
+// makeDocWithMixedCalls builds a Document where entity "caller" has 5 outbound
+// CALLS edges: 3 fully resolved (target_path set via entity SourceFile) and
+// 2 unresolved (no entity in the graph for those IDs, so target_path == "").
+func makeDocWithMixedCalls() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "caller", Name: "Caller", Kind: "SCOPE.Operation", SourceFile: "caller.go", StartLine: 1},
+			// Three resolved callees
+			{ID: "callee1", Name: "CalleeA", Kind: "SCOPE.Operation", SourceFile: "a.go", StartLine: 10},
+			{ID: "callee2", Name: "CalleeB", Kind: "SCOPE.Operation", SourceFile: "b.go", StartLine: 20},
+			{ID: "callee3", Name: "CalleeC", Kind: "SCOPE.Operation", SourceFile: "c.go", StartLine: 30},
+			// No entities for "ghost1" / "ghost2" — those are unresolved targets.
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "caller", ToID: "callee1", Kind: "CALLS", Properties: map[string]string{"line": "5"}},
+			{ID: "r2", FromID: "caller", ToID: "callee2", Kind: "CALLS", Properties: map[string]string{"line": "6"}},
+			{ID: "r3", FromID: "caller", ToID: "callee3", Kind: "CALLS", Properties: map[string]string{"line": "7"}},
+			// ghost1 / ghost2 have no entity → target_path will be empty → unresolved
+			{ID: "r4", FromID: "caller", ToID: "ghost1", Kind: "CALLS", Properties: map[string]string{"line": "8"}},
+			{ID: "r5", FromID: "caller", ToID: "ghost2", Kind: "CALLS", Properties: map[string]string{"line": "9"}},
+		},
+	}
+}
+
+// TestInspect_FiltersUnresolvedCallsByDefault verifies that with the default
+// include_unresolved=false param, only the 3 resolved calls are returned.
+func TestInspect_FiltersUnresolvedCallsByDefault(t *testing.T) {
+	doc := makeDocWithMixedCalls()
+	srv := newTestServer(t, doc)
+
+	out := callInspectWithArgs(t, srv, map[string]any{
+		"group":     "test",
+		"entity_id": "caller",
+		// include_unresolved omitted → defaults to false
+	})
+
+	calls, ok := out["calls"]
+	if !ok {
+		t.Fatalf("missing 'calls' key; got keys: %v", mapKeys(out))
+	}
+	arr, ok := calls.([]any)
+	if !ok {
+		t.Fatalf("'calls' is %T, want []any", calls)
+	}
+	if len(arr) != 3 {
+		t.Errorf("expected 3 resolved calls (unresolved filtered), got %d: %v", len(arr), arr)
+	}
+	// None should have unresolved=true
+	for i, raw := range arr {
+		m := raw.(map[string]any)
+		if v, ok := m["unresolved"]; ok && v == true {
+			t.Errorf("calls[%d] has unresolved=true but should have been filtered out", i)
+		}
+	}
+}
+
+// TestInspect_IncludesUnresolved_WhenRequested verifies that with
+// include_unresolved=true, all 5 edges are returned and the 2 unresolved ones
+// carry an "unresolved: true" annotation.
+func TestInspect_IncludesUnresolved_WhenRequested(t *testing.T) {
+	doc := makeDocWithMixedCalls()
+	srv := newTestServer(t, doc)
+
+	out := callInspectWithArgs(t, srv, map[string]any{
+		"group":              "test",
+		"entity_id":          "caller",
+		"include_unresolved": true,
+	})
+
+	calls, ok := out["calls"]
+	if !ok {
+		t.Fatalf("missing 'calls' key; got keys: %v", mapKeys(out))
+	}
+	arr, ok := calls.([]any)
+	if !ok {
+		t.Fatalf("'calls' is %T, want []any", calls)
+	}
+	if len(arr) != 5 {
+		t.Errorf("expected 5 calls (3 resolved + 2 unresolved), got %d", len(arr))
+	}
+
+	unresolvedCount := 0
+	for _, raw := range arr {
+		m := raw.(map[string]any)
+		if v, ok := m["unresolved"]; ok {
+			if b, ok := v.(bool); ok && b {
+				unresolvedCount++
+			}
+		}
+	}
+	if unresolvedCount != 2 {
+		t.Errorf("expected 2 entries with unresolved=true, got %d", unresolvedCount)
+	}
+}
+
+// TestInspect_AlwaysIncludesCalledByKey verifies that an entity with no
+// inbound CALLS edges still returns called_by: [] (not missing the key).
+func TestInspect_AlwaysIncludesCalledByKey(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "lonely", Name: "LonelyFunc", Kind: "SCOPE.Operation", SourceFile: "lonely.go", StartLine: 1},
+		},
+		Relationships: []graph.Relationship{}, // no callers
+	}
+	srv := newTestServer(t, doc)
+
+	out := callInspect(t, srv, "lonely")
+
+	// called_by must be present even though there are zero callers.
+	raw, ok := out["called_by"]
+	if !ok {
+		t.Fatalf("called_by key is missing; got keys: %v", mapKeys(out))
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("called_by is %T, want []any", raw)
+	}
+	if len(arr) != 0 {
+		t.Errorf("expected empty called_by, got %d entries", len(arr))
+	}
+}
+
+// TestInspect_IncludesMetadata verifies that the metadata block is present and
+// contains the expected fields. When the graph has no GeneratedAt set, the
+// indexed_at field is empty but the key is still present.
+func TestInspect_IncludesMetadata(t *testing.T) {
+	indexedAt := time.Date(2026, 5, 27, 7, 14, 0, 0, time.UTC)
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "SomeFunc", Kind: "SCOPE.Operation", SourceFile: "x.go", StartLine: 1},
+		},
+		IndexedRef:  "develop",
+		IndexedSHA:  "d9eb1bb801ba",
+		GeneratedAt: indexedAt,
+	}
+	srv := newTestServer(t, doc)
+
+	out := callInspect(t, srv, "e1")
+
+	rawMeta, ok := out["metadata"]
+	if !ok {
+		t.Fatalf("metadata key is missing; got keys: %v", mapKeys(out))
+	}
+	meta, ok := rawMeta.(map[string]any)
+	if !ok {
+		t.Fatalf("metadata is %T, want map[string]any", rawMeta)
+	}
+
+	// indexed_ref must be non-empty and match the document.
+	ref, _ := meta["indexed_ref"].(string)
+	if ref == "" {
+		t.Errorf("metadata.indexed_ref is empty; expected %q", doc.IndexedRef)
+	}
+	if ref != doc.IndexedRef {
+		t.Errorf("metadata.indexed_ref = %q, want %q", ref, doc.IndexedRef)
+	}
+
+	// indexed_sha must be present.
+	if _, ok := meta["indexed_sha"]; !ok {
+		t.Error("metadata.indexed_sha key missing")
+	}
+
+	// indexed_at must be a non-empty RFC3339 string.
+	at, _ := meta["indexed_at"].(string)
+	if at == "" {
+		t.Error("metadata.indexed_at is empty; expected RFC3339 timestamp")
+	}
+
+	// age_seconds must be present (any numeric type after JSON round-trip).
+	if _, ok := meta["age_seconds"]; !ok {
+		t.Error("metadata.age_seconds key missing")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -410,7 +410,8 @@ func (s *Server) registerTools() {
 		mcpapi.WithArray("fields"),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
-		mcpapi.WithAny("ref"), // PH1c: optional git ref; defaults to CWD HEAD ref
+		mcpapi.WithAny("ref"),                // PH1c: optional git ref; defaults to CWD HEAD ref
+		mcpapi.WithAny("include_unresolved"), // #2640: when true, include unresolved calls[] with annotation
 	), s.wrap("archigraph_inspect", s.handleGetNode))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_expand",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -880,6 +880,9 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	}
 	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
 	verbose := argBool(req, "verbose", false)
+	// #2640: include_unresolved=false (default) filters calls[] rows where the
+	// target entity could not be resolved (empty target_path or bare repo prefix).
+	includeUnresolved := argBool(req, "include_unresolved", false)
 	allFindings := loadFindings(findingsMemDir(g, lg))
 	// Cross-repo prefixed ID? Resolve repo first for unambiguous lookup.
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
@@ -895,12 +898,12 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 					out["agent_resolved_edges"] = agentEdges
 				}
 				// #2634: line-precise CALLS edges.
-				if calls := inspectOutboundCalls(r, e, scopeIsOne); len(calls) > 0 {
-					out["calls"] = calls
-				}
-				if calledBy := inspectInboundCalls(r, e, scopeIsOne); len(calledBy) > 0 {
-					out["called_by"] = calledBy
-				}
+				// #2640: filter unresolved by default.
+				out["calls"] = inspectOutboundCalls(r, e, scopeIsOne, includeUnresolved)
+				// #2641: called_by always present (empty array when no callers).
+				out["called_by"] = inspectInboundCalls(r, e, scopeIsOne)
+				// #2642: metadata block with index provenance.
+				out["metadata"] = inspectMetadata(r)
 				return jsonResult(out), nil
 			}
 		}
@@ -952,12 +955,12 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 		out["agent_resolved_edges"] = agentEdges
 	}
 	// #2634: line-precise CALLS edges.
-	if calls := inspectOutboundCalls(m.repo, m.ent, scopeIsOne); len(calls) > 0 {
-		out["calls"] = calls
-	}
-	if calledBy := inspectInboundCalls(m.repo, m.ent, scopeIsOne); len(calledBy) > 0 {
-		out["called_by"] = calledBy
-	}
+	// #2640: filter unresolved by default.
+	out["calls"] = inspectOutboundCalls(m.repo, m.ent, scopeIsOne, includeUnresolved)
+	// #2641: called_by always present (empty array when no callers).
+	out["called_by"] = inspectInboundCalls(m.repo, m.ent, scopeIsOne)
+	// #2642: metadata block with index provenance.
+	out["metadata"] = inspectMetadata(m.repo)
 	return jsonResult(out), nil
 }
 
@@ -1014,25 +1017,60 @@ func agentResolvedEdgesForEntity(lr *LoadedRepo, entityID string, scopeIsOne boo
 // #2634 — line-precise CALLS / called_by edges for archigraph_inspect
 // ---------------------------------------------------------------------------
 
+// isUnresolvedCallEdge reports whether an outbound CALLS edge should be
+// considered unresolved — i.e. the target entity could not be found in the
+// graph. An edge is unresolved when:
+//   - target_path is empty (no source file resolved), OR
+//   - the target ID contains no hex chars after the repo prefix (bare "::")
+func isUnresolvedCallEdge(targetPath, targetID string) bool {
+	if targetPath == "" {
+		return true
+	}
+	// Check for bare repo prefix pattern: "repo::" with nothing after.
+	if idx := strings.Index(targetID, "::"); idx >= 0 {
+		suffix := targetID[idx+2:]
+		if suffix == "" {
+			return true
+		}
+		// Entity IDs contain hex chars; if suffix has none, it's unresolved.
+		hasHex := false
+		for _, c := range suffix {
+			if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') {
+				hasHex = true
+				break
+			}
+		}
+		if !hasHex {
+			return true
+		}
+	}
+	return false
+}
+
 // inspectOutboundCalls returns outbound CALLS edges from entity e with line
 // numbers read from the edge Properties["line"] set by extractors.
 // Each entry: {target, target_path, line, via}.
-func inspectOutboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map[string]any {
+//
+// When includeUnresolved is false (the default), edges where the target entity
+// could not be resolved are omitted. When true, all edges are returned and
+// unresolved ones carry an additional "unresolved: true" field. (#2640)
+func inspectOutboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool, includeUnresolved bool) []map[string]any {
 	if lr == nil || lr.Doc == nil {
-		return nil
+		return []map[string]any{}
 	}
-	var out []map[string]any
+	out := []map[string]any{}
 	rels := lr.Doc.Relationships
 	for _, ed := range lr.Adjacency.Outgoing(e.ID) {
 		if !strings.EqualFold(ed.kind, "CALLS") {
 			continue
 		}
-		entry := map[string]any{
-			"target":      ed.target,
-			"target_path": "",
-		}
+		targetID := ed.target
 		if !scopeIsOne {
-			entry["target"] = prefixedID(lr.Repo, ed.target)
+			targetID = prefixedID(lr.Repo, ed.target)
+		}
+		entry := map[string]any{
+			"target":      targetID,
+			"target_path": "",
 		}
 		// Resolve target path from entity index.
 		if tgt := lr.ByID[ed.target]; tgt != nil {
@@ -1041,6 +1079,13 @@ func inspectOutboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []ma
 			if !scopeIsOne {
 				entry["target"] = prefixedID(lr.Repo, ed.target)
 			}
+		}
+		// #2640: check whether this edge is unresolved.
+		targetPath, _ := entry["target_path"].(string)
+		targetVal, _ := entry["target"].(string)
+		unresolved := isUnresolvedCallEdge(targetPath, targetVal)
+		if unresolved && !includeUnresolved {
+			continue
 		}
 		// Line number from relationship properties.
 		lineNum := 0
@@ -1055,6 +1100,9 @@ func inspectOutboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []ma
 			}
 		}
 		entry["line"] = lineNum
+		if unresolved {
+			entry["unresolved"] = true
+		}
 		out = append(out, entry)
 	}
 	return out
@@ -1063,14 +1111,17 @@ func inspectOutboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []ma
 // inspectInboundCalls returns inbound CALLS edges (callers of entity e) with
 // line numbers and a short context snippet from the caller's source.
 // Each entry: {source, source_path, line, context}.
+//
+// Always returns a non-nil slice (empty when no callers) so called_by is
+// always present in the response (#2641).
 func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map[string]any {
 	if lr == nil || lr.Doc == nil {
-		return nil
+		return []map[string]any{}
 	}
 	// lineCache maps absolute source path → slice of trimmed line strings (0-indexed).
 	lineCache := map[string][]string{}
 
-	var out []map[string]any
+	out := []map[string]any{}
 	rels := lr.Doc.Relationships
 	for _, ed := range lr.Adjacency.Incoming(e.ID) {
 		if !strings.EqualFold(ed.kind, "CALLS") {
@@ -1129,6 +1180,29 @@ func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map
 		out = append(out, entry)
 	}
 	return out
+}
+
+// inspectMetadata returns index provenance fields for the inspect response.
+// Surfaces indexed_ref, indexed_sha, indexed_at, and age_seconds so agents
+// know whether the line-number data might be stale. (#2642)
+func inspectMetadata(lr *LoadedRepo) map[string]any {
+	meta := map[string]any{
+		"indexed_ref": "",
+		"indexed_sha": "",
+		"indexed_at":  "",
+		"age_seconds": 0,
+	}
+	if lr == nil || lr.Doc == nil {
+		return meta
+	}
+	meta["indexed_ref"] = lr.Doc.IndexedRef
+	meta["indexed_sha"] = lr.Doc.IndexedSHA
+	if !lr.Doc.GeneratedAt.IsZero() {
+		indexedAt := lr.Doc.GeneratedAt.UTC()
+		meta["indexed_at"] = indexedAt.Format(time.RFC3339)
+		meta["age_seconds"] = int(time.Since(indexedAt).Seconds())
+	}
+	return meta
 }
 
 // readSourceLines opens path and returns all lines as a slice (0-indexed).


### PR DESCRIPTION
## Summary

- **#2640** — `calls[]` now filters unresolved edges (empty `target_path` or bare repo prefix) by default. New param `include_unresolved` (bool, default `false`); when `true`, all edges are returned with `"unresolved": true` on bad rows.
- **#2641** — `called_by` is always present in the response (`called_by: []` when no callers), removing the inconsistent key-absent case that broke consumers doing shape checks.
- **#2642** — `metadata` block added to every inspect response: `{indexed_ref, indexed_sha, indexed_at, age_seconds}` sourced from `lr.Doc` — the same data `archigraph_whoami` surfaces, now per-call so agents can detect stale line numbers inline.

## Test plan

- [x] `TestInspect_FiltersUnresolvedCallsByDefault` — 5 calls (3 resolved, 2 ghost IDs) → default returns 3
- [x] `TestInspect_IncludesUnresolved_WhenRequested` — same fixture with `include_unresolved=true` → 5 returned, 2 with `unresolved: true`
- [x] `TestInspect_AlwaysIncludesCalledByKey` — entity with 0 callers → `called_by: []` key present
- [x] `TestInspect_IncludesMetadata` — metadata block present with non-empty `indexed_ref`
- [x] `TestInspect_BackwardCompat` (from #2635) — still passes
- [x] `go build ./...` clean, `go vet ./...` clean, `gofmt -l` empty

## Files touched

- `internal/mcp/tools.go` — `handleGetNode`, `inspectOutboundCalls`, `inspectInboundCalls`, new `isUnresolvedCallEdge` + `inspectMetadata` helpers
- `internal/mcp/server.go` — added `include_unresolved` param to tool registration
- `internal/mcp/inspect_trio_2640_2641_2642_test.go` — 4 new tests
- `docs/mcp-tools.md` — inspect section updated

Closes #2640
Closes #2641
Closes #2642

🤖 Generated with [Claude Code](https://claude.com/claude-code)