### PR TITLE
feat(extractor/ts): NAVIGATES_TO edges for router.push/navigate/etc (#2655)

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -1891,6 +1891,27 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 			}
 		}
 
+		// Issue #2655 — navigation edge extraction. Detect router.push /
+		// router.navigate / navigation.navigate / Linking.openURL patterns
+		// and emit NAVIGATES_TO edges in addition to (or instead of) CALLS.
+		// We check BEFORE callTarget so the navigation method's member-
+		// expression receiver check gates out plain array.push() calls;
+		// the normal CALLS edge is still emitted for the same call site so
+		// downstream flow BFS can traverse it.
+		if navRoute, navParams, navOK := extractNavigationCall(x, call); navOK {
+			navEdge := emitNavigationEdge(navRoute, navParams, call)
+			navKey := "nav:" + navEdge.ToID
+			if !seen[navKey] {
+				seen[navKey] = true
+				rels = append(rels, navEdge)
+			}
+			// For router.back() there is no meaningful callee to forward to
+			// the normal CALLS path, so skip it.
+			if navRoute == "<back>" {
+				continue
+			}
+		}
+
 		target := x.callTarget(call, frame)
 		if target == "" || target == "require" {
 			continue

--- a/internal/extractors/javascript/issue2655_navigation_test.go
+++ b/internal/extractors/javascript/issue2655_navigation_test.go
@@ -1,0 +1,281 @@
+// Package javascript_test — issue #2655: NAVIGATES_TO edge extraction for
+// Expo Router / React Navigation / Next.js navigation call sites.
+//
+// Tests cover:
+//   - router.push('/path')                          → NAVIGATES_TO route:'/path'
+//   - router.push({pathname: '/x', params: {a, b}}) → route='/x', params='a, b'
+//   - navigation.navigate('Screen')                 → NAVIGATES_TO route:'Screen'
+//   - Linking.openURL('https://...')                → NAVIGATES_TO (external URL)
+//   - foo.push(item)                                → no NAVIGATES_TO edge
+package javascript_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNavigationExtractor_RouterPush_EmitsEdge verifies that router.push('/foo')
+// emits a NAVIGATES_TO edge with ToID="route:/foo". Issue #2655.
+func TestNavigationExtractor_RouterPush_EmitsEdge(t *testing.T) {
+	src := `
+import { useRouter } from "expo-router";
+
+const MyComponent = () => {
+  const router = useRouter();
+  const goFoo = () => {
+    router.push('/foo');
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !hasRelEdge(ents, "goFoo", "NAVIGATES_TO", "route:/foo") {
+		e := findByNameRel(ents, "goFoo")
+		if e != nil {
+			t.Logf("goFoo relationships:")
+			for _, r := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+			}
+		} else {
+			t.Log("entity 'goFoo' not found")
+		}
+		t.Errorf("expected NAVIGATES_TO goFoo→route:/foo, not found")
+	}
+
+	// Verify the route property is set correctly.
+	e := findByNameRel(ents, "goFoo")
+	if e == nil {
+		t.Fatal("entity 'goFoo' not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "NAVIGATES_TO" && r.ToID == "route:/foo" {
+			if r.Properties == nil || r.Properties["route"] != "/foo" {
+				t.Errorf("expected Properties[route]='/foo', got %v", r.Properties)
+			}
+			if r.Properties["via"] != "navigation_call" {
+				t.Errorf("expected Properties[via]='navigation_call', got %v", r.Properties["via"])
+			}
+			return
+		}
+	}
+	t.Error("NAVIGATES_TO edge found but missing expected properties")
+}
+
+// TestNavigationExtractor_RouterPushObjectForm verifies that the object-form
+// navigation call router.push({pathname: '/users/[id]', params: {id, type}})
+// emits a NAVIGATES_TO edge with route='/users/[id]' and params='id, type'.
+// Issue #2655.
+func TestNavigationExtractor_RouterPushObjectForm(t *testing.T) {
+	src := `
+import { useRouter } from "expo-router";
+
+const UserNavigator = () => {
+  const router = useRouter();
+  const goToUser = (id, type) => {
+    router.push({
+      pathname: '/users/[id]',
+      params: { id, type },
+    });
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !hasRelEdge(ents, "goToUser", "NAVIGATES_TO", "route:/users/[id]") {
+		e := findByNameRel(ents, "goToUser")
+		if e != nil {
+			t.Logf("goToUser relationships:")
+			for _, r := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+		t.Fatalf("expected NAVIGATES_TO goToUser→route:/users/[id], not found")
+	}
+
+	// Verify params list is present.
+	e := findByNameRel(ents, "goToUser")
+	if e == nil {
+		t.Fatal("entity 'goToUser' not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "NAVIGATES_TO" && r.ToID == "route:/users/[id]" {
+			if r.Properties == nil {
+				t.Fatal("NAVIGATES_TO edge has no Properties")
+			}
+			gotParams := r.Properties["params"]
+			if gotParams == "" {
+				t.Errorf("expected params to be set, got empty")
+			}
+			// Both 'id' and 'type' must appear in the params list.
+			for _, want := range []string{"id", "type"} {
+				found := false
+				for _, p := range splitParams(gotParams) {
+					if p == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected param %q in params=%q", want, gotParams)
+				}
+			}
+			return
+		}
+	}
+	t.Error("NAVIGATES_TO edge not found on goToUser (after hasRelEdge passed — should not happen)")
+}
+
+// TestNavigationExtractor_NavigationNavigate verifies that
+// navigation.navigate('Home') emits a NAVIGATES_TO edge with route='Home'.
+// Issue #2655.
+func TestNavigationExtractor_NavigationNavigate(t *testing.T) {
+	src := `
+const HomeButton = ({ navigation }) => {
+  const goHome = () => {
+    navigation.navigate('Home');
+  };
+  return null;
+};
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJS(t, src, "javascript", tree)
+
+	if !hasRelEdge(ents, "goHome", "NAVIGATES_TO", "route:Home") {
+		e := findByNameRel(ents, "goHome")
+		if e != nil {
+			t.Logf("goHome relationships:")
+			for _, r := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+		t.Errorf("expected NAVIGATES_TO goHome→route:Home, not found")
+	}
+}
+
+// TestNavigationExtractor_LinkingOpenURL verifies that
+// Linking.openURL('https://example.com') emits a NAVIGATES_TO edge.
+// Issue #2655.
+func TestNavigationExtractor_LinkingOpenURL(t *testing.T) {
+	src := `
+import { Linking } from "react-native";
+
+const openExternal = () => {
+  Linking.openURL('https://example.com/terms');
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !hasRelEdge(ents, "openExternal", "NAVIGATES_TO", "route:https://example.com/terms") {
+		e := findByNameRel(ents, "openExternal")
+		if e != nil {
+			t.Logf("openExternal relationships:")
+			for _, r := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+		t.Errorf("expected NAVIGATES_TO openExternal→route:https://example.com/terms, not found")
+	}
+}
+
+// TestNavigationExtractor_NonNavCall_NoEdge verifies that a plain array .push()
+// call does NOT emit a NAVIGATES_TO edge. Issue #2655.
+func TestNavigationExtractor_NonNavCall_NoEdge(t *testing.T) {
+	src := `
+const addItem = (items, item) => {
+  items.push(item);
+  return items;
+};
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJS(t, src, "javascript", tree)
+
+	e := findByNameRel(ents, "addItem")
+	if e == nil {
+		t.Fatal("entity 'addItem' not found")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "NAVIGATES_TO" {
+			t.Errorf("unexpected NAVIGATES_TO edge on addItem: %v", r)
+		}
+	}
+}
+
+// TestNavigationExtractor_RouterReplace_EmitsEdge verifies that router.replace
+// also emits a NAVIGATES_TO edge. Issue #2655.
+func TestNavigationExtractor_RouterReplace_EmitsEdge(t *testing.T) {
+	src := `
+import { useRouter } from "next/navigation";
+
+const LoginPage = () => {
+  const router = useRouter();
+  const redirectHome = () => {
+    router.replace('/home');
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !hasRelEdge(ents, "redirectHome", "NAVIGATES_TO", "route:/home") {
+		e := findByNameRel(ents, "redirectHome")
+		if e != nil {
+			t.Logf("redirectHome relationships:")
+			for _, r := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+		t.Errorf("expected NAVIGATES_TO redirectHome→route:/home, not found")
+	}
+}
+
+// TestNavigationExtractor_RouterBack_EmitsEdge verifies that router.back()
+// emits a NAVIGATES_TO edge with route='<back>'. Issue #2655.
+func TestNavigationExtractor_RouterBack_EmitsEdge(t *testing.T) {
+	src := `
+import { useRouter } from "expo-router";
+
+const BackButton = () => {
+  const router = useRouter();
+  const goBack = () => {
+    router.back();
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !hasRelEdge(ents, "goBack", "NAVIGATES_TO", "route:<back>") {
+		e := findByNameRel(ents, "goBack")
+		if e != nil {
+			t.Logf("goBack relationships:")
+			for _, r := range e.Relationships {
+				t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+		t.Errorf("expected NAVIGATES_TO goBack→route:<back>, not found")
+	}
+}
+
+// splitParams is a helper that splits a comma-separated params string into
+// individual param key names (trimming spaces).
+func splitParams(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/internal/extractors/javascript/navigation.go
+++ b/internal/extractors/javascript/navigation.go
@@ -1,0 +1,262 @@
+// Package javascript — navigation edge extraction for issue #2655.
+//
+// This file detects navigation call sites across Expo Router, React Navigation,
+// and Next.js patterns, emitting NAVIGATES_TO edges from the caller entity to a
+// route stub (or to the matched destination entity if resolvable).
+//
+// Detected patterns (Phase 1):
+//   - router.push('/path')                     → NAVIGATES_TO, route='/path'
+//   - router.navigate('/path')                 → NAVIGATES_TO, route='/path'
+//   - router.replace('/path')                  → NAVIGATES_TO, route='/path'
+//   - router.back()                            → NAVIGATES_TO, route='<back>'
+//   - router.push({pathname: '/x', params: {a, b}}) → route='/x', params=[a,b]
+//   - navigation.navigate('Screen')            → NAVIGATES_TO, route='Screen'
+//   - navigation.push('Screen')                → NAVIGATES_TO, route='Screen'
+//   - Linking.openURL('https://...')           → NAVIGATES_TO (external)
+//
+// Phase 2 (followup): dedicated archigraph_navigates MCP query tool.
+package javascript
+
+import (
+	"strconv"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// navigationMethodNames is the set of method names recognised as navigation
+// calls. "push" appears both here (router.push / navigation.push) and in
+// builtinMethodNames (Array.push). The navigation detector runs BEFORE the
+// normal callTarget path in extractCallRelationships and gates on the full
+// receiver.method shape to avoid misidentifying plain array .push() calls.
+var navigationMethodNames = map[string]bool{
+	"push":     true,
+	"navigate": true,
+	"replace":  true,
+	"back":     true,
+	"openURL":  true,
+}
+
+// navigationReceiverNames is the set of receiver identifiers whose method
+// calls are treated as navigation, regardless of local variable name aliasing.
+// This is a conservative allowlist: it covers the most common single-word
+// aliases for the Expo Router / React Navigation / Linking APIs.
+var navigationReceiverNames = map[string]bool{
+	"router":     true,
+	"navigation": true,
+	"Linking":    true,
+}
+
+// extractNavigationCall inspects a single call_expression node and, if it
+// matches a navigation pattern, returns the destination route, any param key
+// names extracted from the `params:` object, and ok=true.
+//
+// Three argument shapes are handled:
+//
+//  1. String literal first arg:
+//     router.push('/foo')  →  route='/foo', params=nil
+//
+//  2. Template literal first arg (dynamic — captured as-is):
+//     router.push(`/foo/${id}`)  →  route='`/foo/${id}`', params=nil
+//
+//  3. Object-form first arg with pathname + optional params:
+//     router.push({pathname: '/users/[id]', params: {id, type}})
+//     →  route='/users/[id]', params=['id','type']
+//
+//  4. No first arg (e.g. router.back()):
+//     →  route='<back>'
+func extractNavigationCall(x *extractor, call *sitter.Node) (route string, params []string, ok bool) {
+	if call == nil {
+		return "", nil, false
+	}
+
+	// Must be a call_expression whose function child is a member_expression.
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_expression" {
+		return "", nil, false
+	}
+
+	// Resolve receiver and method names.
+	objNode := fn.ChildByFieldName("object")
+	propNode := fn.ChildByFieldName("property")
+	if objNode == nil || propNode == nil {
+		return "", nil, false
+	}
+
+	receiver := x.nodeText(objNode)
+	method := x.nodeText(propNode)
+
+	// Receiver must be in the allowlist.
+	if !navigationReceiverNames[receiver] {
+		return "", nil, false
+	}
+	// Method must be a navigation verb.
+	if !navigationMethodNames[method] {
+		return "", nil, false
+	}
+
+	// router.back() / navigation.back() — no argument, route stub.
+	if method == "back" {
+		return "<back>", nil, true
+	}
+
+	// Inspect the arguments list.
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		// No args node at all (shouldn't happen for these methods, but be safe).
+		return "<" + method + ">", nil, true
+	}
+
+	// Find the first non-punctuation child of the arguments node.
+	firstArg := firstMeaningfulArg(args)
+	if firstArg == nil {
+		// e.g. Linking.openURL() with no argument — skip.
+		return "", nil, false
+	}
+
+	switch firstArg.Type() {
+	case "string":
+		// Quoted string literal: 'screen' or "/path".
+		raw := x.nodeText(firstArg)
+		route = strings.Trim(raw, `"'`+"`")
+		return route, nil, true
+
+	case "template_string":
+		// Template literal — capture raw text as route (dynamic).
+		route = x.nodeText(firstArg)
+		return route, nil, true
+
+	case "object", "object_expression":
+		// Object-form: {pathname: '/x', params: {a, b, ...}}.
+		return extractObjectFormRoute(x, firstArg)
+
+	default:
+		// Identifier or other expression — dynamic / unresolvable.
+		return "", nil, false
+	}
+}
+
+// firstMeaningfulArg returns the first child of an arguments node that is not
+// a punctuation token ("(", ")", ",").
+func firstMeaningfulArg(args *sitter.Node) *sitter.Node {
+	for i := 0; i < int(args.ChildCount()); i++ {
+		ch := args.Child(i)
+		if ch == nil {
+			continue
+		}
+		t := ch.Type()
+		if t == "(" || t == ")" || t == "," {
+			continue
+		}
+		return ch
+	}
+	return nil
+}
+
+// extractObjectFormRoute parses an object literal node for the `pathname` key
+// and the `params` key, returning the route and param key names.
+func extractObjectFormRoute(x *extractor, obj *sitter.Node) (route string, params []string, ok bool) {
+	for i := 0; i < int(obj.ChildCount()); i++ {
+		child := obj.Child(i)
+		if child == nil {
+			continue
+		}
+		// Both JS and TS grammars use "pair" for key: value inside objects.
+		if child.Type() != "pair" {
+			continue
+		}
+		keyNode := child.ChildByFieldName("key")
+		valNode := child.ChildByFieldName("value")
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		key := strings.Trim(x.nodeText(keyNode), `"'`+"`")
+		switch key {
+		case "pathname":
+			raw := x.nodeText(valNode)
+			route = strings.Trim(raw, `"'`+"`")
+		case "params":
+			params = extractParamKeys(x, valNode)
+		}
+	}
+	if route == "" {
+		return "", nil, false
+	}
+	return route, params, true
+}
+
+// extractParamKeys returns the property/shorthand key names from an object
+// expression used as the `params:` value in a navigation call.
+//
+// Handles both shorthand `{id}` (shorthand_property_identifier) and explicit
+// `{id: value}` (pair) property shapes.
+func extractParamKeys(x *extractor, obj *sitter.Node) []string {
+	if obj == nil {
+		return nil
+	}
+	// Unwrap through one level of parenthesisation.
+	if obj.Type() == "parenthesized_expression" {
+		for i := 0; i < int(obj.ChildCount()); i++ {
+			ch := obj.Child(i)
+			if ch != nil && (ch.Type() == "object" || ch.Type() == "object_expression") {
+				obj = ch
+				break
+			}
+		}
+	}
+	if obj.Type() != "object" && obj.Type() != "object_expression" {
+		return nil
+	}
+
+	var keys []string
+	seen := make(map[string]bool)
+	for i := 0; i < int(obj.ChildCount()); i++ {
+		child := obj.Child(i)
+		if child == nil {
+			continue
+		}
+		var keyName string
+		switch child.Type() {
+		case "pair":
+			if kn := child.ChildByFieldName("key"); kn != nil {
+				keyName = strings.Trim(x.nodeText(kn), `"'`+"`")
+			}
+		case "shorthand_property_identifier", "shorthand_property_identifier_pattern":
+			keyName = x.nodeText(child)
+		}
+		if keyName != "" && !seen[keyName] {
+			seen[keyName] = true
+			keys = append(keys, keyName)
+		}
+	}
+	return keys
+}
+
+// emitNavigationEdge constructs a NAVIGATES_TO RelationshipRecord from a
+// navigation call site. The ToID is the route string (prefixed with "route:")
+// so it forms a stable synthetic stub ID that the linker can later match
+// against declared route entities.
+//
+// Properties set:
+//   - "route"   : the destination route/screen name
+//   - "params"  : comma-separated param key names (omitted when empty)
+//   - "line"    : 1-indexed source line of the call site
+//   - "via"     : "navigation_call" (traceability tag)
+func emitNavigationEdge(route string, params []string, call *sitter.Node) types.RelationshipRecord {
+	toID := "route:" + route
+	props := map[string]string{
+		"route": route,
+		"line":  strconv.Itoa(int(call.StartPoint().Row) + 1),
+		"via":   "navigation_call",
+	}
+	if len(params) > 0 {
+		props["params"] = strings.Join(params, ", ")
+	}
+	return types.RelationshipRecord{
+		ToID:       toID,
+		Kind:       "NAVIGATES_TO",
+		Properties: props,
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -436,6 +436,17 @@ const (
 	RelationshipKindReadsField  RelationshipKind = "READS_FIELD"
 	RelationshipKindWritesField RelationshipKind = "WRITES_FIELD"
 
+	// #2655: Client-side navigation edges. Emitted by the JS/TS extractor
+	// for Expo Router / React Navigation / Next.js navigation call sites.
+	//   NAVIGATES_TO : caller operation → route stub (synthetic "route:<path>")
+	// Properties:
+	//   "route"   : destination route/screen name or path
+	//   "params"  : comma-separated param key names (omitted when empty)
+	//   "line"    : 1-indexed source line of the navigation call
+	//   "via"     : "navigation_call" (traceability tag)
+	// Phase 2 (followup): dedicated archigraph_navigates MCP query tool.
+	RelationshipKindNavigatesTo RelationshipKind = "NAVIGATES_TO"
+
 	// #2183 — Monorepo M6: Bazel BUILD-graph fusion.
 	//   BAZEL_DEPENDS_ON : bazel_target → bazel_target
 	//     Emitted for every entry in a BUILD rule's deps= list that can be
@@ -535,6 +546,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		// #2279 Django ORM field-access edges:
 		RelationshipKindReadsField,
 		RelationshipKindWritesField,
+		// #2655 client-side navigation edges:
+		RelationshipKindNavigatesTo,
 		// #2183 Bazel BUILD-graph fusion:
 		RelationshipKindBazelDependsOn,
 		RelationshipKindBazelDepStatus,


### PR DESCRIPTION
## Summary

- Adds `internal/extractors/javascript/navigation.go` with navigation call-site detection for Expo Router, React Navigation, and Next.js patterns
- Emits `NAVIGATES_TO` edges from caller entities to `route:<path>` stubs, with `Properties["params"]` listing param key names
- Registers `RelationshipKindNavigatesTo = "NAVIGATES_TO"` in `internal/types/kinds.go`
- Hooks into `extractCallRelationships` in `extractor.go` — runs before `callTarget` so the receiver-allowlist guard blocks plain `array.push()` misidentification

## Patterns detected

- `router.push|navigate|replace('/path')` — string literal arg
- `router.push({pathname: '/x', params: {a, b}})` — object form with param extraction
- `router.back()` → `route:<back>` stub
- `navigation.navigate('Screen')` / `navigation.push('Screen')`
- `Linking.openURL('https://...')` — external URL

## Properties on edge

| Property | Example |
|---|---|
| `route` | `/users/[id]` |
| `params` | `id, type` |
| `line` | `42` |
| `via` | `navigation_call` |

## Test plan

- [x] `TestNavigationExtractor_RouterPush_EmitsEdge` — PASS
- [x] `TestNavigationExtractor_RouterPushObjectForm` — PASS (params extracted)
- [x] `TestNavigationExtractor_NavigationNavigate` — PASS
- [x] `TestNavigationExtractor_LinkingOpenURL` — PASS
- [x] `TestNavigationExtractor_NonNavCall_NoEdge` — PASS (array.push not confused)
- [x] `TestNavigationExtractor_RouterReplace_EmitsEdge` — PASS
- [x] `TestNavigationExtractor_RouterBack_EmitsEdge` — PASS
- [x] Full `go test ./internal/extractors/javascript/...` suite — PASS (no regressions)
- [x] `go build ./...` clean
- [x] `go vet` clean
- [x] `gofmt` clean

## Phase 2 followup

File a ticket for `archigraph_navigates` MCP query tool that surfaces route-to-route flows using the new `NAVIGATES_TO` edge kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)