### PR TITLE
feat(ruby): Rails routes.rb + Sinatra endpoint synthesis (#2691)

### DIFF
--- a/cmd/archigraph/issue2691_ruby_test.go
+++ b/cmd/archigraph/issue2691_ruby_test.go
@@ -1,0 +1,164 @@
+// Issue #2691 integration guard: every Rails / Sinatra http_endpoint_definition
+// must point at the handler's source file + line.
+//
+//   - Rails: route declared in config/routes.rb, handler lives in
+//     app/controllers/<name>_controller.rb at the `def <action>` line.
+//     The audit fixture uses both the explicit verb form
+//     (`get '/things/search', to: 'things#search'`), the `resources :things`
+//     macro (7 CRUD endpoints), and a `namespace :api do; resources :widgets end`
+//     block (api/widgets_controller.rb).
+//
+//   - Sinatra: each `get '/x' do … end` block attributes to its own line in
+//     the registration file (same-file by construction).
+//
+// Mirrors the DRF (#2677), Laravel (#2680), Gin/Echo (#2679), JS/TS (#2687)
+// acceptance shape: source_file ends in the handler file, source_line matches
+// the def line.
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func TestIssue2691_Rails_EndpointAttribution(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/audit2678_ruby/rails", "issue2691_rails", nil)
+
+	type ep struct {
+		Name string
+		File string
+		Line int
+	}
+	got := map[string]ep{}
+	for _, e := range doc.Entities {
+		if e.Kind != "http_endpoint_definition" && e.Kind != "http_endpoint" {
+			continue
+		}
+		got[e.Name] = ep{Name: e.Name, File: e.SourceFile, Line: e.StartLine}
+	}
+	if len(got) < 8 {
+		// Sanity floor: 1 explicit verb + 7 resources + 7 namespaced resources = 15.
+		// Allow some slack but catch a regression to "nothing was synthesised".
+		t.Fatalf("Rails fixture: expected >= 8 endpoint definitions, got %d (entities=%v)",
+			len(got), rubyEndpointNames(doc.Entities))
+	}
+
+	// Acceptance per ticket — `GET /things` attributes to ThingsController#index,
+	// `POST /things` to #create. Lines are 1-based against the fixture file.
+	//
+	// things_controller.rb (1-based):
+	//   1: class ThingsController < ApplicationController
+	//   2:   def index
+	//   ...
+	//   10:  def create
+	//   ...
+	cases := []struct {
+		endpoint   string
+		wantFile   string
+		wantLine   int
+		wantAction string
+	}{
+		{"http:GET:/things", "app/controllers/things_controller.rb", 2, "index"},
+		{"http:POST:/things", "app/controllers/things_controller.rb", 10, "create"},
+		{"http:GET:/things/{id}", "app/controllers/things_controller.rb", 6, "show"},
+		{"http:GET:/things/search", "app/controllers/things_controller.rb", 30, "search"},
+		// Namespaced resource: namespace :api do; resources :widgets end →
+		// api/widgets_controller.rb. The Api:: module-prefix maps to a
+		// lowercase subdirectory under app/controllers/ per Rails convention.
+		{"http:GET:/api/widgets", "app/controllers/api/widgets_controller.rb", 3, "index"},
+		{"http:POST:/api/widgets", "app/controllers/api/widgets_controller.rb", 11, "create"},
+	}
+	for _, tc := range cases {
+		g, ok := got[tc.endpoint]
+		if !ok {
+			t.Errorf("endpoint %s missing — synthesized set: %v", tc.endpoint, rubyMapKeys(got))
+			continue
+		}
+		if !strings.HasSuffix(strings.ReplaceAll(g.File, "\\", "/"), tc.wantFile) {
+			t.Errorf("endpoint %s: source_file=%s, want suffix %s (registration site, not handler — #2691 rebind regressed)",
+				tc.endpoint, g.File, tc.wantFile)
+		}
+		if g.Line != tc.wantLine {
+			t.Errorf("endpoint %s: start_line=%d, want %d (def %s line)",
+				tc.endpoint, g.Line, tc.wantLine, tc.wantAction)
+		}
+	}
+}
+
+func TestIssue2691_Sinatra_EndpointAttribution(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/audit2678_ruby/sinatra", "issue2691_sinatra", nil)
+
+	type ep struct {
+		Name string
+		File string
+		Line int
+	}
+	got := map[string]ep{}
+	for _, e := range doc.Entities {
+		if e.Kind != "http_endpoint_definition" && e.Kind != "http_endpoint" {
+			continue
+		}
+		got[e.Name] = ep{Name: e.Name, File: e.SourceFile, Line: e.StartLine}
+	}
+	if len(got) < 4 {
+		t.Fatalf("Sinatra fixture: expected >= 4 endpoint definitions, got %d (entities=%v)",
+			len(got), rubyEndpointNames(doc.Entities))
+	}
+
+	// Sinatra fixture app.rb (1-based):
+	//   1: require 'sinatra'
+	//   2:
+	//   3: get '/things' do
+	//   ...
+	//   8: post '/things' do
+	//   ...
+	//   13: get '/things/:id' do
+	//   ...
+	//   18: delete '/things/:id' do
+	cases := []struct {
+		endpoint string
+		wantLine int
+	}{
+		{"http:GET:/things", 3},
+		{"http:POST:/things", 8},
+		{"http:GET:/things/{id}", 13},
+		{"http:DELETE:/things/{id}", 18},
+	}
+	for _, tc := range cases {
+		g, ok := got[tc.endpoint]
+		if !ok {
+			t.Errorf("endpoint %s missing — synthesized set: %v", tc.endpoint, rubyMapKeys(got))
+			continue
+		}
+		if !strings.HasSuffix(strings.ReplaceAll(g.File, "\\", "/"), "app.rb") {
+			t.Errorf("endpoint %s: source_file=%s, want suffix app.rb",
+				tc.endpoint, g.File)
+		}
+		if g.Line != tc.wantLine {
+			t.Errorf("endpoint %s: start_line=%d, want %d (verb block line)",
+				tc.endpoint, g.Line, tc.wantLine)
+		}
+	}
+}
+
+// rubyEndpointNames returns just the Names of every http endpoint in a doc
+// (debug helper for the #2691 acceptance tests).
+func rubyEndpointNames(es []graph.Entity) []string {
+	out := make([]string, 0, len(es))
+	for _, e := range es {
+		if e.Kind == "http_endpoint_definition" || e.Kind == "http_endpoint" {
+			out = append(out, e.Name)
+		}
+	}
+	return out
+}
+
+func rubyMapKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/archigraph/testdata/audit2678_ruby/rails/app/controllers/api/widgets_controller.rb
+++ b/cmd/archigraph/testdata/audit2678_ruby/rails/app/controllers/api/widgets_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  class WidgetsController < ApplicationController
+    def index
+      render json: { widgets: [] }
+    end
+
+    def show
+      render json: { id: params[:id] }
+    end
+
+    def create
+      render json: { stored: true }
+    end
+
+    def update
+      render json: { updated: true }
+    end
+
+    def destroy
+      render json: { deleted: true }
+    end
+
+    def new
+      render json: { form: 'new' }
+    end
+
+    def edit
+      render json: { form: 'edit' }
+    end
+  end
+end

--- a/cmd/archigraph/testdata/audit2678_ruby/rails/app/controllers/things_controller.rb
+++ b/cmd/archigraph/testdata/audit2678_ruby/rails/app/controllers/things_controller.rb
@@ -1,0 +1,33 @@
+class ThingsController < ApplicationController
+  def index
+    render json: { things: [] }
+  end
+
+  def show
+    render json: { id: params[:id] }
+  end
+
+  def create
+    render json: { stored: true }
+  end
+
+  def update
+    render json: { updated: true }
+  end
+
+  def destroy
+    render json: { deleted: true }
+  end
+
+  def new
+    render json: { form: 'new' }
+  end
+
+  def edit
+    render json: { form: 'edit' }
+  end
+
+  def search
+    render json: { results: [] }
+  end
+end

--- a/cmd/archigraph/testdata/audit2678_ruby/rails/config/routes.rb
+++ b/cmd/archigraph/testdata/audit2678_ruby/rails/config/routes.rb
@@ -1,0 +1,12 @@
+Rails.application.routes.draw do
+  # Explicit verb route — handler lives in app/controllers/things_controller.rb
+  get '/things/search', to: 'things#search'
+
+  # resources macro expands to 7 standard CRUD routes
+  resources :things
+
+  # namespace prefixes the path AND the controller module
+  namespace :api do
+    resources :widgets
+  end
+end

--- a/cmd/archigraph/testdata/audit2678_ruby/sinatra/app.rb
+++ b/cmd/archigraph/testdata/audit2678_ruby/sinatra/app.rb
@@ -1,0 +1,21 @@
+require 'sinatra'
+
+get '/things' do
+  content_type :json
+  '{"things": []}'
+end
+
+post '/things' do
+  content_type :json
+  '{"stored": true}'
+end
+
+get '/things/:id' do
+  content_type :json
+  "{\"id\": #{params[:id]}}"
+end
+
+delete '/things/:id' do
+  content_type :json
+  '{"deleted": true}'
+end

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -313,9 +313,23 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 			continue
 		}
 
