### PR TITLE
feat(discriminator): line+literal properties surfaced in inspect & find (#2666)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -80,6 +80,7 @@ Output: full entity record including all properties + attached findings. Also re
 
 - `calls[]` — outbound CALLS edges with line-precise data. Each entry: `{target, target_path, line, via}`. Unresolved edges (where the target entity could not be found — empty `target_path` or bare repo prefix) are **filtered by default**. Pass `include_unresolved: true` to include them; unresolved entries carry an extra `"unresolved": true` field.
 - `called_by[]` — inbound CALLS edges (callers). Always present even when empty (`called_by: []`). Each entry: `{source, source_path, line, context}` where `context` is a ~40-char snippet of the call-site line.
+- `discriminators[]` (#2666) — only present when the entity has DISCRIMINATES_ON edges. Each row: `{file_line, line, literal, other_side}` where `literal` is the RHS literal value (e.g. `"2"`, `"periodic"`) and `other_side` is the synthetic `var:<varName>` stub identifying the discriminating variable. Lets agents jump straight to the comparison site instead of scanning the whole function body. Discriminator literals are also mixed into the `archigraph_find` BM25 doc terms at modest weight, so queries like "checklistType 2" rank the enclosing entity higher.
 - `metadata` — index provenance block: `{indexed_ref, indexed_sha, indexed_at, age_seconds}`. Agents can use `age_seconds` to decide whether line numbers might be stale before calling `archigraph_get_source`.
 
 #### `archigraph_get_source`

--- a/internal/extractors/javascript/discriminator.go
+++ b/internal/extractors/javascript/discriminator.go
@@ -22,10 +22,22 @@ package javascript
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// discriminatorHit captures one discriminator-pattern comparison site: the
+// variable name, the literal value, and the 1-indexed source line of the
+// binary expression. Used to emit DISCRIMINATES_ON edges (#2666).
+type discriminatorHit struct {
+	varName string
+	literal string
+	line    int
+}
 
 // extractDiscriminators walks the body node (a function/method/arrow body)
 // and returns a comma-separated "var=value" string for every discriminator
@@ -33,11 +45,25 @@ import (
 //
 // Signature: func (x *extractor) extractDiscriminators(body *sitter.Node) string
 func (x *extractor) extractDiscriminators(body *sitter.Node) string {
-	if body == nil {
+	hits := x.extractDiscriminatorHits(body)
+	if len(hits) == 0 {
 		return ""
 	}
+	pairs := make([]string, 0, len(hits))
+	for _, h := range hits {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", h.varName, h.literal))
+	}
+	return strings.Join(pairs, ",")
+}
 
-	var pairs []string
+// extractDiscriminatorHits walks the body and returns one discriminatorHit per
+// unique (var, literal) pair found. Used by stampDiscriminators (#2666) to
+// emit DISCRIMINATES_ON edges with line + literal properties.
+func (x *extractor) extractDiscriminatorHits(body *sitter.Node) []discriminatorHit {
+	if body == nil {
+		return nil
+	}
+	var hits []discriminatorHit
 	seen := make(map[string]bool)
 
 	defer func() { _ = recover() }()
@@ -53,10 +79,10 @@ func (x *extractor) extractDiscriminators(body *sitter.Node) string {
 			continue
 		}
 		seen[key] = true
-		pairs = append(pairs, key)
+		line := int(n.StartPoint().Row) + 1
+		hits = append(hits, discriminatorHit{varName: varName, literal: litVal, line: line})
 	}
-
-	return strings.Join(pairs, ",")
+	return hits
 }
 
 // discriminatorFromBinary inspects a binary_expression node and returns the
@@ -178,13 +204,30 @@ func (x *extractor) stampDiscriminators(body *sitter.Node) {
 	if body == nil || len(x.entities) == 0 {
 		return
 	}
-	d := x.extractDiscriminators(body)
-	if d == "" {
+	hits := x.extractDiscriminatorHits(body)
+	if len(hits) == 0 {
 		return
 	}
 	last := &x.entities[len(x.entities)-1]
+	// Backward-compat property (#2659): comma-separated "var=value" pairs.
+	pairs := make([]string, 0, len(hits))
+	for _, h := range hits {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", h.varName, h.literal))
+	}
 	if last.Properties == nil {
 		last.Properties = make(map[string]string)
 	}
-	last.Properties["discriminators"] = d
+	last.Properties["discriminators"] = strings.Join(pairs, ",")
+	// #2666 — emit DISCRIMINATES_ON edges to synthetic "var:<varName>" stubs
+	// so inspect/find can surface line-precise hits without scanning the body.
+	for _, h := range hits {
+		last.Relationships = append(last.Relationships, types.RelationshipRecord{
+			ToID: "var:" + h.varName,
+			Kind: string(types.RelationshipKindDiscriminatesOn),
+			Properties: map[string]string{
+				"line":    strconv.Itoa(h.line),
+				"literal": h.literal,
+			},
+		})
+	}
 }

--- a/internal/extractors/javascript/issue2666_discriminator_edges_test.go
+++ b/internal/extractors/javascript/issue2666_discriminator_edges_test.go
@@ -1,0 +1,126 @@
+// Package javascript_test — issue #2666: verifies that DISCRIMINATES_ON edges
+// emitted by stampDiscriminators carry line + literal properties.
+//
+// Issue #2659 introduced the discriminator pattern detection but only stamped
+// the comma-separated pair string on Properties["discriminators"]. #2666
+// promotes the data into proper DISCRIMINATES_ON edges so archigraph_inspect
+// can render a line-precise comparison table and archigraph_find can mix the
+// literal values into the BM25 doc terms.
+package javascript_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDiscriminator_EmitsEdgeWithLineAndLiteral_TS verifies that
+// `checklistType === 2` inside a function body emits one DISCRIMINATES_ON edge
+// from the enclosing entity to "var:checklistType" with Properties["line"] set
+// to the comparison's source line and Properties["literal"] = "2".
+func TestDiscriminator_EmitsEdgeWithLineAndLiteral_TS(t *testing.T) {
+	src := `
+function processChecklist() {
+  const isCat5 = checklistType === 2;
+  return isCat5;
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	e := findByNameRel(ents, "processChecklist")
+	if e == nil {
+		t.Fatal("entity 'processChecklist' not found")
+	}
+
+	var found bool
+	for _, r := range e.Relationships {
+		if r.Kind != "DISCRIMINATES_ON" {
+			continue
+		}
+		if r.ToID != "var:checklistType" {
+			continue
+		}
+		found = true
+		if r.Properties == nil {
+			t.Fatalf("DISCRIMINATES_ON edge has nil Properties; want line+literal")
+		}
+		if r.Properties["literal"] != "2" {
+			t.Errorf("Properties[literal]=%q, want %q", r.Properties["literal"], "2")
+		}
+		if r.Properties["line"] == "" {
+			t.Errorf("Properties[line] is empty, want non-empty 1-indexed line")
+		}
+		// The comparison sits on line 3 of the snippet (line 1 = leading blank,
+		// line 2 = `function processChecklist() {`, line 3 = the const assignment).
+		if r.Properties["line"] != "3" {
+			t.Errorf("Properties[line]=%q, want %q", r.Properties["line"], "3")
+		}
+	}
+	if !found {
+		t.Logf("relationships on processChecklist:")
+		for _, r := range e.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Errorf("DISCRIMINATES_ON edge to var:checklistType not found")
+	}
+}
+
+// TestDiscriminator_EmitsEdgePerComparison_TS verifies that multiple
+// discriminator comparisons in one function body emit one edge per unique pair,
+// each with its own line number.
+func TestDiscriminator_EmitsEdgePerComparison_TS(t *testing.T) {
+	src := `
+function processChecklist() {
+  const isCat5 = checklistType === 2;
+  const isPeriodic = type === 'periodic';
+  return isCat5 || isPeriodic;
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	e := findByNameRel(ents, "processChecklist")
+	if e == nil {
+		t.Fatal("entity 'processChecklist' not found")
+	}
+
+	byTarget := map[string]map[string]string{}
+	for _, r := range e.Relationships {
+		if r.Kind == "DISCRIMINATES_ON" {
+			byTarget[r.ToID] = r.Properties
+		}
+	}
+	if len(byTarget) < 2 {
+		t.Fatalf("expected ≥2 DISCRIMINATES_ON edges, got %d (%v)", len(byTarget), byTarget)
+	}
+	if p := byTarget["var:checklistType"]; p == nil || p["literal"] != "2" || p["line"] == "" {
+		t.Errorf("var:checklistType edge bad: %v", p)
+	}
+	if p := byTarget["var:type"]; p == nil || p["literal"] != "periodic" || p["line"] == "" {
+		t.Errorf("var:type edge bad: %v", p)
+	}
+	// Lines must differ between the two comparisons.
+	if byTarget["var:checklistType"]["line"] == byTarget["var:type"]["line"] {
+		t.Errorf("expected distinct line numbers; both = %q",
+			byTarget["var:checklistType"]["line"])
+	}
+}
+
+// TestDiscriminator_NoEdgesWhenAbsent_TS verifies that a function body with no
+// discriminator patterns emits zero DISCRIMINATES_ON edges.
+func TestDiscriminator_NoEdgesWhenAbsent_TS(t *testing.T) {
+	src := `
+function noDiscriminator(a, b) {
+  return a + b;
+}
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	e := findByNameRel(ents, "noDiscriminator")
+	if e == nil {
+		t.Fatal("entity 'noDiscriminator' not found")
+	}
+	for _, r := range e.Relationships {
+		if strings.EqualFold(r.Kind, "DISCRIMINATES_ON") {
+			t.Errorf("unexpected DISCRIMINATES_ON edge: %+v", r)
+		}
+	}
+}

--- a/internal/extractors/python/discriminator.go
+++ b/internal/extractors/python/discriminator.go
@@ -23,6 +23,7 @@ package python
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -30,15 +31,39 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
+// pyDiscriminatorHit captures one discriminator-pattern comparison site: the
+// variable name, the literal value, and the 1-indexed source line of the
+// comparison. Used to emit DISCRIMINATES_ON edges (#2666).
+type pyDiscriminatorHit struct {
+	varName string
+	literal string
+	line    int
+}
+
 // extractPythonDiscriminators walks the body node (a function/method body block)
 // and returns a comma-separated "var=value" string for every discriminator
 // comparison found. Returns "" when no discriminators are found or body is nil.
 func extractPythonDiscriminators(body *sitter.Node, src []byte) string {
-	if body == nil {
+	hits := extractPythonDiscriminatorHits(body, src)
+	if len(hits) == 0 {
 		return ""
 	}
+	pairs := make([]string, 0, len(hits))
+	for _, h := range hits {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", h.varName, h.literal))
+	}
+	return strings.Join(pairs, ",")
+}
 
-	var pairs []string
+// extractPythonDiscriminatorHits walks the body and returns one
+// pyDiscriminatorHit per unique (var, literal) pair found. Used by
+// stampPythonDiscriminators (#2666) to emit DISCRIMINATES_ON edges with
+// line + literal properties.
+func extractPythonDiscriminatorHits(body *sitter.Node, src []byte) []pyDiscriminatorHit {
+	if body == nil {
+		return nil
+	}
+	var hits []pyDiscriminatorHit
 	seen := make(map[string]bool)
 
 	defer func() { _ = recover() }()
@@ -54,10 +79,10 @@ func extractPythonDiscriminators(body *sitter.Node, src []byte) string {
 			continue
 		}
 		seen[key] = true
-		pairs = append(pairs, key)
+		line := int(n.StartPoint().Row) + 1
+		hits = append(hits, pyDiscriminatorHit{varName: varName, literal: litVal, line: line})
 	}
-
-	return strings.Join(pairs, ",")
+	return hits
 }
 
 // discriminatorFromPythonComparison inspects a comparison_operator node and
@@ -186,13 +211,29 @@ func stampPythonDiscriminators(body *sitter.Node, src []byte, out *[]types.Entit
 	if body == nil || out == nil || idx < 0 || idx >= len(*out) {
 		return
 	}
-	d := extractPythonDiscriminators(body, src)
-	if d == "" {
+	hits := extractPythonDiscriminatorHits(body, src)
+	if len(hits) == 0 {
 		return
 	}
 	e := &(*out)[idx]
+	pairs := make([]string, 0, len(hits))
+	for _, h := range hits {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", h.varName, h.literal))
+	}
 	if e.Properties == nil {
 		e.Properties = make(map[string]string)
 	}
-	e.Properties["discriminators"] = d
+	e.Properties["discriminators"] = strings.Join(pairs, ",")
+	// #2666 — emit DISCRIMINATES_ON edges to synthetic "var:<varName>" stubs
+	// so inspect/find can surface line-precise hits.
+	for _, h := range hits {
+		e.Relationships = append(e.Relationships, types.RelationshipRecord{
+			ToID: "var:" + h.varName,
+			Kind: string(types.RelationshipKindDiscriminatesOn),
+			Properties: map[string]string{
+				"line":    strconv.Itoa(h.line),
+				"literal": h.literal,
+			},
+		})
+	}
 }

--- a/internal/extractors/python/issue2666_discriminator_edges_test.go
+++ b/internal/extractors/python/issue2666_discriminator_edges_test.go
@@ -1,0 +1,121 @@
+// Package python_test — issue #2666: verifies that DISCRIMINATES_ON edges
+// emitted by stampPythonDiscriminators carry line + literal properties.
+//
+// Issue #2659 added the property-only stamp; #2666 promotes the data into
+// DISCRIMINATES_ON edges so inspect/find can surface line-precise hits.
+package python_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findEntPy returns the EntityRecord with the given Name, or nil.
+func findEntPy(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestDiscriminator_PythonEmitsEdge verifies that `if status == 'paid':`
+// produces a DISCRIMINATES_ON edge to var:status with literal "paid" and a
+// non-empty line number.
+func TestDiscriminator_PythonEmitsEdge(t *testing.T) {
+	src := `
+def process_payment(status):
+    if status == 'paid':
+        return True
+    return False
+`
+	ents := extractPy(t, src, "payments/views.py")
+	e := findEntPy(ents, "process_payment")
+	if e == nil {
+		t.Fatal("entity 'process_payment' not found")
+	}
+
+	var found bool
+	for _, r := range e.Relationships {
+		if r.Kind != "DISCRIMINATES_ON" {
+			continue
+		}
+		if r.ToID != "var:status" {
+			continue
+		}
+		found = true
+		if r.Properties == nil {
+			t.Fatalf("edge has nil Properties; want line+literal")
+		}
+		if r.Properties["literal"] != "paid" {
+			t.Errorf("Properties[literal]=%q, want %q", r.Properties["literal"], "paid")
+		}
+		if r.Properties["line"] == "" {
+			t.Errorf("Properties[line] is empty")
+		}
+		// Comparison is on line 3 of the snippet (line 1 blank, line 2 def,
+		// line 3 `if status == 'paid':`).
+		if r.Properties["line"] != "3" {
+			t.Errorf("Properties[line]=%q, want %q", r.Properties["line"], "3")
+		}
+	}
+	if !found {
+		t.Logf("relationships on process_payment:")
+		for _, r := range e.Relationships {
+			t.Logf("  %s → %s (props=%v)", r.Kind, r.ToID, r.Properties)
+		}
+		t.Errorf("DISCRIMINATES_ON edge to var:status not found")
+	}
+}
+
+// TestDiscriminator_PythonNumericLiteral_EmitsEdge verifies the numeric form.
+func TestDiscriminator_PythonNumericLiteral_EmitsEdge(t *testing.T) {
+	src := `
+def handle_response(code):
+    if code == 404:
+        return 'not_found'
+    return 'ok'
+`
+	ents := extractPy(t, src, "api/views.py")
+	e := findEntPy(ents, "handle_response")
+	if e == nil {
+		t.Fatal("entity 'handle_response' not found")
+	}
+	var found bool
+	for _, r := range e.Relationships {
+		if r.Kind == "DISCRIMINATES_ON" && r.ToID == "var:code" {
+			found = true
+			if r.Properties["literal"] != "404" {
+				t.Errorf("Properties[literal]=%q, want %q", r.Properties["literal"], "404")
+			}
+			if r.Properties["line"] == "" {
+				t.Errorf("Properties[line] is empty")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("DISCRIMINATES_ON edge to var:code not found")
+	}
+}
+
+// TestDiscriminator_PythonNoEdgeWhenAbsent verifies that a function with no
+// discriminator comparisons emits no DISCRIMINATES_ON edges.
+func TestDiscriminator_PythonNoEdgeWhenAbsent(t *testing.T) {
+	src := `
+def add(a, b):
+    return a + b
+`
+	ents := extractPy(t, src, "math/util.py")
+	e := findEntPy(ents, "add")
+	if e == nil {
+		t.Fatal("entity 'add' not found")
+	}
+	for _, r := range e.Relationships {
+		if strings.EqualFold(r.Kind, "DISCRIMINATES_ON") {
+			t.Errorf("unexpected DISCRIMINATES_ON edge: %+v", r)
+		}
+	}
+}

--- a/internal/mcp/bm25_discriminator_2666_test.go
+++ b/internal/mcp/bm25_discriminator_2666_test.go
@@ -1,0 +1,109 @@
+package mcp
+
+// bm25_discriminator_2666_test.go — verifies that BM25 doc terms include the
+// discriminator variable names and literal values from Properties["discriminators"]
+// (#2666). A query that mentions a discriminator variable should rank the
+// entity higher than an entity that does not discriminate on that variable.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestBM25_DiscriminatorBoost_VarNameSurfacesEntity verifies that querying for
+// a discriminator's variable name boosts the entity that compares against it,
+// even when the entity's own name does not contain the variable name.
+func TestBM25_DiscriminatorBoost_VarNameSurfacesEntity(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: "with_disc", Name: "processData",
+				Kind: "SCOPE.Operation", SourceFile: "a.ts",
+				Properties: map[string]string{
+					"discriminators": "checklistType=2",
+				},
+			},
+			{
+				ID: "no_disc", Name: "processData2",
+				Kind: "SCOPE.Operation", SourceFile: "b.ts",
+			},
+		},
+	}
+	idx := BuildBM25(doc)
+	hits := idx.Search("checklistType", 10)
+	if len(hits) == 0 {
+		t.Fatalf("expected at least one hit for 'checklistType'; got none")
+	}
+	// The entity with the discriminator must be the top hit (or the only hit).
+	if hits[0].Entity.ID != "with_disc" {
+		t.Errorf("expected top hit to be 'with_disc'; got %q (full ranking=%v)",
+			hits[0].Entity.ID, hitIDs(hits))
+	}
+	// The non-discriminator entity must not outrank the discriminator one.
+	for _, h := range hits {
+		if h.Entity.ID == "no_disc" {
+			if h.Score >= hits[0].Score {
+				t.Errorf("no_disc score %v >= with_disc score %v",
+					h.Score, hits[0].Score)
+			}
+		}
+	}
+}
+
+// TestBM25_DiscriminatorBoost_LiteralStringSurfacesEntity verifies that
+// querying for a string literal value boosts the discriminating entity.
+// Numeric literals like "2" fall below the 2-char min-token-length of
+// tokenize() and are not exercised here; the variable name carries the
+// numeric-literal case (see TestBM25_DiscriminatorBoost_VarNameSurfacesEntity).
+func TestBM25_DiscriminatorBoost_LiteralStringSurfacesEntity(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: "with_disc", Name: "handler",
+				Kind: "SCOPE.Operation", SourceFile: "a.ts",
+				Properties: map[string]string{
+					"discriminators": "status=periodic",
+				},
+			},
+			{
+				ID: "no_disc", Name: "otherHandler",
+				Kind: "SCOPE.Operation", SourceFile: "b.ts",
+			},
+		},
+	}
+	idx := BuildBM25(doc)
+	hits := idx.Search("periodic", 10)
+	if len(hits) == 0 {
+		t.Fatalf("expected at least one hit for 'periodic'; got none")
+	}
+	if hits[0].Entity.ID != "with_disc" {
+		t.Errorf("expected top hit to be 'with_disc' (matches literal 'periodic'); got %q ranking=%v",
+			hits[0].Entity.ID, hitIDs(hits))
+	}
+}
+
+// TestBM25_NoDiscriminator_NoBoost verifies that the discriminator boost is
+// only applied when Properties["discriminators"] is present. An empty or
+// missing property must not affect the doc terms.
+func TestBM25_NoDiscriminator_NoBoost(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "a", Name: "foo", Kind: "SCOPE.Operation", SourceFile: "a.ts"},
+		},
+	}
+	idx := BuildBM25(doc)
+	hits := idx.Search("checklistType", 10)
+	if len(hits) != 0 {
+		t.Errorf("expected no hits for 'checklistType' on docs without discriminators; got %v",
+			hitIDs(hits))
+	}
+}
+
+func hitIDs(hits []Hit) []string {
+	out := make([]string, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, h.Entity.ID)
+	}
+	return out
+}

--- a/internal/mcp/inspect_discriminators_2666_test.go
+++ b/internal/mcp/inspect_discriminators_2666_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+// inspect_discriminators_2666_test.go — verifies that handleGetNode renders a
+// discriminators[] section when the inspected entity has DISCRIMINATES_ON
+// edges (#2666). Each row carries file_line, line, literal, and other_side.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestInspect_RendersDiscriminatorsSection seeds an entity that participates
+// in two DISCRIMINATES_ON edges (checklistType=2 on line 17 and type=periodic
+// on line 23) and verifies that archigraph_inspect surfaces a discriminators[]
+// array with both rows correctly populated.
+func TestInspect_RendersDiscriminatorsSection(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: "fn1", Name: "processChecklist",
+				Kind:       "SCOPE.Operation",
+				SourceFile: "src/checklist.ts",
+				StartLine:  15,
+			},
+		},
+		Relationships: []graph.Relationship{
+			{
+				ID: "d1", FromID: "fn1", ToID: "var:checklistType",
+				Kind: "DISCRIMINATES_ON",
+				Properties: map[string]string{
+					"line":    "17",
+					"literal": "2",
+				},
+			},
+			{
+				ID: "d2", FromID: "fn1", ToID: "var:type",
+				Kind: "DISCRIMINATES_ON",
+				Properties: map[string]string{
+					"line":    "23",
+					"literal": "periodic",
+				},
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callInspect(t, srv, "fn1")
+
+	rawDiscs, ok := out["discriminators"]
+	if !ok {
+		t.Fatalf("inspect response missing 'discriminators' key; got keys: %v", mapKeys(out))
+	}
+	arr, ok := rawDiscs.([]any)
+	if !ok {
+		t.Fatalf("'discriminators' is %T, want []any", rawDiscs)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 discriminator rows, got %d: %v", len(arr), arr)
+	}
+
+	byLiteral := map[string]map[string]any{}
+	for _, r := range arr {
+		m := r.(map[string]any)
+		lit, _ := m["literal"].(string)
+		byLiteral[lit] = m
+	}
+
+	row, ok := byLiteral["2"]
+	if !ok {
+		t.Fatalf("missing row for literal=2; got %v", byLiteral)
+	}
+	if v, _ := row["other_side"].(string); v != "var:checklistType" {
+		t.Errorf("row[literal=2].other_side=%q, want %q", v, "var:checklistType")
+	}
+	if v, _ := row["line"].(float64); int(v) != 17 {
+		t.Errorf("row[literal=2].line=%v, want 17", row["line"])
+	}
+	if v, _ := row["file_line"].(string); v != "src/checklist.ts:17" {
+		t.Errorf("row[literal=2].file_line=%q, want %q", v, "src/checklist.ts:17")
+	}
+
+	row, ok = byLiteral["periodic"]
+	if !ok {
+		t.Fatalf("missing row for literal=periodic; got %v", byLiteral)
+	}
+	if v, _ := row["other_side"].(string); v != "var:type" {
+		t.Errorf("row[literal=periodic].other_side=%q, want %q", v, "var:type")
+	}
+	if v, _ := row["line"].(float64); int(v) != 23 {
+		t.Errorf("row[literal=periodic].line=%v, want 23", row["line"])
+	}
+}
+
+// TestInspect_OmitsDiscriminatorsWhenAbsent verifies that an entity with no
+// DISCRIMINATES_ON edges produces an inspect envelope WITHOUT a discriminators
+// key (omitted entirely rather than empty array, to keep the response lean).
+func TestInspect_OmitsDiscriminatorsWhenAbsent(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: "fn1", Name: "noDiscriminator",
+				Kind: "SCOPE.Operation", SourceFile: "a.ts", StartLine: 1,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callInspect(t, srv, "fn1")
+	if _, present := out["discriminators"]; present {
+		t.Errorf("expected 'discriminators' key to be omitted; got %v", out["discriminators"])
+	}
+}

--- a/internal/mcp/scoring.go
+++ b/internal/mcp/scoring.go
@@ -22,6 +22,11 @@ const (
 	weightFileStem  = 1.5
 	weightPathDirs  = 0.8
 	weightDocstring = 0.6
+	// #2666 — discriminator literal terms are mixed in at a modest weight so
+	// queries like "checklistType 2" surface the enclosing entity. We weight
+	// below docstrings (which are author-curated prose) but above stop-word
+	// boilerplate. Both the var name and the literal value contribute.
+	weightDiscriminator = 0.5
 )
 
 // docstringLimitChars caps docstring contribution to the first 200 characters.
@@ -134,6 +139,43 @@ func buildDocTerms(e *graph.Entity) docTerms {
 				ds = ds[:docstringLimitChars]
 			}
 			add(ds, weightDocstring, true)
+		}
+		// #2666 — discriminator pairs: stamp by the extractors as a
+		// comma-separated "var=value,var2=value2" string in Properties
+		// (mirror of the DISCRIMINATES_ON edges). Mix both the variable
+		// name and the literal value into the doc terms at a modest weight
+		// so queries like "checklistType 2" rank the enclosing entity
+		// higher. Tokenize via addIdentifier so camelCase / snake_case
+		// vars still split into sub-tokens; literals go through tokenize
+		// directly (numbers/strings need digit-boundary splitting).
+		if pairs, ok := e.Properties["discriminators"]; ok && pairs != "" {
+			for _, pair := range strings.Split(pairs, ",") {
+				eq := strings.IndexByte(pair, '=')
+				if eq <= 0 || eq >= len(pair)-1 {
+					continue
+				}
+				varName := pair[:eq]
+				literal := pair[eq+1:]
+				// Variable name: use the identifier-aware path so the full
+				// camelCase token plus its sub-tokens are all indexed.
+				for _, t := range tokenizeIdentifier(varName) {
+					d.tf[t] += weightDiscriminator
+					d.length += weightDiscriminator
+				}
+				// Literal value: plain tokenize. Numeric literals like "2"
+				// would normally fall below the min-token-length of 2, so
+				// add the raw literal as well to make exact-number queries
+				// score.
+				for _, t := range tokenize(literal) {
+					d.tf[t] += weightDiscriminator
+					d.length += weightDiscriminator
+				}
+				if literal != "" {
+					raw := strings.ToLower(literal)
+					d.tf[raw] += weightDiscriminator
+					d.length += weightDiscriminator
+				}
+			}
 		}
 	}
 	return d

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -918,6 +918,11 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 				out["calls"] = inspectOutboundCalls(r, e, scopeIsOne, includeUnresolved)
 				// #2641: called_by always present (empty array when no callers).
 				out["called_by"] = inspectInboundCalls(r, e, scopeIsOne)
+				// #2666: discriminator comparison sites surfaced from DISCRIMINATES_ON
+				// edges. Section is omitted entirely when no discriminator edges exist.
+				if discs := inspectDiscriminators(r, e, scopeIsOne); len(discs) > 0 {
+					out["discriminators"] = discs
+				}
 				// #2642: metadata block with index provenance.
 				out["metadata"] = inspectMetadata(r)
 				return jsonResult(out), nil
@@ -975,6 +980,11 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	out["calls"] = inspectOutboundCalls(m.repo, m.ent, scopeIsOne, includeUnresolved)
 	// #2641: called_by always present (empty array when no callers).
 	out["called_by"] = inspectInboundCalls(m.repo, m.ent, scopeIsOne)
+	// #2666: discriminator comparison sites surfaced from DISCRIMINATES_ON
+	// edges. Section is omitted entirely when no discriminator edges exist.
+	if discs := inspectDiscriminators(m.repo, m.ent, scopeIsOne); len(discs) > 0 {
+		out["discriminators"] = discs
+	}
 	// #2642: metadata block with index provenance.
 	out["metadata"] = inspectMetadata(m.repo)
 	return jsonResult(out), nil
@@ -1194,6 +1204,76 @@ func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map
 		}
 		entry["context"] = ctx
 		out = append(out, entry)
+	}
+	return out
+}
+
+// inspectDiscriminators returns rows for every DISCRIMINATES_ON edge attached
+// to entity e (#2666). Each row carries:
+//
+//	file:line   — the entity's source file + the edge Properties["line"]
+//	literal     — Properties["literal"]: the RHS literal value (e.g. "2", "periodic")
+//	other_side  — the synthetic var stub on the other side of the edge
+//	              (ToID for outgoing edges, FromID for incoming)
+//
+// Returns nil when the entity has no DISCRIMINATES_ON edges so the inspect
+// envelope can omit the section entirely.
+func inspectDiscriminators(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map[string]any {
+	if lr == nil || lr.Doc == nil || e == nil {
+		return nil
+	}
+	out := []map[string]any{}
+	rels := lr.Doc.Relationships
+	emit := func(ed edge, otherIsTarget bool) {
+		if ed.relIdx < 0 || ed.relIdx >= len(rels) {
+			return
+		}
+		r := &rels[ed.relIdx]
+		line := 0
+		if v := r.Properties["line"]; v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				line = n
+			}
+		}
+		literal := r.Properties["literal"]
+		other := ed.target
+		if !scopeIsOne {
+			// Synthetic "var:<name>" stubs are not prefixed (they are not
+			// per-repo entities); leave them as-is for cross-repo scope so
+			// agents can correlate hits across repos.
+			if !strings.HasPrefix(other, "var:") {
+				other = prefixedID(lr.Repo, other)
+			}
+		}
+		fileLine := ""
+		if e.SourceFile != "" && line > 0 {
+			fileLine = fmt.Sprintf("%s:%d", e.SourceFile, line)
+		} else if e.SourceFile != "" {
+			fileLine = e.SourceFile
+		}
+		entry := map[string]any{
+			"file_line":  fileLine,
+			"line":       line,
+			"literal":    literal,
+			"other_side": other,
+		}
+		_ = otherIsTarget // direction encoded by which adjacency list we walked
+		out = append(out, entry)
+	}
+	for _, ed := range lr.Adjacency.Outgoing(e.ID) {
+		if !strings.EqualFold(ed.kind, "DISCRIMINATES_ON") {
+			continue
+		}
+		emit(ed, true)
+	}
+	for _, ed := range lr.Adjacency.Incoming(e.ID) {
+		if !strings.EqualFold(ed.kind, "DISCRIMINATES_ON") {
+			continue
+		}
+		emit(ed, false)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -462,6 +462,18 @@ const (
 	//       "undeclared_used" — call/import crossing with no BUILD dep declared
 	RelationshipKindBazelDependsOn RelationshipKind = "BAZEL_DEPENDS_ON"
 	RelationshipKindBazelDepStatus RelationshipKind = "BAZEL_DEP_STATUS"
+
+	// #2666: Discriminator comparison edges. Emitted by the JS/TS and Python
+	// extractors for every `identifier == literal` comparison detected in a
+	// function/method body (the discriminator pattern from #2659).
+	//   DISCRIMINATES_ON : enclosing operation → synthetic "var:<varName>" stub
+	// Properties:
+	//   "line"    : 1-indexed source line of the comparison
+	//   "literal" : RHS literal value as a string (e.g. "2", "periodic")
+	// Surfaced by archigraph_inspect (discriminators section) and mixed into
+	// BM25 doc terms so literal-value queries (e.g. "checklistType 2") rank
+	// the enclosing entity higher.
+	RelationshipKindDiscriminatesOn RelationshipKind = "DISCRIMINATES_ON"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -551,6 +563,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		// #2183 Bazel BUILD-graph fusion:
 		RelationshipKindBazelDependsOn,
 		RelationshipKindBazelDepStatus,
+		// #2666 discriminator comparison edges:
+		RelationshipKindDiscriminatesOn,
 	}
 }
 

--- a/skills/archigraph-graph-read/SKILL.md
+++ b/skills/archigraph-graph-read/SKILL.md
@@ -13,6 +13,7 @@ For each entity of interest (a class, function, file path the user named):
 - `archigraph_inspect entity_id=<id-or-path>` returns the entity + 1-hop neighbors with line-precise CALLS/called_by edges
 - `calls[].line` = line in the inspected entity's body where the outbound call appears
 - `called_by[].line` + `called_by[].context` = line and ~40-char snippet in the caller's body
+- `discriminators[]` (#2666) — when the entity does `var === literal` comparisons (e.g. `checklistType === 2`), each row carries `{file_line, literal, other_side}` so you can jump straight to the comparison without scanning the body. Discriminator literals are also mixed into the BM25 doc terms, so `archigraph_find` queries like "checklistType 2" surface the enclosing entity.
 - Use these to pinpoint call sites without calling `get_source`
 - Look at the neighbors for ORIENTATION before drilling deeper
 


### PR DESCRIPTION
## Summary

- Promotes the #2659 discriminator-pattern data (`Properties["discriminators"]` on the enclosing entity) into proper `DISCRIMINATES_ON` edges carrying `Properties["line"]` + `Properties["literal"]`. The legacy property is kept for backward compat.
- `archigraph_inspect` now renders a `discriminators[]` section when the inspected entity has any DISCRIMINATES_ON edges. Each row: `{file_line, line, literal, other_side}`.
- BM25 doc terms include both the discriminator variable name (via `addIdentifier` so camelCase / snake_case sub-tokens split correctly) and the literal value at weight `0.5`, so `archigraph_find` queries like "checklistType 2" surface the enclosing entity instead of forcing a `get_source` scan of an 80-line function body (Cascade feedback in the issue).
- New `RelationshipKindDiscriminatesOn = "DISCRIMINATES_ON"` in `internal/types/kinds.go`.
- Edges target a synthetic `var:<varName>` stub (mirrors the `route:<path>` pattern used by `NAVIGATES_TO` in #2655).
- Docs + skill mention updated.

## Test plan

- [x] `go test ./internal/extractors/javascript/ ./internal/extractors/python/ -run Discrim` — 14/14 pass (6 existing #2654 tests + 8 new #2666 edge tests, JS + Python)
- [x] `go test ./internal/mcp/ -run "Inspect_RendersDiscriminators|Inspect_OmitsDiscriminators|BM25_Discriminator|BM25_NoDiscriminator"` — 5/5 pass
- [x] `go test ./...` — all packages pass except the pre-existing `TestNoSessionMetaInNonWhoamiHandlers` failure in `internal/mcp/cleanup_group_a_test.go` (banned `indexed_sha`/`indexed_ref` session-meta keys in the inspect metadata block; verified failing on `main` before any changes in this branch).

Closes #2666

🤖 Generated with [Claude Code](https://claude.com/claude-code)