### PR TITLE
fix(extractor/ts): qualify Zustand action entity IDs with store name

### DIFF
--- a/internal/extractors/javascript/destructure_bindings.go
+++ b/internal/extractors/javascript/destructure_bindings.go
@@ -155,12 +155,16 @@ func (x *extractor) scanDestructureDeclarator(decl *sitter.Node, out map[string]
 	// ── Single-property selector form (issue #2632) ──────────────────────────
 	// const softLogout = useAuthStore(s => s.softLogout);
 	if nameNode.Type() == "identifier" {
-		if actionName := x.parseSelectorArrowFn(valueNode); actionName != "" {
+		if storeVar, actionName := x.parseSelectorArrowFn(valueNode); actionName != "" {
 			localName := x.nodeText(nameNode)
 			if localName != "" {
+				// Issue #2631 — qualify the sourceTarget with the store variable so the
+				// CALLS edge resolves to the correct entity when multiple stores share
+				// an action name. Format: <storeVar>::<actionName>.
+				qualifiedTarget := storeVar + "::" + actionName
 				out[localName] = &destructureBinding{
 					localName:    localName,
-					sourceTarget: actionName,
+					sourceTarget: qualifiedTarget,
 					via:          PropViaZustandSelector,
 				}
 				return
@@ -307,32 +311,35 @@ func (x *extractor) classifyDestructureRHS(value *sitter.Node) (via, calleeBase 
 
 // parseSelectorArrowFn detects the single-property Zustand selector pattern (issue #2632):
 //
-//	useAuthStore(s => s.softLogout)          → "softLogout"
-//	useAuthStore((s) => s.softLogout)        → "softLogout"  (parenthesised param)
-//	useAuthStore(state => state.softLogout)  → "softLogout"  (any param name)
-//	useAuthStore(s => s?.softLogout)         → "softLogout"  (optional chain)
+//	useAuthStore(s => s.softLogout)          → ("useAuthStore", "softLogout")
+//	useAuthStore((s) => s.softLogout)        → ("useAuthStore", "softLogout")  (parenthesised param)
+//	useAuthStore(state => state.softLogout)  → ("useAuthStore", "softLogout")  (any param name)
+//	useAuthStore(s => s?.softLogout)         → ("useAuthStore", "softLogout")  (optional chain)
 //
-// Derived-value selectors like useAuthStore(s => Boolean(s.user)) return "" so
+// Derived-value selectors like useAuthStore(s => Boolean(s.user)) return ("", "") so
 // no spurious CALLS edge is emitted for non-callable selected values.
 //
-// Returns the action name on success or "" when the node does not match.
-func (x *extractor) parseSelectorArrowFn(value *sitter.Node) string {
+// Returns (storeVar, actionName) on success or ("", "") when the node does not match.
+// Issue #2631 — storeVar is returned so callers can build the qualified entity ID
+// <storeVar>::<actionName> instead of the bare action name.
+func (x *extractor) parseSelectorArrowFn(value *sitter.Node) (string, string) {
 	if value == nil || value.Type() != "call_expression" {
-		return ""
+		return "", ""
 	}
 	// Callee must be a Zustand hook (useXxxStore).
 	fnNode := value.ChildByFieldName("function")
 	if fnNode == nil {
-		return ""
+		return "", ""
 	}
 	callee := x.calleeLeafName(fnNode)
 	if !isZustandHookName(callee) {
-		return ""
+		return "", ""
 	}
+	storeVar := callee
 	// First argument must be an arrow_function.
 	argsNode := value.ChildByFieldName("arguments")
 	if argsNode == nil {
-		return ""
+		return "", ""
 	}
 	// Find the first non-punctuation child of the arguments node.
 	var arrowNode *sitter.Node
@@ -349,17 +356,17 @@ func (x *extractor) parseSelectorArrowFn(value *sitter.Node) string {
 		break
 	}
 	if arrowNode == nil || arrowNode.Type() != "arrow_function" {
-		return ""
+		return "", ""
 	}
 	// Arrow body must be a simple member_expression (s.action) or
 	// optional member_expression (s?.action).  Anything else (call, binary,
 	// sequence, etc.) is a derived value — skip it.
 	bodyNode := arrowNode.ChildByFieldName("body")
 	if bodyNode == nil {
-		return ""
+		return "", ""
 	}
 	if bodyNode.Type() != "member_expression" && bodyNode.Type() != "optional_chain" {
-		return ""
+		return "", ""
 	}
 
 	// For optional_chain (s?.x) the grammar nests differently; normalise by
@@ -372,11 +379,11 @@ func (x *extractor) parseSelectorArrowFn(value *sitter.Node) string {
 		// access like s.nested.action from being treated as a single action.
 		objNode := bodyNode.ChildByFieldName("object")
 		if objNode == nil {
-			return ""
+			return "", ""
 		}
 		// Allow only a bare identifier (the selector parameter).
 		if objNode.Type() != "identifier" {
-			return ""
+			return "", ""
 		}
 		propNode = bodyNode.ChildByFieldName("property")
 	case "optional_chain":
@@ -393,9 +400,9 @@ func (x *extractor) parseSelectorArrowFn(value *sitter.Node) string {
 		}
 	}
 	if propNode == nil {
-		return ""
+		return "", ""
 	}
-	return x.nodeText(propNode)
+	return storeVar, x.nodeText(propNode)
 }
 
 // calleeLeafName extracts the trailing identifier name from a function expression node.

--- a/internal/extractors/javascript/issue2590_zustand_store_test.go
+++ b/internal/extractors/javascript/issue2590_zustand_store_test.go
@@ -51,14 +51,15 @@ export async function syncEngine() {
 		t.Fatal("syncEngine entity missing")
 	}
 
+	// Issue #2631 — entity IDs are now qualified: <storeVar>::<actionName>.
 	found := false
 	for _, r := range e.Relationships {
-		if r.Kind == "CALLS" && r.ToID == "process" {
+		if r.Kind == "CALLS" && r.ToID == "useSyncQueueStore::process" {
 			if r.Properties != nil && r.Properties["via"] == "zustand_store" {
 				found = true
 				break
 			}
-			t.Logf("CALLS syncEngine→process found but via=%q (want zustand_store); props=%v",
+			t.Logf("CALLS syncEngine→useSyncQueueStore::process found but via=%q (want zustand_store); props=%v",
 				r.Properties["via"], r.Properties)
 		}
 	}
@@ -67,7 +68,7 @@ export async function syncEngine() {
 		for _, r := range e.Relationships {
 			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
 		}
-		t.Errorf("expected CALLS syncEngine→process with via=zustand_store; not found")
+		t.Errorf("expected CALLS syncEngine→useSyncQueueStore::process with via=zustand_store; not found")
 	}
 }
 
@@ -102,18 +103,20 @@ async function processSyncQueue(id) {
 		t.Fatal("expected entity 'processSyncQueue' to be emitted")
 	}
 
+	// Issue #2631 — entity IDs are now qualified: <storeVar>::<actionName>.
 	for _, action := range []string{"markSyncing", "markCompleted", "markFailed"} {
 		e := findByNameRel(ents, "processSyncQueue")
+		qualifiedAction := "useSyncQueueStore::" + action
 		found := false
 		for _, r := range e.Relationships {
-			if r.Kind == "CALLS" && r.ToID == action &&
+			if r.Kind == "CALLS" && r.ToID == qualifiedAction &&
 				r.Properties != nil && r.Properties["via"] == "zustand_store" {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("expected CALLS processSyncQueue→%s (via=zustand_store); not found", action)
+			t.Errorf("expected CALLS processSyncQueue→%s (via=zustand_store); not found", qualifiedAction)
 		}
 	}
 }
@@ -146,9 +149,10 @@ function onSessionExpired() {
 	}
 
 	e := findByNameRel(ents, "onSessionExpired")
+	// Issue #2631 — entity IDs are now qualified: <storeVar>::<actionName>.
 	found := false
 	for _, r := range e.Relationships {
-		if r.Kind == "CALLS" && r.ToID == "logout" &&
+		if r.Kind == "CALLS" && r.ToID == "useAuthStore::logout" &&
 			r.Properties != nil && r.Properties["via"] == "zustand_store" {
 			found = true
 			break
@@ -159,7 +163,7 @@ function onSessionExpired() {
 		for _, r := range e.Relationships {
 			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
 		}
-		t.Errorf("expected CALLS onSessionExpired→logout (via=zustand_store); not found")
+		t.Errorf("expected CALLS onSessionExpired→useAuthStore::logout (via=zustand_store); not found")
 	}
 }
 
@@ -219,9 +223,10 @@ export const useMyStore = create((set, get) => ({
 	tree := parseTSRel(t, []byte(src))
 	ents := runJS(t, src, "typescript", tree)
 
-	fooEnt := findByNameRel(ents, "foo")
+	// Issue #2631 — entity name is now qualified: <storeVar>::<actionName>.
+	fooEnt := findByNameRel(ents, "useMyStore::foo")
 	if fooEnt == nil {
-		t.Fatalf("expected entity 'foo' to be emitted as a standalone entity (issue #2626); got names: %v", func() []string {
+		t.Fatalf("expected entity 'useMyStore::foo' to be emitted as a standalone entity (issue #2626+#2631); got names: %v", func() []string {
 			var ns []string
 			for _, e := range ents {
 				ns = append(ns, e.Name)
@@ -230,16 +235,16 @@ export const useMyStore = create((set, get) => ({
 		}())
 	}
 	if fooEnt.Kind != "SCOPE.Operation" {
-		t.Errorf("foo.Kind = %q, want SCOPE.Operation", fooEnt.Kind)
+		t.Errorf("useMyStore::foo.Kind = %q, want SCOPE.Operation", fooEnt.Kind)
 	}
 	if fooEnt.Subtype != "method" {
-		t.Errorf("foo.Subtype = %q, want method", fooEnt.Subtype)
+		t.Errorf("useMyStore::foo.Subtype = %q, want method", fooEnt.Subtype)
 	}
 	if fooEnt.Properties == nil || fooEnt.Properties["via"] != "zustand_store" {
-		t.Errorf("foo.Properties[via] = %q, want zustand_store; props=%v", fooEnt.Properties["via"], fooEnt.Properties)
+		t.Errorf("useMyStore::foo.Properties[via] = %q, want zustand_store; props=%v", fooEnt.Properties["via"], fooEnt.Properties)
 	}
 	if fooEnt.StartLine == 0 {
-		t.Errorf("foo.StartLine = 0, expected a valid source line (issue #2626 — line range required)")
+		t.Errorf("useMyStore::foo.StartLine = 0, expected a valid source line (issue #2626 — line range required)")
 	}
 }
 
@@ -277,25 +282,26 @@ export async function loginWithBiometrics() {
 	ents := runJS(t, src, "typescript", tree)
 
 	// 1. unlockWithBiometrics must be emitted as a standalone entity.
-	actionEnt := findByNameRel(ents, "unlockWithBiometrics")
+	// Issue #2631 — entity name is now qualified: <storeVar>::<actionName>.
+	actionEnt := findByNameRel(ents, "useAuthStore::unlockWithBiometrics")
 	if actionEnt == nil {
-		t.Fatalf("expected 'unlockWithBiometrics' as a standalone entity (issue #2626); not found")
+		t.Fatalf("expected 'useAuthStore::unlockWithBiometrics' as a standalone entity (issue #2626+#2631); not found")
 	}
 	if actionEnt.Kind != "SCOPE.Operation" {
-		t.Errorf("unlockWithBiometrics.Kind = %q, want SCOPE.Operation", actionEnt.Kind)
+		t.Errorf("useAuthStore::unlockWithBiometrics.Kind = %q, want SCOPE.Operation", actionEnt.Kind)
 	}
 	if actionEnt.StartLine == 0 {
-		t.Errorf("unlockWithBiometrics.StartLine = 0, want non-zero (body line range)")
+		t.Errorf("useAuthStore::unlockWithBiometrics.StartLine = 0, want non-zero (body line range)")
 	}
 
-	// 2. loginWithBiometrics must have a CALLS edge to unlockWithBiometrics.
+	// 2. loginWithBiometrics must have a CALLS edge to the qualified entity ID.
 	caller := findByNameRel(ents, "loginWithBiometrics")
 	if caller == nil {
 		t.Fatal("expected entity 'loginWithBiometrics'")
 	}
 	found := false
 	for _, r := range caller.Relationships {
-		if r.Kind == "CALLS" && r.ToID == "unlockWithBiometrics" &&
+		if r.Kind == "CALLS" && r.ToID == "useAuthStore::unlockWithBiometrics" &&
 			r.Properties != nil && r.Properties["via"] == "zustand_store" {
 			found = true
 			break
@@ -306,7 +312,7 @@ export async function loginWithBiometrics() {
 		for _, r := range caller.Relationships {
 			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
 		}
-		t.Errorf("expected CALLS loginWithBiometrics→unlockWithBiometrics (via=zustand_store); not found")
+		t.Errorf("expected CALLS loginWithBiometrics→useAuthStore::unlockWithBiometrics (via=zustand_store); not found")
 	}
 }
 

--- a/internal/extractors/javascript/issue2631_zustand_id_collision_test.go
+++ b/internal/extractors/javascript/issue2631_zustand_id_collision_test.go
@@ -1,0 +1,131 @@
+// Package javascript_test — issue #2631: Zustand action entity ID collision.
+//
+// PR #2630 shipped emitStoreActionEntities which created entities for each
+// Zustand store action using the action's bare name as the entity ID. When
+// two stores share an action name (e.g. useAuthStore.logout + useAdminStore.logout)
+// they collided into a single entity.
+//
+// Fix: qualify entity IDs with the store variable name using "::" separator.
+//
+//	Before: "logout"
+//	After:  "useAuthStore::logout"
+//
+// Two tests:
+//   - TestZustandStore_DistinctIDsAcrossStores — 2 stores both with a "logout"
+//     action produce 2 distinct entities with distinct IDs.
+//   - TestZustandStore_CallEdgeReferencesQualifiedID — a getState().logout()
+//     call site emits a CALLS edge to "useAuthStore::logout" (not bare "logout").
+package javascript_test
+
+import (
+	"testing"
+)
+
+// TestZustandStore_DistinctIDsAcrossStores verifies that two Zustand stores
+// sharing an action name produce distinct entities with distinct qualified names.
+//
+// Fixture: useAuthStore.logout + useAdminStore.logout
+// Expected: two entities named "useAuthStore::logout" and "useAdminStore::logout"
+// (not a single colliding "logout" entity). Issue #2631.
+func TestZustandStore_DistinctIDsAcrossStores(t *testing.T) {
+	src := `
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+  token: null,
+  logout: () => set({ token: null }),
+}));
+
+export const useAdminStore = create((set) => ({
+  adminToken: null,
+  logout: () => set({ adminToken: null }),
+}));
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	authLogout := findByNameRel(ents, "useAuthStore::logout")
+	if authLogout == nil {
+		t.Errorf("expected entity 'useAuthStore::logout' to be emitted; got names: %v", func() []string {
+			var ns []string
+			for _, e := range ents {
+				ns = append(ns, e.Name)
+			}
+			return ns
+		}())
+	}
+
+	adminLogout := findByNameRel(ents, "useAdminStore::logout")
+	if adminLogout == nil {
+		t.Errorf("expected entity 'useAdminStore::logout' to be emitted; got names: %v", func() []string {
+			var ns []string
+			for _, e := range ents {
+				ns = append(ns, e.Name)
+			}
+			return ns
+		}())
+	}
+
+	// Verify no bare "logout" entity was emitted (old collision shape).
+	bareLogout := findByNameRel(ents, "logout")
+	if bareLogout != nil {
+		t.Errorf("unexpected bare entity 'logout': qualified names should be used (issue #2631)")
+	}
+
+	// Verify the two entities have distinct IDs.
+	if authLogout != nil && adminLogout != nil {
+		if authLogout.ID == adminLogout.ID {
+			t.Errorf("useAuthStore::logout and useAdminStore::logout share the same entity ID %q (issue #2631 — ID collision not fixed)", authLogout.ID)
+		}
+	}
+}
+
+// TestZustandStore_CallEdgeReferencesQualifiedID verifies that a call site
+// using useAuthStore.getState().logout() emits a CALLS edge to the qualified
+// entity ID "useAuthStore::logout" (not the bare "logout"). Issue #2631.
+func TestZustandStore_CallEdgeReferencesQualifiedID(t *testing.T) {
+	src := `
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+  token: null,
+  logout: () => set({ token: null }),
+}));
+
+export function handleExpiry() {
+  useAuthStore.getState().logout();
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	caller := findByNameRel(ents, "handleExpiry")
+	if caller == nil {
+		t.Fatal("expected entity 'handleExpiry' to be emitted")
+	}
+
+	// Must have CALLS edge to the qualified ID.
+	foundQualified := false
+	for _, r := range caller.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "useAuthStore::logout" &&
+			r.Properties != nil && r.Properties["via"] == "zustand_store" {
+			foundQualified = true
+			break
+		}
+	}
+	if !foundQualified {
+		t.Logf("handleExpiry relationships:")
+		for _, r := range caller.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Errorf("expected CALLS handleExpiry→useAuthStore::logout (via=zustand_store); not found (issue #2631)")
+	}
+
+	// Must NOT have a CALLS edge to the bare "logout".
+	for _, r := range caller.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "logout" &&
+			r.Properties != nil && r.Properties["via"] == "zustand_store" {
+			t.Errorf("unexpected CALLS handleExpiry→logout (bare name): edge should use qualified ID useAuthStore::logout (issue #2631)")
+		}
+	}
+}

--- a/internal/extractors/javascript/issue2632_zustand_selector_test.go
+++ b/internal/extractors/javascript/issue2632_zustand_selector_test.go
@@ -45,14 +45,15 @@ export const handleLogout = () => {
 		t.Fatal("expected entity 'handleLogout' to be emitted")
 	}
 
+	// Issue #2631 — ToID is now qualified: <storeVar>::<actionName>.
 	found := false
 	for _, r := range e.Relationships {
-		if r.Kind == "CALLS" && r.ToID == "softLogout" {
+		if r.Kind == "CALLS" && r.ToID == "useAuthStore::softLogout" {
 			if r.Properties != nil && r.Properties["via"] == "zustand_selector" {
 				found = true
 				break
 			}
-			t.Logf("CALLS handleLogout→softLogout found but via=%q (want zustand_selector); props=%v",
+			t.Logf("CALLS handleLogout→useAuthStore::softLogout found but via=%q (want zustand_selector); props=%v",
 				r.Properties["via"], r.Properties)
 		}
 	}
@@ -61,7 +62,7 @@ export const handleLogout = () => {
 		for _, r := range e.Relationships {
 			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
 		}
-		t.Errorf("expected CALLS handleLogout→softLogout with via=zustand_selector; not found")
+		t.Errorf("expected CALLS handleLogout→useAuthStore::softLogout with via=zustand_selector; not found")
 	}
 }
 
@@ -90,9 +91,10 @@ export const handleLogout = () => {
 		t.Fatal("expected entity 'handleLogout' to be emitted")
 	}
 
+	// Issue #2631 — ToID is now qualified: <storeVar>::<actionName>.
 	found := false
 	for _, r := range e.Relationships {
-		if r.Kind == "CALLS" && r.ToID == "softLogout" &&
+		if r.Kind == "CALLS" && r.ToID == "useAuthStore::softLogout" &&
 			r.Properties != nil && r.Properties["via"] == "zustand_selector" {
 			found = true
 			break
@@ -103,7 +105,7 @@ export const handleLogout = () => {
 		for _, r := range e.Relationships {
 			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
 		}
-		t.Errorf("expected CALLS handleLogout→softLogout with via=zustand_selector (parenthesised param); not found")
+		t.Errorf("expected CALLS handleLogout→useAuthStore::softLogout with via=zustand_selector (parenthesised param); not found")
 	}
 }
 
@@ -132,9 +134,10 @@ export const handleLogout = () => {
 		t.Fatal("expected entity 'handleLogout' to be emitted")
 	}
 
+	// Issue #2631 — ToID is now qualified: <storeVar>::<actionName>.
 	found := false
 	for _, r := range e.Relationships {
-		if r.Kind == "CALLS" && r.ToID == "softLogout" &&
+		if r.Kind == "CALLS" && r.ToID == "useAuthStore::softLogout" &&
 			r.Properties != nil && r.Properties["via"] == "zustand_selector" {
 			found = true
 			break
@@ -145,7 +148,7 @@ export const handleLogout = () => {
 		for _, r := range e.Relationships {
 			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
 		}
-		t.Errorf("expected CALLS handleLogout→softLogout with via=zustand_selector (state param name); not found")
+		t.Errorf("expected CALLS handleLogout→useAuthStore::softLogout with via=zustand_selector (state param name); not found")
 	}
 }
 
@@ -174,9 +177,10 @@ export const handleLogout = () => {
 		t.Fatal("expected entity 'handleLogout' to be emitted")
 	}
 
+	// Issue #2631 — ToID is now qualified: <storeVar>::<actionName>.
 	found := false
 	for _, r := range e.Relationships {
-		if r.Kind == "CALLS" && r.ToID == "softLogout" &&
+		if r.Kind == "CALLS" && r.ToID == "useAuthStore::softLogout" &&
 			r.Properties != nil && r.Properties["via"] == "zustand_selector" {
 			found = true
 			break
@@ -187,7 +191,7 @@ export const handleLogout = () => {
 		for _, r := range e.Relationships {
 			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
 		}
-		t.Errorf("expected CALLS handleLogout→softLogout with via=zustand_selector (optional chain); not found")
+		t.Errorf("expected CALLS handleLogout→useAuthStore::softLogout with via=zustand_selector (optional chain); not found")
 	}
 }
 

--- a/internal/extractors/javascript/issue2646_resolve_more_test.go
+++ b/internal/extractors/javascript/issue2646_resolve_more_test.go
@@ -64,13 +64,14 @@ export const useAuthStore = create<AuthState>()(
 	ents := runJS(t, src, "typescript", tree)
 
 	// Both action methods must appear as named entities.
-	login := findByNameRel(ents, "login")
+	// Issue #2631 — entity names are now qualified: <storeVar>::<actionName>.
+	login := findByNameRel(ents, "useAuthStore::login")
 	if login == nil {
-		t.Error("expected SCOPE.Operation entity 'login' to be emitted for Zustand persist store; got nil")
+		t.Error("expected SCOPE.Operation entity 'useAuthStore::login' to be emitted for Zustand persist store; got nil")
 	}
-	logout := findByNameRel(ents, "logout")
+	logout := findByNameRel(ents, "useAuthStore::logout")
 	if logout == nil {
-		t.Error("expected SCOPE.Operation entity 'logout' to be emitted for Zustand persist store; got nil")
+		t.Error("expected SCOPE.Operation entity 'useAuthStore::logout' to be emitted for Zustand persist store; got nil")
 	}
 }
 
@@ -105,9 +106,10 @@ export function handleSignOut() {
 		t.Fatal("expected entity 'handleSignOut' to be emitted")
 	}
 
+	// Issue #2631 — ToID is now qualified: <storeVar>::<actionName>.
 	found := false
 	for _, r := range e.Relationships {
-		if r.Kind == "CALLS" && r.ToID == "logout" {
+		if r.Kind == "CALLS" && r.ToID == "useAuthStore::logout" {
 			if r.Properties != nil && r.Properties["via"] == "zustand_store" {
 				found = true
 				break
@@ -119,7 +121,7 @@ export function handleSignOut() {
 		for _, r := range e.Relationships {
 			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
 		}
-		t.Error("expected CALLS handleSignOut→logout with via=zustand_store for persist-wrapped store")
+		t.Error("expected CALLS handleSignOut→useAuthStore::logout with via=zustand_store for persist-wrapped store")
 	}
 }
 
@@ -148,8 +150,9 @@ export const useSyncQueueStore = create()(
 	tree := parseTSRel(t, []byte(src))
 	ents := runJS(t, src, "typescript", tree)
 
-	if findByNameRel(ents, "enqueue") == nil {
-		t.Error("expected SCOPE.Operation entity 'enqueue' to be emitted for nested-middleware store; got nil")
+	// Issue #2631 — entity names are now qualified: <storeVar>::<actionName>.
+	if findByNameRel(ents, "useSyncQueueStore::enqueue") == nil {
+		t.Error("expected SCOPE.Operation entity 'useSyncQueueStore::enqueue' to be emitted for nested-middleware store; got nil")
 	}
 }
 

--- a/internal/extractors/javascript/zustand_store.go
+++ b/internal/extractors/javascript/zustand_store.go
@@ -555,18 +555,24 @@ func (t *zustandTracker) emitStoreActionEntities(x *extractor) {
 			if nodeMap != nil {
 				fnNode = nodeMap[actionName]
 			}
+			// Issue #2631 — qualify the entity name with the store variable so
+			// two stores sharing an action name (e.g. useAuthStore.logout and
+			// useAdminStore.logout) produce distinct entity IDs.
+			// Format: <storeVar>::<actionName>  (mirrors class method convention).
+			qualifiedName := storeVar + "::" + actionName
 			props := map[string]string{
-				"kind":    "SCOPE.Operation",
-				"subtype": "method",
-				"via":     PropViaZustandStore,
-				"store":   storeVar,
+				"kind":        "SCOPE.Operation",
+				"subtype":     "method",
+				"via":         PropViaZustandStore,
+				"store":       storeVar,
+				"action_name": actionName,
 			}
 			if partFields != "" {
 				props["partialize_fields"] = partFields
 			}
 			sig := storeVar + "." + actionName
 			if fnNode != nil {
-				x.emitWithProps(actionName, "SCOPE.Operation", fnNode, "method", sig, props, nil)
+				x.emitWithProps(qualifiedName, "SCOPE.Operation", fnNode, "method", sig, props, nil)
 			}
 			// When fnNode is nil (should not happen in practice; storeActionNodes
 			// is always co-populated with storeActions), skip silently: the
@@ -635,9 +641,10 @@ func (t *zustandTracker) zustandGetStateActionEdges(x *extractor, callNode *sitt
 		return nil
 	}
 
-	// Emit a CALLS edge from callerName → actionName.
+	// Issue #2631 — use the qualified ID (<storeVar>::<actionName>) so the CALLS
+	// edge resolves to the correct entity when multiple stores share an action name.
 	rel := types.RelationshipRecord{
-		ToID: actionName,
+		ToID: storeVar + "::" + actionName,
 		Kind: "CALLS",
 		Properties: map[string]string{
 			"via":  PropViaZustandStore,
@@ -755,8 +762,10 @@ func (t *zustandTracker) zustandSelectorActionEdges(x *extractor, callNode *sitt
 		return nil
 	}
 
+	// Issue #2631 — qualify the ToID with the store name to match the entity ID
+	// emitted by emitStoreActionEntities.
 	rel := types.RelationshipRecord{
-		ToID: actionName,
+		ToID: storeVar + "::" + actionName,
 		Kind: "CALLS",
 		Properties: map[string]string{
 			"via":  PropViaZustandStore,


### PR DESCRIPTION
## Summary

- Fixes #2631: Zustand action entities used bare action names as entity IDs, causing collisions when two stores share an action name (e.g. `useAuthStore.logout` + `useAdminStore.logout` → same ID)
- Now uses `<storeVar>::<actionName>` format (e.g. `useAuthStore::logout`) in `emitStoreActionEntities`, `zustandGetStateActionEdges`, `zustandSelectorActionEdges`, and the `parseSelectorArrowFn` / `scanDestructureDeclarator` path
- CALLS edges in all three emission paths are updated to reference the qualified ID (approach (a) from the issue — cleaner than a resolver pass)

## Changes

- `internal/extractors/javascript/zustand_store.go` — `emitStoreActionEntities` uses `storeVar + "::" + actionName` as entity name; both edge-emission functions (`zustandGetStateActionEdges`, `zustandSelectorActionEdges`) use qualified `ToID`
- `internal/extractors/javascript/destructure_bindings.go` — `parseSelectorArrowFn` now returns `(storeVar, actionName)` instead of bare `actionName`; `scanDestructureDeclarator` builds qualified `sourceTarget`
- All existing tests updated to the new qualified ID format
- `issue2631_zustand_id_collision_test.go` — 2 new tests: `TestZustandStore_DistinctIDsAcrossStores` (2 stores with `logout` → 2 distinct entities/IDs) and `TestZustandStore_CallEdgeReferencesQualifiedID` (CALLS edge uses `useAuthStore::logout`)

## Test plan

- [ ] `go test ./internal/extractors/javascript/... -count=1` passes (all 19 Zustand-related tests + full suite green)
- [ ] `go vet` and `go build` clean
- [ ] `TestZustandStore_DistinctIDsAcrossStores` — distinct entities for shared action names across stores
- [ ] `TestZustandStore_CallEdgeReferencesQualifiedID` — CALLS edge targets qualified ID

## Tech debt

- The `::` separator is an internal convention; if the graph ever surfaces raw entity Names to users, a display-name alias (Properties["action_name"]) is already stamped on each entity so UIs can render the short name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)