+		// #2691 — Rails-style cross-file hint: when the synthesizer
+		// supplied a `handler_file` property (derived from
+		// 'users#index' → app/controllers/users_controller.rb plus
+		// any enclosing namespace stack), prefer that file as the
+		// same-file lookup target. This disambiguates method names
+		// shared across many controllers (every Rails app has dozens
+		// of `index` / `show` / `create` methods) BEFORE the global
+		// (kind, name) fallback picks the first arbitrary match.
+		lookupFile := r.SourceFile
+		if r.Properties != nil {
+			if hf := r.Properties["handler_file"]; hf != "" {
+				lookupFile = hf
+			}
+		}
 		// Prefer same-file match (handlers and route synthetics are
 		// often emitted from the same file by Phase 1 construction).
-		handlerIdx, found := idx[key{hk, hn, r.SourceFile}]
+		handlerIdx, found := idx[key{hk, hn, lookupFile}]
 		if !found {
 			// Cross-file fallback (#753). Django composed routes record
 			// a `View:<ViewSet>` handler reference whose entity lives in
@@ -403,8 +417,9 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 				r.Language = handler.Language
 			}
 		}
-		// Clear the now-redundant property.
+		// Clear the now-redundant properties.
 		delete(r.Properties, "source_handler")
+		delete(r.Properties, "handler_file")
 		stats.HandlerResolved++
 	}
 

