### PR TITLE
chore(install): drop _ = root placeholder (#2688 followup)

### DIFF
--- a/cmd/archigraph/issue2683_rules_files_test.go
+++ b/cmd/archigraph/issue2683_rules_files_test.go
@@ -171,8 +171,7 @@ func TestIssue2683_MixedStaleSkippedWithWarning(t *testing.T) {
 // reports OK / MISSING / STALE / OUTDATED across the rules files of a
 // registered group.
 func TestIssue2683_DoctorReportsAllStatuses(t *testing.T) {
-	root, repos, cfg := twoRepoGroup(t)
-	_ = root
+	_, repos, cfg := twoRepoGroup(t)
 
 	// Register the group via install.Apply (which also writes initial
 	// rules files into both repos as OK).


### PR DESCRIPTION
Removes unused root parameter assignment from TestIssue2683_DoctorReportsAllStatuses test.