### PR TITLE
fix(drf): endpoint attribution resolves to ViewSet method file (#2677)

### DIFF
--- a/cmd/archigraph/issue2677_drf_attribution_test.go
+++ b/cmd/archigraph/issue2677_drf_attribution_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIssue2677_DRFEndpointAttribution covers the P0 attribution fix:
+// every CRUD and @action endpoint emitted by ApplyDjangoDRFRoutes must
+// attribute its source_file to the ViewSet's source file (and its StartLine
+// to the def line of the handling method), NOT to the routers.py file that
+// merely calls router.register(...).
+//
+// The fixture at testdata/drf_attribution_fixture defines:
+//
+//	myapp/urls.py    — path("api/v1/", include("myapp.routers"))
+//	myapp/routers.py — router.register(r"things", views.ThingViewSet)
+//	myapp/views.py   — class ThingViewSet(viewsets.ModelViewSet):
+//	                       def list(...)               (line 12)
+//	                       @action(... url_path="custom_action", methods=["post"])
+//	                       def custom(...)             (line 17)
+//
+// Expectations:
+//  1. GET /api/v1/things attributes to views.py at the `def list(` line.
+//  2. POST /api/v1/things/custom_action attributes to views.py at the
+//     `def custom(` line (the @action-decorated method).
+//  3. The /api/v1/ mount-point declared in urls.py is still discoverable —
+//     i.e. at least one http_endpoint whose canonical path starts with
+//     /api/v1/ has SourceFile pointing at myapp/urls.py (the include site).
+func TestIssue2677_DRFEndpointAttribution(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/drf_attribution_fixture", "drf_attribution_fixture", nil)
+
+	type endpoint struct {
+		path       string
+		verb       string
+		sourceFile string
+		startLine  int
+	}
+	var got []endpoint
+	for _, e := range doc.Entities {
+		// The http-endpoint-split pass renames `http_endpoint` to either
+		// `http_endpoint_definition` (server-side handlers) or
+		// `http_endpoint_call` (client-side fetches). Definitions are what
+		// this test cares about.
+		if e.Kind != "http_endpoint" && e.Kind != "http_endpoint_definition" {
+			continue
+		}
+		got = append(got, endpoint{
+			path:       e.Properties["path"],
+			verb:       e.Properties["verb"],
+			sourceFile: e.SourceFile,
+			startLine:  e.StartLine,
+		})
+	}
+	if len(got) == 0 {
+		t.Fatalf("no http_endpoint entities emitted by indexer")
+	}
+
+	findByVerbPath := func(verb, path string) *endpoint {
+		for i := range got {
+			if got[i].verb == verb && got[i].path == path {
+				return &got[i]
+			}
+		}
+		return nil
+	}
+
+	listEP := findByVerbPath("GET", "/api/v1/things")
+	if listEP == nil {
+		t.Fatalf("missing GET /api/v1/things — got endpoints: %+v", got)
+	}
+	if !strings.HasSuffix(listEP.sourceFile, "views.py") {
+		t.Errorf("GET /api/v1/things attributes to %q; want views.py", listEP.sourceFile)
+	}
+	if listEP.startLine == 0 {
+		t.Errorf("GET /api/v1/things has no StartLine; want the `def list(` line")
+	}
+	// The fixture's `def list(` lives on line 12; allow tolerance for whitespace
+	// edits in the fixture by accepting any line in the body range [6, 16].
+	if listEP.startLine < 6 || listEP.startLine > 16 {
+		t.Errorf("GET /api/v1/things StartLine=%d; expected within def list() neighbourhood (6..16)",
+			listEP.startLine)
+	}
+
+	customEP := findByVerbPath("POST", "/api/v1/things/custom_action")
+	if customEP == nil {
+		t.Fatalf("missing POST /api/v1/things/custom_action — got endpoints: %+v", got)
+	}
+	if !strings.HasSuffix(customEP.sourceFile, "views.py") {
+		t.Errorf("POST /api/v1/things/custom_action attributes to %q; want views.py",
+			customEP.sourceFile)
+	}
+	if customEP.startLine == 0 {
+		t.Errorf("POST /api/v1/things/custom_action has no StartLine")
+	}
+	// The @action-decorated `def custom(` lives on line 17; accept [13, 22].
+	if customEP.startLine < 13 || customEP.startLine > 22 {
+		t.Errorf("POST /api/v1/things/custom_action StartLine=%d; expected within def custom() neighbourhood (13..22)",
+			customEP.startLine)
+	}
+
+	// Mount-point discoverability: at least one http_endpoint whose path is
+	// under /api/v1/ must attribute to the urls.py file that declared the
+	// include() — otherwise the question "where is /api/v1/ declared?" loses
+	// its anchor in the graph.
+	mountFound := false
+	for _, e := range got {
+		if !strings.HasPrefix(e.path, "/api/v1") {
+			continue
+		}
+		if strings.HasSuffix(e.sourceFile, "urls.py") {
+			mountFound = true
+			break
+		}
+	}
+	if !mountFound {
+		t.Errorf("no http_endpoint under /api/v1/ attributes to urls.py — mount-point discoverability lost")
+	}
+
+	// Spot-check: NO http_endpoint covering a /api/v1/things* path should
+	// attribute to routers.py — that's the regression we are fixing.
+	for _, e := range got {
+		if !strings.HasPrefix(e.path, "/api/v1/things") {
+			continue
+		}
+		if strings.HasSuffix(e.sourceFile, "routers.py") {
+			t.Errorf("regression: endpoint %s %s still attributes to routers.py (#2677)",
+				e.verb, e.path)
+		}
+	}
+}

--- a/cmd/archigraph/testdata/drf_attribution_fixture/myapp/routers.py
+++ b/cmd/archigraph/testdata/drf_attribution_fixture/myapp/routers.py
@@ -1,0 +1,10 @@
+from rest_framework import routers
+
+from . import views
+
+
+router = routers.DefaultRouter()
+router.register(r"things", views.ThingViewSet, basename="thing")
+
+
+urlpatterns = router.urls

--- a/cmd/archigraph/testdata/drf_attribution_fixture/myapp/urls.py
+++ b/cmd/archigraph/testdata/drf_attribution_fixture/myapp/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path, include
+
+
+urlpatterns = [
+    path("api/v1/", include("myapp.routers")),
+]

--- a/cmd/archigraph/testdata/drf_attribution_fixture/myapp/views.py
+++ b/cmd/archigraph/testdata/drf_attribution_fixture/myapp/views.py
@@ -1,0 +1,20 @@
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+
+class ThingViewSet(viewsets.ModelViewSet):
+    """Demo ViewSet exercising both inherited CRUD and a custom @action."""
+
+    queryset = []
+    serializer_class = None
+
+    def list(self, request, *args, **kwargs):
+        # The endpoint GET /api/v1/things must attribute to THIS def line.
+        return Response([])
+
+    @action(detail=False, url_path="custom_action", methods=["post"])
+    def custom(self, request, *args, **kwargs):
+        # The endpoint POST /api/v1/things/custom_action must attribute to
+        # THIS def line, not to routers.py.
+        return Response({"ok": True})

--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -213,6 +213,14 @@ type drfViewSetClass struct {
 	lookupField string
 	// actions are the @action endpoints declared on the class.
 	actions []drfAction
+	// classDefLine is the 1-based line of `class <name>(...)` in the ViewSet's
+	// source file. Used as the fallback StartLine for inherited CRUD methods
+	// that have no `def` in this file (#2677).
+	classDefLine int
+	// methodLines maps a CRUD method name (e.g. "list") to the 1-based line of
+	// its explicit `def <method>(` declaration. Empty entry means the method is
+	// inherited from a mixin and has no body in this file (#2677).
+	methodLines map[string]int
 }
 
 // drfAction is a single @action-decorated method on a ViewSet.
@@ -225,6 +233,10 @@ type drfAction struct {
 	methods []string
 	// detail is true when detail=True (route includes {pk}/).
 	detail bool
+	// methodLine is the 1-based line of `def <methodName>(` in the ViewSet's
+	// source file. Captured so the emitted http_endpoint attributes to the
+	// decorated method body rather than routers.py (#2677).
+	methodLine int
 }
 
 // ApplyDjangoDRFRoutes expands DRF router.register() calls into the full
@@ -268,7 +280,13 @@ func ApplyDjangoDRFRoutes(
 	// property for downstream consumers.
 	var currentURLPrefix string
 
-	emit := func(verb, canonical, sourceFile, viewSet, methodName string) {
+	// emit is invoked for every (verb, path) endpoint to materialise. sourceFile
+	// is the file the handler lives in (typically the ViewSet's source file —
+	// e.g. core/views/building_viewset.py — and ONLY the routers/urlconf file
+	// when the ViewSet class cannot be resolved). sourceLine is the 1-based
+	// line of `def <handler>(` (for explicit / @action methods) or the class
+	// def line (for inherited mixin methods). #2677.
+	emit := func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string) {
 		if canonical == "" || canonical == "/" {
 			return
 		}
@@ -321,6 +339,7 @@ func ApplyDjangoDRFRoutes(
 			Name:               id,
 			Kind:               httpEndpointKind,
 			SourceFile:         sourceFile,
+			StartLine:          sourceLine,
 			Language:           "python",
 			Properties:         props,
 			EnrichmentRequired: false,
@@ -459,6 +478,17 @@ func ApplyDjangoDRFRoutes(
 			}
 			emitViewSetMethodEntities(&out, seenMethods, viewSetName, vc, handlerFile)
 
+			// #2677 — endpoint source attribution: when the ViewSet class was
+			// resolved successfully, emit entities pointing at the ViewSet's
+			// file (and method's def line) so `archigraph_inspect` on the
+			// endpoint surfaces the real handler, not the empty routers.py
+			// registration line. When resolution fails, fall back to relPath
+			// so the entity still has a valid source_file.
+			endpointSourceFile := viewFile
+			if endpointSourceFile == "" {
+				endpointSourceFile = relPath
+			}
+
 			// expandRegisterPrefixes produces composedPrefixes in the same
 			// order as effectivePrefixes, so we can zip them to recover the
 			// parent prefix that applies to each composed prefix. This lets
@@ -469,8 +499,8 @@ func ApplyDjangoDRFRoutes(
 				} else {
 					currentURLPrefix = ""
 				}
-				emitCRUDFamily(emit, fullPrefix, vc, relPath, viewSetName)
-				emitActionRoutes(emit, fullPrefix, vc, relPath, viewSetName)
+				emitCRUDFamily(emit, fullPrefix, vc, endpointSourceFile, viewSetName)
+				emitActionRoutes(emit, fullPrefix, vc, endpointSourceFile, viewSetName)
 			}
 			currentURLPrefix = "" // reset for safety
 		}
@@ -998,7 +1028,7 @@ func expandRegisterPrefixes(
 // exactly ONE canonical placeholder per detail route — the ViewSet's
 // declared lookup_field (defaulting to "pk").
 func emitCRUDFamily(
-	emit func(verb, canonical, sourceFile, viewSet, methodName string),
+	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string),
 	fullPrefix string,
 	vc drfViewSetClass,
 	sourceFile string,
@@ -1007,12 +1037,23 @@ func emitCRUDFamily(
 	emitOneCRUDFamily(emit, fullPrefix, vc.lookupField, vc, sourceFile, viewSetName)
 }
 
+// crudMethodLine returns the 1-based line to attribute to a CRUD endpoint:
+// the explicit `def <method>(` line when the ViewSet overrides the method,
+// otherwise the `class <name>(...)` declaration line. Returns 0 when neither
+// is known so callers leave StartLine unset (#2677).
+func crudMethodLine(vc drfViewSetClass, method string) int {
+	if line, ok := vc.methodLines[method]; ok && line > 0 {
+		return line
+	}
+	return vc.classDefLine
+}
+
 // emitOneCRUDFamily emits the CRUD-route family for a single placeholder
 // shape (e.g. `{pk}` or `{id}`). The first call (with the canonical
 // `lookup_field`) is the source of truth; subsequent calls with alternate
 // placeholders widen the cross-repo match surface (#704 companion).
 func emitOneCRUDFamily(
-	emit func(verb, canonical, sourceFile, viewSet, methodName string),
+	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string),
 	fullPrefix string,
 	placeholder string,
 	vc drfViewSetClass,
@@ -1022,26 +1063,26 @@ func emitOneCRUDFamily(
 	detailBase := fullPrefix + "/{" + placeholder + "}"
 
 	if vc.crudMethods["list"] {
-		emit("GET", canonicalDjango(fullPrefix), sourceFile, viewSetName, "list")
+		emit("GET", canonicalDjango(fullPrefix), sourceFile, crudMethodLine(vc, "list"), viewSetName, "list")
 	}
 	if vc.crudMethods["create"] {
-		emit("POST", canonicalDjango(fullPrefix), sourceFile, viewSetName, "create")
+		emit("POST", canonicalDjango(fullPrefix), sourceFile, crudMethodLine(vc, "create"), viewSetName, "create")
 	}
 	hasDetailVerb := false
 	if vc.crudMethods["retrieve"] {
-		emit("GET", canonicalDjango(detailBase), sourceFile, viewSetName, "retrieve")
+		emit("GET", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "retrieve"), viewSetName, "retrieve")
 		hasDetailVerb = true
 	}
 	if vc.crudMethods["update"] {
-		emit("PUT", canonicalDjango(detailBase), sourceFile, viewSetName, "update")
+		emit("PUT", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "update"), viewSetName, "update")
 		hasDetailVerb = true
 	}
 	if vc.crudMethods["partial_update"] {
-		emit("PATCH", canonicalDjango(detailBase), sourceFile, viewSetName, "partial_update")
+		emit("PATCH", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "partial_update"), viewSetName, "partial_update")
 		hasDetailVerb = true
 	}
 	if vc.crudMethods["destroy"] {
-		emit("DELETE", canonicalDjango(detailBase), sourceFile, viewSetName, "destroy")
+		emit("DELETE", canonicalDjango(detailBase), sourceFile, crudMethodLine(vc, "destroy"), viewSetName, "destroy")
 		hasDetailVerb = true
 	}
 	// Emit an ANY-verb detail fallback ONLY when no per-verb detail routes
@@ -1051,7 +1092,7 @@ func emitOneCRUDFamily(
 	// verb-aware matcher must skip, and it defeated the iter3 calibration
 	// top add-rec #2 (detail routes still showing method=ANY). Fix #1692.
 	if !hasDetailVerb {
-		emit("ANY", canonicalDjango(detailBase), sourceFile, viewSetName, "")
+		emit("ANY", canonicalDjango(detailBase), sourceFile, vc.classDefLine, viewSetName, "")
 	}
 }
 
@@ -1059,7 +1100,7 @@ func emitOneCRUDFamily(
 // ViewSet. For detail=True actions the route is
 // /<prefix>/{lookup}/<url_path>/; for detail=False it is /<prefix>/<url_path>/.
 func emitActionRoutes(
-	emit func(verb, canonical, sourceFile, viewSet, methodName string),
+	emit func(verb, canonical, sourceFile string, sourceLine int, viewSet, methodName string),
 	fullPrefix string,
 	vc drfViewSetClass,
 	sourceFile string,
@@ -1099,8 +1140,12 @@ func emitActionRoutes(
 				actionPath = fullPrefix + "/" + segment
 			}
 			canonical := canonicalDjango(actionPath)
+			actionLine := act.methodLine
+			if actionLine == 0 {
+				actionLine = vc.classDefLine
+			}
 			for _, verb := range methods {
-				emit(verb, canonical, sourceFile, viewSetName, act.methodName)
+				emit(verb, canonical, sourceFile, actionLine, viewSetName, act.methodName)
 			}
 		}
 	}
@@ -1326,6 +1371,7 @@ func parseViewSetClass(src, viewSetName string) drfViewSetClass {
 	// Locate the class declaration to determine the parent class.
 	classBase := ""
 	classBodyStart := -1
+	classDeclByte := -1
 	for _, m := range drfClassDefRe.FindAllStringSubmatchIndex(src, -1) {
 		// m[2:4] -> class name range, m[4:6] -> base list range.
 		name := src[m[2]:m[3]]
@@ -1334,11 +1380,16 @@ func parseViewSetClass(src, viewSetName string) drfViewSetClass {
 		}
 		classBase = src[m[4]:m[5]]
 		classBodyStart = m[1] // end of the `class X(...):` line
+		classDeclByte = m[0]  // start of `class X(...)`  (#2677)
 		break
 	}
 	if classBodyStart == -1 {
 		return out
 	}
+
+	// 1-based line of the `class X(...)` declaration. Used as the fallback
+	// StartLine for inherited CRUD methods (#2677).
+	out.classDefLine = lineOfByteOffset(src, classDeclByte)
 
 	// Carve out the class body — from classBodyStart to end-of-file OR
 	// to the next top-level `class ` / `def ` (column 0). This bounds
@@ -1349,16 +1400,24 @@ func parseViewSetClass(src, viewSetName string) drfViewSetClass {
 	if m := drfLookupFieldRe.FindStringSubmatch(classBody); len(m) >= 2 {
 		out.lookupField = m[1]
 	}
-	out.actions = extractActions(classBody)
+	// classBody starts at classBodyStart in src; pass that offset so
+	// extractActions can compute absolute (src-relative) line numbers for
+	// each @action's `def NAME(` line (#2677).
+	out.actions = extractActions(classBody, src, classBodyStart)
 
 	// Issue #699c — detect which CRUD methods are explicitly defined in
 	// the class body. Only methods with an explicit `def <name>(self` in
 	// the body are marked explicit; all others are inherited from a mixin
 	// or parent class and need a synthetic SCOPE.Operation entity.
 	out.explicitMethods = make(map[string]bool)
-	for _, m := range drfExplicitMethodRe.FindAllStringSubmatch(classBody, -1) {
-		if len(m) >= 2 {
-			out.explicitMethods[m[1]] = true
+	out.methodLines = make(map[string]int)
+	for _, m := range drfExplicitMethodRe.FindAllStringSubmatchIndex(classBody, -1) {
+		if len(m) >= 4 {
+			methodName := classBody[m[2]:m[3]]
+			out.explicitMethods[methodName] = true
+			// #2677 — capture the 1-based line of `def <method>(` in src so
+			// the emitted http_endpoint attributes to it.
+			out.methodLines[methodName] = lineOfByteOffset(src, classBodyStart+m[0])
 		}
 	}
 
@@ -1568,31 +1627,51 @@ func modelViewSetMethods() map[string]bool {
 
 // extractActions returns every @action / @detail_route / @list_route
 // declared inside the given class body.
-func extractActions(body string) []drfAction {
+//
+// `src` and `bodyOffsetInSrc` are passed so each returned drfAction can carry
+// the 1-based src-relative line number of its `def <method>(` line. Callers
+// that don't need line attribution may pass src="" and offset=0; methodLine
+// will then be 0 (#2677).
+func extractActions(body string, src string, bodyOffsetInSrc int) []drfAction {
 	var actions []drfAction
 	for _, hit := range scanDecoratorCalls(body, drfActionOpenRe) {
-		actions = append(actions, parseActionArgs(hit.args, hit.methodName, false))
+		act := parseActionArgs(hit.args, hit.methodName, false)
+		act.methodLine = decoratorLineInSrc(src, bodyOffsetInSrc, hit.methodOffset)
+		actions = append(actions, act)
 	}
 	for _, hit := range scanDecoratorCalls(body, drfLegacyDetailRouteOpenRe) {
 		act := parseActionArgs(hit.args, hit.methodName, true)
 		// detail_route always means detail=True.
 		act.detail = true
+		act.methodLine = decoratorLineInSrc(src, bodyOffsetInSrc, hit.methodOffset)
 		actions = append(actions, act)
 	}
 	for _, hit := range scanDecoratorCalls(body, drfLegacyListRouteOpenRe) {
 		act := parseActionArgs(hit.args, hit.methodName, false)
 		// list_route always means detail=False.
 		act.detail = false
+		act.methodLine = decoratorLineInSrc(src, bodyOffsetInSrc, hit.methodOffset)
 		actions = append(actions, act)
 	}
 	return actions
 }
 
+// decoratorLineInSrc maps a methodOffset returned by scanDecoratorCalls (a
+// byte index into `body`) to a 1-based src-relative line number. Returns 0
+// when src is empty (line tracking disabled).
+func decoratorLineInSrc(src string, bodyOffsetInSrc, methodOffsetInBody int) int {
+	if src == "" || methodOffsetInBody < 0 {
+		return 0
+	}
+	return lineOfByteOffset(src, bodyOffsetInSrc+methodOffsetInBody)
+}
+
 // decoratorCall is one parsed `@<name>(…)` decorator paired with the
 // method declared immediately below it.
 type decoratorCall struct {
-	args       string // body between the outer `(` and the matching `)`
-	methodName string // name from the `def <name>(` line that follows
+	args         string // body between the outer `(` and the matching `)`
+	methodName   string // name from the `def <name>(` line that follows
+	methodOffset int    // byte offset of `def` in the class body (#2677)
 }
 
 // scanDecoratorCalls walks `body` for every occurrence of `openRe` (which
@@ -1628,10 +1707,36 @@ func scanDecoratorCalls(body string, openRe *regexp.Regexp) []decoratorCall {
 		if tail == nil {
 			continue
 		}
-		methodName := body[afterClose+tail[2] : afterClose+tail[3]]
-		out = append(out, decoratorCall{args: args, methodName: methodName})
+		methodNameStart := afterClose + tail[2]
+		methodName := body[methodNameStart : afterClose+tail[3]]
+		// methodOffset points at `def` so the caller can compute its src-line
+		// for endpoint source-line attribution (#2677). The regex tail's
+		// group-0 begins at the whitespace/newline before `def`; scan forward
+		// to the `def` token to land on the meaningful character.
+		defOffset := afterClose + tail[0]
+		for defOffset < methodNameStart && body[defOffset] != 'd' {
+			defOffset++
+		}
+		out = append(out, decoratorCall{
+			args:         args,
+			methodName:   methodName,
+			methodOffset: defOffset,
+		})
 	}
 	return out
+}
+
+// lineOfByteOffset returns the 1-based line number of `src[offset]`. Returns
+// 1 when offset is out of range so callers always get a valid line for
+// downstream Properties storage (#2677).
+func lineOfByteOffset(src string, offset int) int {
+	if offset < 0 {
+		return 1
+	}
+	if offset > len(src) {
+		offset = len(src)
+	}
+	return 1 + strings.Count(src[:offset], "\n")
 }
 
 // scanBalancedClose returns the index of the `)` that balances the

--- a/internal/engine/django_urlconf_nested.go
+++ b/internal/engine/django_urlconf_nested.go
@@ -113,6 +113,51 @@ func ApplyDjangoNestedURLConf(
 		}
 		src := string(content)
 
+		// #2677 — emit one synthetic "URL mount point" http_endpoint per
+		// `path("prefix", include(...))` call so the answer to
+		// "where is /api/v1/ declared?" survives even after DRF/CBV expansion
+		// fully covers every concrete sub-path with per-verb entities (which
+		// triggers DeduplicateNestedURLConfDRF to remove the per-child ANY
+		// entries). The mount-point uses pattern_type=url_mount_point so dedup
+		// passes leave it alone, and a distinct synthetic ID suffix prevents
+		// collisions with concrete-verb entries on the same canonical path.
+		mountEmitted := map[string]bool{}
+		for _, idx := range djangoIncludeStringRe.FindAllStringSubmatchIndex(src, -1) {
+			parentPrefix := src[idx[2]:idx[3]]
+			if parentPrefix == "" {
+				continue
+			}
+			canonical := httproutes.Canonicalize(httproutes.FrameworkDjango,
+				joinDjangoRoutePaths(parentPrefix, ""))
+			if canonical == "" || canonical == "/" {
+				continue
+			}
+			mountID := httproutes.SyntheticID("ANY", canonical) + ":mount"
+			if mountEmitted[mountID] || seen[mountID] {
+				continue
+			}
+			mountEmitted[mountID] = true
+			seen[mountID] = true
+			out = append(out, types.EntityRecord{
+				ID:                 mountID,
+				Name:               mountID,
+				Kind:               httpEndpointKind,
+				SourceFile:         relPath,
+				StartLine:          1 + strings.Count(src[:idx[0]], "\n"),
+				Language:           "python",
+				EnrichmentRequired: false,
+				EnrichmentStatus:   types.StatusPending,
+				QualityScore:       0.5,
+				Properties: map[string]string{
+					"verb":         "ANY",
+					"path":         canonical,
+					"framework":    "django",
+					"pattern_type": "url_mount_point",
+					"url_prefix":   "/" + strings.Trim(parentPrefix, "/"),
+				},
+			})
+		}
+
 		// Find all `path("prefix", include("module.path"))` bindings.
 		for _, m := range djangoIncludeStringRe.FindAllStringSubmatch(src, -1) {
 			parentPrefix := m[1]

--- a/internal/engine/django_urlconf_nested_test.go
+++ b/internal/engine/django_urlconf_nested_test.go
@@ -186,7 +186,11 @@ urlpatterns = [
 }
 
 // TestApplyDjangoNestedURLConf_MissingChildFile verifies that a missing
-// included file is silently skipped (no panic, no spurious entities).
+// included file is silently skipped (no panic, no spurious child route
+// entities). Since #2677 the pass also emits a single `url_mount_point`
+// entity per include() call so the mount site stays discoverable even
+// when the child file is unreachable. Both the no-panic and the
+// no-child-route assertions remain.
 func TestApplyDjangoNestedURLConf_MissingChildFile(t *testing.T) {
 	files := fileMap{
 		"urls.py": `
@@ -201,8 +205,17 @@ urlpatterns = [
 	pyPaths := []string{"urls.py"}
 	// Should not panic.
 	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
-	if len(got) != 0 {
-		t.Errorf("expected no entities for missing child; got %d", len(got))
+	// Expect exactly one entity — the url_mount_point — and zero
+	// urlconf_nested_include child-route entries (the child file is missing).
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 entity (url_mount_point); got %d", len(got))
+	}
+	if got[0].Properties["pattern_type"] != "url_mount_point" {
+		t.Errorf("expected pattern_type=url_mount_point; got %q",
+			got[0].Properties["pattern_type"])
+	}
+	if got[0].Properties["url_prefix"] != "/api" {
+		t.Errorf("expected url_prefix=/api; got %q", got[0].Properties["url_prefix"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Resolves the #2677 P0: every DRF backend endpoint was attributing its `source_file` to the `routers.py` file containing the bare `router.register(...)` call. That file has 0 verb method definitions; the real handlers live in the ViewSet's own file. The endpoint → handler graph was completely severed for the upvate group's 621 backend endpoints.

- `parseViewSetClass` now records the `class ...` def line and, per overridden CRUD method, the `def <name>(` line. `extractActions` records the `def <name>(` line for every `@action` / `@detail_route` / `@list_route` decorator.
- `ApplyDjangoDRFRoutes` routes the resolved ViewSet file (and the corresponding method def line, falling back to the class def line for inherited mixin methods) through the emit closure. When ViewSet resolution fails, the original behavior is preserved (attribution stays on the routers/urlconf file).
- `ApplyDjangoNestedURLConf` emits one synthetic `url_mount_point` `http_endpoint` per `path("prefix", include(...))` call, attributing to the urls.py file at the `path(...)` line. This keeps "where is `/api/v1/` declared?" answerable after DRF/CBV expansion fully covers every sub-path with per-verb entities and the dedup pass drops the per-child ANY entries.

## Test plan

- [x] New integration test `cmd/archigraph/issue2677_drf_attribution_test.go` with fixture `cmd/archigraph/testdata/drf_attribution_fixture/` (urls.py → routers.py → views.py with `ModelViewSet` + `@action`).
  - `GET /api/v1/things` attributes to `views.py` at the `def list(` line.
  - `POST /api/v1/things/custom_action` attributes to `views.py` at the `@action`-decorated `def custom(` line.
  - At least one `/api/v1/` endpoint attributes to `urls.py` (mount-point discoverability).
  - No `/api/v1/things*` endpoint attributes to `routers.py` (regression guard).
- [x] `TestApplyDjangoNestedURLConf_MissingChildFile` updated to expect the `url_mount_point` entity even when the included child module is missing.
- [x] Existing engine test suite green (`go test ./internal/engine/ ./cmd/archigraph/`).
- [ ] Real-data verification on the upvate group: rebuild and spot-check 10 endpoints via `archigraph_inspect` — each must point to a ViewSet method file; `archigraph_find_callers GET /api/v1/buildings` surfaces the real call chain into `building_viewset.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)