--- a/internal/engine/http_endpoint_ruby_producer.go
+++ b/internal/engine/http_endpoint_ruby_producer.go
@@ -1,0 +1,587 @@
+// http_endpoint_ruby_producer.go — Rails routes.rb + Sinatra DSL → http_endpoint_definition synthesis.
+//
+// Two Ruby web frameworks share this file:
+//
+//   - Rails  (config/routes.rb)
+//       get '/things/search', to: 'things#search'
+//       resources :things                          → 7 standard CRUD endpoints
+//       namespace :api do
+//         resources :widgets                       → prefixed with /api
+//       end
+//       scope '/v1' do
+//         get '/health', to: 'health#index'
+//       end
+//
+//     Handlers live in app/controllers/<name>_controller.rb (Rails convention).
+//     The synthesizer derives the expected controller file path from the
+//     "users#index" handler reference + the current namespace stack and
+//     emits it as a `handler_file` property. The shared resolver rebind
+//     (#2680) consumes this property to perform a *path-targeted* same-file
+//     lookup, which prevents the global (kind, name) fallback from picking
+//     the wrong controller for a method name shared across many controllers
+//     (every Rails app has dozens of `index` / `show` / `create` methods).
+//
+//   - Sinatra (app.rb / inline DSL)
+//       get '/things' do
+//         ...
+//       end
+//
+//     Handlers are inline blocks in the same file; we emit the endpoint
+//     with `def_line` pointing at the verb's line so the resolver
+//     post-pass leaves source_file/start_line on the registration site —
+//     which IS the handler site by construction.
+//
+// Refs #2691.
+package engine
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// Fast-path gates
+// ---------------------------------------------------------------------------
+
+// railsRoutesGateRe matches the routes.rb signature block. Files without
+// this anchor are skipped so the synthesizer doesn't fire on arbitrary Ruby.
+var railsRoutesGateRe = regexp.MustCompile(`(?m)\b(?:Rails\.application\.routes\.draw|Routes\.draw)\b`)
+
+// sinatraGateRe matches a Sinatra import. We deliberately require an explicit
+// `require 'sinatra'` (or `require "sinatra/base"`) before scanning verb
+// blocks — bare `get '/x' do ... end` in arbitrary Ruby would otherwise
+// false-positive on Rails routes.rb itself.
+var sinatraGateRe = regexp.MustCompile(`(?m)require\s+['"]sinatra(?:/base|/main)?['"]`)
+
+// ---------------------------------------------------------------------------
+// Compiled regexes
+// ---------------------------------------------------------------------------
+
+// railsVerbRouteRe matches an explicit verb route inside routes.rb:
+//
+//	get '/things', to: 'things#index'
+//	post "/things/:id", to: "things#update"
+//	delete '/things/:id'                  (no handler — bare path only)
+//
+// Capture groups: 1=verb, 2=path, 3=handler ref (e.g. "things#index").
+var railsVerbRouteRe = regexp.MustCompile(
+	`(?m)^\s*(get|post|put|patch|delete|head|options)\s+` +
+		`['"]([^'"\n\r]{1,500})['"]` +
+		`(?:\s*,\s*to:\s*['"]([\w/]+#\w+)['"])?`,
+)
+
+// railsResourcesRe matches `resources :name [, only: [...]] [, except: [...]]`.
+// Capture group 1 = the resource name (symbol body).
+var railsResourcesRe = regexp.MustCompile(`(?m)^\s*resources\s+:(\w+)\b`)
+
+// railsResourceSingularRe matches singular `resource :name` (Rails singular
+// resource — 6 routes, no index, no :id segment). We emit the same shape as
+// resources for now; the dominant convention in real apps is plural.
+var railsResourceSingularRe = regexp.MustCompile(`(?m)^\s*resource\s+:(\w+)\b`)
+
+// railsNamespaceOpenRe matches `namespace :name do`. The closing `end`
+// is tracked separately by walkRailsBlocks.
+var railsNamespaceOpenRe = regexp.MustCompile(`(?m)^\s*namespace\s+:(\w+)\s+do\b`)
+
+// railsScopeOpenRe matches `scope '/prefix' do` (path-only form). The
+// `scope module: …` and `scope path: …, module: …` forms are also accepted
+// — we look for the first single- or double-quoted string after `scope`.
+var railsScopeOpenRe = regexp.MustCompile(
+	`(?m)^\s*scope\s+(?:(?:path\s*:\s*)?['"]([^'"\n\r]+)['"]|:(\w+))[^\n\r]*\bdo\b`,
+)
+
+// railsBlockEndRe matches a bare `end` line — the close of a namespace /
+// scope block. We use a regex (rather than tokenising) because Rails routes
+// files are flat and `end` tokens inside string literals are vanishingly
+// rare in the wild.
+var railsBlockEndRe = regexp.MustCompile(`(?m)^\s*end\s*$`)
+
+// sinatraVerbBlockRe matches a Sinatra verb registration:
+//
+//	get '/things' do
+//	post "/things/:id" do |id|
+//
+// Capture groups: 1=verb, 2=path.
+var sinatraVerbBlockRe = regexp.MustCompile(
+	`(?m)^\s*(get|post|put|patch|delete|head|options)\s+` +
+		`['"]([^'"\n\r]{1,500})['"]\s*` +
+		`(?:\|[^|]*\|\s*)?` +
+		`do\b`,
+)
+
+// ---------------------------------------------------------------------------
+// CRUD expansion tables
+// ---------------------------------------------------------------------------
+
+// railsResourcesRoutes are the 7 standard routes emitted by `resources :name`.
+// Naming follows Rails' canonical action names so the handler resolves to
+// the matching controller method.
+var railsResourcesRoutes = []struct{ method, suffix, action string }{
+	{"GET", "", "index"},
+	{"POST", "", "create"},
+	{"GET", "/new", "new"},
+	{"GET", "/:id", "show"},
+	{"GET", "/:id/edit", "edit"},
+	{"PUT", "/:id", "update"},
+	{"PATCH", "/:id", "update"},
+	{"DELETE", "/:id", "destroy"},
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+// emitFileFn extends emitFn with a handler-file hint (used by Rails to point
+// the resolver at the controller file derived from "users#index") and a
+// 1-based def-line (used by Sinatra to anchor the synthetic at the verb
+// block's line in the same file). Either may be empty / 0 for callers that
+// don't need them.
+type emitFileFn func(method, canonicalPath, framework, refKind, refName, handlerFile string, defLine int)
+
+// synthesizeRailsRoutes scans a Ruby file for Rails routes.rb registrations
+// and calls emit per (verb, canonical-path, framework, handlerKind,
+// handlerName, handlerFile, defLine). routes.rb is matched by the
+// `Rails.application.routes.draw` sentinel — non-matching files are skipped.
+//
+// `routesPath` is the path of the routes.rb file. It's used to derive the
+// project root so handler files can be located at `app/controllers/<name>_controller.rb`.
+func synthesizeRailsRoutes(content, routesPath string, emit emitFileFn) {
+	if !railsRoutesGateRe.MatchString(content) {
+		return
+	}
+	rootDir := deriveRailsRoot(routesPath)
+	walkRailsBlocks(content, "", "", rootDir, emit)
+}
+
+// synthesizeSinatra scans a Ruby file for Sinatra verb-block registrations
+// and calls emit per (verb, canonical-path, "sinatra", "", "",
+// handlerFile=path, defLine=line-of-block). The handler is the block body
+// in the same file, so source_file/start_line attribution lands on the
+// registration line — which IS the handler line by construction.
+func synthesizeSinatra(content, path string, emit emitFileFn) {
+	if !sinatraGateRe.MatchString(content) {
+		return
+	}
+	for _, idx := range sinatraVerbBlockRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[idx[2]:idx[3]])
+		raw := content[idx[4]:idx[5]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		// def_line points at the verb block's own line; the synthetic's
+		// source_file is the registration file (which is also the
+		// handler file for Sinatra).
+		defLine := lineOfOffset(content, idx[2])
+		emit(verb, canonical, "sinatra", "", "", path, defLine)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rails routes.rb block walker
+// ---------------------------------------------------------------------------
+
+// walkRailsBlocks recursively scans `content` for verb routes, resources,
+// nested namespaces / scopes. `pathPrefix` and `modulePrefix` are the
+// composed prefixes from enclosing blocks: namespace :api contributes both
+// "/api" and "Api::" (module prefix maps to controller subdirectory and
+// class name in Rails' default conventions).
+func walkRailsBlocks(content, pathPrefix, modulePrefix, rootDir string, emit emitFileFn) {
+	// Process verb routes at this scope level first. We match across the
+	// whole content (no scope-aware filtering) because the dominant
+	// convention is to declare verb routes at the same depth as resources
+	// — but only when no enclosing block introduces a different prefix.
+	// Real-world routes files almost never mix `get` at root scope with a
+	// `get` inside `namespace :admin do` for the same path, so this
+	// simplification is safe.
+	if pathPrefix == "" && modulePrefix == "" {
+		// Strip nested `namespace`/`scope` blocks so verb routes inside
+		// them don't get double-counted (they'll be re-emitted by the
+		// recursive call with the correct prefix).
+		flat := stripRailsNestedBlocks(content)
+		emitRailsVerbRoutes(flat, "", "", rootDir, emit)
+		emitRailsResources(flat, "", "", rootDir, emit)
+	} else {
+		// At a nested level we receive only the body of the enclosing
+		// block (already stripped of its own nested children). Match
+		// every verb route + resources in this body.
+		emitRailsVerbRoutes(content, pathPrefix, modulePrefix, rootDir, emit)
+		emitRailsResources(content, pathPrefix, modulePrefix, rootDir, emit)
+	}
+	// Recurse into nested namespace / scope blocks.
+	for _, blk := range findRailsBlocks(content) {
+		childPath := pathPrefix
+		childModule := modulePrefix
+		switch blk.kind {
+		case "namespace":
+			childPath = joinPathFragments(pathPrefix, "/"+blk.name)
+			if modulePrefix == "" {
+				childModule = capitalize(blk.name)
+			} else {
+				childModule = modulePrefix + "::" + capitalize(blk.name)
+			}
+		case "scope_path":
+			childPath = joinPathFragments(pathPrefix, blk.name)
+		case "scope_module":
+			if modulePrefix == "" {
+				childModule = capitalize(blk.name)
+			} else {
+				childModule = modulePrefix + "::" + capitalize(blk.name)
+			}
+		}
+		// Strip THIS block's own nested children before recursing one
+		// level deeper so verb routes inside grand-children aren't
+		// emitted at the wrong prefix.
+		body := stripRailsNestedBlocks(blk.body)
+		emitRailsVerbRoutes(body, childPath, childModule, rootDir, emit)
+		emitRailsResources(body, childPath, childModule, rootDir, emit)
+		// Recurse for grand-children.
+		walkRailsBlocks(blk.body, childPath, childModule, rootDir, emit)
+	}
+}
+
+// railsBlock describes one namespace / scope block discovered in routes.rb.
+type railsBlock struct {
+	kind string // "namespace" | "scope_path" | "scope_module"
+	name string // "/api" for scope_path, "api" for namespace/scope_module
+	body string // content between `do` and matching `end`
+}
+
+// findRailsBlocks returns every top-level namespace/scope block in content,
+// pairing each `do` with its matching `end` by counting block tokens.
+func findRailsBlocks(content string) []railsBlock {
+	var out []railsBlock
+	// Find the next `namespace ... do` or `scope ... do` opener.
+	type opener struct {
+		kind, name string
+		start, end int // byte offset of the matching `end` line, computed lazily
+	}
+	// Single pass: walk character by character, when we hit an opener, find
+	// its matching `end` by counting any other `do` / `end` tokens between.
+	i := 0
+	for i < len(content) {
+		// Try namespace first, then scope, at the current position.
+		if m := railsNamespaceOpenRe.FindStringSubmatchIndex(content[i:]); m != nil && m[0] == 0 {
+			body, after, ok := extractRailsBlockBody(content, i+m[1])
+			if !ok {
+				i = i + m[1]
+				continue
+			}
+			out = append(out, railsBlock{kind: "namespace", name: content[i+m[2] : i+m[3]], body: body})
+			i = after
+			continue
+		}
+		if m := railsScopeOpenRe.FindStringSubmatchIndex(content[i:]); m != nil && m[0] == 0 {
+			// Path form (group 1) or module form (group 2)?
+			kind := "scope_path"
+			var name string
+			if m[2] >= 0 {
+				name = content[i+m[2] : i+m[3]]
+				if !strings.HasPrefix(name, "/") {
+					name = "/" + name
+				}
+			} else if m[4] >= 0 {
+				kind = "scope_module"
+				name = content[i+m[4] : i+m[5]]
+			}
+			body, after, ok := extractRailsBlockBody(content, i+m[1])
+			if !ok {
+				i = i + m[1]
+				continue
+			}
+			out = append(out, railsBlock{kind: kind, name: name, body: body})
+			i = after
+			continue
+		}
+		i++
+	}
+	return out
+}
+
+// extractRailsBlockBody returns the text between the `do` token at start and
+// its matching `end` line, plus the byte offset just past the `end`. Nested
+// `do`/`end` pairs are tracked so blocks like `namespace :a do; namespace :b
+// do; end; end` close at the correct point.
+//
+// Detection of `do` / `end` is simplified: we treat any line starting with
+// `end` (after whitespace) as a closer, and any line containing the regex
+// matches in railsNamespaceOpenRe / railsScopeOpenRe / a `do` token at end
+// of line followed by newline as an opener. This is sufficient for Rails
+// routes.rb, which is by convention a flat declarative DSL.
+func extractRailsBlockBody(content string, start int) (body string, after int, ok bool) {
+	depth := 1
+	// Walk line by line so we can use the end-of-line regex anchors.
+	pos := start
+	for pos < len(content) {
+		// Find next line.
+		newline := strings.IndexByte(content[pos:], '\n')
+		var line string
+		var lineEnd int
+		if newline < 0 {
+			line = content[pos:]
+			lineEnd = len(content)
+		} else {
+			line = content[pos : pos+newline]
+			lineEnd = pos + newline + 1
+		}
+		// Count openers on this line: any `... do` at end of line OR a
+		// `do |...|` pattern. We treat namespace/scope openers and bare
+		// `do` blocks uniformly: if the line ends with `do` or `do |…|`,
+		// it opens a block.
+		trimmed := strings.TrimSpace(line)
+		// Strip trailing comment.
+		if hashIdx := strings.IndexByte(trimmed, '#'); hashIdx >= 0 {
+			trimmed = strings.TrimSpace(trimmed[:hashIdx])
+		}
+		if trimmed != "" {
+			if endsWithDo(trimmed) {
+				depth++
+			}
+			if trimmed == "end" {
+				depth--
+				if depth == 0 {
+					return content[start:pos], lineEnd, true
+				}
+			}
+		}
+		pos = lineEnd
+		if newline < 0 {
+			break
+		}
+	}
+	return "", 0, false
+}
+
+// endsWithDo reports whether a trimmed routes.rb line ends with a `do`
+// token (with or without a `|args|` block-parameter list).
+func endsWithDo(line string) bool {
+	if strings.HasSuffix(line, " do") || line == "do" {
+		return true
+	}
+	// `do |x, y|` form — strip the `|...|` and re-check.
+	if idx := strings.LastIndexByte(line, '|'); idx > 0 {
+		if pre := strings.TrimSpace(line[:idx]); strings.HasSuffix(pre, "|") {
+			// Find the preceding `|`.
+			j := strings.IndexByte(pre[:len(pre)-1], '|')
+			if j > 0 {
+				before := strings.TrimSpace(pre[:j])
+				if strings.HasSuffix(before, " do") || before == "do" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// stripRailsNestedBlocks returns content with every top-level namespace /
+// scope block replaced by an equivalent number of newlines (so line offsets
+// are preserved). Used so verb routes inside a nested block aren't
+// double-counted when emitting the outer scope's routes.
+func stripRailsNestedBlocks(content string) string {
+	if !strings.Contains(content, " do") {
+		return content
+	}
+	var b strings.Builder
+	b.Grow(len(content))
+	i := 0
+	for i < len(content) {
+		blocked := false
+		for _, re := range []*regexp.Regexp{railsNamespaceOpenRe, railsScopeOpenRe} {
+			if m := re.FindStringSubmatchIndex(content[i:]); m != nil && m[0] == 0 {
+				_, after, ok := extractRailsBlockBody(content, i+m[1])
+				if !ok {
+					break
+				}
+				// Replace the [i, after) range with newlines preserving count.
+				for j := i; j < after; j++ {
+					if content[j] == '\n' {
+						b.WriteByte('\n')
+					} else {
+						b.WriteByte(' ')
+					}
+				}
+				i = after
+				blocked = true
+				break
+			}
+		}
+		if blocked {
+			continue
+		}
+		b.WriteByte(content[i])
+		i++
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Per-line emitters
+// ---------------------------------------------------------------------------
+
+// emitRailsVerbRoutes scans content for explicit verb routes and calls emit.
+// pathPrefix is prepended to the matched path; modulePrefix is used when the
+// `to:` handler reference is namespaced via a current `namespace`/`scope
+// module:` block (it modifies the controller file path).
+func emitRailsVerbRoutes(content, pathPrefix, modulePrefix, rootDir string, emit emitFileFn) {
+	for _, m := range railsVerbRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		raw := m[2]
+		fullPath := joinPathFragments(pathPrefix, ensureLeadingSlash(raw))
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, fullPath)
+		// Handler ref: "controller#action" → Controller class + method name.
+		// Namespace prefix is applied to the controller path lookup.
+		handlerKind, handlerName, handlerFile := "", "", ""
+		if len(m) >= 4 && m[3] != "" {
+			handlerKind, handlerName, handlerFile = parseRailsHandlerRef(m[3], modulePrefix, rootDir)
+		}
+		emit(verb, canonical, "rails", handlerKind, handlerName, handlerFile, 0)
+	}
+}
+
+// emitRailsResources expands `resources :name` and `resource :name` macros
+// into the 7 (or 6) canonical CRUD routes.
+func emitRailsResources(content, pathPrefix, modulePrefix, rootDir string, emit emitFileFn) {
+	for _, m := range railsResourcesRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		name := m[1]
+		base := joinPathFragments(pathPrefix, "/"+name)
+		for _, r := range railsResourcesRoutes {
+			raw := base + r.suffix
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+			handlerKind, handlerName, handlerFile := resolveRailsAction(name, r.action, modulePrefix, rootDir)
+			emit(r.method, canonical, "rails_resources", handlerKind, handlerName, handlerFile, 0)
+		}
+	}
+	for _, m := range railsResourceSingularRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		name := m[1]
+		base := joinPathFragments(pathPrefix, "/"+name)
+		// Singular: 6 routes (no index, no :id segment since it's a single resource).
+		singular := []struct{ method, suffix, action string }{
+			{"POST", "", "create"},
+			{"GET", "/new", "new"},
+			{"GET", "", "show"},
+			{"GET", "/edit", "edit"},
+			{"PUT", "", "update"},
+			{"PATCH", "", "update"},
+			{"DELETE", "", "destroy"},
+		}
+		for _, r := range singular {
+			raw := base + r.suffix
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+			handlerKind, handlerName, handlerFile := resolveRailsAction(name, r.action, modulePrefix, rootDir)
+			emit(r.method, canonical, "rails_resource", handlerKind, handlerName, handlerFile, 0)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Handler-ref / controller-file derivation
+// ---------------------------------------------------------------------------
+
+// parseRailsHandlerRef parses a Rails `to:` handler reference of the form
+// "controller#action" or "namespace/controller#action" into the
+// (handlerKind="SCOPE.Operation", handlerName=<action>, handlerFile=<controller .rb path>).
+//
+// Rails convention: 'users#index' → UsersController#index in
+// app/controllers/users_controller.rb. The Ruby extractor emits methods
+// with bare names (Name="index"), so the qualified name is just the
+// action; the resolver uses handlerFile to disambiguate when the same
+// action name appears in multiple controllers.
+func parseRailsHandlerRef(ref, modulePrefix, rootDir string) (kind, name, file string) {
+	hash := strings.IndexByte(ref, '#')
+	if hash <= 0 || hash == len(ref)-1 {
+		return "", "", ""
+	}
+	controllerPath := ref[:hash]
+	action := ref[hash+1:]
+	// "namespace/controller" segments map to subdirectories under
+	// app/controllers/. Module prefix from `namespace :api do` similarly
+	// maps to a subdirectory.
+	parts := strings.Split(controllerPath, "/")
+	dir := "app/controllers"
+	if modulePrefix != "" {
+		dir = filepath.Join(dir, strings.ToLower(strings.ReplaceAll(modulePrefix, "::", "/")))
+	}
+	for i := 0; i < len(parts)-1; i++ {
+		dir = filepath.Join(dir, parts[i])
+	}
+	leaf := parts[len(parts)-1] + "_controller.rb"
+	rel := filepath.Join(dir, leaf)
+	if rootDir != "" {
+		rel = filepath.Join(rootDir, rel)
+	}
+	return "SCOPE.Operation", action, filepath.ToSlash(rel)
+}
+
+// resolveRailsAction derives the controller file path + action name for a
+// resources expansion. `resourceName` is the (plural) resource symbol;
+// `action` is one of index/show/create/update/destroy/new/edit.
+func resolveRailsAction(resourceName, action, modulePrefix, rootDir string) (kind, name, file string) {
+	// `resources :things` → ThingsController in app/controllers/things_controller.rb.
+	dir := "app/controllers"
+	if modulePrefix != "" {
+		dir = filepath.Join(dir, strings.ToLower(strings.ReplaceAll(modulePrefix, "::", "/")))
+	}
+	leaf := resourceName + "_controller.rb"
+	rel := filepath.Join(dir, leaf)
+	if rootDir != "" {
+		rel = filepath.Join(rootDir, rel)
+	}
+	return "SCOPE.Operation", action, filepath.ToSlash(rel)
+}
+
+// deriveRailsRoot walks up from routesPath until the parent of `config/`
+// (i.e. the Rails project root). Returns the project root with forward
+// slashes; empty when no `config/` ancestor is found (which would be
+// abnormal — routes.rb should always live in config/).
+func deriveRailsRoot(routesPath string) string {
+	norm := filepath.ToSlash(routesPath)
+	idx := strings.LastIndex(norm, "/config/")
+	if idx < 0 {
+		// File is named config/routes.rb at repo root.
+		if strings.HasPrefix(norm, "config/") {
+			return ""
+		}
+		// Fallback: assume the parent dir of the file's directory is root.
+		return filepath.ToSlash(filepath.Dir(filepath.Dir(norm)))
+	}
+	return norm[:idx]
+}
+
+// capitalize uppercases the first byte of s. Used to convert a Ruby symbol
+// (`:api`) into the corresponding module name (`Api`) for namespace
+// composition.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	if s[0] >= 'a' && s[0] <= 'z' {
+		return string(s[0]-32) + s[1:]
+	}
+	return s
+}
+
+// ensureLeadingSlash prepends "/" when missing so joinPathFragments composes
+// correctly regardless of whether the source omitted the leading slash
+// (`get 'things'` is legal Rails, equivalent to `get '/things'`).
+func ensureLeadingSlash(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if p[0] != '/' {
+		return "/" + p
+	}
+	return p
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -241,6 +241,28 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		}
 	}
 
+	// emitFile wraps emit and stamps `handler_file` (cross-file hint,
+	// #2691 — Rails maps "users#index" to app/controllers/users_controller.rb)
+	// plus StartLine (#2691 — Sinatra anchors the synthetic at its verb
+	// block line in the same file). Either may be empty / 0.
+	emitFile := func(method, canonicalPath, framework, refKind, refName, handlerFile string, defLine int) {
+		before := len(entities)
+		emit(method, canonicalPath, framework, refKind, refName)
+		if len(entities) == before {
+			return
+		}
+		last := &entities[len(entities)-1]
+		if handlerFile != "" {
+			if last.Properties == nil {
+				last.Properties = map[string]string{}
+			}
+			last.Properties["handler_file"] = handlerFile
+		}
+		if defLine > 0 {
+			last.StartLine = defLine
+		}
+	}
+
 	// makeRuntimeEmit wraps the consumer-side emit with a FETCHES edge
 	// emission (#721). The edge's FromID is a kind-qualified reference
 	// (`<kind>:<name>`) that the downstream resolver binds to a stamped
@@ -363,6 +385,16 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// languages share the same Spring APIs.
 		synthesizeJavaClientWithRuntime(string(content), emitClientRuntime)
 	case "ruby":
+		// Producer side (#2691): Rails routes.rb DSL + Sinatra verb blocks.
+		// Rails synthesizer derives the expected controller file path from the
+		// "users#index" handler ref + enclosing namespace stack and stamps it as
+		// `handler_file`; the resolver post-pass (#2680 rebind) consumes that hint
+		// for path-targeted same-file lookup.
+		synthesizeRailsRoutes(string(content), path, emitFile)
+		// Sinatra blocks are inline — same-file by construction. emitFile stamps
+		// StartLine on the synthetic so the audit2678 attribution lands on the
+		// verb block's line in app.rb.
+		synthesizeSinatra(string(content), path, emitFile)
 		// Consumer side (#721 wave 2b): Net::HTTP, Faraday, HTTParty, RestClient.
 		synthesizeRubyClientWithRuntime(string(content), emitClientRuntime)
 	case "csharp":


### PR DESCRIPTION
## Summary

Closes #2691. Adds producer-side http_endpoint_definition synthesis for Rails (config/routes.rb DSL) and Sinatra (inline verb blocks) — the last two mainstream backend frameworks without endpoint catalog coverage.

- `synthesizeRailsRoutes` parses routes.rb: explicit `get '/x', to: 'users#index'`, `resources :name` (7 CRUD), singular `resource :name` (6 CRUD), `namespace :api do … end` (prefixes path + controller subdir), `scope '/v1' do … end`. Block-aware walker tracks `(pathPrefix, modulePrefix)` and emits each synthetic with a `handler_file` hint derived from canonical Rails layout.
- `synthesizeSinatra` parses `get '/path' do … end` blocks (gated on `require 'sinatra'`). Same-file by construction — handler line is stamped directly via the new `emitFile` wrapper.
- `ResolveHTTPEndpointHandlers` consumes `handler_file` for path-targeted same-file lookup, disambiguating Ruby's bare-named methods (`Name="index"`, `Name="create"`) before the global (kind, name) fallback picks the wrong controller.

## Before / after

- Before: `audit2678_ruby/rails` → 0 http_endpoint_definition entities. `audit2678_ruby/sinatra` → 0 entities.
- After: Rails fixture → 17 endpoints (1 explicit + 8 `resources :things` + 8 namespaced `resources :widgets`), all attributed to `app/controllers/.../*_controller.rb` at the `def <action>` line. Sinatra fixture → 4 endpoints, all attributed to `app.rb` at the verb block's line.

## Test plan

- [x] `go test ./cmd/archigraph/ -run TestIssue2691 -v` — both subtests pass
- [x] `go test ./internal/engine/...` — green
- [x] `go test ./internal/extractors/ruby/...` — green
- [x] Full `go test ./cmd/archigraph/...` — only pre-existing `TestAudit2678Go_GinEchoAttribution` failure (also fails on `origin/main`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)