### PR TITLE
fix(mcp/impact_radius): qualify in-degree count by named vs module callers

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -630,11 +630,28 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 			continue
 		}
 
-		// Precompute in-degree for risk scoring.
-		inDegreeMap := map[string]int{}
+		// Precompute in-degree for risk scoring, broken down by caller kind.
+		// namedCallerMap counts inbound edges whose source is a named operation
+		// (Function, Method, Class, Component, Operation, etc.).
+		// moduleCallerMap counts inbound edges whose source is a file/module
+		// container node (SCOPE.Component, SCOPE.Module, File, Module, etc.).
+		// totalDegreeMap is the simple sum of all inbound edges (used for scoring).
+		namedCallerMap := map[string]int{}
+		moduleCallerMap := map[string]int{}
+		totalDegreeMap := map[string]int{}
 		for i := range r.Doc.Relationships {
 			rel := &r.Doc.Relationships[i]
-			inDegreeMap[rel.ToID]++
+			totalDegreeMap[rel.ToID]++
+			if src := byID[rel.FromID]; src != nil {
+				if isModuleFileEntity(src) {
+					moduleCallerMap[rel.ToID]++
+				} else {
+					namedCallerMap[rel.ToID]++
+				}
+			} else {
+				// Source not in byID — treat as named to avoid under-counting.
+				namedCallerMap[rel.ToID]++
+			}
 		}
 
 		// Impact radius = entities that transitively depend on `target`.
@@ -668,8 +685,8 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 			if e == nil {
 				continue
 			}
