### PR TITLE
fix(daemon/watcher): TS/TSX file changes now trigger reindex (#2645)

### DIFF
--- a/cmd/archigraph/daemon_tier.go
+++ b/cmd/archigraph/daemon_tier.go
@@ -287,6 +287,12 @@ func tierEvictCallback(key tier.SlotKey) {
 // the newest source-file mtime in the repo. If the repo has changed since the
 // graph was last indexed, enqueue a reactive reindex so the query is served
 // from the most up-to-date graph on the next request.
+//
+// #2645: also ensure the fsnotify subscription is live after a cold wake.
+// In the normal path the subscription is kept through WARM→COLD (the Pause
+// is now deferred to COLD→EXPIRED), but an EXPIRED slot that got re-indexed
+// will have had its subscription removed. Resume is idempotent, so this call
+// is safe even when the subscription is already active.
 func tierReloadCallback(key tier.SlotKey) error {
 	stateDir := daemon.StateDirForRepoRef(key.RepoPath, key.Ref)
 	fbPath := filepath.Join(stateDir, "graph.fb")
@@ -296,6 +302,11 @@ func tierReloadCallback(key tier.SlotKey) error {
 		return err
 	}
 	release()
+
+	// Re-establish the fsnotify subscription on cold wake (#2645).
+	if daemonWatcherMgr != nil {
+		daemonWatcherMgr.Resume(key.RepoPath, key.Ref)
+	}
 
 	// Stale-detection: if the repo has file changes newer than graph.fb,
 	// enqueue a reactive reindex so the next query gets a fresh graph.

--- a/internal/daemon/tier/tier.go
+++ b/internal/daemon/tier/tier.go
@@ -577,21 +577,29 @@ func (m *Manager) scan() {
 	// This runs outside the lock so it can call m.onEvict safely.
 	pressureEvicted := m.scanPressureEvict()
 
-	// PH2a: pause watcher subscriptions for newly-COLD slots.
+	// PH2a: release in-memory graphs for newly-COLD slots but keep the
+	// fsnotify subscription alive so file edits during the COLD window still
+	// trigger reindex. (#2645: removing the subscription here caused TS/TSX
+	// changes to go undetected when a repo had been idle for >60 min.)
 	wh := m.watcher // read under mu already released; field is write-once after init
 	for _, k := range toEvict {
 		m.onEvict(k)
-		if wh != nil {
-			wh.Pause(k.RepoPath, k.Ref)
-		}
+		// wh.Pause intentionally NOT called here — subscription removal is
+		// deferred to the COLD→EXPIRED path below so that watcher events keep
+		// firing while the graph is cold-but-still-on-disk.
 	}
 	if len(toEvict) > 0 || pressureEvicted > 0 {
 		runtime.GC() // nudge GC so released graph objects are reclaimed promptly
 	}
 
 	// PH6: perform disk eviction for newly expired slots.
-	if m.onDiskEvict != nil {
-		for _, k := range toExpire {
+	// Only EXPIRED slots lose their fsnotify subscription — at that point the
+	// graph.fb has been deleted and there is nothing to reindex into.
+	for _, k := range toExpire {
+		if wh != nil {
+			wh.Pause(k.RepoPath, k.Ref)
+		}
+		if m.onDiskEvict != nil {
 			freed, err := m.onDiskEvict(k)
 			if err != nil {
 				m.logger.Error("tier: expired-evict FAILED", "repo", k.RepoPath, "ref", k.Ref, "err", err)
@@ -666,12 +674,12 @@ func (m *Manager) scanPressureEvict() int {
 	}
 	m.mu.Unlock()
 
-	wh := m.watcher
+	// Evict in-memory graphs only; do NOT remove fsnotify subscriptions on
+	// pressure-driven WARM→COLD (same reasoning as the TTL scan: #2645).
+	// Subscriptions are only removed when a slot reaches EXPIRED and its
+	// graph.fb is deleted from disk.
 	for _, k := range toEvict {
 		m.onEvict(k)
-		if wh != nil {
-			wh.Pause(k.RepoPath, k.Ref)
-		}
 	}
 	return len(toEvict)
 }

--- a/internal/daemon/tier/tier_watcher_test.go
+++ b/internal/daemon/tier/tier_watcher_test.go
@@ -2,6 +2,11 @@ package tier_test
 
 // tier_watcher_test.go — integration tests for PH2a watcher pause/resume
 // driven by tier transitions. PH2a of epic #2087 (#2096).
+//
+// #2645: WARM→COLD no longer fires Pause — the fsnotify subscription is kept
+// alive through the COLD window so that TS/TSX (and all other source) file
+// edits continue to trigger reindex while the graph is cold-on-disk.
+// Pause is now deferred to COLD→EXPIRED (when the graph.fb is deleted).
 
 import (
 	"sync"
@@ -45,10 +50,14 @@ func (f *fakeWatcherHook) resumedCount() int {
 }
 
 // ---------------------------------------------------------------------------
-// Test: WARM→COLD fires Pause
+// Test: WARM→COLD does NOT fire Pause (#2645)
+//
+// Before #2645, the watcher subscription was removed when a slot went COLD,
+// silently dropping file-change events for repos idle for >60 min.
+// The fix defers Pause to COLD→EXPIRED so the subscription stays alive.
 // ---------------------------------------------------------------------------
 
-func TestWatcherPausedOnCold(t *testing.T) {
+func TestWatcherNotPausedOnCold(t *testing.T) {
 	clock, advance := makeClock()
 	hook := &fakeWatcherHook{}
 	var evictCount atomic.Int32
@@ -75,14 +84,75 @@ func TestWatcherPausedOnCold(t *testing.T) {
 		t.Fatalf("want COLD, got %s", got)
 	}
 
+	// The in-memory graph should have been evicted…
 	if evictCount.Load() != 1 {
 		t.Fatalf("want 1 eviction, got %d", evictCount.Load())
 	}
-	if hook.pausedCount() != 1 {
-		t.Fatalf("want 1 Pause call, got %d", hook.pausedCount())
+	// …but the fsnotify subscription must NOT have been removed (#2645).
+	if hook.pausedCount() != 0 {
+		t.Fatalf("#2645: Pause must NOT fire on WARM→COLD; got %d Pause calls", hook.pausedCount())
 	}
 	if hook.resumedCount() != 0 {
 		t.Fatalf("want 0 Resume calls before wake, got %d", hook.resumedCount())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: COLD→EXPIRED fires Pause
+//
+// The subscription should be removed only when the graph.fb is deleted from
+// disk (COLD→EXPIRED), because at that point there is nothing to reindex into.
+// ---------------------------------------------------------------------------
+
+func TestWatcherPausedOnExpired(t *testing.T) {
+	cfg := tier.DefaultTTLConfig()
+	// Use short expired window so we can drive COLD→EXPIRED in the test.
+	cfg.ExpiredWindow = 2 * time.Minute
+	cfg.ExpiredWindowWorktree = 2 * time.Minute
+
+	clock, advance := makeClock()
+	hook := &fakeWatcherHook{}
+	var diskEvictCount atomic.Int32
+
+	m := tier.NewManagerForTestWithDiskEvict(cfg, clock,
+		noopEvict,
+		noopReload,
+		func(k tier.SlotKey) (int64, error) {
+			diskEvictCount.Add(1)
+			return 0, nil
+		},
+	)
+	m.SetWatcherHook(hook)
+
+	key := tier.SlotKey{RepoPath: "/repo/expired", Ref: "feat/gone"}
+	m.Register(key, false, tier.SlotKindBranchFeature)
+
+	// Drive to COLD.
+	advance(6 * time.Minute)
+	m.Scan()
+	advance(61 * time.Minute)
+	m.Scan()
+	if got := m.Get(key); got != tier.TierCold {
+		t.Fatalf("prereq: want COLD, got %s", got)
+	}
+	// Still no Pause during COLD.
+	if hook.pausedCount() != 0 {
+		t.Fatalf("#2645: Pause must not fire on WARM→COLD; got %d", hook.pausedCount())
+	}
+
+	// Drive COLD→EXPIRED.
+	advance(3 * time.Minute)
+	m.Scan()
+	if got := m.Get(key); got != tier.TierExpired {
+		t.Fatalf("want EXPIRED, got %s", got)
+	}
+
+	// NOW Pause should fire (subscription removed because graph.fb was deleted).
+	if hook.pausedCount() != 1 {
+		t.Fatalf("want 1 Pause call on EXPIRED, got %d", hook.pausedCount())
+	}
+	if diskEvictCount.Load() != 1 {
+		t.Fatalf("want 1 disk evict, got %d", diskEvictCount.Load())
 	}
 }
 
@@ -94,7 +164,6 @@ func TestWatcherResumedOnColdWake(t *testing.T) {
 	clock, advance := makeClock()
 	hook := &fakeWatcherHook{}
 
-	resumeOrder := make([]string, 0)
 	reloadOrder := make([]string, 0)
 	var mu sync.Mutex
 
@@ -113,7 +182,6 @@ func TestWatcherResumedOnColdWake(t *testing.T) {
 		},
 	)
 	m.SetWatcherHook(hook)
-	_ = resumeOrder
 
 	key := tier.SlotKey{RepoPath: "/repo/ph2a-wake", Ref: "feat/x"}
 	m.Register(key, false, tier.SlotKindBranchFeature)
@@ -263,12 +331,13 @@ func TestConcurrentColdWakesWithWatcherHook(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test: stale detection — IsPaused is false after cold-wake
+// Test: stale detection — no Pause after WARM→COLD, Resume after cold-wake
 // ---------------------------------------------------------------------------
 
 func TestSlotNotPausedAfterWake(t *testing.T) {
 	// Simulate the full cycle: register → evict → wake.
 	// After the wake the slot should be HOT and watcher should be resumed.
+	// #2645: there should be 0 Pause calls (Pause deferred to EXPIRED).
 	clock, advance := makeClock()
 	hook := &fakeWatcherHook{}
 
@@ -284,11 +353,12 @@ func TestSlotNotPausedAfterWake(t *testing.T) {
 	m.Scan()
 	_ = m.Touch(key) // cold wake
 
-	// After the wake the slot is HOT; the hook should have 1 Pause + 1 Resume.
-	if hook.pausedCount() != 1 {
-		t.Errorf("want 1 Pause call, got %d", hook.pausedCount())
+	// After the wake the slot is HOT; subscription was never removed (#2645),
+	// and Resume fires on the cold wake.
+	if hook.pausedCount() != 0 {
+		t.Errorf("#2645: want 0 Pause calls (deferred to EXPIRED), got %d", hook.pausedCount())
 	}
 	if hook.resumedCount() != 1 {
-		t.Errorf("want 1 Resume call, got %d", hook.resumedCount())
+		t.Errorf("want 1 Resume call after cold wake, got %d", hook.resumedCount())
 	}
 }

--- a/internal/daemon/watch/watcher_test.go
+++ b/internal/daemon/watch/watcher_test.go
@@ -367,6 +367,119 @@ func TestForceRescan(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// #2645 regression tests: TS/TSX and other source file changes must trigger
+// the sink. These are the canonical regression tests for issue #2645 —
+// "daemon watcher isn't picking up TS/TSX file changes in core-mobile".
+// ---------------------------------------------------------------------------
+
+// TestWatcher_TSFileChange_TriggersReindex verifies that editing a .tsx file
+// in a watched repo fires the sink within 5 s. This is the direct regression
+// test for #2645: watcher events from TS/TSX files must flow through to the
+// debounce → sink → reindex enqueue chain.
+func TestWatcher_TSFileChange_TriggersReindex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+	src := filepath.Join(repo, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-create a .tsx fixture so subsequent writes are tracked-file edits
+	// (same scenario as editing an existing component in core-mobile).
+	initial := filepath.Join(src, "Component.tsx")
+	if err := os.WriteFile(initial, []byte("export default () => null;"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doneCh := make(chan string, 4)
+	w, err := newTestWatcher(200*time.Millisecond, func(repoPath string, _ bool) {
+		doneCh <- repoPath
+	})
+	if err != nil {
+		t.Fatalf("new watcher: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+
+	// Simulate the developer saving an edit to the .tsx file.
+	if err := os.WriteFile(initial, []byte("export default () => <View/>;"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case got := <-doneCh:
+		if got != repo {
+			t.Errorf("sink got repo=%q, want %q", got, repo)
+		}
+		// Success: the watcher fired for the TS file change within 5 s.
+	case <-time.After(5 * time.Second):
+		t.Fatal("#2645 regression: watcher did not fire within 5 s for .tsx edit")
+	}
+}
+
+// TestWatcher_AcceptsAllSupportedExtensions verifies that .ts, .tsx, .js,
+// .jsx, .py and .go edits all trigger watcher events. None of these are in
+// SkipExts, so they should all reach the sink.
+func TestWatcher_AcceptsAllSupportedExtensions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	type tc struct {
+		ext     string
+		content string
+	}
+	cases := []tc{
+		{".ts", "export const x = 1;"},
+		{".tsx", "export default () => null;"},
+		{".js", "module.exports = {};"},
+		{".jsx", "export default () => null;"},
+		{".py", "x = 1"},
+		{".go", "package main"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.ext, func(t *testing.T) {
+			t.Parallel()
+			repo := t.TempDir()
+			src := filepath.Join(repo, "src")
+			if err := os.MkdirAll(src, 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			doneCh := make(chan struct{}, 4)
+			w, err := newTestWatcher(150*time.Millisecond, func(_ string, _ bool) {
+				doneCh <- struct{}{}
+			})
+			if err != nil {
+				t.Fatalf("new watcher: %v", err)
+			}
+			defer w.Stop()
+			if _, err := w.AddRepo(repo); err != nil {
+				t.Fatalf("AddRepo: %v", err)
+			}
+
+			f := filepath.Join(src, "file"+c.ext)
+			if err := os.WriteFile(f, []byte(c.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			select {
+			case <-doneCh:
+				// OK — extension was not filtered.
+			case <-time.After(3 * time.Second):
+				t.Errorf("#2645: watcher did not fire for %s file within 3 s", c.ext)
+			}
+		})
+	}
+}
+
 // TestExtendedStats verifies that ExtendedStats returns per-repo counters
 // after some events.
 func TestExtendedStats(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Root cause (Hypothesis 4)**: M2 lazy-subscription design (issue #2179) removed fsnotify subscriptions on WARM→COLD tier transitions after 60 min idle. Any TS/TSX file edits while a repo was COLD generated no watcher events → no debounce → no `scheduler.Enqueue` → stale line numbers.
- **Fix**: Defer `wh.Pause` from WARM→COLD to COLD→EXPIRED in `tier.go` (both TTL-scan and pressure-evict paths). The fsnotify subscription now survives the COLD window and is only removed when `graph.fb` is physically deleted (EXPIRED).
- **Bonus**: Added `Resume` in `tierReloadCallback` so repos that went through EXPIRED and were re-indexed re-subscribe on cold wake.

## Changed files

- `internal/daemon/tier/tier.go` — moved `wh.Pause` from `toEvict` (WARM→COLD) loop to `toExpire` (COLD→EXPIRED) loop; same for `scanPressureEvict`.
- `cmd/archigraph/daemon_tier.go` — `tierReloadCallback` now calls `daemonWatcherMgr.Resume` on cold wake.
- `internal/daemon/tier/tier_watcher_test.go` — updated to assert Pause does NOT fire on WARM→COLD; added `TestWatcherPausedOnExpired` for COLD→EXPIRED.
- `internal/daemon/watch/watcher_test.go` — added `TestWatcher_TSFileChange_TriggersReindex` and `TestWatcher_AcceptsAllSupportedExtensions`.

## Test plan

- [x] `go vet ./internal/daemon/... ./cmd/archigraph/...` — clean
- [x] `go build ./internal/daemon/... ./cmd/archigraph/...` — clean
- [x] `go test ./internal/daemon/... ./internal/install/watchers/... -count=1` — 16 packages PASS
- [x] `TestWatcher_TSFileChange_TriggersReindex` — .tsx edit fires sink within 5s
- [x] `TestWatcher_AcceptsAllSupportedExtensions` — .ts/.tsx/.js/.jsx/.py/.go all pass
- [x] `TestWatcherNotPausedOnCold` — WARM→COLD no longer fires Pause
- [x] `TestWatcherPausedOnExpired` — COLD→EXPIRED fires Pause

## Tech debt note

The M2 idle-daemon goal (zero fsnotify fds for idle groups) is partially walked back: repos now keep their fsnotify subscription through the COLD window (60 min). The fd cost per COLD repo is proportional to its directory count (typically 20–200 dirs). For large multi-group daemons with many idle repos this could re-introduce the inotify watch-count pressure that M2 was designed to avoid. A future follow-up could track inotify usage and selectively drop subscriptions only under fd pressure — without coupling to the graph-tier lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)