### PR TITLE
feat(nav): params_keys + endpoints/find_callers route-resolve surface (#2665)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -114,6 +114,8 @@ Results are **ranked by call frequency** (descending) within each hop level, the
 
 > **Deprecation**: prefer `archigraph_neighbors(direction=in)` for new code.
 
+**Route-literal resolution (#2665).** If `entity_id` starts with `/` AND does not match any entity by ID or name, the handler treats it as an in-app route literal: it searches NAVIGATES_TO edges whose `ToID == "route:<literal>"` (or whose `Properties["route"]` equals the literal) and returns the push-site callers directly. Each caller carries `file`, `line`, `route`, and `params_keys` (JSON array) so you can immediately answer "which call-sites pass param X?". Response includes `resolved_as: "navigation_route"` so callers can branch on the resolution mode.
+
 #### `archigraph_find_paths`
 
 Key parameters: `from` (required), `to` (required), `max_hops` (default 5).
@@ -180,6 +182,13 @@ Output: cross-repo HTTP/Kafka/WS link records with match confidence.
 Key parameters: `action` (required: `definitions`/`calls`/`stats`), `path_contains`, `method`, `orphan_only`, `limit` (default 20), `offset` (default 0), `token_budget` (default 800), `format` (`terse`/`full`).
 
 Filters (`path_contains`, `method`) are applied **before** `limit`.
+
+**Navigation surface (#2665).** Two new params fold in-app NAVIGATES_TO routes (Expo Router, React Navigation, Next.js, etc.) into the same tool surface so agents don't need to remember `archigraph_navigates`:
+
+- `kind="navigation"` — short-circuits any `action` and returns aggregated navigation routes only. Each entry carries `route`, `to_id`, `call_sites`, `params_keys` (sorted, deduped JSON array merged across call-sites), and a `sample_*` locator pointing at the first push-site.
+- `include_navigation=true` (with `action=definitions`) — preserves the HTTP-definitions payload and appends a `navigation_routes` array + `navigation_count` for side-by-side comparison.
+
+`path_contains` filters routes by case-insensitive substring on the route literal in both modes.
 
 #### `archigraph_clusters`
 

--- a/internal/extractors/javascript/issue2665_navigation_params_keys_test.go
+++ b/internal/extractors/javascript/issue2665_navigation_params_keys_test.go
@@ -1,0 +1,185 @@
+// Package javascript_test — issue #2665: params_keys property on NAVIGATES_TO
+// edges. Builds on #2655/#2658 by capturing the static keys of the `params:`
+// object literal as a sorted, deduped JSON array string. This is what unlocks
+// "which callers pass param X / which are missing it?" diff queries.
+package javascript_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findNavParamsKeys returns the params_keys property of the first NAVIGATES_TO
+// edge on entity `name`, or "" if no such edge / property exists.
+func findNavParamsKeys(ents []types.EntityRecord, name string) string {
+	e := findByNameRel(ents, name)
+	if e == nil {
+		return ""
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "NAVIGATES_TO" && r.Properties != nil {
+			return r.Properties["params_keys"]
+		}
+	}
+	return ""
+}
+
+// decodeParamsKeys parses a params_keys JSON array string into a Go slice for
+// assertion convenience.
+func decodeParamsKeys(t *testing.T, raw string) []string {
+	t.Helper()
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("params_keys is not a JSON array: %q (%v)", raw, err)
+	}
+	return out
+}
+
+// TestNavParamsKeys_Shorthand verifies that shorthand `{a, b}` extracts both
+// keys, sorted and JSON-encoded.
+func TestNavParamsKeys_Shorthand(t *testing.T) {
+	src := `
+import { useRouter } from "expo-router";
+
+const Comp = () => {
+  const router = useRouter();
+  const go = (b, a) => {
+    router.push({ pathname: '/x', params: { b, a } });
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	got := decodeParamsKeys(t, findNavParamsKeys(ents, "go"))
+	want := []string{"a", "b"} // sorted
+	if len(got) != len(want) {
+		t.Fatalf("params_keys: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("params_keys[%d]: got %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestNavParamsKeys_KeyValue verifies that explicit `{key: value}` form also
+// captures keys (not values).
+func TestNavParamsKeys_KeyValue(t *testing.T) {
+	src := `
+const Comp = ({ navigation }) => {
+  const go = () => {
+    navigation.navigate('Detail', { id: 7, mode: 'edit' });
+  };
+  return null;
+};
+`
+	// navigation.navigate(name, params) — second-arg style is NOT yet in the
+	// extractor's contract (object-form lives on router.push); but the same
+	// shape via router.push must work. Use router.push here to keep the test
+	// targeted at the params_keys extraction.
+	src = `
+import { useRouter } from "expo-router";
+const Comp = () => {
+  const router = useRouter();
+  const go = () => {
+    router.push({ pathname: '/detail', params: { id: 7, mode: 'edit' } });
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	got := decodeParamsKeys(t, findNavParamsKeys(ents, "go"))
+	want := []string{"id", "mode"}
+	if len(got) != len(want) {
+		t.Fatalf("params_keys: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("params_keys[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestNavParamsKeys_Spread verifies that spread elements are recorded as the
+// sentinel "...spread" so callers know dynamic keys may exist.
+func TestNavParamsKeys_Spread(t *testing.T) {
+	src := `
+import { useRouter } from "expo-router";
+const Comp = () => {
+  const router = useRouter();
+  const go = (rest) => {
+    router.push({ pathname: '/x', params: { id: 1, ...rest } });
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	got := decodeParamsKeys(t, findNavParamsKeys(ents, "go"))
+	foundSpread := false
+	foundID := false
+	for _, k := range got {
+		if k == "...spread" {
+			foundSpread = true
+		}
+		if k == "id" {
+			foundID = true
+		}
+	}
+	if !foundSpread {
+		t.Errorf("expected ...spread sentinel in params_keys; got %v", got)
+	}
+	if !foundID {
+		t.Errorf("expected 'id' key in params_keys; got %v", got)
+	}
+}
+
+// TestNavParamsKeys_VariableRef verifies that `params: opts` (variable
+// reference, not an object literal) yields an empty JSON array — we
+// deliberately do NOT perform data-flow analysis, but we still emit the
+// property so callers can distinguish "no params arg" from "dynamic params".
+func TestNavParamsKeys_VariableRef(t *testing.T) {
+	src := `
+import { useRouter } from "expo-router";
+const Comp = (opts) => {
+  const router = useRouter();
+  const go = () => {
+    router.push({ pathname: '/x', params: opts });
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	raw := findNavParamsKeys(ents, "go")
+	if raw != "[]" {
+		t.Fatalf("expected params_keys=[] for variable-ref params, got %q", raw)
+	}
+}
+
+// TestNavParamsKeys_OmittedWhenNoParamsArg verifies that calls without a
+// params object (e.g. router.push('/foo') string-only) do NOT carry a
+// params_keys property, so the property's presence is a meaningful signal.
+func TestNavParamsKeys_OmittedWhenNoParamsArg(t *testing.T) {
+	src := `
+import { useRouter } from "expo-router";
+const Comp = () => {
+  const router = useRouter();
+  const go = () => { router.push('/foo'); };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	raw := findNavParamsKeys(ents, "go")
+	if raw != "" {
+		t.Errorf("expected NO params_keys property for string-only push, got %q", raw)
+	}
+}

--- a/internal/extractors/javascript/navigation.go
+++ b/internal/extractors/javascript/navigation.go
@@ -21,7 +21,9 @@
 package javascript
 
 import (
+	"encoding/json"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -232,8 +234,16 @@ func extractObjectFormRoute(x *extractor, obj *sitter.Node) (route string, param
 // extractParamKeys returns the property/shorthand key names from an object
 // expression used as the `params:` value in a navigation call.
 //
-// Handles both shorthand `{id}` (shorthand_property_identifier) and explicit
-// `{id: value}` (pair) property shapes.
+// Handles:
+//   - explicit `{id: value}` (pair)
+//   - shorthand `{id}` (shorthand_property_identifier[_pattern])
+//   - spread elements `{...rest}` — recorded as the sentinel "...spread" so
+//     downstream queries know dynamic keys may exist (#2665)
+//
+// If the params value is not an object literal (e.g. a variable reference like
+// `params: opts`), returns an empty slice — we deliberately do NOT perform any
+// data-flow analysis here. Caller can distinguish "no params object" (nil)
+// from "params object with non-static contents" (empty slice).
 func extractParamKeys(x *extractor, obj *sitter.Node) []string {
 	if obj == nil {
 		return nil
@@ -249,7 +259,10 @@ func extractParamKeys(x *extractor, obj *sitter.Node) []string {
 		}
 	}
 	if obj.Type() != "object" && obj.Type() != "object_expression" {
-		return nil
+		// #2665: caller passed e.g. `params: opts` — variable reference.
+		// Return empty (non-nil) so emitNavigationEdge can record an empty
+		// params_keys array (dynamic params, no static keys recoverable).
+		return []string{}
 	}
 
 	var keys []string
@@ -267,6 +280,10 @@ func extractParamKeys(x *extractor, obj *sitter.Node) []string {
 			}
 		case "shorthand_property_identifier", "shorthand_property_identifier_pattern":
 			keyName = x.nodeText(child)
+		case "spread_element":
+			// #2665: record that a spread exists so consumers know dynamic
+			// keys may be present beyond the static set.
+			keyName = "...spread"
 		}
 		if keyName != "" && !seen[keyName] {
 			seen[keyName] = true
@@ -282,10 +299,15 @@ func extractParamKeys(x *extractor, obj *sitter.Node) []string {
 // against declared route entities.
 //
 // Properties set:
-//   - "route"   : the destination route/screen name
-//   - "params"  : comma-separated param key names (omitted when empty)
-//   - "line"    : 1-indexed source line of the call site
-//   - "via"     : "navigation_call" (traceability tag)
+//   - "route"       : the destination route/screen name
+//   - "params"      : comma-separated param key names (omitted when empty)
+//   - "params_keys" : JSON array string of sorted, deduped param keys (#2665).
+//                     Empty array "[]" indicates the params object existed but
+//                     contained no statically-extractable keys (e.g. variable
+//                     reference). Property is omitted entirely when no params
+//                     object was observed.
+//   - "line"        : 1-indexed source line of the call site
+//   - "via"         : "navigation_call" (traceability tag)
 func emitNavigationEdge(route string, params []string, call *sitter.Node) types.RelationshipRecord {
 	toID := "route:" + route
 	props := map[string]string{
@@ -295,6 +317,28 @@ func emitNavigationEdge(route string, params []string, call *sitter.Node) types.
 	}
 	if len(params) > 0 {
 		props["params"] = strings.Join(params, ", ")
+	}
+	// #2665: emit params_keys whenever a params object was observed (params != nil),
+	// even when empty — distinguishes "no params arg" from "params: <dynamic>".
+	if params != nil {
+		// Dedupe + sort. extractParamKeys already dedupes, but normalise here
+		// so callers that build the edge from other paths get the same shape.
+		seen := make(map[string]struct{}, len(params))
+		uniq := make([]string, 0, len(params))
+		for _, k := range params {
+			if k == "" {
+				continue
+			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			uniq = append(uniq, k)
+		}
+		sort.Strings(uniq)
+		if b, err := json.Marshal(uniq); err == nil {
+			props["params_keys"] = string(b)
+		}
 	}
 	return types.RelationshipRecord{
 		ToID:       toID,

--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -414,13 +414,29 @@ func respondPaginated[T any](
 // ---------------------------------------------------------------------------
 
 // handleEndpoints dispatches on action= to the appropriate endpoint handler.
+//
+// #2665: when kind="navigation" (or include_navigation=true on action=definitions),
+// the handler also/only returns in-app navigation routes derived from
+// NAVIGATES_TO edges rather than http_endpoint_definition entities. This folds
+// the dedicated archigraph_navigates surface into the discoverable endpoints
+// tool.
 func (s *Server) handleEndpoints(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	action, err := req.RequireString("action")
 	if err != nil {
 		return mcpapi.NewToolResultError(err.Error()), nil
 	}
+	// #2665: kind=navigation short-circuit (any action), returns navigation
+	// routes only. include_navigation merges navigation routes into the
+	// definitions output.
+	kind := strings.ToLower(argString(req, "kind", ""))
+	if kind == "navigation" {
+		return s.handleEndpointNavigation(ctx, req)
+	}
 	switch action {
 	case "definitions":
+		if argBool(req, "include_navigation", false) {
+			return s.handleEndpointDefinitionsWithNavigation(ctx, req)
+		}
 		return s.handleEndpointDefinitions(ctx, req)
 	case "calls":
 		return s.handleEndpointCalls(ctx, req)
@@ -431,6 +447,207 @@ func (s *Server) handleEndpoints(ctx context.Context, req mcpapi.CallToolRequest
 			"unknown action " + action + " (allowed: definitions, calls, stats)",
 		), nil
 	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_endpoints — navigation route surface (#2665)
+// ---------------------------------------------------------------------------
+
+// navigationRouteItem is the wire shape for a single in-app navigation route
+// surfaced via archigraph_endpoints with kind=navigation or
+// include_navigation=true.
+type navigationRouteItem struct {
+	Kind         string `json:"kind"`            // always "navigation"
+	Route        string `json:"route"`           // the route literal (e.g. "/users/[id]")
+	ToID         string `json:"to_id"`           // route stub ID ("route:/users/[id]")
+	CallSites    int    `json:"call_sites"`      // number of NAVIGATES_TO edges pointing here
+	ParamsKeys   string `json:"params_keys"`     // merged sorted JSON array of all observed param keys
+	SampleFromID string `json:"sample_from_id"`  // one prefixed caller ID (for quick locate)
+	SampleFile   string `json:"sample_file,omitempty"`
+	SampleLine   int    `json:"sample_line,omitempty"`
+	Repo         string `json:"repo,omitempty"`
+}
+
+// collectNavigationRoutes aggregates NAVIGATES_TO edges across the given repos
+// into one navigationRouteItem per distinct route (ToID). Param keys are
+// merged across all call-sites, deduped, and sorted. The first caller (by
+// repo + from_id sort order) supplies the sample locator fields.
+func collectNavigationRoutes(repos []*LoadedRepo, pathContains string) []navigationRouteItem {
+	// Aggregate per ToID.
+	type agg struct {
+		route       string
+		callSites   int
+		paramKeys   map[string]struct{}
+		sampleRepo  string
+		sampleFrom  string
+		sampleFile  string
+		sampleLine  int
+		sampleSeen  bool
+	}
+	byTo := make(map[string]*agg)
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		// Build a quick local-id → entity map for sample-file/line resolution.
+		byID := r.ByID
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if rel.Kind != "NAVIGATES_TO" {
+				continue
+			}
+			route := ""
+			if rel.Properties != nil {
+				route = rel.Properties["route"]
+			}
+			if pathContains != "" && !strings.Contains(strings.ToLower(route), pathContains) {
+				continue
+			}
+			a, ok := byTo[rel.ToID]
+			if !ok {
+				a = &agg{route: route, paramKeys: make(map[string]struct{})}
+				byTo[rel.ToID] = a
+			}
+			a.callSites++
+			// Merge param keys: prefer params_keys JSON, fall back to legacy params CSV.
+			if rel.Properties != nil {
+				if pk := rel.Properties["params_keys"]; pk != "" {
+					var arr []string
+					if err := json.Unmarshal([]byte(pk), &arr); err == nil {
+						for _, k := range arr {
+							if k != "" {
+								a.paramKeys[k] = struct{}{}
+							}
+						}
+					}
+				} else if pcsv := rel.Properties["params"]; pcsv != "" {
+					for _, p := range strings.Split(pcsv, ",") {
+						p = strings.TrimSpace(p)
+						if p != "" {
+							a.paramKeys[p] = struct{}{}
+						}
+					}
+				}
+			}
+			if !a.sampleSeen {
+				a.sampleRepo = r.Repo
+				a.sampleFrom = prefixedID(r.Repo, rel.FromID)
+				if e := byID[rel.FromID]; e != nil {
+					a.sampleFile = e.SourceFile
+				}
+				if rel.Properties != nil {
+					if ls, ok := rel.Properties["line"]; ok {
+						if n, err := strconv.Atoi(ls); err == nil {
+							a.sampleLine = n
+						}
+					}
+				}
+				a.sampleSeen = true
+			}
+		}
+	}
+
+	out := make([]navigationRouteItem, 0, len(byTo))
+	for toID, a := range byTo {
+		keys := make([]string, 0, len(a.paramKeys))
+		for k := range a.paramKeys {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		paramsJSON := "[]"
+		if b, err := json.Marshal(keys); err == nil {
+			paramsJSON = string(b)
+		}
+		out = append(out, navigationRouteItem{
+			Kind:         "navigation",
+			Route:        a.route,
+			ToID:         toID,
+			CallSites:    a.callSites,
+			ParamsKeys:   paramsJSON,
+			SampleFromID: a.sampleFrom,
+			SampleFile:   a.sampleFile,
+			SampleLine:   a.sampleLine,
+			Repo:         a.sampleRepo,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Route < out[j].Route })
+	return out
+}
+
+// handleEndpointNavigation handles archigraph_endpoints when kind=navigation:
+// returns only in-app navigation routes (NAVIGATES_TO edges aggregated by
+// destination). #2665.
+func (s *Server) handleEndpointNavigation(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	pathContains := strings.ToLower(argString(req, "path_contains", ""))
+	routes := collectNavigationRoutes(repos, pathContains)
+
+	limit := argInt(req, "limit", 20)
+	offset := argInt(req, "offset", 0)
+	total := len(routes)
+	if offset > 0 && offset < len(routes) {
+		routes = routes[offset:]
+	} else if offset >= len(routes) {
+		routes = nil
+	}
+	if limit > 0 && len(routes) > limit {
+		routes = routes[:limit]
+	}
+	if routes == nil {
+		routes = []navigationRouteItem{}
+	}
+	return jsonResult(map[string]any{
+		"kind":          "navigation",
+		"count":         len(routes),
+		"total":         total,
+		"offset":        offset,
+		"path_contains": pathContains,
+		"routes":        routes,
+	}), nil
+}
+
+// handleEndpointDefinitionsWithNavigation runs the normal definitions handler
+// and then appends a "navigation_routes" key with the aggregated NAVIGATES_TO
+// routes. The HTTP definitions response shape is preserved untouched so
+// existing callers see no regression. #2665.
+func (s *Server) handleEndpointDefinitionsWithNavigation(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	res, err := s.handleEndpointDefinitions(ctx, req)
+	if err != nil || res == nil {
+		return res, err
+	}
+	// Decode the JSON result, splice in navigation routes, re-encode.
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return res, nil // best-effort; return HTTP-only response on group error
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	pathContains := strings.ToLower(argString(req, "path_contains", ""))
+	navRoutes := collectNavigationRoutes(repos, pathContains)
+
+	// Append by decoding the underlying JSON content the result already carries.
+	for i := range res.Content {
+		tc, ok := res.Content[i].(mcpapi.TextContent)
+		if !ok {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(tc.Text), &m); err != nil {
+			continue
+		}
+		m["include_navigation"] = true
+		m["navigation_routes"] = navRoutes
+		m["navigation_count"] = len(navRoutes)
+		out, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		res.Content[i] = mcpapi.NewTextContent(string(out))
+	}
+	return res, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -127,6 +128,17 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 	_, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return nil, errRes
+	}
+	// #2665: route-literal resolution. When entity_id starts with "/" AND no
+	// entity matches by ID/name across loaded repos, treat it as a route
+	// literal: find NAVIGATES_TO edges whose ToID is "route:<literal>" (or
+	// whose Properties["route"] matches) and return the push-site callers
+	// directly. This makes find_callers discoverable for in-app navigation
+	// without users having to remember the dedicated archigraph_navigates tool.
+	if strings.HasPrefix(entityID, "/") && !entityExistsAnywhere(lg, entityID) {
+		if res := s.tryFindCallersByRoute(req, lg, entityID); res != nil {
+			return res, nil
+		}
 	}
 	depth := argInt(req, "depth", 1)
 	if depth < 1 {
@@ -1437,4 +1449,135 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 		"truncated": total > len(out),
 		"note":      "Dead code candidates. Class 1 (confidence 0.6): isolated entities with no edges — may be an extraction gap. Class 2 (confidence 0.85): unreferenced public operations carrying a dead-code marker. Verify before deletion — some entry points are invoked via reflection or config.",
 	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// #2665 — route-literal resolution for archigraph_find_callers
+// ---------------------------------------------------------------------------
+
+// entityExistsAnywhere reports whether the given id matches an entity ID or
+// Name across any repo in the group. Used by findCallersStructured to decide
+// whether to attempt route-literal resolution.
+func entityExistsAnywhere(lg *LoadedGroup, id string) bool {
+	if lg == nil {
+		return false
+	}
+	_, local := splitPrefixed(id)
+	probe := id
+	if local != "" {
+		probe = local
+	}
+	for _, r := range lg.Repos {
+		if r == nil || r.Doc == nil {
+			continue
+		}
+		if _, ok := r.ByID[probe]; ok {
+			return true
+		}
+		for i := range r.Doc.Entities {
+			if r.Doc.Entities[i].Name == probe {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// tryFindCallersByRoute resolves a route literal (e.g. "/users/[id]") by
+// walking NAVIGATES_TO edges in reverse and returning their source entities
+// as callers. Returns nil if no matching edges exist so the caller can fall
+// through to the standard not-found path.
+//
+// Match rules (in order of preference):
+//  1. rel.ToID == "route:" + literal
+//  2. Properties["route"] == literal
+//  3. Properties["route"] case-insensitive equals literal (final fallback)
+//
+// Each returned caller carries file:line + the NAVIGATES_TO params_keys so
+// the agent can immediately answer "which call sites pass param X?".
+func (s *Server) tryFindCallersByRoute(req mcpapi.CallToolRequest, lg *LoadedGroup, routeLit string) map[string]any {
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	type routeCaller struct {
+		EntityID   string `json:"id"`
+		Name       string `json:"name"`
+		Repo       string `json:"repo,omitempty"`
+		SourceFile string `json:"file,omitempty"`
+		StartLine  int    `json:"line,omitempty"`
+		Route      string `json:"route,omitempty"`
+		ParamsKeys string `json:"params_keys,omitempty"`
+		HopCount   int    `json:"hop_count"`
+	}
+	var callers []routeCaller
+	wantToID := "route:" + routeLit
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if rel.Kind != "NAVIGATES_TO" {
+				continue
+			}
+			match := rel.ToID == wantToID
+			if !match && rel.Properties != nil {
+				if rel.Properties["route"] == routeLit {
+					match = true
+				} else if strings.EqualFold(rel.Properties["route"], routeLit) {
+					match = true
+				}
+			}
+			if !match {
+				continue
+			}
+			line := 0
+			route := routeLit
+			paramsKeys := ""
+			if rel.Properties != nil {
+				if ls := rel.Properties["line"]; ls != "" {
+					if n, perr := strconv.Atoi(ls); perr == nil {
+						line = n
+					}
+				}
+				if rt := rel.Properties["route"]; rt != "" {
+					route = rt
+				}
+				paramsKeys = rel.Properties["params_keys"]
+			}
+			rc := routeCaller{
+				EntityID:   prefixedID(r.Repo, rel.FromID),
+				Repo:       r.Repo,
+				StartLine:  line,
+				Route:      route,
+				ParamsKeys: paramsKeys,
+				HopCount:   1,
+			}
+			if e := r.ByID[rel.FromID]; e != nil {
+				rc.Name = e.Name
+				rc.SourceFile = e.SourceFile
+			}
+			callers = append(callers, rc)
+		}
+	}
+	if len(callers) == 0 {
+		return nil
+	}
+	sort.Slice(callers, func(i, j int) bool {
+		if callers[i].Repo != callers[j].Repo {
+			return callers[i].Repo < callers[j].Repo
+		}
+		if callers[i].SourceFile != callers[j].SourceFile {
+			return callers[i].SourceFile < callers[j].SourceFile
+		}
+		return callers[i].StartLine < callers[j].StartLine
+	})
+	return map[string]any{
+		"entity_id":       routeLit,
+		"entity_name":     routeLit,
+		"resolved_as":     "navigation_route",
+		"navigation_edge": "NAVIGATES_TO",
+		"depth":           1,
+		"callers":         callers,
+		"count":           len(callers),
+		"note":            "Route literal resolved via NAVIGATES_TO incoming edges (#2665). params_keys (JSON array) on each caller indicates which navigation params are statically passed.",
+	}
 }

--- a/internal/mcp/issue2665_nav_surface_test.go
+++ b/internal/mcp/issue2665_nav_surface_test.go
@@ -1,0 +1,242 @@
+// issue2665_nav_surface_test.go — integration tests for the navigation
+// surface added to archigraph_endpoints and archigraph_find_callers (#2665).
+//
+// Covers:
+//   - archigraph_endpoints(kind=navigation) returns aggregated NAVIGATES_TO routes
+//   - archigraph_endpoints(action=definitions, include_navigation=true) adds the
+//     "navigation_routes" key alongside HTTP definitions
+//   - archigraph_find_callers("/route/path") resolves a route literal via
+//     reverse NAVIGATES_TO traversal and returns call-site entities with
+//     file:line + params_keys
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// buildNavSurfaceDoc builds a small fixture with three call-sites navigating
+// to two routes plus one HTTP endpoint definition for the include_navigation
+// merge test.
+//
+//	pushA --NAVIGATES_TO--> route:/users/[id]  (params_keys=["id","mode"])
+//	pushB --NAVIGATES_TO--> route:/users/[id]  (params_keys=["id"])
+//	pushC --NAVIGATES_TO--> route:/dashboard   (no params)
+//
+// HTTP definition: GET /api/users (so include_navigation merging is observable).
+func buildNavSurfaceDoc() *graph.Document {
+	doc := &graph.Document{Repo: "ns-repo"}
+	doc.Entities = []graph.Entity{
+		{ID: "pushA", Name: "pushA", Kind: "function", SourceFile: "screens/a.tsx", StartLine: 10},
+		{ID: "pushB", Name: "pushB", Kind: "function", SourceFile: "screens/b.tsx", StartLine: 20},
+		{ID: "pushC", Name: "pushC", Kind: "function", SourceFile: "screens/c.tsx", StartLine: 30},
+		{
+			ID: "ep1", Name: "GET /api/users", Kind: "http_endpoint_definition",
+			SourceFile: "api/users.go", StartLine: 5,
+			Properties: map[string]string{"path": "/api/users", "verb": "GET"},
+		},
+	}
+	doc.Relationships = []graph.Relationship{
+		{
+			ID: "n1", FromID: "pushA", ToID: "route:/users/[id]", Kind: "NAVIGATES_TO",
+			Properties: map[string]string{
+				"route":       "/users/[id]",
+				"params":      "id, mode",
+				"params_keys": `["id","mode"]`,
+				"line":        "12",
+				"via":         "navigation_call",
+			},
+		},
+		{
+			ID: "n2", FromID: "pushB", ToID: "route:/users/[id]", Kind: "NAVIGATES_TO",
+			Properties: map[string]string{
+				"route":       "/users/[id]",
+				"params":      "id",
+				"params_keys": `["id"]`,
+				"line":        "22",
+				"via":         "navigation_call",
+			},
+		},
+		{
+			ID: "n3", FromID: "pushC", ToID: "route:/dashboard", Kind: "NAVIGATES_TO",
+			Properties: map[string]string{
+				"route": "/dashboard",
+				"line":  "32",
+				"via":   "navigation_call",
+			},
+		},
+	}
+	return doc
+}
+
+func callEndpointsTool(t *testing.T, srv *Server, args map[string]any) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleEndpoints(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleEndpoints error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("endpoints tool error: %v", res)
+	}
+	return extractResultJSON(t, res)
+}
+
+// TestEndpoints_KindNavigation verifies that kind=navigation surfaces the
+// distinct NAVIGATES_TO routes with aggregated params_keys and call-site
+// counts. #2665.
+func TestEndpoints_KindNavigation(t *testing.T) {
+	srv := newTestServer(t, buildNavSurfaceDoc())
+	out := callEndpointsTool(t, srv, map[string]any{
+		"action": "definitions", // ignored — kind=navigation short-circuits
+		"kind":   "navigation",
+		"group":  "test",
+	})
+
+	if k, _ := out["kind"].(string); k != "navigation" {
+		t.Fatalf("expected kind='navigation', got %q", k)
+	}
+	routesRaw, ok := out["routes"].([]any)
+	if !ok {
+		t.Fatalf("response missing 'routes' slice: %v", out)
+	}
+	if len(routesRaw) != 2 {
+		t.Fatalf("expected 2 distinct routes (users/dashboard), got %d: %v", len(routesRaw), routesRaw)
+	}
+
+	// Find the /users/[id] route entry and verify aggregated params_keys
+	// merged from both call-sites ("id" + "mode").
+	var users map[string]any
+	for _, r := range routesRaw {
+		m, _ := r.(map[string]any)
+		if rt, _ := m["route"].(string); rt == "/users/[id]" {
+			users = m
+			break
+		}
+	}
+	if users == nil {
+		t.Fatalf("did not find /users/[id] route in output: %v", routesRaw)
+	}
+	cs, _ := users["call_sites"].(float64)
+	if cs != 2 {
+		t.Errorf("expected call_sites=2 for /users/[id], got %v", cs)
+	}
+	pk, _ := users["params_keys"].(string)
+	if pk != `["id","mode"]` {
+		t.Errorf("expected merged params_keys=[\"id\",\"mode\"], got %q", pk)
+	}
+}
+
+// TestEndpoints_IncludeNavigation verifies that action=definitions with
+// include_navigation=true returns the standard HTTP definitions payload AND
+// a "navigation_routes" key with the aggregated NAVIGATES_TO routes. #2665.
+func TestEndpoints_IncludeNavigation(t *testing.T) {
+	srv := newTestServer(t, buildNavSurfaceDoc())
+	out := callEndpointsTool(t, srv, map[string]any{
+		"action":             "definitions",
+		"include_navigation": true,
+		"group":              "test",
+	})
+
+	// HTTP definitions should still be present (lines, count, total fields).
+	if _, ok := out["total"]; !ok {
+		t.Errorf("expected HTTP-definitions envelope keys to be present; got %v", out)
+	}
+	// Navigation routes should be merged in.
+	nr, ok := out["navigation_routes"].([]any)
+	if !ok {
+		t.Fatalf("expected 'navigation_routes' slice in merged response: %v", out)
+	}
+	if len(nr) != 2 {
+		t.Errorf("expected 2 nav routes, got %d", len(nr))
+	}
+	navCount, _ := out["navigation_count"].(float64)
+	if navCount != 2 {
+		t.Errorf("expected navigation_count=2, got %v", navCount)
+	}
+	if v, _ := out["include_navigation"].(bool); !v {
+		t.Errorf("expected include_navigation=true in response")
+	}
+}
+
+// TestFindCallers_RouteLiteralResolves verifies that passing a route literal
+// (string starting with "/") to archigraph_find_callers resolves it via the
+// NAVIGATES_TO reverse traversal and returns push-site callers carrying
+// file:line + params_keys. #2665.
+func TestFindCallers_RouteLiteralResolves(t *testing.T) {
+	srv := newTestServer(t, buildNavSurfaceDoc())
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"entity_id": "/users/[id]",
+		"group":     "test",
+	}
+	res, err := srv.handleFindCallers(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleFindCallers error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("tool returned error: %v", res)
+	}
+	out := extractResultJSON(t, res)
+
+	if r, _ := out["resolved_as"].(string); r != "navigation_route" {
+		t.Errorf("expected resolved_as='navigation_route', got %q", r)
+	}
+	callersRaw, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("response missing 'callers' slice: %v", out)
+	}
+	if len(callersRaw) != 2 {
+		t.Fatalf("expected 2 callers for /users/[id], got %d: %v", len(callersRaw), callersRaw)
+	}
+	// Each caller must carry file, line, route, params_keys.
+	sawIDOnly := false
+	sawIDAndMode := false
+	for _, c := range callersRaw {
+		m, _ := c.(map[string]any)
+		if f, _ := m["file"].(string); f == "" {
+			t.Errorf("caller missing 'file': %v", m)
+		}
+		if line, _ := m["line"].(float64); line == 0 {
+			t.Errorf("caller missing 'line': %v", m)
+		}
+		pk, _ := m["params_keys"].(string)
+		switch pk {
+		case `["id"]`:
+			sawIDOnly = true
+		case `["id","mode"]`:
+			sawIDAndMode = true
+		}
+	}
+	if !sawIDOnly || !sawIDAndMode {
+		t.Errorf("expected one caller with params_keys=[\"id\"] and one with [\"id\",\"mode\"]; sawIDOnly=%v sawIDAndMode=%v", sawIDOnly, sawIDAndMode)
+	}
+}
+
+// TestFindCallers_NonRouteEntityFallsThrough verifies that an entity_id that
+// happens to start with "/" but matches no NAVIGATES_TO edge falls through
+// to the standard "entity not found" error path rather than silently
+// returning the route-resolve empty case.
+func TestFindCallers_NonRouteEntityFallsThrough(t *testing.T) {
+	srv := newTestServer(t, buildNavSurfaceDoc())
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"entity_id": "/does/not/exist",
+		"group":     "test",
+	}
+	res, err := srv.handleFindCallers(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError=true for unknown route literal; got %v", res)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -627,14 +627,16 @@ func (s *Server) registerTools() {
 	// format="terse" (default) returns one-line "lines" entries; "full" returns
 	// per-record structs with kind + deduplicated properties (path/verb stripped).
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_endpoints",
-		mcpapi.WithDescription("HTTP endpoints: definitions|calls|stats. path_contains+method filter first."),
+		mcpapi.WithDescription("HTTP endpoints: definitions|calls|stats. kind=navigation: NAVIGATES_TO."),
 		mcpapi.WithString("action", mcpapi.Required()),
 		mcpapi.WithBoolean("orphan_only", mcpapi.DefaultBool(false)),
+		mcpapi.WithBoolean("include_navigation", mcpapi.DefaultBool(false)), // #2665
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(20)),
 		mcpapi.WithNumber("offset", mcpapi.DefaultNumber(0)),
 		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(800)),
 		mcpapi.WithAny("path_contains"),
 		mcpapi.WithAny("method"),
+		mcpapi.WithAny("kind"), // #2665 — kind=navigation routes via NAVIGATES_TO
 		mcpapi.WithAny("format"),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithAny("group"),

--- a/skills/archigraph-graph-read/SKILL.md
+++ b/skills/archigraph-graph-read/SKILL.md
@@ -24,6 +24,11 @@ When you need to traverse:
 
 Other useful read tools to layer in: `archigraph_traces` (process-flow BFS), `archigraph_cross_links` (HTTP/Kafka/WS cross-repo), `archigraph_clusters` (Louvain communities), `archigraph_module_analysis`, `archigraph_subgraph`.
 
+### In-app navigation (#2665)
+For Expo Router / React Navigation / Next.js push-sites, two shortcuts fold the NAVIGATES_TO graph into the existing read tools:
+- `archigraph_endpoints(kind="navigation")` — list distinct routes, with merged `params_keys` (sorted, deduped JSON array) per route. Use this to answer "which screens take param X?".
+- `archigraph_find_callers("/route/literal")` — pass a literal beginning with `/`; the handler reverse-traverses NAVIGATES_TO and returns push-site callers with `file`, `line`, and per-call `params_keys`. Use this when adding a required param: callers whose `params_keys` is missing the new key are the diff candidates.
+
 ## When the READ phase is enough
 Many user questions resolve at Step 2 (inspect a single entity, read the neighbors). Don't over-traverse. Three rules:
 1. STOP when the entities you've seen answer the user's question

--- a/skills/using-archigraph/SKILL.md
+++ b/skills/using-archigraph/SKILL.md
@@ -285,6 +285,26 @@ archigraph_endpoints(action="stats")
 → { "totals": { "definitions": 12, "calls": 8, "orphan_calls": 2 }, "migrated": true }
 ```
 
+#### `archigraph_endpoints(kind="navigation")` — in-app navigation routes (#2665)
+Surfaces NAVIGATES_TO routes (Expo Router, React Navigation, Next.js) through
+the same endpoints tool. Each entry merges param keys across all call-sites as
+a sorted JSON array, so you can answer "which screens take param X / which
+are missing it?" with one call.
+
+```
+archigraph_endpoints(kind="navigation", path_contains="/users")
+→ { "routes": [{ "route": "/users/[id]", "call_sites": 3, "params_keys": "[\"id\",\"mode\"]", ... }] }
+
+# Side-by-side with HTTP definitions:
+archigraph_endpoints(action="definitions", include_navigation=true)
+→ { "definitions": [...], "navigation_routes": [...], "navigation_count": 4 }
+```
+
+`archigraph_find_callers("/route/literal")` is the natural inverse: pass a
+literal beginning with `/` and the handler resolves it via reverse
+NAVIGATES_TO traversal, returning push-site callers with `file`, `line`, and
+`params_keys` for each call.
+
 ---
 
 ### 3.6 Queue management tools


### PR DESCRIPTION
Closes #2665.

## Summary

Three small, composable changes that close the "discoverability + diff-query" gap on the NAVIGATES_TO surface added in #2657 + #2658:

- **Extractor — `params_keys` on NAVIGATES_TO edges.** `internal/extractors/javascript/navigation.go` now writes `Properties["params_keys"]` as a sorted, deduped JSON array string (e.g. `[\"id\",\"mode\"]`). Handles shorthand `{a, b}`, explicit `{k: v}`, and spread (`...rest` → `"...spread"` sentinel). Variable-reference params emit `[]` so callers can distinguish "no params arg" from "dynamic params". No data-flow.
- **`archigraph_endpoints` — navigation surface.** Two new params:
  - `kind="navigation"` — short-circuits any `action`; returns aggregated NAVIGATES_TO routes with merged `params_keys` and `call_sites` count.
  - `include_navigation=true` (with `action=definitions`) — appends a `navigation_routes` array alongside the HTTP definitions payload.
- **`archigraph_find_callers` — route literal resolution.** When `entity_id` starts with `/` AND no entity matches by ID/name, the handler reverse-traverses NAVIGATES_TO and returns push-site callers with `file`, `line`, `route`, and `params_keys`. Response carries `resolved_as: "navigation_route"`.

## Acceptance checklist (from #2665)

- [x] NAVIGATES_TO edges carry `Properties["params_keys"]` (sorted, deduped, JSON array string).
- [x] `archigraph_endpoints` returns navigation routes when caller passes `include_navigation=true` or `kind=navigation`.
- [x] `find_callers("/path/literal")` resolves route node and lists push-site callers with `file:line` + `params_keys`.
- [x] Updated tool docs (`docs/mcp-tools.md`) + skills (`skills/using-archigraph/SKILL.md`, `skills/archigraph-graph-read/SKILL.md`).

## Test plan

- [x] Extractor unit tests: shorthand, key:value, spread, variable-ref, omitted (`internal/extractors/javascript/issue2665_navigation_params_keys_test.go`).
- [x] MCP integration tests: `kind=navigation`, `include_navigation`, route-literal find_callers, fall-through for unknown route (`internal/mcp/issue2665_nav_surface_test.go`).
- [x] `go test ./...` from repo root: all green except the pre-existing/approved `TestNoSessionMetaInNonWhoamiHandlers` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)