-			risk := impactRiskScore(e, inDegreeMap[id])
-			reason := buildRiskReason(e, inDegreeMap[id])
+			risk := impactRiskScore(e, totalDegreeMap[id])
+			reason := buildRiskReason(e, namedCallerMap[id], moduleCallerMap[id], totalDegreeMap[id])
 			results = append(results, affected{
 				EntityID:   prefixedID(r.Repo, e.ID),
 				Name:       e.Name,
@@ -711,10 +728,21 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 }
 
 // buildRiskReason produces a short human-readable reason string for the risk score.
-func buildRiskReason(e *graph.Entity, inDegree int) string {
+// namedCallers is the count of inbound edges from named operation entities (Function,
+// Method, Class, Component, Operation, etc.). moduleNodes is the count from file/module
+// container entities (SCOPE.Component, SCOPE.Module, File, Module, etc.). total is
+// their sum. When the two counts differ we emit a qualified breakdown so consumers
+// understand how much of the in-degree is actual named callers vs structural noise.
+func buildRiskReason(e *graph.Entity, namedCallers, moduleNodes, total int) string {
 	parts := []string{}
-	if inDegree > 5 {
-		parts = append(parts, fmt.Sprintf("high in-degree (%d callers)", inDegree))
+	if total > 5 {
+		if moduleNodes == 0 {
+			// All callers are named — simple, unambiguous message.
+			parts = append(parts, fmt.Sprintf("high in-degree (%d named callers)", namedCallers))
+		} else {
+			// Mixed: qualify the breakdown so consumers are not misled.
+			parts = append(parts, fmt.Sprintf("high in-degree (%d named callers, %d module/file nodes; total %d inbound edges)", namedCallers, moduleNodes, total))
+		}
 	}
 	k := strings.ToLower(e.Kind)
 	if strings.Contains(k, "http_endpoint") || strings.Contains(k, "endpoint") {
@@ -1040,6 +1068,26 @@ func isStdlibEntity(e *graph.Entity) bool {
 	if e.Properties["is_external"] == "true" ||
 		e.Properties["is_stdlib"] == "true" ||
 		e.Properties["external"] == "true" {
+		return true
+	}
+	return false
+}
+
+// isModuleFileEntity returns true when an entity is a file or module container
+// node rather than a named callable operation. These nodes (SCOPE.Component,
+// SCOPE.Module, File, Module, Package, Namespace, Directory) appear as inbound
+// edge sources in the graph but do not represent actual callers of a function;
+// they are structural containers that inflate the raw in-degree count.
+func isModuleFileEntity(e *graph.Entity) bool {
+	k := e.Kind
+	// SCOPE.* prefix always indicates a container/file node.
+	if strings.HasPrefix(k, "SCOPE.") {
+		return true
+	}
+	lower := strings.ToLower(k)
+	// Bare kind names that represent container/file concepts.
+	switch lower {
+	case "file", "module", "package", "namespace", "directory", "folder":
 		return true
 	}
 	return false

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -723,6 +723,139 @@ func TestImpactRadius_RootHasNoUpstreamImpact(t *testing.T) {
 	}
 }
 
+// buildMixedCallerDoc builds a doc for #2644 testing.
+//
+// Graph shape (impact_radius walks INBOUND edges from the queried entity):
+//
+//	ent-hub (Function)    → CALLS →    ent-leaf (Function)
+//	ent-named-{1..4} (Function)     → CALLS     → ent-hub  (4 named callers)
+//	ent-mod-{1..9}   (SCOPE.Component) → CONTAINS → ent-hub  (9 module/file nodes)
+//
+// impact_radius(ent-leaf): finds ent-hub as a 1-hop inbound caller.
+// ent-hub total in-degree = 4 CALLS (named) + 9 CONTAINS (module) = 13.
+func buildMixedCallerDoc() *graph.Document {
+	entities := []graph.Entity{
+		{ID: "ent-leaf", Name: "lowLevelHelper", Kind: "Function", SourceFile: "helper.ts"},
+		{ID: "ent-hub", Name: "useInspectorHomeData", Kind: "Function", SourceFile: "hooks.ts", StartLine: 10},
+	}
+	rels := []graph.Relationship{
+		// hub calls leaf — hub appears in impact_radius(leaf) results.
+		{FromID: "ent-hub", ToID: "ent-leaf", Kind: "CALLS"},
+	}
+	// 4 named callers of hub.
+	for i := 1; i <= 4; i++ {
+		id := fmt.Sprintf("ent-named-%d", i)
+		entities = append(entities, graph.Entity{
+			ID: id, Name: fmt.Sprintf("CallerFunc%d", i), Kind: "Function", SourceFile: "callers.ts",
+		})
+		rels = append(rels, graph.Relationship{FromID: id, ToID: "ent-hub", Kind: "CALLS"})
+	}
+	// 9 module/file nodes pointing to hub.
+	for i := 1; i <= 9; i++ {
+		id := fmt.Sprintf("ent-mod-%d", i)
+		entities = append(entities, graph.Entity{
+			ID: id, Name: fmt.Sprintf("module%d.ts", i), Kind: "SCOPE.Component", SourceFile: fmt.Sprintf("module%d.ts", i),
+		})
+		rels = append(rels, graph.Relationship{FromID: id, ToID: "ent-hub", Kind: "CONTAINS"})
+	}
+	return minDoc(entities, rels)
+}
+
+// TestImpactRadius_NamedVsModuleCallerBreakdown verifies #2644:
+// when an affected entity has both named callers and module/file nodes in its
+// inbound edges, risk_reason must emit the qualified breakdown form.
+func TestImpactRadius_NamedVsModuleCallerBreakdown(t *testing.T) {
+	doc := buildMixedCallerDoc()
+	srv := newTestServer(t, doc)
+
+	// Query impact of ent-leaf: ent-hub is the 1-hop inbound caller.
+	// ent-hub has in-degree 13 (4 named CALLS + 9 CONTAINS module nodes).
+	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
+		"entity_id": "ent-leaf",
+		"hops":      float64(1),
+	})
+	affected, ok := out["affected"].([]any)
+	if !ok || len(affected) == 0 {
+		t.Fatalf("expected at least 1 affected entity, got %v", out["affected"])
+	}
+	// Find ent-hub in results.
+	var hubEntry map[string]any
+	for _, a := range affected {
+		m := a.(map[string]any)
+		if m["name"] == "useInspectorHomeData" {
+			hubEntry = m
+			break
+		}
+	}
+	if hubEntry == nil {
+		t.Fatal("useInspectorHomeData not found in affected list")
+	}
+	reason, _ := hubEntry["risk_reason"].(string)
+	// Must mention named callers and module/file node breakdown.
+	if !strings.Contains(reason, "named callers") {
+		t.Errorf("risk_reason should contain 'named callers'; got: %q", reason)
+	}
+	if !strings.Contains(reason, "module/file nodes") {
+		t.Errorf("risk_reason should contain 'module/file nodes'; got: %q", reason)
+	}
+	if !strings.Contains(reason, "inbound edges") {
+		t.Errorf("risk_reason should contain 'inbound edges'; got: %q", reason)
+	}
+}
+
+// TestImpactRadius_NamedOnly verifies that when all inbound edges come from
+// named operation entities (no module/file nodes), risk_reason uses the
+// simplified "N named callers" form without a module breakdown.
+func TestImpactRadius_NamedOnly(t *testing.T) {
+	// Graph: ent-hub → ent-leaf; 6 named callers → ent-hub; 0 module nodes.
+	// impact_radius(ent-leaf) → ent-hub in affected with in-degree 6 (named only).
+	entities := []graph.Entity{
+		{ID: "ent-leaf", Name: "leafFunc", Kind: "Function", SourceFile: "leaf.go"},
+		{ID: "ent-hub", Name: "coreHelper", Kind: "Function", SourceFile: "core.go"},
+	}
+	rels := []graph.Relationship{
+		{FromID: "ent-hub", ToID: "ent-leaf", Kind: "CALLS"},
+	}
+	for i := 1; i <= 6; i++ {
+		id := fmt.Sprintf("ent-named-%d", i)
+		entities = append(entities, graph.Entity{
+			ID: id, Name: fmt.Sprintf("Caller%d", i), Kind: "Function", SourceFile: "callers.go",
+		})
+		rels = append(rels, graph.Relationship{FromID: id, ToID: "ent-hub", Kind: "CALLS"})
+	}
+	doc := minDoc(entities, rels)
+	srv := newTestServer(t, doc)
+
+	// impact_radius(ent-leaf): ent-hub appears in affected with 6 named callers.
+	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
+		"entity_id": "ent-leaf",
+		"hops":      float64(1),
+	})
+	affected, ok := out["affected"].([]any)
+	if !ok || len(affected) == 0 {
+		t.Fatalf("expected at least 1 affected entity, got %v", out["affected"])
+	}
+	var hubEntry map[string]any
+	for _, a := range affected {
+		m := a.(map[string]any)
+		if m["name"] == "coreHelper" {
+			hubEntry = m
+			break
+		}
+	}
+	if hubEntry == nil {
+		t.Fatal("coreHelper not found in affected list")
+	}
+	reason, _ := hubEntry["risk_reason"].(string)
+	// Should use simple "N named callers" without module breakdown.
+	if !strings.Contains(reason, "named callers") {
+		t.Errorf("risk_reason should contain 'named callers'; got: %q", reason)
+	}
+	if strings.Contains(reason, "module/file nodes") {
+		t.Errorf("risk_reason should NOT mention module/file nodes when there are none; got: %q", reason)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TestSubgraph_FormatMarkdown (format=markdown path of the unified tool)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #2644: `archigraph_impact_radius` was reporting inflated in-degree counts (e.g. "13 callers") because `buildRiskReason` counted all inbound edges including SCOPE.Component file/module container nodes alongside actual named operation callers.
- Added `isModuleFileEntity()` helper to classify inbound edge sources as named callers vs module/file nodes.
- `buildRiskReason` now receives `(namedCallers, moduleNodes, total)` and emits the qualified form: `"4 named callers, 9 module/file nodes; total 13 inbound edges"` when both are present, or the simpler `"6 named callers"` when there are no module nodes.
- Risk scoring (`impactRiskScore`) continues to use the total in-degree to preserve structural signal.

## Test plan

- [x] `TestImpactRadius_NamedVsModuleCallerBreakdown` — fixture with 4 named CALLS + 9 SCOPE.Component CONTAINS on a hub entity; verifies risk_reason contains "named callers", "module/file nodes", and "inbound edges"
- [x] `TestImpactRadius_NamedOnly` — fixture with 6 named callers, 0 module nodes; verifies risk_reason says "named callers" and does NOT mention "module/file nodes"
- [x] All pre-existing `TestImpactRadius_*` tests continue to pass
- [x] Full `./internal/mcp/...` suite passes (excluding pre-existing `TestSchemaContract_AllHandlerArgsDeclared` failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)