### PR TITLE
feat(mcp/find): default to cwd-resolved repo, cross_repo=true opt-in (#2643)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -66,7 +66,9 @@ Output: ranked list of matching entities with source file + line.
 
 #### `archigraph_find`
 
-Key parameters: `query` (required), `mode` (`bfs`/`ids`), `depth` (default 3), `token_budget` (default 800), `max_results` (default 50, ceiling 200), `min_score` (default 0.15), `repo_filter[]`, `context_filter[]`, `fields[]`.
+Key parameters: `query` (required), `mode` (`bfs`/`ids`), `depth` (default 3), `token_budget` (default 800), `max_results` (default 50, ceiling 200), `min_score` (default 0.15), `repo_filter[]`, `cross_repo` (bool, default `false`), `context_filter[]`, `fields[]`.
+
+**Scope default (since #2643):** when neither `repo_filter` nor `cross_repo=true` is supplied, the search is scoped to the cwd-resolved repo. Pass `cross_repo=true` to span all repos in the group. If cwd cannot be resolved to a repo, all repos are searched as a fallback.
 
 Output: BM25-scored entities with BFS expansion. Tail trimmed below `min_score`.
 

--- a/internal/mcp/find_default_repo_2643_test.go
+++ b/internal/mcp/find_default_repo_2643_test.go
@@ -1,0 +1,221 @@
+// find_default_repo_2643_test.go — tests for #2643: archigraph_find defaults
+// to the cwd-resolved repo rather than searching all repos in the group.
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// newTestServerWithPaths is like newTestServer but returns the per-repo
+// registry paths so tests can pass them as cwd arguments to trigger
+// cwd-based repo resolution (required for #2643 tests).
+//
+// repoPaths[i] is the registered Path for docs[i].
+func newTestServerWithPaths(t *testing.T, docs ...*graph.Document) (*Server, []string) {
+	t.Helper()
+
+	paths := make([]string, len(docs))
+	for i := range docs {
+		paths[i] = t.TempDir()
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{}},
+	}}
+
+	type namedDoc struct {
+		name string
+		doc  *graph.Document
+		path string
+	}
+	named := make([]namedDoc, 0, len(docs))
+	for i, doc := range docs {
+		name := doc.Repo
+		if name == "" {
+			name = "repo" + string(rune('1'+i))
+		}
+		named = append(named, namedDoc{name, doc, paths[i]})
+		reg.Groups["test"].Repos[name] = RegistryRepo{Path: paths[i]}
+	}
+
+	st := NewState(reg)
+	st.mu.Lock()
+	lg := &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{}}
+	for _, nd := range named {
+		doc := nd.doc
+		byID := make(map[string]*graph.Entity, len(doc.Entities))
+		for i := range doc.Entities {
+			byID[doc.Entities[i].ID] = &doc.Entities[i]
+		}
+		lg.Repos[nd.name] = &LoadedRepo{
+			Repo:       nd.name,
+			Doc:        doc,
+			LabelIndex: BuildLabelIndex(doc),
+			BM25:       BuildBM25(doc),
+			Adjacency:  buildAdjacency(doc, nd.name),
+			CallsAdj:   buildCallsAdjacency(doc),
+			StepAdj:    buildStepAdjacency(doc),
+			ByID:       byID,
+		}
+	}
+	st.groups["test"] = lg
+	st.mu.Unlock()
+
+	srv := &Server{State: st, Tel: NewTelemetry(0)}
+	return srv, paths
+}
+
+// buildFindDefaultRepoFixture returns two docs with distinct, non-overlapping entities.
+// repo A ("mobile") contains mobile-only symbols.
+// repo B ("backend") contains backend-only symbols.
+func buildFindDefaultRepoFixture() (*graph.Document, *graph.Document) {
+	mobile := &graph.Document{
+		Repo: "mobile",
+		Entities: []graph.Entity{
+			{ID: "fn_sync_push", Name: "syncPushNotification",
+				Kind: "SCOPE.Function", SourceFile: "src/push.ts", StartLine: 10},
+			{ID: "fn_device_register", Name: "deviceRegister",
+				Kind: "SCOPE.Function", SourceFile: "src/device.ts", StartLine: 5},
+		},
+	}
+	backend := &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "fn_api_handler", Name: "apiInspectionHandler",
+				Kind: "SCOPE.Function", SourceFile: "api/views.py", StartLine: 42},
+			{ID: "fn_db_query", Name: "dbScheduleQuery",
+				Kind: "SCOPE.Function", SourceFile: "db/queries.py", StartLine: 7},
+		},
+	}
+	return mobile, backend
+}
+
+// TestFind_DefaultsCurrentRepoWhenCwdResolvable verifies that when no
+// repo_filter or cross_repo flag is supplied, find scopes to the
+// cwd-resolved repo only. Query matches entities in both repos but only
+// mobile entities should be returned when cwd is inside the mobile repo.
+func TestFind_DefaultsCurrentRepoWhenCwdResolvable(t *testing.T) {
+	mobile, backend := buildFindDefaultRepoFixture()
+	srv, paths := newTestServerWithPaths(t, mobile, backend)
+	mobilePath := paths[0] // cwd will be inside the mobile repo
+
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group": "test",
+		"query": "sync device api inspection db schedule",
+		"cwd":   mobilePath,
+		"full":  true,
+	})
+
+	if res == "" {
+		t.Fatal("expected non-empty result")
+	}
+
+	// Mobile entities must appear.
+	if !strings.Contains(res, "syncPushNotification") && !strings.Contains(res, "deviceRegister") {
+		t.Errorf("expected at least one mobile entity; got:\n%s", res)
+	}
+
+	// Backend entities must NOT appear (cwd resolved to mobile repo only).
+	if strings.Contains(res, "apiInspectionHandler") || strings.Contains(res, "dbScheduleQuery") {
+		t.Errorf("cross-repo bleed: backend entities leaked into mobile-scoped find; got:\n%s", res)
+	}
+}
+
+// TestFind_CrossRepoTrueSpansAll verifies that cross_repo=true returns hits
+// from both repos even when cwd is inside one specific repo.
+func TestFind_CrossRepoTrueSpansAll(t *testing.T) {
+	mobile, backend := buildFindDefaultRepoFixture()
+	srv, paths := newTestServerWithPaths(t, mobile, backend)
+	mobilePath := paths[0]
+
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group":      "test",
+		"query":      "sync device api inspection",
+		"cwd":        mobilePath,
+		"cross_repo": true,
+		"full":       true,
+		"min_score":  0.0, // defeat min_score to ensure both repos' hits appear
+	})
+
+	if res == "" {
+		t.Fatal("expected non-empty result with cross_repo=true")
+	}
+
+	// Expect at least one entity from each repo.
+	hasMobile := strings.Contains(res, "syncPushNotification") || strings.Contains(res, "deviceRegister")
+	hasBackend := strings.Contains(res, "apiInspectionHandler") || strings.Contains(res, "dbScheduleQuery")
+
+	if !hasMobile {
+		t.Errorf("cross_repo=true: expected mobile entities; got:\n%s", res)
+	}
+	if !hasBackend {
+		t.Errorf("cross_repo=true: expected backend entities; got:\n%s", res)
+	}
+}
+
+// TestFind_RepoFilterTakesPriority verifies that when repo_filter is set
+// alongside cross_repo=true, repo_filter wins (explicit always beats opt-in).
+func TestFind_RepoFilterTakesPriority(t *testing.T) {
+	mobile, backend := buildFindDefaultRepoFixture()
+	srv, paths := newTestServerWithPaths(t, mobile, backend)
+	mobilePath := paths[0]
+
+	// repo_filter=["backend"] + cross_repo=true → only backend results.
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group":       "test",
+		"query":       "sync device api inspection schedule",
+		"cwd":         mobilePath,
+		"repo_filter": []any{"backend"},
+		"cross_repo":  true,
+		"full":        true,
+		"min_score":   0.0,
+	})
+
+	if res == "" {
+		t.Fatal("expected non-empty result")
+	}
+
+	// Backend entities must appear.
+	if !strings.Contains(res, "apiInspectionHandler") && !strings.Contains(res, "dbScheduleQuery") {
+		t.Errorf("repo_filter=[backend]: expected backend entities; got:\n%s", res)
+	}
+
+	// Mobile entities must NOT appear (repo_filter wins).
+	if strings.Contains(res, "syncPushNotification") || strings.Contains(res, "deviceRegister") {
+		t.Errorf("repo_filter=[backend]: mobile entities leaked; got:\n%s", res)
+	}
+}
+
+// TestFind_NoResolvableCwdFallsBack verifies that when cwd does not resolve
+// to any registered repo and no repo_filter/cross_repo is set, find searches
+// all repos (graceful fallback).
+func TestFind_NoResolvableCwdFallsBack(t *testing.T) {
+	mobile, backend := buildFindDefaultRepoFixture()
+	// Use newTestServer (not newTestServerWithPaths) so cwd "/" won't match any
+	// registered repo path and resolution returns CWDResolution{Source:"none"}.
+	srv := newTestServer(t, mobile, backend)
+
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group":     "test",
+		"query":     "sync device api inspection schedule",
+		"cwd":       "/", // root — cannot match any t.TempDir() path
+		"full":      true,
+		"min_score": 0.0,
+	})
+
+	if res == "" {
+		t.Fatal("expected non-empty result when cwd is unresolvable (fallback to all repos)")
+	}
+
+	// At least one entity from each repo must appear, since we search all.
+	hasMobile := strings.Contains(res, "syncPushNotification") || strings.Contains(res, "deviceRegister")
+	hasBackend := strings.Contains(res, "apiInspectionHandler") || strings.Contains(res, "dbScheduleQuery")
+
+	if !hasMobile || !hasBackend {
+		t.Errorf("unresolvable-cwd fallback: expected entities from both repos; mobile=%v backend=%v\nout:\n%s",
+			hasMobile, hasBackend, res)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -385,12 +385,13 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_get_source", s.handleGetNodeSource))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_find",
-		mcpapi.WithDescription("BM25 graph query. query=. min_score>=0.15 trims tail. max_results caps at 200."),
+		mcpapi.WithDescription("BM25 graph query. cwd-repo default; cross_repo=true spans all. min_score>=0.15."),
 		mcpapi.WithString("query", mcpapi.Required()),
 		mcpapi.WithString("mode", mcpapi.DefaultString("bfs")),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(3)),
 		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(800)),
 		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithBoolean("cross_repo", mcpapi.DefaultBool(false)), // #2643: opt-in to search all repos
 		mcpapi.WithBoolean("full", mcpapi.DefaultBool(false)),
 		mcpapi.WithBoolean("include_noise", mcpapi.DefaultBool(false)),
 		// verbose=true (default false), min_score (default 0.15), max_results (default 50, ceiling 200)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -436,8 +436,24 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 		maxResults = 200
 	}
 	repoFilter := argStringSlice(req, "repo_filter")
