### PR TITLE
fix(mcp/persona_event): declare depth + chain args in schema

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -858,6 +858,8 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("persona", mcpapi.Required()),
 		mcpapi.WithString("event_type", mcpapi.Required()),
 		mcpapi.WithAny("target_persona"),
+		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(0)),
+		mcpapi.WithArray("chain"),
 		mcpapi.WithAny("metadata"),
 	), s.wrap("archigraph_persona_event", s.handlePersonaEvent))
 


### PR DESCRIPTION
## Summary
- Added missing `depth` (number) and `chain` (array) parameters to archigraph_persona_event tool schema
- These parameters were implemented in handlePersonaEvent but not declared in the MCP tool registration
- Fixes TestSchemaContract_AllHandlerArgsDeclared which has been failing for 5+ PRs

## Test plan
- [x] TestSchemaContract_AllHandlerArgsDeclared passes
- [x] gofmt + go vet + go build all pass
- [x] No breaking changes to API

Closes #2651