### PR TITLE
feat(nav): react-router + Next.js NAVIGATES_TO extraction (#2671)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -158,7 +158,14 @@ Output: nodes+edges JSON (`raw`) or human-readable Markdown summary (`markdown`)
 
 #### `archigraph_navigates`
 
-Query NAVIGATES_TO edges emitted by the JS/TS navigation extractor (router.push, navigation.navigate, etc.). Phase 2 of #2655 (#2658).
+Query NAVIGATES_TO edges emitted by the JS/TS navigation extractor. Coverage spans:
+
+- Expo Router / React Navigation: `router.push`, `router.replace`, `router.navigate`, `navigation.navigate`, `navigation.push`, `Linking.openURL` (#2655 / #2658 / #2665).
+- react-router-dom v6+: direct-call navigators (`const navigate = useNavigate(); navigate('/path', {state: {...}})`), JSX components (`<Link to>`, `<NavLink to>`, `<Navigate to>`, `<Redirect to>`) (#2671).
+- react-router-dom v5: `useHistory().push` / `.replace` (#2671).
+- Next.js: `useRouter().push` / `.replace`, `<Link href>` from `next/link` (#2671).
+
+Edges carry `Properties[line]`, `Properties[route]`, and `Properties[params_keys]` (sorted, deduped JSON array of static key names from `{params: {...}}` / `{state: {...}}` object literals).
 
 Key parameters:
 - `entity_id` — source (outgoing) or destination (incoming) entity, as `repo::id`.
@@ -184,7 +191,7 @@ Key parameters: `action` (required: `definitions`/`calls`/`stats`), `path_contai
 
 Filters (`path_contains`, `method`) are applied **before** `limit`.
 
-**Navigation surface (#2665).** Two new params fold in-app NAVIGATES_TO routes (Expo Router, React Navigation, Next.js, etc.) into the same tool surface so agents don't need to remember `archigraph_navigates`:
+**Navigation surface (#2665, expanded #2671).** Two params fold in-app NAVIGATES_TO routes (Expo Router, React Navigation, react-router-dom v5+v6 — including `<Link>` / `<NavLink>` / `<Navigate>` JSX components — and Next.js `useRouter`/`<Link href>`) into the same tool surface so agents don't need to remember `archigraph_navigates`:
 
 - `kind="navigation"` — short-circuits any `action` and returns aggregated navigation routes only. Each entry carries `route`, `to_id`, `call_sites`, `params_keys` (sorted, deduped JSON array merged across call-sites), and a `sample_*` locator pointing at the first push-site.
 - `include_navigation=true` (with `action=definitions`) — preserves the HTTP-definitions payload and appends a `navigation_routes` array + `navigation_count` for side-by-side comparison.

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -213,6 +213,12 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 	// `const nav = useNavigation(); nav.navigate('X')`.
 	x.navHookVars = buildNavigationHookVarTable(x, root)
 
+	// Phase 3 of #2671 — react-router-dom direct-call navigator binding.
+	// `const navigate = useNavigate()` binds `navigate` to a callable
+	// function; extractDirectNavigatorCall consults this table to emit
+	// NAVIGATES_TO edges from bare `navigate('/path')` call sites.
+	x.navigatorFnVars = buildNavigatorFnVarTable(x, root)
+
 	// Issue #2553 — build the dispatch-map registry before walk() so that
 	// callTarget can synthesise CALLS edges when it sees RESOLVERS[k](args).
 	x.dispatchMaps = x.buildDispatchMaps(root)
@@ -374,6 +380,13 @@ type extractor struct {
 	// calls are recognised as navigation edges even when the receiver name
 	// is not in the static navigationReceiverNames allowlist.
 	navHookVars map[string]bool
+
+	// navigatorFnVars — Phase 3 of #2671 (react-router direct-call form).
+	// Built alongside navHookVars in Extract(); maps local variable names
+	// bound to a direct-call navigator hook (currently react-router-dom's
+	// useNavigate) to true. extractDirectNavigatorCall consults this map to
+	// recognise `navigate('/path', {state: ...})` as a NAVIGATES_TO edge.
+	navigatorFnVars map[string]bool
 
 	// dispatchMaps — Issue #2553. Built once per file in buildDispatchMaps
 	// (called from Extract before walk). Maps variable names that hold a
@@ -1875,7 +1888,12 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 		return nil
 	}
 	calls := findAllNodes(body, "call_expression", "new_expression")
-	if len(calls) == 0 {
+	// Issue #2671 — JSX navigation components (<Link>, <NavLink>, <Navigate>,
+	// <Redirect>, next/link's <Link href=...>) are emitted from any body that
+	// renders them; they do not depend on a call_expression being present.
+	// Collect them up-front so a JSX-only body (no calls) still yields edges.
+	jsxNavRels := x.extractJSXNavigationRelationships(body)
+	if len(calls) == 0 && len(jsxNavRels) == 0 {
 		return nil
 	}
 	seen := make(map[string]bool, len(calls))
@@ -1950,6 +1968,20 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 			}
 		}
 
+		// Issue #2671 — react-router-dom direct-call navigator. The function
+		// child is a bare identifier (no member expression), and the
+		// identifier was bound to useNavigate() earlier in the file. Emit a
+		// NAVIGATES_TO edge alongside (not instead of) the bare CALLS edge so
+		// callTarget's normal path can still emit the underlying call.
+		if navRoute, navParams, navOK := extractDirectNavigatorCall(x, call); navOK {
+			navEdge := emitNavigationEdge(navRoute, navParams, "", call)
+			navKey := "nav:" + navEdge.ToID
+			if !seen[navKey] {
+				seen[navKey] = true
+				rels = append(rels, navEdge)
+			}
+		}
+
 		target := x.callTarget(call, frame)
 		if target == "" || target == "require" {
 			continue
@@ -2014,6 +2046,22 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 			hookRels := x.extractReactQueryHookCalls(call, callerName, frame, seen)
 			rels = append(rels, hookRels...)
 		}
+	}
+
+	// Issue #2671 — append JSX-navigation edges collected at the top of the
+	// function. Dedupe against the call-derived NAVIGATES_TO edges by ToID +
+	// line so a route reached via both `navigate('/x')` and `<Link to="/x">`
+	// on the same line is not double-counted (rare, but cheap to guard).
+	for _, jr := range jsxNavRels {
+		key := "nav:" + jr.ToID
+		if line, ok := jr.Properties["line"]; ok {
+			key += ":" + line
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		rels = append(rels, jr)
 	}
 	return rels
 }

--- a/internal/extractors/javascript/issue2671_react_router_nav_test.go
+++ b/internal/extractors/javascript/issue2671_react_router_nav_test.go
@@ -1,0 +1,394 @@
+// Package javascript_test — issue #2671: react-router-dom v6+ and Next.js
+// NAVIGATES_TO extraction. Builds on #2655 / #2658 / #2665 by adding coverage
+// for the patterns dominant in upvate-core-frontend (which had 0 navigation
+// edges before this change).
+//
+// Patterns covered here:
+//
+//   - const navigate = useNavigate(); navigate('/path')         (react-router v6 direct call)
+//   - navigate('/path', {state: {foo, bar}})                    (with state object)
+//   - navigate(`/users/${id}`)                                  (template literal)
+//   - navigate({pathname: '/x', search: '?q=1'})                (object form)
+//   - <Link to="/path">, <NavLink to="/path">                   (react-router v6 JSX)
+//   - <Navigate to="/path" />, <Redirect to="/path" />          (react-router JSX redirects)
+//   - <Link href="/path">                                       (next/link JSX)
+//   - useRouter().push('/path')                                 (Next.js — receiver form)
+//   - useHistory().push('/path')                                (react-router v5 — receiver form)
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findNavEdges returns every NAVIGATES_TO edge on entity `name`. Empty slice
+// when the entity has no such edges or doesn't exist.
+func findNavEdges(ents []types.EntityRecord, name string) []types.RelationshipRecord {
+	e := findByNameRel(ents, name)
+	if e == nil {
+		return nil
+	}
+	out := make([]types.RelationshipRecord, 0, len(e.Relationships))
+	for _, r := range e.Relationships {
+		if r.Kind == "NAVIGATES_TO" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// hasNavEdgeTo reports whether `name` has a NAVIGATES_TO edge to "route:<route>".
+func hasNavEdgeTo(ents []types.EntityRecord, name, route string) bool {
+	for _, r := range findNavEdges(ents, name) {
+		if r.ToID == "route:"+route {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// react-router-dom v6: direct-call navigator (useNavigate)
+// ---------------------------------------------------------------------------
+
+// TestRRNav_DirectCall_StringLiteral verifies that the canonical
+// `const navigate = useNavigate(); navigate('/inspections')` shape emits a
+// NAVIGATES_TO edge with route='/inspections' from the enclosing handler.
+func TestRRNav_DirectCall_StringLiteral(t *testing.T) {
+	src := `
+import { useNavigate } from "react-router-dom";
+
+const InspectionsButton = () => {
+  const navigate = useNavigate();
+  const onClick = () => {
+    navigate('/inspections');
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	if !hasNavEdgeTo(ents, "onClick", "/inspections") {
+		t.Fatalf("expected NAVIGATES_TO route:/inspections on onClick; edges=%v",
+			findNavEdges(ents, "onClick"))
+	}
+}
+
+// TestRRNav_DirectCall_TemplateLiteral verifies dynamic routes are
+// normalised to the {*} sentinel — matching the Expo Router behaviour.
+func TestRRNav_DirectCall_TemplateLiteral(t *testing.T) {
+	src := `
+import { useNavigate } from "react-router-dom";
+
+const Comp = () => {
+  const navigate = useNavigate();
+  const goTo = (id) => {
+    navigate(` + "`/users/${id}/profile`" + `);
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	if !hasNavEdgeTo(ents, "goTo", "/users/{*}/profile") {
+		t.Fatalf("expected NAVIGATES_TO route:/users/{*}/profile on goTo; edges=%v",
+			findNavEdges(ents, "goTo"))
+	}
+}
+
+// TestRRNav_DirectCall_StateParamsKeys verifies that the `state` object on
+// `navigate('/path', {state: {a, b}})` populates params_keys as a sorted
+// JSON array, identical in shape to the Expo Router params extraction.
+func TestRRNav_DirectCall_StateParamsKeys(t *testing.T) {
+	src := `
+import { useNavigate } from "react-router-dom";
+
+const Comp = () => {
+  const navigate = useNavigate();
+  const submit = (b, a) => {
+    navigate('/done', { state: { b, a } });
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	got := decodeParamsKeys(t, findNavParamsKeys(ents, "submit"))
+	want := []string{"a", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("params_keys: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("params_keys[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestRRNav_DirectCall_ObjectForm verifies the navigate({pathname, search})
+// shape produces a route='/x' edge and surfaces the option keys.
+func TestRRNav_DirectCall_ObjectForm(t *testing.T) {
+	src := `
+import { useNavigate } from "react-router-dom";
+
+const Comp = () => {
+  const navigate = useNavigate();
+  const open = () => {
+    navigate({ pathname: '/search', search: '?q=foo' });
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	if !hasNavEdgeTo(ents, "open", "/search") {
+		t.Fatalf("expected NAVIGATES_TO route:/search on open; edges=%v",
+			findNavEdges(ents, "open"))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// react-router-dom v6: JSX components (<Link>, <NavLink>, <Navigate>)
+// ---------------------------------------------------------------------------
+
+// TestRRNav_JSX_Link verifies <Link to="/path"> renders a NAVIGATES_TO edge
+// on the enclosing component, with via=jsx_nav and tag=Link.
+func TestRRNav_JSX_Link(t *testing.T) {
+	src := `
+import { Link } from "react-router-dom";
+
+const NavBar = () => {
+  return (
+    <Link to="/dashboard">Dashboard</Link>
+  );
+};
+`
+	tree := parseTSX(t, []byte(src))
+	ents := extractTSX(t, []byte(src), tree)
+	edges := findNavEdges(ents, "NavBar")
+	if len(edges) != 1 {
+		t.Fatalf("expected exactly one NAVIGATES_TO on NavBar, got %d: %v", len(edges), edges)
+	}
+	if edges[0].ToID != "route:/dashboard" {
+		t.Errorf("expected route:/dashboard, got %q", edges[0].ToID)
+	}
+	if edges[0].Properties["via"] != "jsx_nav" {
+		t.Errorf("expected via=jsx_nav, got %q", edges[0].Properties["via"])
+	}
+	if edges[0].Properties["tag"] != "Link" {
+		t.Errorf("expected tag=Link, got %q", edges[0].Properties["tag"])
+	}
+}
+
+// TestRRNav_JSX_NavLink verifies <NavLink to="/path"> is also recognised.
+func TestRRNav_JSX_NavLink(t *testing.T) {
+	src := `
+import { NavLink } from "react-router-dom";
+
+const SideBar = () => {
+  return (
+    <NavLink to="/buildings">Buildings</NavLink>
+  );
+};
+`
+	tree := parseTSX(t, []byte(src))
+	ents := extractTSX(t, []byte(src), tree)
+	if !hasNavEdgeTo(ents, "SideBar", "/buildings") {
+		t.Fatalf("expected NAVIGATES_TO route:/buildings on SideBar; edges=%v",
+			findNavEdges(ents, "SideBar"))
+	}
+}
+
+// TestRRNav_JSX_Navigate verifies the <Navigate to="/path" /> redirect
+// component (typically used as a route element).
+func TestRRNav_JSX_Navigate(t *testing.T) {
+	src := `
+import { Navigate } from "react-router-dom";
+
+const Protected = ({ ok }) => {
+  return ok ? <div /> : <Navigate to="/login" />;
+};
+`
+	tree := parseTSX(t, []byte(src))
+	ents := extractTSX(t, []byte(src), tree)
+	if !hasNavEdgeTo(ents, "Protected", "/login") {
+		t.Fatalf("expected NAVIGATES_TO route:/login on Protected; edges=%v",
+			findNavEdges(ents, "Protected"))
+	}
+}
+
+// TestRRNav_JSX_Redirect verifies the older react-router-dom v5 <Redirect to=...>
+// component is also picked up (corpora often still contain mixed v5/v6 usage).
+func TestRRNav_JSX_Redirect(t *testing.T) {
+	src := `
+import { Redirect } from "react-router-dom";
+
+const Old = () => {
+  return <Redirect to="/v2/home" />;
+};
+`
+	tree := parseTSX(t, []byte(src))
+	ents := extractTSX(t, []byte(src), tree)
+	if !hasNavEdgeTo(ents, "Old", "/v2/home") {
+		t.Fatalf("expected NAVIGATES_TO route:/v2/home on Old; edges=%v",
+			findNavEdges(ents, "Old"))
+	}
+}
+
+// TestRRNav_JSX_Link_TemplateLiteral verifies a template-literal `to` value
+// is normalised through the {*} sentinel.
+func TestRRNav_JSX_Link_TemplateLiteral(t *testing.T) {
+	src := `
+import { Link } from "react-router-dom";
+
+const UserCard = ({ id }) => {
+  return <Link to={` + "`/users/${id}`" + `}>View</Link>;
+};
+`
+	tree := parseTSX(t, []byte(src))
+	ents := extractTSX(t, []byte(src), tree)
+	if !hasNavEdgeTo(ents, "UserCard", "/users/{*}") {
+		t.Fatalf("expected NAVIGATES_TO route:/users/{*} on UserCard; edges=%v",
+			findNavEdges(ents, "UserCard"))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Next.js: useRouter().push() + <Link href=...>
+// ---------------------------------------------------------------------------
+
+// TestNextNav_RouterPush verifies useRouter().push('/x') — already covered by
+// the existing receiver-method path via #2658's navHookVars table, but pinned
+// here so a regression in the Next.js shape is caught explicitly.
+func TestNextNav_RouterPush(t *testing.T) {
+	src := `
+import { useRouter } from "next/router";
+
+const Header = () => {
+  const router = useRouter();
+  const goHome = () => {
+    router.push('/');
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	if !hasNavEdgeTo(ents, "goHome", "/") {
+		t.Fatalf("expected NAVIGATES_TO route:/ on goHome; edges=%v",
+			findNavEdges(ents, "goHome"))
+	}
+}
+
+// TestNextNav_RouterReplace verifies router.replace('/x') from Next.js.
+func TestNextNav_RouterReplace(t *testing.T) {
+	src := `
+import { useRouter } from "next/router";
+
+const SessionGuard = () => {
+  const router = useRouter();
+  const bounce = () => {
+    router.replace('/login');
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	if !hasNavEdgeTo(ents, "bounce", "/login") {
+		t.Fatalf("expected NAVIGATES_TO route:/login on bounce; edges=%v",
+			findNavEdges(ents, "bounce"))
+	}
+}
+
+// TestNextNav_JSX_LinkHref verifies <Link href="/x"> from next/link emits a
+// NAVIGATES_TO edge — the prop name differs from react-router's `to`.
+func TestNextNav_JSX_LinkHref(t *testing.T) {
+	src := `
+import Link from "next/link";
+
+const NavBar = () => {
+  return (
+    <Link href="/about">About</Link>
+  );
+};
+`
+	tree := parseTSX(t, []byte(src))
+	ents := extractTSX(t, []byte(src), tree)
+	edges := findNavEdges(ents, "NavBar")
+	if len(edges) != 1 {
+		t.Fatalf("expected exactly one NAVIGATES_TO on NavBar, got %d: %v", len(edges), edges)
+	}
+	if edges[0].ToID != "route:/about" {
+		t.Errorf("expected route:/about, got %q", edges[0].ToID)
+	}
+	if edges[0].Properties["tag"] != "Link" {
+		t.Errorf("expected tag=Link, got %q", edges[0].Properties["tag"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// react-router-dom v5: useHistory()
+// ---------------------------------------------------------------------------
+
+// TestRRNav_UseHistory_Push verifies the v5 history.push('/x') pattern is
+// recognised via the existing navHookVars receiver-method path.
+func TestRRNav_UseHistory_Push(t *testing.T) {
+	src := `
+import { useHistory } from "react-router-dom";
+
+const Comp = () => {
+  const history = useHistory();
+  const goNext = () => {
+    history.push('/next');
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	if !hasNavEdgeTo(ents, "goNext", "/next") {
+		t.Fatalf("expected NAVIGATES_TO route:/next on goNext; edges=%v",
+			findNavEdges(ents, "goNext"))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases — make sure we don't emit edges for unrelated patterns
+// ---------------------------------------------------------------------------
+
+// TestRRNav_NoSpuriousLink verifies a lowercase <a href=...> (HTML intrinsic)
+// is NOT picked up as a nav edge — only the PascalCase Link/NavLink/etc.
+func TestRRNav_NoSpuriousLink(t *testing.T) {
+	src := `
+const NavBar = () => {
+  return <a href="/dashboard">Dashboard</a>;
+};
+`
+	tree := parseTSX(t, []byte(src))
+	ents := extractTSX(t, []byte(src), tree)
+	if edges := findNavEdges(ents, "NavBar"); len(edges) != 0 {
+		t.Errorf("expected no NAVIGATES_TO edges for <a href=...>, got %v", edges)
+	}
+}
+
+// TestRRNav_NoSpuriousNavigateBareCall verifies a bare `navigate('/x')` is
+// NOT emitted as a nav edge when there is no useNavigate() binding in scope
+// (e.g. `navigate` is just a local function name).
+func TestRRNav_NoSpuriousNavigateBareCall(t *testing.T) {
+	src := `
+const Comp = () => {
+  const navigate = (path) => console.log(path);
+  const go = () => {
+    navigate('/foo');
+  };
+  return null;
+};
+`
+	tree := parseTSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+	if edges := findNavEdges(ents, "go"); len(edges) != 0 {
+		t.Errorf("expected no NAVIGATES_TO edges when navigate is a plain local, got %v", edges)
+	}
+}

--- a/internal/extractors/javascript/navigation.go
+++ b/internal/extractors/javascript/navigation.go
@@ -18,6 +18,19 @@
 //   - Template-literal routes: router.push(`/users/${id}`) → route='/users/{*}'
 //   - Hook-rename binding: const nav = useNavigation(); nav.navigate('X')
 //     detected via hookVarToNavModule table scanned alongside hookVarToModule.
+//
+// Phase 3 additions (#2671) — react-router-dom v6+ and Next.js coverage:
+//   - const navigate = useNavigate(); navigate('/path', {state: {...}})
+//     direct-call navigator (no member expression); the route is the first
+//     argument and params_keys are extracted from the optional `state`/options
+//     object's second argument.
+//   - navigate({pathname, search, hash}) — single object form.
+//   - <Link to="/path">, <NavLink to="/path">, <Navigate to="/path">,
+//     <Redirect to="/path"> — react-router-dom v6+ JSX components.
+//   - <Link href="/path"> — next/link JSX component (href prop).
+//   - Programmatic redirects via window.location.assign('/x') and
+//     `window.location.href = '/x'` are intentionally NOT handled here — they
+//     are too noisy to gate on receiver name alone.
 package javascript
 
 import (
@@ -62,9 +75,22 @@ func normalizeTemplateLiteralRoute(raw string) string {
 //
 // Phase 2 of #2658 — hook-rename binding detection.
 var navigationHookNames = map[string]bool{
-	"useNavigation": true,
-	"useRouter":     true,
-	"useNavigate":   true,
+	"useNavigation": true, // React Navigation (Expo / RN)
+	"useRouter":     true, // Next.js / Expo Router
+	"useNavigate":   true, // react-router-dom v6 (also tracked separately for direct-call form)
+	"useHistory":    true, // react-router-dom v5 (history.push, history.replace)
+}
+
+// directNavigatorHookNames is the subset of navigation hooks whose return value
+// is itself a callable navigator function — invoked directly as `nav('/path')`
+// rather than via a method on a receiver object. Currently react-router-dom's
+// useNavigate is the canonical case.
+//
+// Bindings detected against this set populate `navigatorFnVars` (see
+// buildNavigatorFnVarTable) and are matched by extractDirectNavigatorCall.
+// Phase 3 of navigation extraction (#2671).
+var directNavigatorHookNames = map[string]bool{
+	"useNavigate": true,
 }
 
 // navigationMethodNames is the set of method names recognised as navigation
@@ -527,7 +553,6 @@ func (x *extractor) findVariableBinding(root *sitter.Node, varName string, refNo
 				}
 			}
 		}
-
 		count := int(n.ChildCount())
 		for i := count - 1; i >= 0; i-- {
 			stack = append(stack, n.Child(i))
@@ -654,4 +679,361 @@ func (x *extractor) updateNavigatesEdgeParamKeys(varName string, keys []string) 
 			}
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 (#2671) — react-router-dom direct-call navigator + JSX components
+// ---------------------------------------------------------------------------
+
+// isNavigatorFnVar reports whether varName is bound to a direct-call navigator
+// function — currently only react-router-dom's `useNavigate()` return value.
+// Populated by buildNavigatorFnVarTable in Extract().
+func (x *extractor) isNavigatorFnVar(varName string) bool {
+	return x.navigatorFnVars[varName]
+}
+
+// buildNavigatorFnVarTable scans the AST for variable declarations of the form
+// `const <varName> = <hookName>(...)` where <hookName> ∈ directNavigatorHookNames.
+// Returns a map varName → true for every variable that holds a direct-call
+// navigator function. Phase 3 of navigation extraction (#2671).
+//
+// Mirrors buildNavigationHookVarTable but with a separate map because the
+// receiver-method form (`nav.push`) and direct-call form (`nav('/x')`) have
+// disjoint receiver semantics — conflating them would cause `useNavigate()`'s
+// return value (a function, not an object) to be matched against
+// receiver-method patterns it cannot satisfy.
+func buildNavigatorFnVarTable(x *extractor, root *sitter.Node) map[string]bool {
+	if root == nil {
+		return nil
+	}
+	out := make(map[string]bool)
+	stack := make([]*sitter.Node, 0, 64)
+	stack = append(stack, root)
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if n == nil {
+			continue
+		}
+		if n.Type() == "variable_declarator" {
+			nameNode := n.ChildByFieldName("name")
+			valNode := n.ChildByFieldName("value")
+			if nameNode != nil && valNode != nil && valNode.Type() == "call_expression" {
+				localName := x.nodeText(nameNode)
+				if localName != "" && !strings.ContainsAny(localName, "{}[].,") {
+					fnNode := valNode.ChildByFieldName("function")
+					if fnNode != nil {
+						hookName := x.nodeText(fnNode)
+						if directNavigatorHookNames[hookName] {
+							out[localName] = true
+						}
+					}
+				}
+			}
+		}
+		count := int(n.ChildCount())
+		for i := count - 1; i >= 0; i-- {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// extractDirectNavigatorCall inspects a call_expression whose callee is a bare
+// identifier (not a member expression) and, if that identifier is bound to a
+// direct-call navigator (react-router-dom's useNavigate), returns the
+// destination route plus any param keys extracted from the second argument
+// (the options/state object).
+//
+// Three argument shapes are handled:
+//
+//  1. String literal first arg:
+//     navigate('/foo')           → route='/foo'
+//     navigate('/foo', {state: {a, b}})
+//                                → route='/foo', params=['a','b']
+//
+//  2. Template literal first arg (dynamic):
+//     navigate(`/users/${id}`)   → route='/users/{*}'
+//
+//  3. Object-form first arg (react-router supports
+//     navigate({pathname, search, hash})):
+//     navigate({pathname: '/x', search: '?q=1'})
+//                                → route='/x', params=['search']
+func extractDirectNavigatorCall(x *extractor, call *sitter.Node) (route string, params []string, ok bool) {
+	if call == nil {
+		return "", nil, false
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "identifier" {
+		return "", nil, false
+	}
+	name := x.nodeText(fn)
+	if !x.isNavigatorFnVar(name) {
+		return "", nil, false
+	}
+
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return "", nil, false
+	}
+	firstArg, secondArg := firstTwoMeaningfulArgs(args)
+	if firstArg == nil {
+		return "", nil, false
+	}
+
+	switch firstArg.Type() {
+	case "string":
+		raw := x.nodeText(firstArg)
+		route = strings.Trim(raw, `"'`+"`")
+	case "template_string":
+		route = normalizeTemplateLiteralRoute(x.nodeText(firstArg))
+	case "object", "object_expression":
+		// react-router v6 supports navigate({pathname, search, hash}) — a
+		// single object form, similar to expo-router. Reuse the object-form
+		// parser but fall back to a key-set extraction when `pathname` is
+		// absent.
+		r, p, _, parsed := extractObjectFormRoute(x, firstArg)
+		if parsed {
+			return r, p, true
+		}
+		// No pathname key — capture the literal key set as params so callers
+		// can still introspect the call shape. Route is unresolvable in that
+		// case; emit no edge.
+		return "", nil, false
+	default:
+		return "", nil, false
+	}
+
+	if route == "" {
+		return "", nil, false
+	}
+
+	// Second argument: react-router v6 navigate(to, {state, replace, relative})
+	// The `state` value, when an object literal, surfaces a useful set of keys
+	// for downstream "who passes <key>?" diff queries — mirrors params_keys on
+	// router.push({params: {...}}). When the second arg is an object literal
+	// without a `state` key, fall back to the object's own keys as the
+	// params_keys set so options like `replace`, `relative` are visible.
+	if secondArg != nil && (secondArg.Type() == "object" || secondArg.Type() == "object_expression") {
+		params = extractNavigateOptionsKeys(x, secondArg)
+	}
+	return route, params, true
+}
+
+// firstTwoMeaningfulArgs returns the first and second non-punctuation children
+// of an arguments node. Either return may be nil when fewer args are present.
+func firstTwoMeaningfulArgs(args *sitter.Node) (first, second *sitter.Node) {
+	count := 0
+	for i := 0; i < int(args.ChildCount()); i++ {
+		ch := args.Child(i)
+		if ch == nil {
+			continue
+		}
+		t := ch.Type()
+		if t == "(" || t == ")" || t == "," {
+			continue
+		}
+		count++
+		if count == 1 {
+			first = ch
+		} else if count == 2 {
+			second = ch
+			return
+		}
+	}
+	return
+}
+
+// extractNavigateOptionsKeys parses the options object passed as the second
+// argument to react-router's navigate(to, opts). When the object has a
+// `state:` key whose value is itself an object literal, returns that nested
+// object's keys (the most informative case). Otherwise returns the top-level
+// option keys — useful for surfacing `replace`, `relative`, etc.
+func extractNavigateOptionsKeys(x *extractor, obj *sitter.Node) []string {
+	if obj == nil {
+		return nil
+	}
+	// Look for a `state:` pair with an object-literal value first.
+	for i := 0; i < int(obj.ChildCount()); i++ {
+		child := obj.Child(i)
+		if child == nil || child.Type() != "pair" {
+			continue
+		}
+		keyNode := child.ChildByFieldName("key")
+		valNode := child.ChildByFieldName("value")
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		key := strings.Trim(x.nodeText(keyNode), `"'`+"`")
+		if key == "state" && (valNode.Type() == "object" || valNode.Type() == "object_expression") {
+			if keys, _ := extractParamKeys(x, valNode); keys != nil {
+				return keys
+			}
+			return []string{}
+		}
+	}
+	// Fall back to the options object's own keys.
+	keys, _ := extractParamKeys(x, obj)
+	return keys
+}
+
+// jsxNavTagToProp lists JSX components recognised as navigation entry points
+// together with the prop name that carries the destination route literal.
+//
+//   - react-router-dom v6+: <Link to>, <NavLink to>, <Navigate to>, <Redirect to>
+//   - next/link:            <Link href>
+//
+// Both `to` and `href` are checked on every recognised tag so a single Link
+// import resolves whether the surrounding code is react-router or Next.js.
+var jsxNavTagToProp = map[string][]string{
+	"Link":     {"to", "href"},
+	"NavLink":  {"to"},
+	"Navigate": {"to"},
+	"Redirect": {"to"},
+}
+
+// extractJSXNavigationRelationships scans body for JSX nav components
+// (<Link to=...>, <NavLink to=...>, <Navigate to=...>, <Redirect to=...>,
+// <Link href=...>) and emits one NAVIGATES_TO edge per recognised element.
+//
+// The destination route comes from a string-literal or template-literal value
+// on the matched prop; non-literal values (e.g. expression containers like
+// {`/users/${id}`} or {path}) are normalised when possible (template) or
+// dropped otherwise — we do not perform data-flow analysis.
+//
+// Properties set mirror emitNavigationEdge:
+//   - route, line, via="jsx_nav"
+//   - tag — the JSX tag name (Link / NavLink / Navigate / Redirect)
+//   - params_keys — omitted (JSX components do not carry a `state` arg in
+//     a uniform position; future work).
+//
+// Self-renders are not a concern here: navigation tags are imported components
+// from react-router-dom / next-link, never the enclosing component itself.
+func (x *extractor) extractJSXNavigationRelationships(body *sitter.Node) []types.RelationshipRecord {
+	if body == nil {
+		return nil
+	}
+	jsxNodes := findAllNodes(body,
+		"jsx_opening_element",
+		"jsx_self_closing_element",
+	)
+	if len(jsxNodes) == 0 {
+		return nil
+	}
+	var rels []types.RelationshipRecord
+	seen := make(map[string]bool, len(jsxNodes))
+	for _, jx := range jsxNodes {
+		nameNode := jx.ChildByFieldName("name")
+		if nameNode == nil {
+			continue
+		}
+		tag := x.nodeText(nameNode)
+		propNames, ok := jsxNavTagToProp[tag]
+		if !ok {
+			continue
+		}
+		route, line := jsxNavRouteFromAttrs(x, jx, propNames)
+		if route == "" {
+			continue
+		}
+		// Dedupe per (tag,route,line) so a list-like render that draws the
+		// same Link many times doesn't inflate the edge count, but distinct
+		// destinations on different lines all survive.
+		key := tag + "|" + route + "|" + strconv.Itoa(line)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		props := map[string]string{
+			"route": route,
+			"line":  strconv.Itoa(line),
+			"via":   "jsx_nav",
+			"tag":   tag,
+		}
+		rels = append(rels, types.RelationshipRecord{
+			ToID:       "route:" + route,
+			Kind:       "NAVIGATES_TO",
+			Properties: props,
+		})
+	}
+	return rels
+}
+
+// jsxNavRouteFromAttrs walks the attributes of a JSX opening/self-closing
+// element and returns the first string-literal or template-literal value of
+// any attribute whose name matches one of propNames. Line is the 1-indexed
+// source line of the JSX element.
+//
+// Supports:
+//   - <Link to="/x">         (string literal)
+//   - <Link to={"/x"}>       (jsx_expression wrapping a string)
+//   - <Link to={`/x/${id}`}> (template literal, normalised to /x/{*})
+//
+// Non-literal expressions (identifiers, member expressions, function calls)
+// return "" — they require runtime evaluation we don't do.
+func jsxNavRouteFromAttrs(x *extractor, jx *sitter.Node, propNames []string) (string, int) {
+	line := int(jx.StartPoint().Row) + 1
+	for i := 0; i < int(jx.ChildCount()); i++ {
+		attr := jx.Child(i)
+		if attr == nil || attr.Type() != "jsx_attribute" {
+			continue
+		}
+		// First child is the attribute name (property_identifier).
+		var nameChild *sitter.Node
+		for j := 0; j < int(attr.ChildCount()); j++ {
+			c := attr.Child(j)
+			if c != nil && (c.Type() == "property_identifier" || c.Type() == "identifier") {
+				nameChild = c
+				break
+			}
+		}
+		if nameChild == nil {
+			continue
+		}
+		attrName := x.nodeText(nameChild)
+		match := false
+		for _, p := range propNames {
+			if p == attrName {
+				match = true
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+		// The attribute value follows the name; look for a string,
+		// template_string, or jsx_expression child.
+		for j := 0; j < int(attr.ChildCount()); j++ {
+			val := attr.Child(j)
+			if val == nil || val == nameChild {
+				continue
+			}
+			switch val.Type() {
+			case "string":
+				raw := x.nodeText(val)
+				return strings.Trim(raw, `"'`+"`"), line
+			case "template_string":
+				return normalizeTemplateLiteralRoute(x.nodeText(val)), line
+			case "jsx_expression":
+				// Unwrap a single child string / template literal.
+				for k := 0; k < int(val.ChildCount()); k++ {
+					inner := val.Child(k)
+					if inner == nil {
+						continue
+					}
+					switch inner.Type() {
+					case "string":
+						raw := x.nodeText(inner)
+						return strings.Trim(raw, `"'`+"`"), line
+					case "template_string":
+						return normalizeTemplateLiteralRoute(x.nodeText(inner)), line
+					}
+				}
+			}
+		}
+	}
+	return "", line
 }


### PR DESCRIPTION
## Summary

Closes #2671. Adds JavaScript/TypeScript navigation extraction for the web-frontend stack so `NAVIGATES_TO` is no longer Expo-Router-only.

Patterns covered (all emit the same edge shape as #2655 / #2665 — `Properties[line]`, `Properties[route]`, `Properties[params_keys]`):

- **react-router-dom v6 direct-call**: `const navigate = useNavigate(); navigate('/path', {state: {...}})`. `state` object keys populate `params_keys`.
- **react-router-dom v6 JSX**: `<Link to>`, `<NavLink to>`, `<Navigate to>`, `<Redirect to>` — `Properties[via]="jsx_nav"`, `Properties[tag]=<component>`.
- **react-router-dom v5**: `useHistory().push` / `.replace` (added `useHistory` to `navigationHookNames`).
- **Next.js**: `useRouter().push/.replace`, `<Link href="/path">` from `next/link` (same JSX scanner picks both `to` and `href` on `Link`).
- **Object form**: `navigate({pathname, search, hash})` for react-router v6.

## Real-data verification

Rebuilt `upvate` group on this branch:
- `upvate-core-frontend`: 0 → **89** `NAVIGATES_TO` edges (well above the ≥50 acceptance threshold).
- `core-mobile`: **27** edges (unchanged — no regression on existing Expo Router patterns).

Sample routes: `/client-details/{*}`, `/buildings/building-details/{*}`, `/signin`, `/devices`, `/me-email-templates/{*}`. Both `via="navigation_call"` and `via="jsx_nav"` edges present.

## Test plan

- [x] Unit tests: `go test ./internal/extractors/javascript/ -run 'TestRRNav|TestNextNav'` — 15/15 pass.
- [x] Full extractor suite: `go test ./internal/extractors/javascript/...` — pass.
- [x] Real-data rebuild on `upvate-core-frontend` shows 89 edges with valid route literals, `params_keys` for state objects, and `tag`/`via` properties differentiating JSX vs call-site origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)