+	crossRepo := argBool(req, "cross_repo", false)
 	contextFilter := contextFilterSet(argStringSlice(req, "context_filter"))
 	mode := argString(req, "mode", "bfs")
+
+	// #2643: default to cwd-resolved repo to avoid cross-repo noise.
+	// Priority order:
+	//   1. repo_filter set explicitly → use it (existing behaviour).
+	//   2. cross_repo=true           → search all repos (new opt-in).
+	//   3. neither, cwd resolves     → filter to the cwd-resolved repo.
+	//   4. neither, cwd unresolved   → search all repos (graceful fallback).
+	if len(repoFilter) == 0 && !crossRepo {
+		cwd := s.inferCWD(req)
+		cwdRes := ResolveCWD(s.State, cwd)
+		if cwdRes.RepoSlug != "" {
+			repoFilter = []string{cwdRes.RepoSlug}
+		}
+		// If cwd doesn't resolve, repoFilter stays nil → reposToConsider returns all.
+	}
 
 	repos := reposToConsider(lg, repoFilter)
 	if len(repos) == 0 {

--- a/skills/using-archigraph/SKILL.md
+++ b/skills/using-archigraph/SKILL.md
@@ -127,6 +127,11 @@ BM25-ranked graph query, optionally BFS-expanded from each top hit. The
 primary discovery tool — reach for it when you know what you are looking for
 but not where it lives.
 
+**Scope default (since #2643):** by default the search is scoped to the
+cwd-resolved repo (eliminates cross-repo noise in single-repo workflows).
+Pass `cross_repo=true` to span all repos in the group, or use `repo_filter`
+to select specific repos explicitly.
+
 Key parameters:
 - `question` — natural-language query (BM25 tokenises it against entity labels
   and qualified names).
@@ -134,7 +139,10 @@ Key parameters:
   0 to skip BFS entirely).
 - `token_budget` — max approximate tokens in compact output (default 800;
   lower for orientation, higher for deep inventory).
-- `repo_filter` — restrict to one or more repos by slug.
+- `repo_filter` — restrict to one or more repos by slug (takes priority over
+  `cross_repo`).
+- `cross_repo` — set `true` to search all repos in the group (opt-in; default
+  `false`).
 - `context_filter` — restrict BFS traversal to specific edge kinds
   (`CALLS`, `IMPORTS`, `PUBLISHES_TO`, etc.).
 
@@ -142,6 +150,7 @@ Key parameters:
 archigraph_find(question="payment processing charge refund", depth=2, token_budget=600)
 archigraph_find(question="order HTTP routes endpoints", repo_filter=["orders-api"], depth=1)
 archigraph_find(question="auth token validation middleware", context_filter=["CALLS"], depth=3)
+archigraph_find(question="auth token", cross_repo=true)   # span all repos
 ```
 
 CLI equivalent: `archigraph search "payment processing"` (thin RPC wrapper)


### PR DESCRIPTION
## Summary

- `archigraph_find` previously searched all repos in a group by default, producing cross-repo noise (e.g. Python backend + frontend hits) when investigating single-repo issues.
- New default: when neither `repo_filter` nor `cross_repo=true` is supplied, find scopes to the cwd-resolved repo.
- `cross_repo=true` opts back into the old global-search behavior.
- `repo_filter` (existing) always takes priority over `cross_repo`.
- If cwd doesn't resolve to any registered repo, falls back to all repos (graceful).

## Decision logic

`internal/mcp/tools.go` — `handleQueryGraph`, after the `repoFilter` parse (~line 438):

```go
if len(repoFilter) == 0 && !crossRepo {
    cwd := s.inferCWD(req)
    cwdRes := ResolveCWD(s.State, cwd)
    if cwdRes.RepoSlug != "" {
        repoFilter = []string{cwdRes.RepoSlug}
    }
}
```

## Test plan

- [x] `TestFind_DefaultsCurrentRepoWhenCwdResolvable` — cwd inside repo A → only repo A hits
- [x] `TestFind_CrossRepoTrueSpansAll` — same cwd, `cross_repo=true` → hits from both repos
- [x] `TestFind_RepoFilterTakesPriority` — `repo_filter=[B]` + `cross_repo=true` → only repo B
- [x] `TestFind_NoResolvableCwdFallsBack` — cwd=`/` (unresolvable) → all repos searched

## Backward-compat

Callers that relied on global-by-default search should pass `cross_repo=true`. The `repo_filter` param continues to work exactly as before.

Closes #2643

🤖 Generated with [Claude Code](https://claude.com/claude-code)