### PR TITLE
feat(extractors): discriminator-pattern extraction (var === literal)

### DIFF
--- a/internal/extractors/javascript/discriminator.go
+++ b/internal/extractors/javascript/discriminator.go
@@ -1,0 +1,190 @@
+// discriminator.go — Issue #2654.
+//
+// Extracts discriminator-pattern comparisons from JS/TS function/method bodies
+// and stamps them as Properties["discriminators"] on the enclosing entity.
+//
+// A discriminator comparison is a BinaryExpression where:
+//   - operator is ===, ==, or !== (and the symmetric reversed forms)
+//   - LHS is a bare identifier (not a complex expression, not typeof)
+//   - RHS is a primitive literal: string, number, true, false, null
+//
+// Emitted format: "var1=val1,var2=val2" (comma-separated, equals-separated pairs).
+// Example: status===1 and type==='periodic' → "status=1,type=periodic"
+//
+// Filter rules (avoid noise):
+//   - Skip when LHS is a typeof_expression
+//   - Skip when RHS is another identifier (var-to-var equality, not a binding)
+//   - Skip when LHS is not a plain identifier (complex expressions, member access)
+//
+// The function is intentionally tolerant: a panic inside the walk is recovered
+// and an empty string returned so the primary extraction pipeline is unaffected.
+package javascript
+
+import (
+	"fmt"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// extractDiscriminators walks the body node (a function/method/arrow body)
+// and returns a comma-separated "var=value" string for every discriminator
+// comparison found. Returns "" when no discriminators are found or body is nil.
+//
+// Signature: func (x *extractor) extractDiscriminators(body *sitter.Node) string
+func (x *extractor) extractDiscriminators(body *sitter.Node) string {
+	if body == nil {
+		return ""
+	}
+
+	var pairs []string
+	seen := make(map[string]bool)
+
+	defer func() { _ = recover() }()
+
+	nodes := findAllNodes(body, "binary_expression")
+	for _, n := range nodes {
+		varName, litVal, ok := x.discriminatorFromBinary(n)
+		if !ok {
+			continue
+		}
+		key := fmt.Sprintf("%s=%s", varName, litVal)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		pairs = append(pairs, key)
+	}
+
+	return strings.Join(pairs, ",")
+}
+
+// discriminatorFromBinary inspects a binary_expression node and returns the
+// (variableName, literalValue, true) triple when the node is a discriminator
+// pattern. Returns ("", "", false) for non-discriminator expressions.
+//
+// Detection: walks the children of the binary_expression to find:
+//  1. An operator child whose Type() is "===", "==", or "!=="
+//  2. A "left" field that is a plain identifier (not typeof, not member access)
+//  3. A "right" field that is a primitive literal (string/number/true/false/null)
+//
+// Symmetric form: if LHS is a literal and RHS is an identifier (e.g. `1 === status`)
+// the pair is also captured with (identifier, literal) order.
+func (x *extractor) discriminatorFromBinary(n *sitter.Node) (varName, litVal string, ok bool) {
+	if n == nil || n.Type() != "binary_expression" {
+		return "", "", false
+	}
+
+	// Walk children to find the operator.
+	hasDiscrimOp := false
+	for i := 0; i < int(n.ChildCount()); i++ {
+		ch := n.Child(i)
+		if ch == nil {
+			continue
+		}
+		t := ch.Type()
+		if t == "===" || t == "==" || t == "!==" {
+			hasDiscrimOp = true
+			break
+		}
+	}
+	if !hasDiscrimOp {
+		return "", "", false
+	}
+
+	left := n.ChildByFieldName("left")
+	right := n.ChildByFieldName("right")
+	if left == nil || right == nil {
+		return "", "", false
+	}
+
+	// Normal form: identifier === literal
+	if left.Type() == "identifier" && isDiscriminatorLiteral(right) {
+		varName = x.nodeText(left)
+		litVal = x.discriminatorLiteralValue(right)
+		if varName != "" && litVal != "" {
+			return varName, litVal, true
+		}
+	}
+
+	// Reversed form: literal === identifier (e.g. `1 === status`)
+	if right.Type() == "identifier" && isDiscriminatorLiteral(left) {
+		varName = x.nodeText(right)
+		litVal = x.discriminatorLiteralValue(left)
+		if varName != "" && litVal != "" {
+			return varName, litVal, true
+		}
+	}
+
+	return "", "", false
+}
+
+// isDiscriminatorLiteral returns true when n is a primitive literal that
+// qualifies as the RHS of a discriminator comparison. Accepted types:
+//   - string (and template_string / template_literal)
+//   - number
+//   - true, false, null
+//
+// Excluded: typeof_expression, identifiers, call_expression, member_expression,
+// template_substitution (complex template), unary_expression (e.g. -1 is not
+// excluded but handled via the number branch; !x is excluded because it is not
+// a literal). Note: unary_expression where operator is "-" followed by a number
+// literal (negative numbers) would be missed; that is an acceptable trade-off
+// since negative numeric discriminators are uncommon in real UI code.
+func isDiscriminatorLiteral(n *sitter.Node) bool {
+	if n == nil {
+		return false
+	}
+	switch n.Type() {
+	case "string", "template_string", "template_literal",
+		"number",
+		"true", "false",
+		"null":
+		return true
+	}
+	return false
+}
+
+// discriminatorLiteralValue extracts the display value from a literal node.
+// String literals have their surrounding quotes stripped. Other literals
+// return their raw text.
+func (x *extractor) discriminatorLiteralValue(n *sitter.Node) string {
+	if n == nil {
+		return ""
+	}
+	raw := x.nodeText(n)
+	if raw == "" {
+		return ""
+	}
+	switch n.Type() {
+	case "string", "template_string", "template_literal":
+		// Strip surrounding quotes/backticks.
+		if len(raw) >= 2 {
+			first, last := raw[0], raw[len(raw)-1]
+			if (first == '"' && last == '"') ||
+				(first == '\'' && last == '\'') ||
+				(first == '`' && last == '`') {
+				return raw[1 : len(raw)-1]
+			}
+		}
+	}
+	return raw
+}
+
+// stampDiscriminators stamps Properties["discriminators"] on the last entity
+// appended to x.entities when the discriminators string is non-empty.
+// Called immediately after emitting a function/method/arrow entity.
+func (x *extractor) stampDiscriminators(body *sitter.Node) {
+	if body == nil || len(x.entities) == 0 {
+		return
+	}
+	d := x.extractDiscriminators(body)
+	if d == "" {
+		return
+	}
+	last := &x.entities[len(x.entities)-1]
+	if last.Properties == nil {
+		last.Properties = make(map[string]string)
+	}
+	last.Properties["discriminators"] = d
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -664,6 +664,8 @@ func (x *extractor) handleFunctionDeclaration(n *sitter.Node, parentClass string
 	// graph is complete.
 	rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 	x.emitWithRels(name, "SCOPE.Operation", n, subtype, sig, rels)
+	// Issue #2654 — stamp discriminator comparisons found in the body.
+	x.stampDiscriminators(body)
 
 	// Recurse into the body for nested declarations.
 	// Increment funcDepth so handleVariableDeclarator suppresses non-addressable
@@ -738,6 +740,8 @@ func (x *extractor) handleMethodDefinition(n *sitter.Node, _ string, cb *classBi
 	frame := x.functionParamFrame(params, cb)
 	rels := x.extractCallRelationships(body, name, frame)
 	x.emitWithRels(name, "SCOPE.Operation", n, "method", fmt.Sprintf("method %s", name), rels)
+	// Issue #2654 — stamp discriminator comparisons found in the body.
+	x.stampDiscriminators(body)
 }
 
 // handlePublicFieldDefinition handles class-body field assignments whose RHS
@@ -829,6 +833,8 @@ func (x *extractor) handlePublicFieldDefinition(n *sitter.Node, parentClass stri
 	sig := fmt.Sprintf("%s%s = (...) =>", sigParts, name)
 
 	x.emitWithRels(name, "SCOPE.Operation", valueNode, "method", sig, rels)
+	// Issue #2654 — stamp discriminator comparisons found in the body.
+	x.stampDiscriminators(body)
 
 	// Recurse into the body for nested declarations.
 	// Increment funcDepth so nested const declarations inside this arrow
@@ -1160,6 +1166,8 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		// Issue #610 — PascalCase arrow components emit RENDERS edges.
 		rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = (...) =>", name), rels)
+		// Issue #2654 — stamp discriminator comparisons found in the body.
+		x.stampDiscriminators(body)
 		if body != nil {
 			// Increment funcDepth so nested const declarations inside this
 			// arrow body are not emitted as addressable entities (#1748).
@@ -1180,6 +1188,8 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		// Issue #610 — PascalCase function-expression components emit RENDERS edges.
 		rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = function", name), rels)
+		// Issue #2654 — stamp discriminator comparisons found in the body.
+		x.stampDiscriminators(body)
 		if body != nil {
 			// Increment funcDepth so nested const declarations inside this
 			// function-expression body are not emitted as addressable entities (#1748).

--- a/internal/extractors/javascript/issue2654_discriminator_test.go
+++ b/internal/extractors/javascript/issue2654_discriminator_test.go
@@ -1,0 +1,204 @@
+// Package javascript_test — issue #2654 discriminator-pattern extraction tests.
+//
+// Verifies that BinaryExpression nodes of the form `identifier === literal`
+// are detected in function/method bodies and stamped as
+// Properties["discriminators"] on the enclosing entity.
+//
+// Six cases:
+//  1. TestDiscriminator_TSStrictEquality_NumericLiteral  — status === 1
+//  2. TestDiscriminator_TSStrictEquality_StringLiteral   — type === 'periodic'
+//  3. TestDiscriminator_MultipleInSameEntity             — 3 discriminators in one function
+//  4. TestDiscriminator_SkipsTypeof                      — typeof x === 'string' (skip)
+//  5. TestDiscriminator_SkipsVarToVar                    — a === b (skip)
+//  6. TestDiscriminator_ReversedForm                     — 1 === status (also captured)
+package javascript_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// parseTSDiscriminator parses source with the TypeScript grammar.
+func parseTSDiscriminator(t *testing.T, src []byte) *sitter.Tree {
+	t.Helper()
+	p := sitter.NewParser()
+	p.SetLanguage(tstypescript.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, src)
+	if err != nil {
+		t.Fatalf("parseTSDiscriminator: %v", err)
+	}
+	return tree
+}
+
+// extractTSForDiscriminator runs the TypeScript extractor and returns entities.
+func extractTSForDiscriminator(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	content := []byte(src)
+	tree := parseTSDiscriminator(t, content)
+	ext := javascript.New()
+	ents, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     "test.tsx",
+		Content:  content,
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+// discriminatorProp returns the "discriminators" property of the entity named
+// entityName, or "" when the entity is not found or the property is absent.
+func discriminatorProp(ents []types.EntityRecord, entityName string) string {
+	for i := range ents {
+		if ents[i].Name == entityName {
+			return ents[i].Properties["discriminators"]
+		}
+	}
+	return ""
+}
+
+// TestDiscriminator_TSStrictEquality_NumericLiteral verifies that a numeric
+// strict-equality comparison (`status === 1`) inside a function body is
+// captured as discriminator "status=1" on the enclosing function entity.
+func TestDiscriminator_TSStrictEquality_NumericLiteral(t *testing.T) {
+	src := `
+function checkStatus() {
+  if (status === 1) {
+    return true;
+  }
+  return false;
+}
+`
+	ents := extractTSForDiscriminator(t, src)
+	got := discriminatorProp(ents, "checkStatus")
+	if got == "" {
+		t.Fatalf("checkStatus: discriminators property is empty; want 'status=1'")
+	}
+	if !strings.Contains(got, "status=1") {
+		t.Errorf("checkStatus: discriminators=%q, want it to contain 'status=1'", got)
+	}
+}
+
+// TestDiscriminator_TSStrictEquality_StringLiteral verifies that a string
+// strict-equality comparison (`type === 'periodic'`) inside a function body is
+// captured as discriminator "type=periodic" on the enclosing function entity.
+func TestDiscriminator_TSStrictEquality_StringLiteral(t *testing.T) {
+	src := `
+function handleType() {
+  const isPeriodic = type === 'periodic';
+  return isPeriodic;
+}
+`
+	ents := extractTSForDiscriminator(t, src)
+	got := discriminatorProp(ents, "handleType")
+	if got == "" {
+		t.Fatalf("handleType: discriminators property is empty; want 'type=periodic'")
+	}
+	if !strings.Contains(got, "type=periodic") {
+		t.Errorf("handleType: discriminators=%q, want it to contain 'type=periodic'", got)
+	}
+}
+
+// TestDiscriminator_MultipleInSameEntity verifies that multiple discriminator
+// comparisons inside a single function body all appear in the property.
+func TestDiscriminator_MultipleInSameEntity(t *testing.T) {
+	src := `
+function processChecklist() {
+  const isCat5 = checklistType === 2;
+  const isPeriodic = type === 'periodic';
+  if (status === 1) {
+    return 'paid';
+  }
+  return null;
+}
+`
+	ents := extractTSForDiscriminator(t, src)
+	got := discriminatorProp(ents, "processChecklist")
+	if got == "" {
+		t.Fatalf("processChecklist: discriminators property is empty; want 3 discriminators")
+	}
+	wantPairs := []string{"checklistType=2", "type=periodic", "status=1"}
+	for _, pair := range wantPairs {
+		if !strings.Contains(got, pair) {
+			t.Errorf("processChecklist: discriminators=%q, want it to contain %q", got, pair)
+		}
+	}
+}
+
+// TestDiscriminator_SkipsTypeof verifies that typeof checks (`typeof x === 'string'`)
+// are NOT emitted as discriminators, because the LHS is a typeof_expression,
+// not a bare identifier.
+func TestDiscriminator_SkipsTypeof(t *testing.T) {
+	src := `
+function validateInput(x) {
+  if (typeof x === 'string') {
+    return true;
+  }
+  return false;
+}
+`
+	ents := extractTSForDiscriminator(t, src)
+	got := discriminatorProp(ents, "validateInput")
+	// The typeof form should NOT produce a discriminator. If the property is
+	// non-empty it must not contain a typeof-derived pair.
+	if got != "" {
+		// A typeof_expression on the LHS should be excluded. The pair would look
+		// like "x=string" which is incorrect (x is not the variable being compared
+		// to 'string'; typeof x is a type check, not a value binding).
+		// We allow other discriminators if present, but if the only expression is
+		// the typeof check and it produces a pair, that is a bug.
+		t.Logf("validateInput: discriminators=%q (want empty for typeof-only body)", got)
+		// Fail only if a typeof-derived pair appears (heuristic: "x=string").
+		if got == "x=string" {
+			t.Errorf("validateInput: discriminators=%q — typeof check was incorrectly captured", got)
+		}
+	}
+}
+
+// TestDiscriminator_SkipsVarToVar verifies that equality checks between two
+// identifiers (`a === b`) are NOT emitted as discriminators.
+func TestDiscriminator_SkipsVarToVar(t *testing.T) {
+	src := `
+function compareVars(a, b) {
+  if (a === b) {
+    return true;
+  }
+  return false;
+}
+`
+	ents := extractTSForDiscriminator(t, src)
+	got := discriminatorProp(ents, "compareVars")
+	if got != "" {
+		t.Errorf("compareVars: discriminators=%q, want empty (var-to-var should be skipped)", got)
+	}
+}
+
+// TestDiscriminator_ReversedForm verifies that the reversed form (`1 === status`)
+// is also captured correctly with (variable, literal) order.
+func TestDiscriminator_ReversedForm(t *testing.T) {
+	src := `
+function checkPaid() {
+  if (1 === status) {
+    return 'paid';
+  }
+}
+`
+	ents := extractTSForDiscriminator(t, src)
+	got := discriminatorProp(ents, "checkPaid")
+	if got == "" {
+		t.Fatalf("checkPaid: discriminators property is empty; want 'status=1'")
+	}
+	if !strings.Contains(got, "status=1") {
+		t.Errorf("checkPaid: discriminators=%q, want it to contain 'status=1'", got)
+	}
+}

--- a/internal/extractors/python/discriminator.go
+++ b/internal/extractors/python/discriminator.go
@@ -1,0 +1,198 @@
+// discriminator.go — Issue #2654.
+//
+// Extracts discriminator-pattern comparisons from Python function/method bodies
+// and stamps them as Properties["discriminators"] on the enclosing entity.
+//
+// A discriminator comparison is a comparison_operator node where:
+//   - operator is == or != (not "is", "is not", "in", "not in")
+//   - LHS is a bare identifier
+//   - RHS is a primitive literal (integer, float, string, true, false, none)
+//
+// Emitted format: "var1=val1,var2=val2" (comma-separated, equals-separated pairs).
+// Example: `if status == 'paid':` → "status=paid"
+//
+// Filter rules (avoid noise):
+//   - Skip when RHS is another identifier (var-to-var equality)
+//   - Skip when LHS is not a plain identifier (attribute access, subscripts, etc.)
+//   - Skip reversed forms only when LHS is a literal and RHS is an identifier
+//     (these are also captured with correct order)
+//
+// The function is tolerant: a panic inside the walk is recovered and an empty
+// string returned so the primary extraction pipeline is unaffected.
+package python
+
+import (
+	"fmt"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractPythonDiscriminators walks the body node (a function/method body block)
+// and returns a comma-separated "var=value" string for every discriminator
+// comparison found. Returns "" when no discriminators are found or body is nil.
+func extractPythonDiscriminators(body *sitter.Node, src []byte) string {
+	if body == nil {
+		return ""
+	}
+
+	var pairs []string
+	seen := make(map[string]bool)
+
+	defer func() { _ = recover() }()
+
+	nodes := findAll(body, "comparison_operator")
+	for _, n := range nodes {
+		varName, litVal, ok := discriminatorFromPythonComparison(n, src)
+		if !ok {
+			continue
+		}
+		key := fmt.Sprintf("%s=%s", varName, litVal)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		pairs = append(pairs, key)
+	}
+
+	return strings.Join(pairs, ",")
+}
+
+// discriminatorFromPythonComparison inspects a comparison_operator node and
+// returns (variableName, literalValue, true) when the node is a discriminator
+// pattern. Returns ("", "", false) otherwise.
+//
+// Tree-sitter Python grammar: comparison_operator children are laid out as:
+//
+//	child[0] = left operand
+//	child[1] = operator token (text is "==", "!=", "is", etc.)
+//	child[2] = right operand
+//	(child[3] = another operator, child[4] = another operand for chained comparisons)
+//
+// We only inspect the first comparison pair (child[0..2]).
+func discriminatorFromPythonComparison(n *sitter.Node, src []byte) (varName, litVal string, ok bool) {
+	if n == nil || n.Type() != "comparison_operator" {
+		return "", "", false
+	}
+	if n.ChildCount() < 3 {
+		return "", "", false
+	}
+
+	left := n.Child(0)
+	opNode := n.Child(1)
+	right := n.Child(2)
+
+	if left == nil || opNode == nil || right == nil {
+		return "", "", false
+	}
+
+	// Operator must be == or !=
+	opText := nodeText(opNode, src)
+	if opText != "==" && opText != "!=" {
+		return "", "", false
+	}
+
+	// Normal form: identifier == literal
+	if left.Type() == "identifier" && isPythonDiscriminatorLiteral(right) {
+		v := nodeText(left, src)
+		l := pythonLiteralValue(right, src)
+		if v != "" && l != "" {
+			return v, l, true
+		}
+	}
+
+	// Reversed form: literal == identifier (e.g. `'paid' == status`)
+	if right.Type() == "identifier" && isPythonDiscriminatorLiteral(left) {
+		v := nodeText(right, src)
+		l := pythonLiteralValue(left, src)
+		if v != "" && l != "" {
+			return v, l, true
+		}
+	}
+
+	return "", "", false
+}
+
+// isPythonDiscriminatorLiteral returns true when n is a tree-sitter Python
+// literal node that qualifies as the comparison operand in a discriminator.
+// Accepted types (tree-sitter Python grammar node types):
+//   - "integer"   — numeric integer literal
+//   - "float"     — numeric float literal
+//   - "string"    — string literal (single- or double-quoted, raw, etc.)
+//   - "true"      — Python True keyword
+//   - "false"     — Python False keyword
+//   - "none"      — Python None keyword
+func isPythonDiscriminatorLiteral(n *sitter.Node) bool {
+	if n == nil {
+		return false
+	}
+	switch n.Type() {
+	case "integer", "float",
+		"string",
+		"true", "false",
+		"none":
+		return true
+	}
+	return false
+}
+
+// pythonLiteralValue extracts the display value from a Python literal node.
+// String literals have their surrounding quotes stripped. Other literals
+// return their raw text.
+func pythonLiteralValue(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	raw := strings.TrimSpace(nodeText(n, src))
+	if raw == "" {
+		return ""
+	}
+	if n.Type() == "string" {
+		// Strip surrounding quotes: single ('), double ("), or triple-quoted forms.
+		// Handle: 'x', "x", r'x', b"x", etc. Strip any leading prefix (r, b, f, u).
+		s := raw
+		// Skip prefix characters (r, b, f, u, R, B, F, U) before the quote.
+		for len(s) > 0 && (s[0] == 'r' || s[0] == 'R' ||
+			s[0] == 'b' || s[0] == 'B' ||
+			s[0] == 'f' || s[0] == 'F' ||
+			s[0] == 'u' || s[0] == 'U') {
+			s = s[1:]
+		}
+		// Triple-quoted strings.
+		if strings.HasPrefix(s, `"""`) && strings.HasSuffix(s, `"""`) && len(s) >= 6 {
+			return s[3 : len(s)-3]
+		}
+		if strings.HasPrefix(s, "'''") && strings.HasSuffix(s, "'''") && len(s) >= 6 {
+			return s[3 : len(s)-3]
+		}
+		// Single-quoted strings.
+		if len(s) >= 2 {
+			first, last := s[0], s[len(s)-1]
+			if (first == '"' && last == '"') ||
+				(first == '\'' && last == '\'') {
+				return s[1 : len(s)-1]
+			}
+		}
+	}
+	return raw
+}
+
+// stampPythonDiscriminators stamps Properties["discriminators"] on the entity
+// at index idx in the out slice when discriminators are found in body.
+// Called immediately after appending a function/method entity.
+func stampPythonDiscriminators(body *sitter.Node, src []byte, out *[]types.EntityRecord, idx int) {
+	if body == nil || out == nil || idx < 0 || idx >= len(*out) {
+		return
+	}
+	d := extractPythonDiscriminators(body, src)
+	if d == "" {
+		return
+	}
+	e := &(*out)[idx]
+	if e.Properties == nil {
+		e.Properties = make(map[string]string)
+	}
+	e.Properties["discriminators"] = d
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -696,8 +696,11 @@ func walkNode(
 			}
 			rec.Relationships = append(rec.Relationships,
 				extractCallRelationships(node.ChildByFieldName("body"), file.Content, selfName, parentClass, imports, constReg)...)
+			funcIdx := len(*out)
 			*out = append(*out, rec)
 			*funcCount++
+			// Issue #2654 — stamp discriminator comparisons found in the body.
+			stampPythonDiscriminators(node.ChildByFieldName("body"), file.Content, out, funcIdx)
 		}
 		return // do not recurse into function body for nested definitions
 
@@ -719,8 +722,11 @@ func walkNode(
 				}
 				rec.Relationships = append(rec.Relationships,
 					extractCallRelationships(inner.ChildByFieldName("body"), file.Content, selfName, parentClass, imports, constReg)...)
+				decoratedFuncIdx := len(*out)
 				*out = append(*out, rec)
 				*funcCount++
+				// Issue #2654 — stamp discriminator comparisons found in the body.
+				stampPythonDiscriminators(inner.ChildByFieldName("body"), file.Content, out, decoratedFuncIdx)
 			}
 		case "class_definition":
 			rec := buildClass(inner, file)

--- a/internal/extractors/python/issue2654_discriminator_test.go
+++ b/internal/extractors/python/issue2654_discriminator_test.go
@@ -1,0 +1,66 @@
+// Package python_test — issue #2654 discriminator-pattern extraction tests.
+//
+// Verifies that comparison_operator nodes of the form `identifier == literal`
+// are detected in function/method bodies and stamped as
+// Properties["discriminators"] on the enclosing entity.
+//
+// One case for Python equality:
+//   - TestDiscriminator_PythonEquality — `if status == 'paid':` → "status=paid"
+package python_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pyDiscriminatorProp returns the "discriminators" property of the entity named
+// entityName, or "" when the entity is not found or the property is absent.
+func pyDiscriminatorProp(ents []types.EntityRecord, entityName string) string {
+	for i := range ents {
+		if ents[i].Name == entityName {
+			return ents[i].Properties["discriminators"]
+		}
+	}
+	return ""
+}
+
+// TestDiscriminator_PythonEquality verifies that an equality comparison
+// (`if status == 'paid':`) inside a Python function body is captured as
+// discriminator "status=paid" on the enclosing function entity.
+func TestDiscriminator_PythonEquality(t *testing.T) {
+	src := `
+def process_payment(status):
+    if status == 'paid':
+        return True
+    return False
+`
+	ents := extractPy(t, src, "payments/views.py")
+	got := pyDiscriminatorProp(ents, "process_payment")
+	if got == "" {
+		t.Fatalf("process_payment: discriminators property is empty; want 'status=paid'")
+	}
+	if !strings.Contains(got, "status=paid") {
+		t.Errorf("process_payment: discriminators=%q, want it to contain 'status=paid'", got)
+	}
+}
+
+// TestDiscriminator_PythonNumericEquality verifies that a numeric equality
+// comparison (`if code == 404:`) is captured as discriminator "code=404".
+func TestDiscriminator_PythonNumericEquality(t *testing.T) {
+	src := `
+def handle_response(code):
+    if code == 404:
+        return 'not_found'
+    return 'ok'
+`
+	ents := extractPy(t, src, "api/views.py")
+	got := pyDiscriminatorProp(ents, "handle_response")
+	if got == "" {
+		t.Fatalf("handle_response: discriminators property is empty; want 'code=404'")
+	}
+	if !strings.Contains(got, "code=404") {
+		t.Errorf("handle_response: discriminators=%q, want it to contain 'code=404'", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Detects `BinaryExpression` nodes where LHS is a bare identifier and RHS is a primitive literal (`===`, `==`, `!==` in JS/TS; `==`, `!=` in Python)
- Stamps `Properties["discriminators"] = "var1=val1,var2=val2"` on the enclosing function/method/arrow entity
- Real motivation: `const isCat5 = checklistType === 2` and `if status === 1 { /* paid */ }` encode operational semantics invisible to the graph — now indexed

## Filter rules (avoid noise)

- Skip `typeof x === 'string'` (LHS is a `typeof_expression`, not a bare identifier)
- Skip `a === b` (RHS is an identifier, not a literal — var-to-var equality)
- Skip complex LHS (member access, function calls, etc.)
- Reversed form `1 === status` is captured with correct (variable, literal) order

## Files touched

- `internal/extractors/javascript/discriminator.go` — new file: `extractDiscriminators`, `discriminatorFromBinary`, `isDiscriminatorLiteral`, `discriminatorLiteralValue`, `stampDiscriminators`
- `internal/extractors/javascript/extractor.go` — 4 hook points: `handleFunctionDeclaration`, `handleMethodDefinition`, `handlePublicFieldDefinition`, arrow/function-expression branch in `handleVariableDeclarator`
- `internal/extractors/python/discriminator.go` — new file: `extractPythonDiscriminators`, `discriminatorFromPythonComparison`, `isPythonDiscriminatorLiteral`, `pythonLiteralValue`, `stampPythonDiscriminators`
- `internal/extractors/python/extractor.go` — 2 hook points: `walkNode` function_definition + decorated_definition

## Test plan

- [x] `TestDiscriminator_TSStrictEquality_NumericLiteral` — `status === 1` → `status=1` PASS
- [x] `TestDiscriminator_TSStrictEquality_StringLiteral` — `type === 'periodic'` → `type=periodic` PASS
- [x] `TestDiscriminator_MultipleInSameEntity` — 3 discriminators in one function → all 3 appear PASS
- [x] `TestDiscriminator_SkipsTypeof` — `typeof x === 'string'` → no discriminator PASS
- [x] `TestDiscriminator_SkipsVarToVar` — `a === b` → no discriminator PASS
- [x] `TestDiscriminator_ReversedForm` — `1 === status` → `status=1` PASS
- [x] `TestDiscriminator_PythonEquality` — `if status == 'paid':` → `status=paid` PASS
- [x] `TestDiscriminator_PythonNumericEquality` — `if code == 404:` → `code=404` PASS
- [x] `go test ./internal/extractors/...` — full suite PASS (no regressions)
- [x] `gofmt` clean, `go vet` clean, `go build` clean

Closes #2654

🤖 Generated with [Claude Code](https://claude.com/claude-code)