### PR TITLE
feat(install): write archigraph rules block to .windsurfrules, .cursorrules, copilot-instructions (#2683)

### DIFF
--- a/cmd/archigraph/issue2683_rules_files_test.go
+++ b/cmd/archigraph/issue2683_rules_files_test.go
@@ -1,0 +1,255 @@
+package main
+
+// End-to-end tests for issue #2683: `archigraph install` writes the
+// canonical archigraph rules block to every IDE-rules file convention
+// (AGENTS.md, CLAUDE.md, .windsurfrules, .cursorrules,
+// .codeium/instructions.md, .github/copilot-instructions.md) in each
+// registered repo, and `archigraph doctor` reports the per-repo state.
+//
+// These tests do NOT spawn the daemon or call launchctl — they drive
+// install.Apply directly with a synthesized two-repo group config and
+// stub out the OS-service / watcher / hook / MCP machinery.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/install"
+	"github.com/cajasmota/archigraph/internal/install/rulesfiles"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// twoRepoGroup builds a GroupConfig with two empty repo directories on
+// disk; returns the absolute paths so individual tests can seed extra
+// files into them before invoking install.Apply.
+func twoRepoGroup(t *testing.T) (root string, repos []string, cfg *registry.GroupConfig) {
+	t.Helper()
+	root = t.TempDir()
+	for i, slug := range []string{"alpha", "beta"} {
+		p := filepath.Join(root, slug)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir repo %d: %v", i, err)
+		}
+		repos = append(repos, p)
+	}
+	cfg = &registry.GroupConfig{
+		Name: "issue2683",
+		Repos: []registry.Repo{
+			{Slug: "alpha", Path: repos[0]},
+			{Slug: "beta", Path: repos[1]},
+		},
+	}
+	return
+}
+
+// applyWithStubs invokes install.Apply with everything stubbed out
+// except rules-file writing.
+func applyWithStubs(t *testing.T, group string, cfg *registry.GroupConfig) *install.Result {
+	t.Helper()
+	// Redirect archigraph state to a private tmp dir so we never touch
+	// the developer's real ~/.archigraph during tests.
+	state := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", state)
+	t.Setenv("HOME", state)
+
+	res, err := install.Apply(install.Options{
+		Group:        group,
+		Config:       cfg,
+		BinPath:      "/usr/local/bin/archigraph", // fake; never executed
+		SkipHooks:    true,
+		SkipWatchers: true,
+		SkipMCP:      true,
+	})
+	if err != nil {
+		t.Fatalf("install.Apply: %v", err)
+	}
+	return res
+}
+
+// TestIssue2683_FreshInstall_WritesAllSixFiles confirms a brand-new
+// repo gets every Target populated with the canonical block.
+func TestIssue2683_FreshInstall_WritesAllSixFiles(t *testing.T) {
+	_, repos, cfg := twoRepoGroup(t)
+	applyWithStubs(t, cfg.Name, cfg)
+
+	for _, repo := range repos {
+		for _, target := range rulesfiles.Targets {
+			path := filepath.Join(repo, target)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Errorf("%s missing: %v", path, err)
+				continue
+			}
+			if !strings.Contains(string(data), rulesfiles.StartMarker) {
+				t.Errorf("%s: start marker missing", path)
+			}
+			if !strings.Contains(string(data), "archigraph MCP") {
+				t.Errorf("%s: payload missing", path)
+			}
+		}
+	}
+}
+
+// TestIssue2683_ReInstall_Idempotent confirms running install twice
+// does NOT duplicate the block in any rules file.
+func TestIssue2683_ReInstall_Idempotent(t *testing.T) {
+	_, repos, cfg := twoRepoGroup(t)
+	applyWithStubs(t, cfg.Name, cfg)
+	applyWithStubs(t, cfg.Name, cfg)
+
+	for _, repo := range repos {
+		for _, target := range rulesfiles.Targets {
+			data, err := os.ReadFile(filepath.Join(repo, target))
+			if err != nil {
+				t.Fatalf("read %s: %v", target, err)
+			}
+			count := strings.Count(string(data), rulesfiles.StartMarker)
+			if count != 1 {
+				t.Errorf("%s/%s: expected exactly 1 block, got %d", filepath.Base(repo), target, count)
+			}
+		}
+	}
+}
+
+// TestIssue2683_StaleGraphifyOverwritten confirms a pure-stale graphify
+// file is overwritten with the canonical block.
+func TestIssue2683_StaleGraphifyOverwritten(t *testing.T) {
+	_, repos, cfg := twoRepoGroup(t)
+
+	stale := "# Graphify\n\n- Run `graphify update` for fresh data\n- See graphify-out/GRAPH_REPORT.md\n"
+	if err := os.WriteFile(filepath.Join(repos[0], ".windsurfrules"), []byte(stale), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res := applyWithStubs(t, cfg.Name, cfg)
+	replaced := res.RulesFilesStaleReplaced[repos[0]]
+	if len(replaced) == 0 {
+		t.Fatalf("expected ReplacedStale for repo %s, got: %+v", repos[0], res.RulesFilesStaleReplaced)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(repos[0], ".windsurfrules"))
+	if strings.Contains(string(data), "graphify") {
+		t.Errorf("graphify content not removed: %s", data)
+	}
+}
+
+// TestIssue2683_MixedStaleSkippedWithWarning confirms a mixed-content
+// file is left alone and surfaced via RulesFilesStaleSkipped.
+func TestIssue2683_MixedStaleSkippedWithWarning(t *testing.T) {
+	_, repos, cfg := twoRepoGroup(t)
+
+	mixed := "# Engineering Notes\n\n" +
+		"This repo owns the billing service and exposes /v2/invoices.\n" +
+		"Owners: @platform-team (see CODEOWNERS at the repo root).\n" +
+		"Historical: graphify was used here before we migrated.\n" +
+		"Refer to docs/architecture.md for the system design overview.\n" +
+		"Refer to docs/runbooks for operational procedures and SLOs.\n" +
+		"Incidents are tracked in PagerDuty using the billing rota.\n" +
+		"Deployment uses ArgoCD with manual sync on main.\n"
+	if err := os.WriteFile(filepath.Join(repos[0], ".cursorrules"), []byte(mixed), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res := applyWithStubs(t, cfg.Name, cfg)
+	skipped := res.RulesFilesStaleSkipped[repos[0]]
+	if len(skipped) == 0 {
+		t.Fatalf("expected SkippedMixedStale for repo %s, got: %+v", repos[0], res.RulesFilesStaleSkipped)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(repos[0], ".cursorrules"))
+	if !strings.Contains(string(data), "billing service") {
+		t.Errorf("user content lost: %s", data)
+	}
+	if strings.Contains(string(data), rulesfiles.StartMarker) {
+		t.Errorf("block was written to mixed-stale file; should have been skipped")
+	}
+}
+
+// TestIssue2683_DoctorReportsAllStatuses confirms `archigraph doctor`
+// reports OK / MISSING / STALE / OUTDATED across the rules files of a
+// registered group.
+func TestIssue2683_DoctorReportsAllStatuses(t *testing.T) {
+	root, repos, cfg := twoRepoGroup(t)
+	_ = root
+
+	// Register the group via install.Apply (which also writes initial
+	// rules files into both repos as OK).
+	applyWithStubs(t, cfg.Name, cfg)
+
+	// Mutate repo[0] so we get one of every status:
+	//   AGENTS.md            → OK (untouched)
+	//   CLAUDE.md            → OUTDATED (rewrite with v=0 marker)
+	//   .windsurfrules       → STALE (replace with graphify content)
+	//   .cursorrules         → MISSING (delete)
+	if err := os.WriteFile(
+		filepath.Join(repos[0], "CLAUDE.md"),
+		[]byte("<!-- archigraph:mcp-usage:start v=0 -->\nold\n<!-- archigraph:mcp-usage:end -->\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("seed CLAUDE.md: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(repos[0], ".windsurfrules"),
+		[]byte("# Graphify\n\nUse `graphify update`\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("seed .windsurfrules: %v", err)
+	}
+	if err := os.Remove(filepath.Join(repos[0], ".cursorrules")); err != nil {
+		t.Fatalf("remove .cursorrules: %v", err)
+	}
+
+	// Doctor refuses to run without an install.json — seed a minimal
+	// one so it proceeds past the gate. We only care about the
+	// rules-files surface here; other surfaces will report drift but
+	// that does not affect this test.
+	stateDir := filepath.Join(os.Getenv("HOME"), ".archigraph")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	statePath := filepath.Join(stateDir, "install.json")
+	if err := install.WriteState(statePath, install.NewState(install.ModeCopy)); err != nil {
+		t.Fatalf("seed install.json: %v", err)
+	}
+
+	// Run doctor. It will fail several non-rules-files checks (no
+	// daemon, no CLI sha, etc.) but the rules-files surface is what we
+	// assert on.
+	report, err := install.RunDoctor(install.DoctorOptions{StatePath: statePath})
+	if err != nil {
+		t.Fatalf("RunDoctor: %v", err)
+	}
+
+	// Find the rules-files check for repo[0].
+	target := "rules-files/" + cfg.Name + "/" + filepath.Base(repos[0])
+	var found bool
+	for _, c := range report.Checks {
+		if c.Surface != target {
+			continue
+		}
+		found = true
+		joined := strings.Join(c.Drift, "\n")
+		if !strings.Contains(joined, "CLAUDE.md [OUTDATED]") {
+			t.Errorf("CLAUDE.md OUTDATED not reported: %s", joined)
+		}
+		if !strings.Contains(joined, ".windsurfrules [STALE]") {
+			t.Errorf(".windsurfrules STALE not reported: %s", joined)
+		}
+		if !strings.Contains(joined, ".cursorrules [MISSING]") {
+			t.Errorf(".cursorrules MISSING not reported: %s", joined)
+		}
+		// AGENTS.md should NOT appear (it's OK).
+		if strings.Contains(joined, "AGENTS.md") {
+			t.Errorf("AGENTS.md should not be in drift list (it was OK): %s", joined)
+		}
+	}
+	if !found {
+		var surfaces []string
+		for _, c := range report.Checks {
+			surfaces = append(surfaces, c.Surface)
+		}
+		t.Fatalf("rules-files check for %s not found; saw: %v", target, surfaces)
+	}
+}

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -33,7 +33,9 @@ import (
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/install/mcpreg"
+	"github.com/cajasmota/archigraph/internal/install/rulesfiles"
 	"github.com/cajasmota/archigraph/internal/install/skilllink"
+	"github.com/cajasmota/archigraph/internal/registry"
 )
 
 // DoctorSchemaVersion is the JSON schema version for DoctorReport.
@@ -194,6 +196,11 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 	// ── Check 5: .gitignore in tracked repos ────────────────────────────────
 	for _, repo := range state.Gitignore.Repos {
 		report.Checks = append(report.Checks, checkGitignore(repo))
+	}
+
+	// ── Check 6: Per-repo IDE rules files (issue #2683) ─────────────────────
+	for _, c := range checkRulesFiles() {
+		report.Checks = append(report.Checks, c)
 	}
 
 	// ── Check 7: Stale staging dirs ─────────────────────────────────────────
@@ -559,6 +566,77 @@ func checkGitignore(repoRoot string) CheckResult {
 	if !hasGitignoreEntry(data, archigraphGitignoreEntry) {
 		cr.OK = false
 		cr.Drift = []string{fmt.Sprintf("/.archigraph/ missing from %s", gitignorePath)}
+	}
+	return cr
+}
+
+// checkRulesFiles scans every registered repo (across every archigraph
+// group) for the per-IDE rules files defined in the rulesfiles package
+// (AGENTS.md, CLAUDE.md, .windsurfrules, .cursorrules,
+// .codeium/instructions.md, .github/copilot-instructions.md).
+//
+// Per repo, one CheckResult is emitted. The check is OK when every
+// target file contains the current archigraph block; otherwise it lists
+// each non-OK file by status (MISSING/STALE/OUTDATED). Severity is
+// Warning — a missing rules block doesn't break archigraph, but it does
+// mean the corresponding IDE agent won't reach for the MCP first.
+//
+// Failures of the registry read are returned as a single Info-severity
+// check so a fresh machine (no groups yet) doesn't appear "broken".
+func checkRulesFiles() []CheckResult {
+	groups, err := registry.Groups()
+	if err != nil {
+		return []CheckResult{{
+			Surface:  "rules-files",
+			OK:       false,
+			Severity: SeverityInfo,
+			Drift:    []string{fmt.Sprintf("cannot read registry: %v", err)},
+		}}
+	}
+	if len(groups) == 0 {
+		// No groups registered — nothing to scan. Don't emit a check.
+		return nil
+	}
+
+	var results []CheckResult
+	for _, g := range groups {
+		cfg, lerr := registry.LoadGroupConfig(g.ConfigPath)
+		if lerr != nil || cfg == nil {
+			results = append(results, CheckResult{
+				Surface:  "rules-files/" + g.Name,
+				OK:       false,
+				Severity: SeverityWarning,
+				Drift:    []string{fmt.Sprintf("cannot load group config %s: %v", g.ConfigPath, lerr)},
+			})
+			continue
+		}
+		for _, repo := range cfg.Repos {
+			results = append(results, scanRulesFilesForRepo(g.Name, repo.Path))
+		}
+	}
+	return results
+}
+
+// scanRulesFilesForRepo runs rulesfiles.Scan on a single repo and
+// converts the result into a CheckResult.
+func scanRulesFilesForRepo(group, repoPath string) CheckResult {
+	cr := CheckResult{
+		Surface:  fmt.Sprintf("rules-files/%s/%s", group, filepath.Base(repoPath)),
+		OK:       true,
+		Severity: SeverityWarning,
+	}
+	statuses := rulesfiles.Scan(repoPath)
+	for _, st := range statuses {
+		if st.Status == rulesfiles.StatusOK {
+			continue
+		}
+		cr.OK = false
+		label := strings.ToUpper(string(st.Status))
+		if st.Detail != "" {
+			cr.Drift = append(cr.Drift, fmt.Sprintf("%s [%s] — %s", st.Target, label, st.Detail))
+		} else {
+			cr.Drift = append(cr.Drift, fmt.Sprintf("%s [%s]", st.Target, label))
+		}
 	}
 	return cr
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/install/hooks"
 	"github.com/cajasmota/archigraph/internal/install/mcpreg"
+	"github.com/cajasmota/archigraph/internal/install/rulesfiles"
 	"github.com/cajasmota/archigraph/internal/install/watchers"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
@@ -30,6 +31,10 @@ type Options struct {
 	SkipHooks    bool
 	SkipWatchers bool
 	SkipMCP      bool
+	// SkipRulesFiles skips writing per-repo IDE rules files
+	// (AGENTS.md, CLAUDE.md, .windsurfrules, .cursorrules,
+	// .codeium/instructions.md, .github/copilot-instructions.md).
+	SkipRulesFiles bool
 }
 
 // Result reports what an Apply call did so the CLI can print a summary.
@@ -39,6 +44,16 @@ type Result struct {
 	WatcherUnits    []string                 // unit-file paths
 	WatcherStatuses []watchers.WatcherStatus // per-unit activation state
 	MCPSettings     []string                 // settings.json paths touched
+	// RulesFiles maps repo path → relative rules-file paths written
+	// (e.g. ".windsurfrules"). Empty when SkipRulesFiles is true.
+	RulesFiles map[string][]string
+	// RulesFilesStaleSkipped maps repo path → rules-file paths left
+	// untouched because they contain mixed predecessor + unrelated
+	// content. The user is warned to migrate these manually.
+	RulesFilesStaleSkipped map[string][]string
+	// RulesFilesStaleReplaced maps repo path → rules-file paths that
+	// were entirely predecessor content and got overwritten.
+	RulesFilesStaleReplaced map[string][]string
 }
 
 // Apply registers the group, writes its config, then installs hooks +
@@ -98,6 +113,39 @@ func Apply(opts Options) (*Result, error) {
 				}
 			}
 			res.HooksInstalled = append(res.HooksInstalled, repo)
+		}
+		if !opts.SkipRulesFiles {
+			if !opts.DryRun {
+				wr, werr := rulesfiles.WriteAll(repo, rulesfiles.WriteOptions{
+					GroupName: opts.Group,
+				})
+				if werr != nil {
+					return nil, fmt.Errorf("rules files for %s: %w", repo, werr)
+				}
+				if wr != nil {
+					if res.RulesFiles == nil {
+						res.RulesFiles = map[string][]string{}
+					}
+					res.RulesFiles[repo] = wr.Written
+					if len(wr.SkippedMixedStale) > 0 {
+						if res.RulesFilesStaleSkipped == nil {
+							res.RulesFilesStaleSkipped = map[string][]string{}
+						}
+						res.RulesFilesStaleSkipped[repo] = wr.SkippedMixedStale
+					}
+					if len(wr.ReplacedStale) > 0 {
+						if res.RulesFilesStaleReplaced == nil {
+							res.RulesFilesStaleReplaced = map[string][]string{}
+						}
+						res.RulesFilesStaleReplaced[repo] = wr.ReplacedStale
+					}
+				}
+			} else {
+				if res.RulesFiles == nil {
+					res.RulesFiles = map[string][]string{}
+				}
+				res.RulesFiles[repo] = append([]string{}, rulesfiles.Targets...)
+			}
 		}
 		if !opts.SkipWatchers && opts.Config.Features.Watchers {
 			u := watchers.Unit{Group: opts.Group, Repo: repo, BinPath: opts.BinPath}

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -1,0 +1,468 @@
+// Package rulesfiles writes the canonical "how to use the archigraph MCP"
+// rules block into every per-repo IDE rules file convention.
+//
+// Different IDE coding agents read different per-repo files for their
+// project-level system prompt:
+//
+//   - Claude Code      → AGENTS.md, CLAUDE.md
+//   - Codex / OpenAI   → AGENTS.md
+//   - Windsurf Cascade → .windsurfrules
+//   - Cursor Composer  → .cursorrules
+//   - Codeium          → .codeium/instructions.md
+//   - GitHub Copilot   → .github/copilot-instructions.md
+//
+// `archigraph install` historically only wrote the rules block into
+// AGENTS.md, which meant Cascade and Cursor sessions did not learn that
+// the archigraph MCP exists (issue #2683). This package generalises that
+// writer so the same idempotent, marker-wrapped block is written to every
+// known convention.
+//
+// All writes are idempotent: the block is bounded by
+// <!-- archigraph:mcp-usage:start v=1 --> ... <!-- archigraph:mcp-usage:end -->
+// and an existing block is replaced in-place. Files that already contain
+// content unrelated to archigraph are preserved byte-for-byte outside the
+// markers.
+//
+// "Stale predecessor" handling: the older `graphify` tool wrote its own
+// guidance into the same rules files. When we encounter a file that
+// references graphify but has no archigraph block, we either overwrite
+// (if the file is entirely about graphify — heuristic: short + every
+// non-blank line references graphify or is markdown structure) or leave
+// it and emit a warning so the user can migrate manually.
+package rulesfiles
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// BlockVersion is the version embedded in the start marker. Bumping the
+// version causes doctor to flag any file whose block uses an older
+// version as OUTDATED so the next `archigraph install` rewrites it.
+const BlockVersion = 1
+
+// StartMarker / EndMarker bound the managed region inside every rules
+// file. Keep this stable across releases — bumping the marker syntax
+// breaks idempotent updates of files written by older binaries.
+var (
+	StartMarker = fmt.Sprintf("<!-- archigraph:mcp-usage:start v=%d -->", BlockVersion)
+	EndMarker   = "<!-- archigraph:mcp-usage:end -->"
+)
+
+// startMarkerAnyVersion matches an existing archigraph block regardless
+// of its embedded version number, so we can replace older blocks in
+// place. The end marker is unversioned and a literal string.
+var startMarkerAnyVersion = regexp.MustCompile(`<!-- archigraph:mcp-usage:start v=\d+ -->`)
+
+// blockRegexAnyVersion captures the entire marker-wrapped region (start
+// + content + end), with DOTALL so newlines inside the block are
+// consumed.
+var blockRegexAnyVersion = regexp.MustCompile(
+	`(?s)<!-- archigraph:mcp-usage:start v=\d+ -->.*?` +
+		regexp.QuoteMeta(EndMarker))
+
+// PredecessorTokens are the names of older tools whose guidance, if
+// found in a rules file, indicates a stale file that probably misleads
+// AI agents (e.g. it points them at `graphify update` or paths like
+// `graphify-out/GRAPH_REPORT.md`). The list is intentionally narrow —
+// adding generic words here risks false positives.
+var PredecessorTokens = []string{
+	"graphify",
+}
+
+// Targets is the canonical list of per-repo rules-file paths the
+// installer writes to, in deterministic order. Paths use forward
+// slashes; callers join them with the repo root via filepath.Join.
+//
+// The order is also the order in which doctor reports them, so the user
+// sees a consistent grouping per repo.
+var Targets = []string{
+	"AGENTS.md",
+	"CLAUDE.md",
+	".windsurfrules",
+	".cursorrules",
+	".codeium/instructions.md",
+	".github/copilot-instructions.md",
+}
+
+// Status is the per-file state reported by Scan / doctor.
+type Status string
+
+const (
+	// StatusOK means the file contains the current archigraph block.
+	StatusOK Status = "ok"
+	// StatusMissing means the file does not exist at all.
+	StatusMissing Status = "missing"
+	// StatusStale means the file references a predecessor tool but has
+	// no archigraph block — install would either overwrite (short, pure
+	// stale content) or warn (mixed content).
+	StatusStale Status = "stale"
+	// StatusOutdated means the file has an archigraph block but its
+	// version marker is older than BlockVersion.
+	StatusOutdated Status = "outdated"
+)
+
+// FileStatus reports the install state of a single rules file.
+type FileStatus struct {
+	// Path is the absolute path of the file (whether it exists or not).
+	Path string
+	// Target is the relative path under the repo root (e.g. ".windsurfrules").
+	Target string
+	// Status is the high-level state (OK/Missing/Stale/Outdated).
+	Status Status
+	// Detail is a one-line human-readable explanation when Status != OK.
+	Detail string
+}
+
+// WriteOptions tunes per-repo write behaviour.
+type WriteOptions struct {
+	// GroupName is the archigraph group this repo belongs to. Embedded
+	// in the rendered block when non-empty.
+	GroupName string
+	// Logger receives info/warning lines; defaults to os.Stderr.
+	Logger io.Writer
+}
+
+// WriteResult is the outcome of writing rules files into a single repo.
+type WriteResult struct {
+	// Written lists the rules files that were created or updated.
+	Written []string
+	// SkippedMixedStale lists files left untouched because they mix
+	// archigraph-unrelated content with predecessor references. The
+	// installer warns the user to migrate these manually.
+	SkippedMixedStale []string
+	// ReplacedStale lists files that were entirely predecessor content
+	// and got overwritten with the canonical archigraph block.
+	ReplacedStale []string
+}
+
+// WriteAll renders the canonical block and upserts it into every Target
+// under repoRoot. It is safe to call repeatedly; updates are idempotent
+// and predecessor handling is best-effort (failures are logged, never
+// fatal).
+//
+// Errors are returned only for genuine I/O problems (permission denied,
+// disk full); per-file decisions (skip-mixed-stale, replace-stale) are
+// reported via the returned WriteResult.
+func WriteAll(repoRoot string, opts WriteOptions) (*WriteResult, error) {
+	if opts.Logger == nil {
+		opts.Logger = os.Stderr
+	}
+	block := RenderBlock(opts.GroupName)
+
+	res := &WriteResult{}
+	for _, target := range Targets {
+		abs := filepath.Join(repoRoot, target)
+		action, err := upsert(abs, block)
+		if err != nil {
+			return res, fmt.Errorf("rulesfiles: %s: %w", target, err)
+		}
+		switch action {
+		case actionWroteFresh, actionReplacedBlock, actionAppended:
+			res.Written = append(res.Written, target)
+		case actionReplacedStale:
+			res.Written = append(res.Written, target)
+			res.ReplacedStale = append(res.ReplacedStale, target)
+			fmt.Fprintf(opts.Logger,
+				"archigraph install: replaced stale graphify content in %s\n", abs)
+		case actionSkippedMixedStale:
+			res.SkippedMixedStale = append(res.SkippedMixedStale, target)
+			fmt.Fprintf(opts.Logger,
+				"archigraph install: file %s contains stale graphify content; please migrate manually or remove\n", abs)
+		}
+	}
+	return res, nil
+}
+
+// Scan returns the FileStatus for every Target under repoRoot without
+// writing anything. Used by `archigraph doctor`.
+func Scan(repoRoot string) []FileStatus {
+	out := make([]FileStatus, 0, len(Targets))
+	for _, target := range Targets {
+		abs := filepath.Join(repoRoot, target)
+		st := classify(abs)
+		st.Target = target
+		out = append(out, st)
+	}
+	return out
+}
+
+// RenderBlock returns the canonical marker-wrapped guidance block for
+// the given group. The block is the same across all rules files — IDEs
+// have different conventions for *which* file to read, but the content
+// inside the markers is identical, so an agent that sees the block in
+// any one file gets the full guidance.
+func RenderBlock(groupName string) string {
+	var b strings.Builder
+	if groupName == "" {
+		groupName = "<group-name>"
+	}
+
+	fmt.Fprintln(&b, StartMarker)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "## archigraph MCP")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "This repo is part of archigraph group **%s**. archigraph is an "+
+		"architecture knowledge graph available via MCP. When you (an AI coding "+
+		"agent) need to understand how this codebase fits together, prefer the "+
+		"archigraph MCP tools over `grep` + reading files.\n", groupName)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "### When to use archigraph instead of grep")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| Question shape | Prefer |")
+	fmt.Fprintln(&b, "|---|---|")
+	fmt.Fprintln(&b, "| \"Where is `X` defined?\" | `archigraph_find` |")
+	fmt.Fprintln(&b, "| \"What does `X` look like + its neighbors?\" | `archigraph_inspect` |")
+	fmt.Fprintln(&b, "| \"Who calls `X`?\" | `archigraph_expand` / `archigraph_find_callers` |")
+	fmt.Fprintln(&b, "| \"End-to-end flow when user does X?\" | `archigraph_traces` |")
+	fmt.Fprintln(&b, "| \"How does the frontend talk to the backend?\" | `archigraph_cross_links` |")
+	fmt.Fprintln(&b, "| \"Show me the source of `X`\" | `archigraph_get_source` |")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "### When grep IS still better")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "- Substring search across all files for non-entity strings (comments, TODOs).")
+	fmt.Fprintln(&b, "- Anything where you need raw file contents in bulk.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "### Anti-patterns")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "- Don't read an entire file to find one function — `archigraph_inspect` returns it directly.")
+	fmt.Fprintln(&b, "- Don't glob for a class name across the repo — `archigraph_find` indexes it.")
+	fmt.Fprintln(&b, "- Don't traverse imports manually — `archigraph_expand` does it via the IMPORTS edge.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "The full agent guide is delivered automatically in the MCP `instructions` handshake when you connect.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "_Do not edit between the markers — this block is auto-updated by `archigraph install`._")
+	fmt.Fprintln(&b)
+	fmt.Fprint(&b, EndMarker)
+	return b.String()
+}
+
+// ── internal helpers ─────────────────────────────────────────────────
+
+// action codes returned by upsert; surfaced to WriteAll so callers can
+// log per-file decisions.
+type action int
+
+const (
+	actionUnknown action = iota
+	actionWroteFresh
+	actionReplacedBlock
+	actionAppended
+	actionReplacedStale
+	actionSkippedMixedStale
+)
+
+// upsert reads path, decides what to do, and writes back atomically.
+// See package doc for the decision tree.
+func upsert(path, block string) (action, error) {
+	existing, err := os.ReadFile(path)
+	switch {
+	case err != nil && !os.IsNotExist(err):
+		return actionUnknown, fmt.Errorf("read %s: %w", path, err)
+
+	case os.IsNotExist(err) || len(existing) == 0:
+		if err := atomicWrite(path, []byte(block)); err != nil {
+			return actionUnknown, err
+		}
+		return actionWroteFresh, nil
+
+	case blockRegexAnyVersion.Match(existing):
+		// Existing archigraph block — replace in-place. This also covers
+		// the OUTDATED case (block exists with older version marker).
+		out := blockRegexAnyVersion.ReplaceAll(existing, []byte(strings.TrimRight(block, "\n")))
+		if err := atomicWrite(path, out); err != nil {
+			return actionUnknown, err
+		}
+		return actionReplacedBlock, nil
+
+	case hasPredecessorRef(existing):
+		// File has no archigraph block but references a predecessor.
+		// Decide between full-overwrite (pure stale) and skip-with-warning
+		// (mixed content).
+		if isPureStaleFile(existing) {
+			if err := atomicWrite(path, []byte(block)); err != nil {
+				return actionUnknown, err
+			}
+			return actionReplacedStale, nil
+		}
+		return actionSkippedMixedStale, nil
+
+	default:
+		// File exists with unrelated content — append the block with a
+		// blank-line separator, preserving every byte of user content.
+		buf := make([]byte, 0, len(existing)+len(block)+2)
+		buf = append(buf, existing...)
+		if existing[len(existing)-1] != '\n' {
+			buf = append(buf, '\n')
+		}
+		buf = append(buf, '\n')
+		buf = append(buf, []byte(block)...)
+		if err := atomicWrite(path, buf); err != nil {
+			return actionUnknown, err
+		}
+		return actionAppended, nil
+	}
+}
+
+// classify returns the FileStatus for a single absolute path.
+func classify(abs string) FileStatus {
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return FileStatus{Path: abs, Status: StatusMissing, Detail: "file does not exist"}
+		}
+		return FileStatus{Path: abs, Status: StatusMissing, Detail: fmt.Sprintf("read: %v", err)}
+	}
+
+	if m := startMarkerAnyVersion.FindSubmatch(data); m != nil {
+		// Parse the version embedded in the start marker.
+		v := extractBlockVersion(string(m[0]))
+		if v == BlockVersion {
+			return FileStatus{Path: abs, Status: StatusOK}
+		}
+		return FileStatus{
+			Path:   abs,
+			Status: StatusOutdated,
+			Detail: fmt.Sprintf("archigraph block v=%d, current v=%d", v, BlockVersion),
+		}
+	}
+
+	if hasPredecessorRef(data) {
+		mixed := !isPureStaleFile(data)
+		detail := "contains predecessor (graphify) references"
+		if mixed {
+			detail += " mixed with unrelated content; manual migration recommended"
+		} else {
+			detail += "; next `archigraph install` will overwrite"
+		}
+		return FileStatus{Path: abs, Status: StatusStale, Detail: detail}
+	}
+
+	// File exists but has no archigraph block and no stale refs. From
+	// the doctor's point of view this is still a problem — the rules
+	// block is missing.
+	return FileStatus{
+		Path:   abs,
+		Status: StatusMissing,
+		Detail: "file exists but has no archigraph block; run `archigraph install`",
+	}
+}
+
+// extractBlockVersion parses "v=N" out of the start marker. Returns 0
+// if the marker is malformed (treated as outdated).
+var versionRe = regexp.MustCompile(`v=(\d+)`)
+
+func extractBlockVersion(marker string) int {
+	m := versionRe.FindStringSubmatch(marker)
+	if len(m) < 2 {
+		return 0
+	}
+	var n int
+	for _, c := range m[1] {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+// hasPredecessorRef returns true when data references any predecessor
+// tool name. Case-insensitive substring match.
+func hasPredecessorRef(data []byte) bool {
+	lower := strings.ToLower(string(data))
+	for _, tok := range PredecessorTokens {
+		if strings.Contains(lower, strings.ToLower(tok)) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPureStaleFile is the "the entire file is predecessor content"
+// heuristic. We treat a file as pure-stale when:
+//
+//   - It is short (≤ 30 lines total), AND
+//   - Every non-blank, non-markdown-structural line references at
+//     least one predecessor token.
+//
+// "Markdown structural" lines are headings, list bullets, code-fence
+// markers, horizontal rules — content that frames the stale text but
+// doesn't carry independent meaning.
+func isPureStaleFile(data []byte) bool {
+	const maxLines = 30
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	lines := 0
+	for scanner.Scan() {
+		lines++
+		if lines > maxLines {
+			return false
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if isMarkdownStructural(line) {
+			continue
+		}
+		if !lineMentionsPredecessor(line) {
+			return false
+		}
+	}
+	return true
+}
+
+func isMarkdownStructural(line string) bool {
+	switch {
+	case strings.HasPrefix(line, "#"):
+		return true
+	case strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "* ") || strings.HasPrefix(line, "+ "):
+		// Even bullet lines must still mention the predecessor to count
+		// as stale — but here we treat the bullet *marker itself* as
+		// structural. The caller still checks lineMentionsPredecessor
+		// on the full line, which includes the bullet content. So bullet
+		// lines whose payload doesn't reference graphify will correctly
+		// flip isPureStaleFile to false.
+		return false
+	case line == "---" || line == "***" || line == "___":
+		return true
+	case strings.HasPrefix(line, "```"):
+		return true
+	case strings.HasPrefix(line, ">"):
+		return false
+	}
+	return false
+}
+
+func lineMentionsPredecessor(line string) bool {
+	lower := strings.ToLower(line)
+	for _, tok := range PredecessorTokens {
+		if strings.Contains(lower, strings.ToLower(tok)) {
+			return true
+		}
+	}
+	return false
+}
+
+// atomicWrite writes data to path via a tmp-file + rename. Parent dirs
+// are created as needed so .codeium/ and .github/ are handled
+// transparently.
+func atomicWrite(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}

--- a/internal/install/rulesfiles/rulesfiles_test.go
+++ b/internal/install/rulesfiles/rulesfiles_test.go
@@ -1,0 +1,245 @@
+package rulesfiles
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWriteAll_FreshRepo verifies that a brand-new repo gets every
+// target rules file populated with the canonical block.
+func TestWriteAll_FreshRepo(t *testing.T) {
+	repo := t.TempDir()
+	var logger bytes.Buffer
+
+	res, err := WriteAll(repo, WriteOptions{GroupName: "demo", Logger: &logger})
+	if err != nil {
+		t.Fatalf("WriteAll: %v", err)
+	}
+
+	if len(res.Written) != len(Targets) {
+		t.Fatalf("expected %d targets written, got %d (%v)", len(Targets), len(res.Written), res.Written)
+	}
+
+	for _, target := range Targets {
+		path := filepath.Join(repo, target)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("missing target %s: %v", target, err)
+		}
+		if !bytes.Contains(data, []byte(StartMarker)) {
+			t.Errorf("%s: start marker not found", target)
+		}
+		if !bytes.Contains(data, []byte(EndMarker)) {
+			t.Errorf("%s: end marker not found", target)
+		}
+		if !bytes.Contains(data, []byte("archigraph MCP")) {
+			t.Errorf("%s: block payload not found", target)
+		}
+		if !bytes.Contains(data, []byte("**demo**")) {
+			t.Errorf("%s: group name not embedded", target)
+		}
+	}
+}
+
+// TestWriteAll_Idempotent verifies that a second run does not duplicate
+// the block.
+func TestWriteAll_Idempotent(t *testing.T) {
+	repo := t.TempDir()
+	if _, err := WriteAll(repo, WriteOptions{GroupName: "demo"}); err != nil {
+		t.Fatalf("first WriteAll: %v", err)
+	}
+	if _, err := WriteAll(repo, WriteOptions{GroupName: "demo"}); err != nil {
+		t.Fatalf("second WriteAll: %v", err)
+	}
+
+	for _, target := range Targets {
+		path := filepath.Join(repo, target)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", target, err)
+		}
+		count := bytes.Count(data, []byte(StartMarker))
+		if count != 1 {
+			t.Errorf("%s: expected exactly one block, found %d", target, count)
+		}
+	}
+}
+
+// TestWriteAll_ReplacesOlderVersionBlock verifies that a block with an
+// older version marker is replaced in-place.
+func TestWriteAll_ReplacesOlderVersionBlock(t *testing.T) {
+	repo := t.TempDir()
+	oldBlock := "<!-- archigraph:mcp-usage:start v=0 -->\nstale\n<!-- archigraph:mcp-usage:end -->\n"
+	if err := os.WriteFile(filepath.Join(repo, ".windsurfrules"), []byte(oldBlock), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := WriteAll(repo, WriteOptions{GroupName: "demo"}); err != nil {
+		t.Fatalf("WriteAll: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(repo, ".windsurfrules"))
+	if bytes.Contains(data, []byte("v=0")) {
+		t.Errorf("old version marker still present: %s", data)
+	}
+	if !bytes.Contains(data, []byte("v=1")) {
+		t.Errorf("new version marker missing: %s", data)
+	}
+}
+
+// TestWriteAll_PreservesUnrelatedContent ensures that pre-existing
+// content with no archigraph block and no predecessor refs is preserved
+// and the block is appended.
+func TestWriteAll_PreservesUnrelatedContent(t *testing.T) {
+	repo := t.TempDir()
+	original := "# My Project\n\nLocal notes that mention nothing relevant.\n"
+	if err := os.WriteFile(filepath.Join(repo, "CLAUDE.md"), []byte(original), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := WriteAll(repo, WriteOptions{GroupName: "demo"}); err != nil {
+		t.Fatalf("WriteAll: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(repo, "CLAUDE.md"))
+	if !bytes.Contains(data, []byte("# My Project")) {
+		t.Errorf("original content lost: %s", data)
+	}
+	if !bytes.Contains(data, []byte(StartMarker)) {
+		t.Errorf("block not appended")
+	}
+}
+
+// TestWriteAll_PureStaleGraphifyOverwritten covers the heuristic for
+// "the whole file is predecessor content" — should be overwritten and
+// a log line emitted.
+func TestWriteAll_PureStaleGraphifyOverwritten(t *testing.T) {
+	repo := t.TempDir()
+	stale := "# Graphify\n\n- Run `graphify update` to refresh the graph\n- See graphify-out/GRAPH_REPORT.md\n"
+	if err := os.WriteFile(filepath.Join(repo, ".windsurfrules"), []byte(stale), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var logger bytes.Buffer
+	res, err := WriteAll(repo, WriteOptions{GroupName: "demo", Logger: &logger})
+	if err != nil {
+		t.Fatalf("WriteAll: %v", err)
+	}
+	if len(res.ReplacedStale) == 0 {
+		t.Fatalf("expected ReplacedStale, got %+v", res)
+	}
+	data, _ := os.ReadFile(filepath.Join(repo, ".windsurfrules"))
+	if bytes.Contains(data, []byte("graphify")) {
+		t.Errorf("graphify content not removed: %s", data)
+	}
+	if !strings.Contains(logger.String(), "replaced stale graphify content") {
+		t.Errorf("expected log line, got: %s", logger.String())
+	}
+}
+
+// TestWriteAll_MixedStaleSkippedWithWarning covers the case where a
+// file mentions graphify alongside unrelated content — should NOT be
+// overwritten; a warning is emitted.
+func TestWriteAll_MixedStaleSkippedWithWarning(t *testing.T) {
+	repo := t.TempDir()
+	mixed := "# Engineering Handbook\n\n" +
+		"This repo is the canonical source of truth for our payments API.\n" +
+		"It exposes the /v2/charges endpoint and consumes the orders.created topic.\n" +
+		"Historical note: an older indexing tool called graphify was used here.\n" +
+		"Please use the on-call rota in PagerDuty for incidents.\n" +
+		"Refer to docs/architecture.md for the full system design.\n" +
+		"Refer to docs/runbooks for operational procedures.\n" +
+		"Owners are listed in CODEOWNERS at the repo root.\n"
+	if err := os.WriteFile(filepath.Join(repo, ".windsurfrules"), []byte(mixed), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var logger bytes.Buffer
+	res, err := WriteAll(repo, WriteOptions{GroupName: "demo", Logger: &logger})
+	if err != nil {
+		t.Fatalf("WriteAll: %v", err)
+	}
+	if len(res.SkippedMixedStale) == 0 {
+		t.Fatalf("expected SkippedMixedStale, got %+v", res)
+	}
+	data, _ := os.ReadFile(filepath.Join(repo, ".windsurfrules"))
+	if !bytes.Contains(data, []byte("payments API")) {
+		t.Errorf("user content lost: %s", data)
+	}
+	if bytes.Contains(data, []byte(StartMarker)) {
+		t.Errorf("block was written despite mixed-stale; should have been skipped")
+	}
+	if !strings.Contains(logger.String(), "please migrate manually") {
+		t.Errorf("expected warning, got: %s", logger.String())
+	}
+}
+
+// TestScan_StatusesAcrossFileShapes covers MISSING / STALE / OUTDATED /
+// OK in a single repo.
+func TestScan_StatusesAcrossFileShapes(t *testing.T) {
+	repo := t.TempDir()
+
+	// AGENTS.md → OK (current block).
+	current := RenderBlock("demo") + "\n"
+	if err := os.WriteFile(filepath.Join(repo, "AGENTS.md"), []byte(current), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	// CLAUDE.md → OUTDATED (older version).
+	old := "<!-- archigraph:mcp-usage:start v=0 -->\nbody\n<!-- archigraph:mcp-usage:end -->\n"
+	if err := os.WriteFile(filepath.Join(repo, "CLAUDE.md"), []byte(old), 0o644); err != nil {
+		t.Fatalf("seed CLAUDE.md: %v", err)
+	}
+
+	// .windsurfrules → STALE (graphify content, no block).
+	stale := "# Graphify\nRun `graphify update`\n"
+	if err := os.WriteFile(filepath.Join(repo, ".windsurfrules"), []byte(stale), 0o644); err != nil {
+		t.Fatalf("seed .windsurfrules: %v", err)
+	}
+
+	// .cursorrules, .codeium/instructions.md, .github/copilot-instructions.md → MISSING.
+
+	statuses := Scan(repo)
+	byTarget := map[string]FileStatus{}
+	for _, s := range statuses {
+		byTarget[s.Target] = s
+	}
+
+	if got := byTarget["AGENTS.md"].Status; got != StatusOK {
+		t.Errorf("AGENTS.md: expected OK, got %s", got)
+	}
+	if got := byTarget["CLAUDE.md"].Status; got != StatusOutdated {
+		t.Errorf("CLAUDE.md: expected OUTDATED, got %s", got)
+	}
+	if got := byTarget[".windsurfrules"].Status; got != StatusStale {
+		t.Errorf(".windsurfrules: expected STALE, got %s", got)
+	}
+	if got := byTarget[".cursorrules"].Status; got != StatusMissing {
+		t.Errorf(".cursorrules: expected MISSING, got %s", got)
+	}
+	if got := byTarget[".codeium/instructions.md"].Status; got != StatusMissing {
+		t.Errorf(".codeium/instructions.md: expected MISSING, got %s", got)
+	}
+	if got := byTarget[".github/copilot-instructions.md"].Status; got != StatusMissing {
+		t.Errorf(".github/copilot-instructions.md: expected MISSING, got %s", got)
+	}
+}
+
+// TestIsPureStaleFile checks the short-pure-stale heuristic.
+func TestIsPureStaleFile(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"pure stale", "# Graphify\n\n- Run `graphify update`\n- See graphify-out/GRAPH_REPORT.md\n", true},
+		{"mixed", "# Project\n\nWe use graphify here.\nAlso unrelated note about payments.\n", false},
+		{"too long", strings.Repeat("graphify line\n", 40), false},
+		{"empty", "", true}, // vacuously pure
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isPureStaleFile([]byte(tc.in))
+			if got != tc.want {
+				t.Errorf("isPureStaleFile(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2683.

`archigraph install` previously wrote the canonical mcp-usage rules block only into `AGENTS.md` per registered repo. Cascade (Windsurf) reads `.windsurfrules`, Cursor reads `.cursorrules`, Copilot Chat reads `.github/copilot-instructions.md`, and Codeium reads `.codeium/instructions.md` — none of those got the archigraph guidance, so those agents defaulted to grep+read and ignored the MCP entirely. On upvate repos the `.windsurfrules` files were also stale with predecessor (`graphify`) content, making Cascade actively unhelpful.

- New package `internal/install/rulesfiles` generalises the writer: it renders one canonical block bounded by `<!-- archigraph:mcp-usage:start v=1 -->` / `<!-- archigraph:mcp-usage:end -->` and upserts it into all six target files per repo. Existing blocks are replaced in-place (idempotent); a version bump in the start marker is treated as OUTDATED and rewritten on the next install.
- Stale predecessor handling: files that mention `graphify` but have no archigraph block are either overwritten (short + every non-blank line references graphify → "pure stale") or left alone with a warning (mixed content → manual migration). The classifier is unit-tested across both shapes.
- Wired into `install.Apply` so every repo in every registered group gets the block on `archigraph install`. Behaviour is opt-out via the new `SkipRulesFiles` option for callers that don't want it.
- `archigraph doctor` gains a new `rules-files/<group>/<repo>` surface that reports per-file status (`OK` / `MISSING` / `STALE` / `OUTDATED`) for every registered repo.

## Test plan

- [x] `go test ./internal/install/rulesfiles/...` — unit tests cover fresh write, idempotent re-run, version-bump in-place replace, preservation of unrelated user content, pure-stale overwrite, mixed-stale skip-with-warning, scan-status across `MISSING` / `STALE` / `OUTDATED` / `OK`.
- [x] `go test ./cmd/archigraph/... -run Issue2683` — end-to-end via `install.Apply` with a two-repo group: fresh install writes all 6 files in both repos; re-install does not duplicate the block; pure-stale `graphify` `.windsurfrules` is overwritten and surfaced in `RulesFilesStaleReplaced`; mixed-content `.cursorrules` is preserved and surfaced in `RulesFilesStaleSkipped`; doctor reports the four statuses simultaneously on one repo.
- [x] `go test ./internal/install/... ./internal/cli/...` — all existing install and CLI tests still pass.
- [x] `go vet ./...` clean on the touched packages.
- [ ] Manual: run `archigraph install` against the upvate group and confirm Cascade in `upvate_core` reaches for `archigraph_find` in a fresh session without prompting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)