### PR TITLE
fix(flask,fastapi): endpoint attribution → handler def line (#2678 audit)

### DIFF
--- a/cmd/archigraph/issue2678_audit_python_test.go
+++ b/cmd/archigraph/issue2678_audit_python_test.go
@@ -1,0 +1,100 @@
+// Issue #2678 — production-pipeline guard for Python web-framework
+// endpoint attribution.
+//
+// PR #2677 confirmed that DRF/Django endpoints were misattributed to the
+// routing/registration file instead of the handler method file. #2678 is
+// the systemic audit: every web-framework extractor that emits HTTP
+// endpoint entities must stamp source_file at the handler def and
+// source_line at the `def <handler>` line — never the decorator line and
+// never the default 0.
+//
+// This file is the Python side of that audit. It runs the full production
+// Indexer.Run on small fixtures and asserts the attribution invariants
+// for the two implemented decorator-based frameworks (Flask + FastAPI).
+// Tornado, Pyramid and Starlette have no endpoint extractor today and
+// are intentionally out of scope here — recorded as NOT IMPLEMENTED in
+// the audit report.
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// endpointDef looks up the http_endpoint_definition entity with the given
+// synthetic ID (`http:<METHOD>:<path>`) in the indexed graph. The Indexer
+// emits exactly one definition per (verb, path) per side; this helper
+// returns the first match or fails the test.
+func endpointDef(t *testing.T, entities []graph.Entity, id string) graph.Entity {
+	t.Helper()
+	for _, e := range entities {
+		if e.Kind != "http_endpoint_definition" {
+			continue
+		}
+		if e.ID == id || e.Name == id {
+			return e
+		}
+	}
+	t.Fatalf("issue #2678: no http_endpoint_definition with ID %q in the graph (entities=%d)", id, len(entities))
+	return graph.Entity{}
+}
+
+// assertEndpointAttributedTo asserts that the endpoint's source_file ends
+// with handlerSuffix (so the test is path-portable) and that source_line
+// equals wantLine — the line of the handler `def`, not the decorator.
+func assertEndpointAttributedTo(t *testing.T, e graph.Entity, handlerSuffix string, wantLine int) {
+	t.Helper()
+	if !strings.HasSuffix(e.SourceFile, handlerSuffix) {
+		t.Errorf("issue #2678: endpoint %s source_file = %q, want suffix %q (attribution should point at the handler file)", e.ID, e.SourceFile, handlerSuffix)
+	}
+	if e.StartLine != wantLine {
+		t.Errorf("issue #2678: endpoint %s source_line = %d, want %d (the `def <handler>` line, not the decorator line and not 0)", e.ID, e.StartLine, wantLine)
+	}
+}
+
+// TestPythonEndpointAttribution_Flask runs the production index pipeline
+// against the Flask fixture and asserts every endpoint is attributed to
+// app.py at the `def <handler>` line. Guards #2678 for Flask.
+func TestPythonEndpointAttribution_Flask(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/audit2678_python/flask_app", "audit2678_flask", nil)
+
+	// `def health` is on L16, `def get_user` on L21, `def create_user` on L26.
+	// Keep these in sync with cmd/archigraph/testdata/audit2678_python/flask_app/app.py.
+	cases := []struct {
+		id       string
+		wantLine int
+	}{
+		{"http:GET:/health", 16},
+		{"http:GET:/users/{user_id}", 21},
+		{"http:POST:/users", 26},
+	}
+	for _, tc := range cases {
+		e := endpointDef(t, doc.Entities, tc.id)
+		assertEndpointAttributedTo(t, e, "app.py", tc.wantLine)
+	}
+}
+
+// TestPythonEndpointAttribution_FastAPI runs the production index pipeline
+// against the FastAPI fixture and asserts every endpoint is attributed to
+// main.py at the `def <handler>` line — including the `async def` handler,
+// which previously also had source_line=0. Guards #2678 for FastAPI.
+func TestPythonEndpointAttribution_FastAPI(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/audit2678_python/fastapi_app", "audit2678_fastapi", nil)
+
+	// `def health` is on L16, `async def create_item` on L21, `def
+	// delete_user` on L26. Keep these in sync with the fixture file.
+	cases := []struct {
+		id       string
+		wantLine int
+	}{
+		{"http:GET:/health", 16},
+		{"http:POST:/items", 21},
+		{"http:DELETE:/users/{user_id}", 26},
+	}
+	for _, tc := range cases {
+		e := endpointDef(t, doc.Entities, tc.id)
+		assertEndpointAttributedTo(t, e, "main.py", tc.wantLine)
+	}
+}

--- a/cmd/archigraph/testdata/audit2678_python/fastapi_app/main.py
+++ b/cmd/archigraph/testdata/audit2678_python/fastapi_app/main.py
@@ -1,0 +1,27 @@
+"""FastAPI attribution fixture for issue #2678.
+
+Endpoints are declared via @app.<verb> / @router.<verb>; the handler def
+line recorded on each http_endpoint_definition must point at the `def`
+line, not the decorator line. Line numbers are stable — keep the
+integration test's expected lines in sync with the layout below.
+"""
+
+from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter(prefix="/v1")
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@router.post("/items")
+async def create_item():
+    return {}
+
+
+@app.delete("/users/{user_id}")
+def delete_user(user_id: int):
+    return None

--- a/cmd/archigraph/testdata/audit2678_python/flask_app/app.py
+++ b/cmd/archigraph/testdata/audit2678_python/flask_app/app.py
@@ -1,0 +1,27 @@
+"""Flask attribution fixture for issue #2678.
+
+Endpoints declared via @app.route / @bp.<verb>; the handler def line
+recorded on each http_endpoint_definition must point at the `def` line,
+not the decorator line. Line numbers below are stable — adjust the
+integration test's expected lines if this file changes.
+"""
+
+from flask import Flask, Blueprint
+
+app = Flask(__name__)
+bp = Blueprint("api", __name__)
+
+
+@app.route("/health")
+def health():
+    return "ok"
+
+
+@bp.get("/users/<int:user_id>")
+def get_user(user_id):
+    return {}
+
+
+@bp.post("/users")
+def create_user():
+    return {}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -227,6 +227,20 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 	emit := makeEmit("http_endpoint_synthesis", "source_handler")
 	emitClient := makeEmit("http_endpoint_client_synthesis", "source_caller")
 
+	// emitDef wraps emit and stamps StartLine on the just-appended entity.
+	// Used by decorator-based python frameworks (Flask, FastAPI) where the
+	// handler def lives in the same file as the decorator: source_file is
+	// already correct, but source_line was previously left at 0. Issue
+	// #2678 requires the line to point at the `def <handler>` line, not
+	// the decorator line and not the default 0.
+	emitDef := func(method, canonicalPath, framework, refKind, refName string, defLine int) {
+		before := len(entities)
+		emit(method, canonicalPath, framework, refKind, refName)
+		if defLine > 0 && len(entities) > before {
+			entities[len(entities)-1].StartLine = defLine
+		}
+	}
+
 	// makeRuntimeEmit wraps the consumer-side emit with a FETCHES edge
 	// emission (#721). The edge's FromID is a kind-qualified reference
 	// (`<kind>:<name>`) that the downstream resolver binds to a stamped
@@ -306,8 +320,8 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// emitting a synthetic with `source_handler=Route:<path>`
 		// (Spring-style placeholder), which the resolver dropped and
 		// the response-shape extractor could not parse. #753.
-		synthesizeFlask(string(content), emit)
-		synthesizeFastAPI(string(content), emit)
+		synthesizeFlask(string(content), emitDef)
+		synthesizeFastAPI(string(content), emitDef)
 		// Producer side: Django composed Routes (from django_routes.go).
 		// Method is unknown statically, so emit with verb=ANY.
 		synthesizeDjangoFromComposed(entities, path, emit)
@@ -588,39 +602,43 @@ var flaskRouteRe = regexp.MustCompile(`@\w+\.route\s*\(\s*["']([^"'\n\r]+)["']([
 // accepted because both are idiomatic in the wild.
 var flaskMethodsArgRe = regexp.MustCompile(`methods\s*=\s*[\[\(]([^\]\)]+)[\]\)]`)
 
-func synthesizeFlask(content string, emit emitFn) {
+func synthesizeFlask(content string, emit emitDefFn) {
 	if !strings.Contains(content, ".route(") && !strings.Contains(content, ".get(") &&
 		!strings.Contains(content, ".post(") && !strings.Contains(content, ".put(") &&
 		!strings.Contains(content, ".patch(") && !strings.Contains(content, ".delete(") {
 		return
 	}
-	// Shorthand verbs first — they have an unambiguous verb.
-	for _, m := range flaskRouteVerbDecoratorRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 4 {
+	// Shorthand verbs first — they have an unambiguous verb. Use the
+	// SubmatchIndex variant so we can derive the 1-based line of the
+	// handler `def` (capture group 3) for issue #2678 attribution.
+	for _, idx := range flaskRouteVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 8 {
 			continue
 		}
-		verb := strings.ToUpper(m[1])
-		raw := m[2]
-		handler := m[3]
+		verb := strings.ToUpper(content[idx[2]:idx[3]])
+		raw := content[idx[4]:idx[5]]
+		handler := content[idx[6]:idx[7]]
 		canonical := httproutes.Canonicalize(httproutes.FrameworkFlask, raw)
-		emit(verb, canonical, "flask", "Controller", handler)
+		defLine := lineOfOffset(content, idx[6])
+		emit(verb, canonical, "flask", "Controller", handler, defLine)
 	}
 	// Generic .route(...) form.
-	for _, m := range flaskRouteRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 4 {
+	for _, idx := range flaskRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 8 {
 			continue
 		}
-		raw := m[1]
-		extras := m[2]
-		handler := m[3]
+		raw := content[idx[2]:idx[3]]
+		extras := content[idx[4]:idx[5]]
+		handler := content[idx[6]:idx[7]]
 		canonical := httproutes.Canonicalize(httproutes.FrameworkFlask, raw)
+		defLine := lineOfOffset(content, idx[6])
 		methods := parseFlaskMethods(extras)
 		if len(methods) == 0 {
 			// Flask's default: no `methods` kwarg means GET only.
 			methods = []string{"GET"}
 		}
 		for _, verb := range methods {
-			emit(verb, canonical, "flask", "Controller", handler)
+			emit(verb, canonical, "flask", "Controller", handler, defLine)
 		}
 	}
 }
@@ -656,20 +674,23 @@ func parseFlaskMethods(args string) []string {
 // @Depends) are allowed.
 var fastapiVerbDecoratorRe = regexp.MustCompile(`@(?:app|router|api|\w+_router)\.(get|post|put|patch|delete|head|options|trace)\s*\(\s*["']([^"'\n\r]+)["'][^)]*\)\s*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`)
 
-func synthesizeFastAPI(content string, emit emitFn) {
+func synthesizeFastAPI(content string, emit emitDefFn) {
 	if !strings.Contains(content, "FastAPI") && !strings.Contains(content, "APIRouter") &&
 		!strings.Contains(content, "@app.") && !strings.Contains(content, "@router.") {
 		return
 	}
-	for _, m := range fastapiVerbDecoratorRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 4 {
+	// SubmatchIndex variant so the 1-based line of the handler `def`
+	// (capture group 3) can be recovered for issue #2678 attribution.
+	for _, idx := range fastapiVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 8 {
 			continue
 		}
-		verb := strings.ToUpper(m[1])
-		raw := m[2]
-		handler := m[3]
+		verb := strings.ToUpper(content[idx[2]:idx[3]])
+		raw := content[idx[4]:idx[5]]
+		handler := content[idx[6]:idx[7]]
 		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, raw)
-		emit(verb, canonical, "fastapi", "Controller", handler)
+		defLine := lineOfOffset(content, idx[6])
+		emit(verb, canonical, "fastapi", "Controller", handler, defLine)
 	}
 }
 
@@ -1039,6 +1060,26 @@ func synthesizeGraphQLResolvers(content string, emit emitFn) {
 // emitFn is the closure signature used by each per-framework synthesiser.
 // (method, canonicalPath, framework, handlerKind, handlerName)
 type emitFn func(method, canonicalPath, framework, handlerKind, handlerName string)
+
+// emitDefFn extends emitFn with a `defLine` argument carrying the 1-based
+// line of the handler's `def` statement. Used by per-framework synthesisers
+// (Flask, FastAPI) where the handler def lives in the same file as the
+// routing decorator and the line is recoverable from the match offset.
+// A defLine of 0 means "unknown" and leaves StartLine untouched.
+type emitDefFn func(method, canonicalPath, framework, handlerKind, handlerName string, defLine int)
+
+// lineOfOffset returns the 1-based line number containing byte offset `off`
+// in `content`. Newlines are counted up to (but not including) the offset,
+// so the very first line is line 1.
+func lineOfOffset(content string, off int) int {
+	if off < 0 {
+		return 0
+	}
+	if off > len(content) {
+		off = len(content)
+	}
+	return 1 + strings.Count(content[:off], "\n")
+}
 
 // joinPathFragments concatenates a class-level prefix with a method-level
 // path, mirroring the slash convention used by joinRoutePaths in


### PR DESCRIPTION
## Summary
- Python web-framework endpoint-attribution audit from #2678 (extension of #2677).
- Flask + FastAPI synthesised `http_endpoint_definition` entities now stamp `source_line` at the handler `def` (capture-group offset → 1-based line); previously left at the default `0`. `source_file` was already correct for these in-file-decorator frameworks.
- Tornado, Pyramid, Starlette have no endpoint extractor today (only detection rules) — recorded as **NOT IMPLEMENTED**, intentionally out of scope per the audit charter.

## Per-framework verdict
| Framework | Verdict | Notes |
|---|---|---|
| Flask (`@app.route`, `@bp.<verb>`) | **BUGGY → fixed** | `source_line=0` → def line |
| FastAPI (`@app.<verb>`, `@router.<verb>`, incl. `async def`) | **BUGGY → fixed** | `source_line=0` → def line |
| FastAPI `app.include_router(...)` | CLEAN | Synthesiser emits from the router's own file; attribution already lands on the handler file |
| Starlette (`Route(...)`, `Mount`) | NOT IMPLEMENTED | Only framework-detection YAML; no endpoint extractor |
| Tornado (`RequestHandler` + `Application(handlers=[...])`) | NOT IMPLEMENTED | Only framework-detection YAML; no endpoint extractor |
| Pyramid (`config.add_route` + `view_config`) | NOT IMPLEMENTED | Only framework-detection YAML; no endpoint extractor |

## Cross-cutting finding
The synthesis pass (`internal/engine/http_endpoint_synthesis.go`) shared the same `emitFn` across every per-framework synthesiser. None of them stamped `StartLine`. The fix is local (a thin `emitDefFn` wrapper + `lineOfOffset` helper) so future producer-side synthesisers can opt in by accepting `emitDefFn` without disturbing the existing call sites for Java/Spring, Django, Express, NestJS, Go routers, Axum, Laravel, etc.

## Test plan
- [x] `go test ./internal/engine/ -run 'TestSynth_Flask|TestSynth_FastAPI'` — existing regex-based unit tests still pass.
- [x] `go test ./cmd/archigraph/ -run 'TestPythonEndpointAttribution_'` — new production-pipeline integration tests assert def-line attribution for Flask + FastAPI (including `async def`).
- [x] `go test ./internal/engine/` — full engine suite green.
- [x] `go build ./...` clean.

Refs #2678, #2677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)