### PR TITLE
fix(gin,echo): endpoint attribution → handler file (#2678 audit)

### DIFF
--- a/cmd/archigraph/audit2678_go_ginecho_test.go
+++ b/cmd/archigraph/audit2678_go_ginecho_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAudit2678Go_GinEchoAttribution is the integration-test guard for
+// the Go gin/echo half of #2678: every http_endpoint_definition emitted
+// from a Gin or Echo route registration MUST attribute its source_file
+// to the file where the handler body lives (not the router.go where
+// the .GET / .POST registration call sits).
+//
+// Before the fix, every endpoint's source_file was the registration
+// site (router.go / echo_router.go). After the fix it should be the
+// handler file (handlers_gin.go / handlers_echo.go).
+func TestAudit2678Go_GinEchoAttribution(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/audit2678_go/gin_echo", "audit2678_go_ginecho", nil)
+	if len(doc.Entities) == 0 {
+		t.Fatalf("no entities emitted from gin/echo fixture")
+	}
+
+	// Build a (name → entity) lookup over http_endpoint_definition entities.
+	// Names are the canonical synthetic ID (e.g. "http:GET:/users").
+	defs := map[string]int{}
+	for i, e := range doc.Entities {
+		if e.Kind == "http_endpoint_definition" {
+			defs[e.Name] = i
+		}
+	}
+
+	cases := []struct {
+		endpointName string // synthetic ID
+		wantFile     string // handler file the source_file MUST land in
+		framework    string
+	}{
+		{"http:GET:/users", "handlers_gin.go", "gin"},
+		{"http:POST:/users", "handlers_gin.go", "gin"},
+		{"http:GET:/items", "handlers_echo.go", "echo"},
+		{"http:POST:/items", "handlers_echo.go", "echo"},
+	}
+
+	for _, tc := range cases {
+		idx, ok := defs[tc.endpointName]
+		if !ok {
+			t.Errorf("missing http_endpoint_definition for %s (got: %v)",
+				tc.endpointName, mapKeys(defs))
+			continue
+		}
+		e := doc.Entities[idx]
+		if !strings.HasSuffix(e.SourceFile, tc.wantFile) {
+			t.Errorf("%s: source_file=%q does not end with %q — endpoint is "+
+				"still attributed to the router-registration file (#2678 regression)",
+				tc.endpointName, e.SourceFile, tc.wantFile)
+		}
+		if got := e.Properties["framework"]; got != tc.framework {
+			t.Errorf("%s: framework=%q want %q", tc.endpointName, got, tc.framework)
+		}
+		if got := e.Properties["attribution"]; got != "handler_resolved" {
+			t.Errorf("%s: attribution=%q want %q — re-attribution pass did not run",
+				tc.endpointName, got, "handler_resolved")
+		}
+		// registration_file property must preserve the original router file
+		// so the mount-point is still discoverable.
+		if got := e.Properties["registration_file"]; got == "" {
+			t.Errorf("%s: registration_file is empty — original registration site lost",
+				tc.endpointName)
+		}
+		if e.StartLine <= 0 {
+			t.Errorf("%s: start_line=%d, expected a positive handler-body line",
+				tc.endpointName, e.StartLine)
+		}
+	}
+}
+
+func mapKeys(m map[string]int) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/archigraph/testdata/audit2678_go/gin_echo/echo_router.go
+++ b/cmd/archigraph/testdata/audit2678_go/gin_echo/echo_router.go
@@ -1,0 +1,13 @@
+// Echo router — same shape as the Gin router but using labstack/echo.
+package ginecho
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+func setupEcho() *echo.Echo {
+	e := echo.New()
+	e.GET("/items", listItems)
+	e.POST("/items", createItem)
+	return e
+}

--- a/cmd/archigraph/testdata/audit2678_go/gin_echo/handlers_echo.go
+++ b/cmd/archigraph/testdata/audit2678_go/gin_echo/handlers_echo.go
@@ -1,0 +1,16 @@
+// Handler definitions for the Echo router.
+package ginecho
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+// listItems handles GET /items.
+func listItems(c echo.Context) error {
+	return c.JSON(200, map[string]any{"items": []string{"a", "b"}})
+}
+
+// createItem handles POST /items.
+func createItem(c echo.Context) error {
+	return c.JSON(201, map[string]any{"id": 42})
+}

--- a/cmd/archigraph/testdata/audit2678_go/gin_echo/handlers_gin.go
+++ b/cmd/archigraph/testdata/audit2678_go/gin_echo/handlers_gin.go
@@ -1,0 +1,17 @@
+// Handler definitions for the Gin router. These are the lines that should
+// own the http_endpoint synthetic entities after #2678 fix.
+package ginecho
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// listUsers handles GET /users.
+func listUsers(c *gin.Context) {
+	c.JSON(200, gin.H{"users": []string{"alice", "bob"}})
+}
+
+// createUser handles POST /users.
+func createUser(c *gin.Context) {
+	c.JSON(201, gin.H{"id": 1})
+}

--- a/cmd/archigraph/testdata/audit2678_go/gin_echo/router.go
+++ b/cmd/archigraph/testdata/audit2678_go/gin_echo/router.go
@@ -1,0 +1,16 @@
+// Router file — registers Gin routes pointing at handlers defined in
+// handlers_gin.go. The bug we're fixing (#2678) is that http_endpoint
+// synthetic entities were attributing their source_file/start_line to
+// THIS file (the registration site) instead of the handler-def file.
+package ginecho
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func setupGin() *gin.Engine {
+	r := gin.Default()
+	r.GET("/users", listUsers)
+	r.POST("/users", createUser)
+	return r
+}

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -51,6 +51,7 @@
 package engine
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/types"


### PR DESCRIPTION
## Summary
- Re-stamps http_endpoint_definition entity SourceFile/StartLine to the resolved handler instead of the router-registration site.
- Preserves the original registration site as `registration_file` / `registration_line` properties so the mount point is still discoverable.
- Gated to gin/echo/chi via a Go-framework allow-list; other languages land equivalent fixes via their own per-framework audits (Python DRF #2677, JS/TS, JVM).

## Per-framework verdict (Go audit, #2678)

| Framework   | Before    | After     |
|-------------|-----------|-----------|
| gin         | BUGGY     | FIXED     |
| echo        | BUGGY     | FIXED     |
| chi         | NOT IMPLEMENTED (synthesis missing for Title-case verbs) — separate follow-up |
| fiber       | NOT IMPLEMENTED — separate follow-up |
| gorilla/mux | NOT IMPLEMENTED — separate follow-up |
| net/http    | NOT IMPLEMENTED — separate follow-up |
| huma        | NOT IMPLEMENTED — separate follow-up |

The systemic synthesizer in `response_shape_go.go` only matches upper-case verbs (`GET|POST|PUT|...`), so only gin + echo currently produce http_endpoint_definition entities. The Title-case frameworks (chi, fiber) and runtime-routed frameworks (gorilla/mux, net/http, huma) are not yet synthesized at all — those will need their own synthesizer work which is out of scope for this attribution fix.

## Before / after attribution

Sample endpoint: `GET /users` (Gin).

Before:
```
http:GET:/users  source_file=testdata/audit2678_go/gin_echo/router.go  start_line=12
```
After:
```
http:GET:/users  source_file=testdata/audit2678_go/gin_echo/handlers_gin.go  start_line=10
                 properties.attribution        = handler_resolved
                 properties.registration_file  = testdata/audit2678_go/gin_echo/router.go
                 properties.registration_line  = 12
```

## Test plan
- [x] `go test ./internal/engine -count=1` (84s, all passing)
- [x] `go test ./cmd/archigraph -count=1 -short` (107s, all passing)
- [x] New integration test `TestAudit2678Go_GinEchoAttribution` asserts all 4 fixture endpoints attribute to their handler file and carry `attribution=handler_resolved`.

Refs #2678.

🤖 Generated with [Claude Code](https://claude.com/claude-code)