### PR TITLE
fix(discriminator): production pipeline emits edges + integration test guard (#2670)

### DIFF
--- a/cmd/archigraph/issue2670_discriminator_pipeline_test.go
+++ b/cmd/archigraph/issue2670_discriminator_pipeline_test.go
@@ -1,0 +1,115 @@
+// Issue #2670 — production-pipeline integration test for DISCRIMINATES_ON.
+//
+// PR #2667 (#2666) introduced DISCRIMINATES_ON edges in the per-language
+// extractors with unit tests that drive stampDiscriminators directly. Issue
+// #2670 is the #2604-class meta-bug guard: assert that the FULL production
+// index pipeline (cmd/archigraph Indexer.Run, the same path the daemon
+// invokes on rebuild) emits the edges on a fixture containing
+// `x === 2` / `x == 2` discriminator patterns.
+//
+// Why this test exists: the unit tests in internal/extractors/{javascript,
+// python}/issue2666_discriminator_edges_test.go call extractor.Extract()
+// directly, which exercises one level of the pipeline. They cannot catch a
+// regression where (a) the synthetic "var:<name>" ToID gets pruned by a
+// post-resolver pass, (b) the DISCRIMINATES_ON kind is not registered for
+// serialisation, or (c) some other downstream stage drops the edge before
+// it lands in graph.Document.Relationships. This test runs the entire
+// pipeline against a fixture on disk and asserts the edges survive all the
+// way to the final graph.Document — the same surface the daemon hands to
+// MCP queries.
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDiscriminatorPipeline_EmitsEdgesEndToEnd indexes the discriminator
+// fixture through the production Indexer and asserts that DISCRIMINATES_ON
+// edges with the expected synthetic var:* targets are present in the final
+// graph.Document. Guards against the #2670 meta-bug class where unit tests
+// pass but real builds emit zero edges.
+func TestDiscriminatorPipeline_EmitsEdgesEndToEnd(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/discriminator_fixture", "discriminator_fixture", nil)
+
+	// Aggregate every DISCRIMINATES_ON edge in the final document so the
+	// failure diagnostic can show what the pipeline actually produced.
+	type edgeView struct {
+		fromID, toID, literal, line, lang string
+	}
+	var hits []edgeView
+	for _, r := range doc.Relationships {
+		if r.Kind != "DISCRIMINATES_ON" {
+			continue
+		}
+		hits = append(hits, edgeView{
+			fromID:  r.FromID,
+			toID:    r.ToID,
+			literal: r.Properties["literal"],
+			line:    r.Properties["line"],
+			lang:    r.Properties["language"],
+		})
+	}
+
+	if len(hits) == 0 {
+		t.Logf("graph stats: entities=%d relationships=%d", len(doc.Entities), len(doc.Relationships))
+		// Dump a sample of relationship kinds so a future regression points
+		// straight at the missing pipeline stage rather than a generic
+		// "no edges" failure.
+		kindCounts := map[string]int{}
+		for _, r := range doc.Relationships {
+			kindCounts[r.Kind]++
+		}
+		t.Logf("relationship kinds in graph: %v", kindCounts)
+		t.Fatalf("issue #2670: expected ≥1 DISCRIMINATES_ON edge from the production index pipeline, got 0 — the extractor or a downstream pass is dropping edges")
+	}
+
+	// We want at least one var:* edge per language fixture (TS + Python).
+	// Both fixtures share the same identifiers (checklistType / checklist_type,
+	// role, status) so simply assert ≥3 total edges and that at least one
+	// of each language showed up.
+	if len(hits) < 3 {
+		t.Errorf("issue #2670: expected ≥3 DISCRIMINATES_ON edges across the fixture (one per discriminator literal × 2 languages), got %d: %+v", len(hits), hits)
+	}
+
+	wantTargets := map[string]bool{
+		"var:checklistType":  false, // TS
+		"var:role":           false, // TS + Python
+		"var:status":         false, // TS + Python
+		"var:checklist_type": false, // Python
+	}
+	for _, h := range hits {
+		if _, ok := wantTargets[h.toID]; ok {
+			wantTargets[h.toID] = true
+		}
+		// Every edge must carry the line and literal properties stamped by
+		// the extractor (#2666). If the daemon's serializer drops unknown
+		// edge properties the next regression would silently degrade the
+		// inspect / find_callers surfaces.
+		if h.literal == "" {
+			t.Errorf("DISCRIMINATES_ON edge to %s missing Properties[literal]: %+v", h.toID, h)
+		}
+		if h.line == "" {
+			t.Errorf("DISCRIMINATES_ON edge to %s missing Properties[line]: %+v", h.toID, h)
+		}
+	}
+	missing := []string{}
+	for k, seen := range wantTargets {
+		if !seen {
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		var sb strings.Builder
+		for _, h := range hits {
+			sb.WriteString("  ")
+			sb.WriteString(h.toID)
+			sb.WriteString(" literal=")
+			sb.WriteString(h.literal)
+			sb.WriteString(" line=")
+			sb.WriteString(h.line)
+			sb.WriteString("\n")
+		}
+		t.Errorf("issue #2670: expected DISCRIMINATES_ON edges to targets %v but missing %v.\nObserved edges:\n%s", wantTargets, missing, sb.String())
+	}
+}

--- a/cmd/archigraph/testdata/discriminator_fixture/checklist.py
+++ b/cmd/archigraph/testdata/discriminator_fixture/checklist.py
@@ -1,0 +1,9 @@
+# Fixture for issue #2670 — verify the production extract pipeline emits
+# DISCRIMINATES_ON edges for discriminator-pattern comparisons in real files.
+
+
+def process_checklist(checklist_type, role, status):
+    is_cat5 = checklist_type == 2
+    is_admin = role == "admin"
+    is_active = status == "active"
+    return is_cat5 and is_admin and is_active

--- a/cmd/archigraph/testdata/discriminator_fixture/checklist.ts
+++ b/cmd/archigraph/testdata/discriminator_fixture/checklist.ts
@@ -1,0 +1,9 @@
+// Fixture for issue #2670 — verify the production extract pipeline emits
+// DISCRIMINATES_ON edges for discriminator-pattern comparisons in real files.
+
+export function processChecklist(checklistType: number, role: string, status: string) {
+  const isCat5 = checklistType === 2;
+  const isAdmin = role === 'admin';
+  const isActive = status === 'active';
+  return isCat5 && isAdmin && isActive;
+}


### PR DESCRIPTION
## Summary

- Adds the missing integration-test guard for #2670 (the #2604-class meta-bug class): a fixture-driven test that runs the **full Indexer.Run pipeline** (same path the daemon uses on rebuild) and asserts DISCRIMINATES_ON edges land in the final `graph.Document` with `line` + `literal` properties intact.
- Resolves the headline question by confirming the production pipeline is operative on real data: upvate group rebuild → **714 DISCRIMINATES_ON edges** (403 upvate_core_frontend + 183 upvate_core + 128 core-mobile), well above the issue's ≥10 acceptance threshold.

## Root-cause investigation

The issue described a divergence: unit tests passing, real rebuild emitting 0 edges. Walked the pipeline end-to-end:

1. **Extractor entry point** — `stampDiscriminators` IS called from the production extract path (`internal/extractors/javascript/extractor.go` lines 681, 757, 850, 1183, 1205 and `internal/extractors/python/extractor.go`). Not test-only.
2. **Kind registration** — `RelationshipKindDiscriminatesOn` IS in `AllRelationshipKinds()` (`internal/types/kinds.go:567`) and there is no separate serializer allow-list; `cmd/archigraph/index.go` buildDocument emits every kind it sees.
3. **Synthetic `var:<name>` ToID survival** — `buildDocument` (lines 3640-3658) defaults `FromID` to the parent entity ID when empty and persists the edge regardless of whether the ToID resolves to an existing entity. The resolver's `ReferencesEmbeddedWithAllowlist` records `Unmatched` against unresolved stubs but **does not drop** them.
4. **Empirical verification** — built the current HEAD binary, inspected `~/.archigraph/store/*/refs/develop/graph.fb` for upvate's three repos: 403 / 183 / 128 DISCRIMINATES_ON edges present, with the synthetic `var:*` targets and `line` / `literal` properties intact.

Conclusion: the pipeline is operative on `develop` HEAD. The original report likely reflected a transient daemon state running an older binary (pre-#2667). The lasting hazard is the lack of an end-to-end guard.

## The guard

`cmd/archigraph/issue2670_discriminator_pipeline_test.go` runs `runIndexerOn(...)` (the same helper the rest of the cmd/archigraph e2e tests use — Indexer.Run) against a tiny TS + Python fixture containing the canonical sites from the issue:

- `checklistType === 2`
- `role === 'admin'`
- `status === 'active'`
- Python equivalents (`checklist_type == 2`, `role == "admin"`, `status == "active"`)

Asserts:
- ≥1 DISCRIMINATES_ON edge survives to `graph.Document.Relationships` (would fail the issue's repro condition if a regression dropped them).
- ≥3 edges total across the fixture.
- Each of `var:checklistType`, `var:checklist_type`, `var:role`, `var:status` is observed.
- Every edge carries `Properties["line"]` and `Properties["literal"]`.

On failure the test dumps the relationship-kind histogram so a future regression points straight at the missing pipeline stage.

## Files changed

- `cmd/archigraph/issue2670_discriminator_pipeline_test.go` (new — integration test)
- `cmd/archigraph/testdata/discriminator_fixture/checklist.ts` (new — fixture)
- `cmd/archigraph/testdata/discriminator_fixture/checklist.py` (new — fixture)

## Test plan

- [x] `go test -run TestDiscriminatorPipeline_EmitsEdgesEndToEnd ./cmd/archigraph/` — PASS
- [x] `go test -run "TestDiscriminator|Issue2666" ./internal/extractors/javascript/ ./internal/extractors/python/ ./cmd/archigraph/` — all PASS (no regression on existing unit tests)
- [x] `go vet ./cmd/archigraph/` — clean
- [x] Real-data verification: `archigraph status upvate` after daemon rebuild — 714 DISCRIMINATES_ON edges (403 + 183 + 128) across the three repos.

Refs #2670, #2666, #2659, #2654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)