### PR TITLE
feat(go): gorilla/mux + net/http + huma endpoint synthesis (#2684 #2685 #2686)

### DIFF
--- a/cmd/archigraph/issue2684_2685_2686_go_trio_test.go
+++ b/cmd/archigraph/issue2684_2685_2686_go_trio_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGoTrio_EndpointSynthesis is the integration guard for issues
+// #2684 (gorilla/mux), #2685 (net/http stdlib including Go 1.22
+// method-prefix patterns), and #2686 (huma OpenAPI). For each
+// framework the production pipeline must:
+//
+//  1. Emit at least 2 http_endpoint_definition entities from the
+//     fixture.
+//  2. After the shared resolver rebind, every emitted definition's
+//     source_file lands in the handler file (handlers.go), not the
+//     registration site (router.go).
+//  3. Properties[registration_source_file] preserves the original
+//     registration file (so the route mount-point is still
+//     discoverable) and Properties[registration_start_line] preserves
+//     the original line, both stashed by the resolver rebind.
+//  4. StartLine is positive and refers to the handler def line in the
+//     handler file.
+func TestGoTrio_EndpointSynthesis(t *testing.T) {
+	cases := []struct {
+		name        string
+		fixturePath string
+		framework   string
+		wantHandler string // suffix of source_file after rebind
+		// Expected (verb, path) tuples we MUST find synthesized. Each
+		// must end up attributed to wantHandler.
+		expected []struct{ verb, path string }
+	}{
+		{
+			name:        "gorilla_mux",
+			fixturePath: "testdata/audit2678_go_trio/gorilla",
+			framework:   "gorilla",
+			wantHandler: "handlers.go",
+			expected: []struct{ verb, path string }{
+				{"GET", "/users"},
+				{"GET", "/users/{id}"},
+				{"HEAD", "/users/{id}"},
+				{"POST", "/items"},
+				{"GET", "/health"},
+			},
+		},
+		{
+			name:        "net_http_stdlib",
+			fixturePath: "testdata/audit2678_go_trio/nethttp",
+			framework:   "nethttp",
+			wantHandler: "handlers.go",
+			expected: []struct{ verb, path string }{
+				{"ANY", "/legacy"},
+				{"ANY", "/items"},
+				{"GET", "/users/{id}"},
+				{"POST", "/users"},
+			},
+		},
+		{
+			name:        "huma",
+			fixturePath: "testdata/audit2678_go_trio/huma",
+			framework:   "huma",
+			wantHandler: "handlers.go",
+			expected: []struct{ verb, path string }{
+				{"GET", "/users/{id}"},
+				{"POST", "/users"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := runIndexerOn(t, tc.fixturePath, "go_trio_"+tc.name, nil)
+			if len(doc.Entities) == 0 {
+				t.Fatalf("no entities emitted from %s fixture", tc.name)
+			}
+
+			defs := map[string]int{}
+			for i, e := range doc.Entities {
+				if e.Kind == "http_endpoint_definition" {
+					defs[e.Name] = i
+				}
+			}
+
+			// Assertion 1: at least 2 http_endpoint_definition entities.
+			if len(defs) < 2 {
+				t.Fatalf("%s: got %d http_endpoint_definition entities, want ≥ 2 (names: %v)",
+					tc.name, len(defs), keysOf(defs))
+			}
+
+			for _, want := range tc.expected {
+				id := "http:" + want.verb + ":" + want.path
+				idx, ok := defs[id]
+				if !ok {
+					t.Errorf("%s: missing http_endpoint_definition for %s (got: %v)",
+						tc.name, id, keysOf(defs))
+					continue
+				}
+				e := doc.Entities[idx]
+
+				// Assertion 2: source_file rebound to the handler file.
+				if !strings.HasSuffix(e.SourceFile, tc.wantHandler) {
+					t.Errorf("%s %s: source_file=%q does not end with %q — "+
+						"resolver did not rebind to handler file",
+						tc.name, id, e.SourceFile, tc.wantHandler)
+				}
+
+				// Framework property must reflect the right synthesizer.
+				if got := e.Properties["framework"]; got != tc.framework {
+					t.Errorf("%s %s: framework=%q want %q",
+						tc.name, id, got, tc.framework)
+				}
+
+				// Assertion 3: registration_source_file + _start_line are
+				// stashed by the rebind. They're only stashed when the
+				// rebind actually moved the entity (handler in a different
+				// file from the registration site), which is the case for
+				// every fixture endpoint here by construction.
+				if got := e.Properties["registration_source_file"]; got == "" {
+					t.Errorf("%s %s: registration_source_file is empty — "+
+						"resolver rebind did not stash the original registration site",
+						tc.name, id)
+				} else if !strings.HasSuffix(got, "router.go") {
+					t.Errorf("%s %s: registration_source_file=%q does not end with router.go",
+						tc.name, id, got)
+				}
+				if got := e.Properties["registration_start_line"]; got == "" || got == "0" {
+					t.Errorf("%s %s: registration_start_line=%q, want a positive line number",
+						tc.name, id, got)
+				}
+
+				// Assertion 4: StartLine refers to the handler def line.
+				if e.StartLine <= 0 {
+					t.Errorf("%s %s: start_line=%d, want positive handler-def line",
+						tc.name, id, e.StartLine)
+				}
+			}
+		})
+	}
+}
+
+func keysOf(m map[string]int) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/archigraph/testdata/audit2678_go_trio/gorilla/handlers.go
+++ b/cmd/archigraph/testdata/audit2678_go_trio/gorilla/handlers.go
@@ -1,0 +1,24 @@
+// Handler definitions for the gorilla/mux router fixture. After the
+// resolver rebind, each http_endpoint_definition's source_file should
+// land in THIS file (not router.go).
+package gorillafixture
+
+import (
+	"net/http"
+)
+
+func listUsers(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`{"users":[]}`))
+}
+
+func getUser(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`{"id":1}`))
+}
+
+func createItem(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusCreated)
+}
+
+func healthCheck(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}

--- a/cmd/archigraph/testdata/audit2678_go_trio/gorilla/router.go
+++ b/cmd/archigraph/testdata/audit2678_go_trio/gorilla/router.go
@@ -1,0 +1,22 @@
+// gorilla/mux router — registers routes that point at handlers defined
+// in handlers.go. The #2684 endpoint synthesis emits one
+// http_endpoint_definition per (verb, path) tuple; the shared resolver
+// then rebinds source_file/source_line to the handler def.
+package gorillafixture
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func setupRouter() *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc("/users", listUsers).Methods("GET")
+	r.HandleFunc("/users/{id}", getUser).Methods("GET", "HEAD")
+	r.HandleFunc("/items", createItem).Methods(http.MethodPost)
+
+	api := r.PathPrefix("/api").Subrouter()
+	api.HandleFunc("/health", healthCheck).Methods("GET")
+	return r
+}

--- a/cmd/archigraph/testdata/audit2678_go_trio/huma/handlers.go
+++ b/cmd/archigraph/testdata/audit2678_go_trio/huma/handlers.go
@@ -1,0 +1,19 @@
+// Handler definitions for the huma router fixture. After resolver
+// rebind, http_endpoint_definition.source_file should land here.
+package humafixture
+
+import (
+	"context"
+)
+
+func getUser(ctx context.Context, in *GetUserInput) (*GetUserOutput, error) {
+	out := &GetUserOutput{}
+	out.Body.ID = in.ID
+	return out, nil
+}
+
+func createUser(ctx context.Context, in *CreateUserInput) (*CreateUserOutput, error) {
+	out := &CreateUserOutput{}
+	out.Body.ID = "u_1"
+	return out, nil
+}

--- a/cmd/archigraph/testdata/audit2678_go_trio/huma/router.go
+++ b/cmd/archigraph/testdata/audit2678_go_trio/huma/router.go
@@ -1,0 +1,47 @@
+// huma OpenAPI fixture — huma.Register binds an Operation struct to a
+// handler. The handler is the third argument; the Operation literal
+// carries Method + Path that we extract.
+package humafixture
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type GetUserInput struct {
+	ID string `path:"id"`
+}
+
+type GetUserOutput struct {
+	Body struct {
+		ID string `json:"id"`
+	}
+}
+
+type CreateUserInput struct {
+	Body struct {
+		Name string `json:"name"`
+	}
+}
+
+type CreateUserOutput struct {
+	Body struct {
+		ID string `json:"id"`
+	}
+}
+
+func register(api huma.API) {
+	huma.Register(api, huma.Operation{
+		Method:  http.MethodGet,
+		Path:    "/users/{id}",
+		Summary: "Get user by id",
+	}, getUser)
+
+	huma.Register(api, huma.Operation{
+		Method:  "POST",
+		Path:    "/users",
+		Summary: "Create user",
+	}, createUser)
+}

--- a/cmd/archigraph/testdata/audit2678_go_trio/nethttp/handlers.go
+++ b/cmd/archigraph/testdata/audit2678_go_trio/nethttp/handlers.go
@@ -1,0 +1,24 @@
+// Handler definitions for the net/http stdlib router fixture. The
+// integration test asserts source_file rebinds here from router.go and
+// that the original registration line is preserved as a property.
+package nethttpfixture
+
+import (
+	"net/http"
+)
+
+func legacyHandler(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("legacy"))
+}
+
+func itemsHandler(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`{"items":[]}`))
+}
+
+func getUser(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`{"id":1}`))
+}
+
+func createUser(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusCreated)
+}

--- a/cmd/archigraph/testdata/audit2678_go_trio/nethttp/router.go
+++ b/cmd/archigraph/testdata/audit2678_go_trio/nethttp/router.go
@@ -1,0 +1,19 @@
+// net/http stdlib router fixture for issue #2685. Exercises three
+// registration shapes: package-level http.HandleFunc (ANY verb), local
+// http.ServeMux HandleFunc (ANY verb), and Go 1.22+ method-prefix
+// patterns where the verb is the first token of the pattern string.
+package nethttpfixture
+
+import (
+	"net/http"
+)
+
+func setup() *http.ServeMux {
+	http.HandleFunc("/legacy", legacyHandler)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/items", itemsHandler)
+	mux.HandleFunc("GET /users/{id}", getUser)
+	mux.HandleFunc("POST /users", createUser)
+	return mux
+}

--- a/internal/engine/http_endpoint_go_trio.go
+++ b/internal/engine/http_endpoint_go_trio.go
@@ -1,0 +1,319 @@
+// Endpoint synthesis for the Go "trio" of router frameworks that
+// follow-up issues #2684 / #2685 / #2686 surfaced as unsupported during
+// the #2678 audit:
+//
+//   - gorilla/mux:  r.HandleFunc("/path", handler).Methods("GET")
+//   - net/http:     http.HandleFunc("/path", handler)
+//                   mux.HandleFunc("/path", handler)         // Go 1.22 ServeMux
+//                   mux.HandleFunc("GET /users/{id}", h)      // Go 1.22 method prefix
+//   - huma:         huma.Register(api, huma.Operation{Method: "GET", Path: "/x"}, h)
+//
+// All three frameworks share the same producer-side contract as the
+// existing gin/echo/chi/fiber synthesizers (#2682): emit one
+// http_endpoint per (verb, path, handler) tuple with a
+// `source_handler="Controller:<name>"` reference so the shared resolver
+// in http_endpoint_resolve.go can rebind source_file / source_line to
+// the handler def. The synthesizers therefore only have to extract the
+// three tuple components; the rebind side is already framework-agnostic.
+//
+// Each synthesizer is import-guarded to keep the false-positive rate
+// near zero: the regexes use generic method-call shapes that would
+// otherwise match unrelated code (e.g. `mux.HandleFunc` inside an
+// unrelated wrapper, or `huma.Register` aliased to something else).
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// gorilla/mux — issue #2684
+// ---------------------------------------------------------------------------
+
+// gorillaRouteRe matches a gorilla/mux route registration:
+//
+//	r.HandleFunc("/path", handler).Methods("GET")
+//	api.HandleFunc("/users/{id}", getUser).Methods("GET", "POST")
+//	sub.HandleFunc("/x", h.Create).Methods(http.MethodPut)
+//
+// Group 1 is the path, group 2 is the handler identifier, group 3 is
+// the raw .Methods(...) argument list. A subsequent regex parses the
+// argument list into individual verbs.
+//
+// The .Methods(...) suffix is OPTIONAL — gorilla treats a HandleFunc
+// without .Methods as accepting any verb. When absent we emit an "ANY"
+// endpoint so the route is still discoverable; downstream cross-repo
+// matchers treat ANY as wildcard-compatible (see
+// http_endpoint_match.go).
+var gorillaRouteRe = regexp.MustCompile(
+	`\b\w+\s*\.\s*HandleFunc\s*\(\s*` +
+		"`" + `?["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]` + "`" + `?\s*,\s*([\w.]+)\s*\)` +
+		`(?:\s*\.\s*Methods\s*\(([^)]*)\))?`,
+)
+
+// gorillaVerbRe extracts each verb literal from the .Methods(...) arg
+// list. Accepts both `"GET"` and `http.MethodGet` shapes.
+var gorillaVerbRe = regexp.MustCompile(
+	`(?:["` + "`" + `](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)["` + "`" + `])` +
+		`|` +
+		`(?:http\.Method(Get|Post|Put|Patch|Delete|Head|Options))`,
+)
+
+// goFileUsesGorillaMux reports whether the file imports gorilla/mux.
+// Used to gate the .HandleFunc synthesizer because `HandleFunc` is also
+// the net/http stdlib name — without an import gate the two synthesizers
+// would double-emit on the same call site.
+func goFileUsesGorillaMux(content string) bool {
+	return strings.Contains(content, "github.com/gorilla/mux")
+}
+
+// synthesizeGorillaMux scans a Go file for gorilla/mux route
+// registrations and emits one synthetic http_endpoint per (verb, path)
+// pair. When .Methods(...) lists multiple verbs (e.g. GET + POST on the
+// same path), one synthetic per verb is emitted so each entry has a
+// distinct canonical ID.
+//
+// Each synthetic is stamped with the 1-based line number of the
+// `.HandleFunc(...)` call in the source file. The shared resolver in
+// http_endpoint_resolve.go uses that line to populate
+// `registration_start_line` before rebinding StartLine to the handler
+// def line — so the route mount-point stays discoverable after the
+// rebind.
+func synthesizeGorillaMux(content string, emit emitDefFn) {
+	if !goFileUsesGorillaMux(content) {
+		return
+	}
+	for _, m := range gorillaRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		// FindAllStringSubmatchIndex returns 2*N indices: start/end for
+		// the whole match and for each capture group. Groups 1-3 carry
+		// path, handler, methods-arg.
+		if len(m) < 8 {
+			continue
+		}
+		rawPath := content[m[2]:m[3]]
+		handler := content[m[4]:m[5]]
+		var methodsArg string
+		if m[6] >= 0 {
+			methodsArg = content[m[6]:m[7]]
+		}
+		if i := strings.LastIndex(handler, "."); i >= 0 {
+			handler = handler[i+1:]
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, rawPath)
+		regLine := lineOfOffset(content, m[0])
+
+		verbs := parseGorillaVerbs(methodsArg)
+		if len(verbs) == 0 {
+			// .Methods(...) absent or empty → gorilla accepts any verb.
+			verbs = []string{"ANY"}
+		}
+		for _, verb := range verbs {
+			emit(verb, canonical, "gorilla", "Controller", handler, regLine)
+		}
+	}
+}
+
+// parseGorillaVerbs extracts verb strings from a .Methods(...) argument
+// list. Returns a deduplicated, upper-cased slice in the order each verb
+// first appears. An empty input yields an empty slice (caller decides
+// the default behavior).
+func parseGorillaVerbs(arg string) []string {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, m := range gorillaVerbRe.FindAllStringSubmatch(arg, -1) {
+		var v string
+		switch {
+		case m[1] != "":
+			v = strings.ToUpper(m[1])
+		case m[2] != "":
+			v = strings.ToUpper(m[2])
+		}
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// net/http stdlib — issue #2685
+// ---------------------------------------------------------------------------
+
+// stdlibHandleFuncRe matches net/http stdlib HandleFunc registrations:
+//
+//	http.HandleFunc("/x", handler)               // package-level mux
+//	mux.HandleFunc("/x", handler)                // local *http.ServeMux
+//	mux.HandleFunc("GET /users/{id}", handler)    // Go 1.22+ method prefix
+//
+// Group 1 is the pattern (which may contain a verb prefix in Go 1.22+),
+// group 2 is the handler identifier.
+//
+// Note: this regex *also* matches `r.HandleFunc("/x", h)` on a
+// gorilla/mux router. The synthesizer is gated on the absence of a
+// gorilla/mux import so the two paths never run on the same file.
+var stdlibHandleFuncRe = regexp.MustCompile(
+	`\b\w+\s*\.\s*HandleFunc\s*\(\s*` +
+		"`" + `?["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]` + "`" + `?\s*,\s*([\w.]+)`,
+)
+
+// stdlibMethodPrefixRe parses a Go 1.22+ "VERB /path" pattern string
+// into (verb, path). The verb prefix is optional in Go 1.22; when
+// absent the pattern is the full path and the verb is ANY.
+var stdlibMethodPrefixRe = regexp.MustCompile(
+	`^\s*(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(.+)$`,
+)
+
+// goFileUsesNetHTTPStdlib reports whether the file looks like it
+// registers handlers on the net/http stdlib mux. We accept either the
+// canonical `"net/http"` import (which everyone has) plus at least one
+// of the two registration entry points: the package-level
+// `http.HandleFunc(...)` call OR a call to `http.NewServeMux()` whose
+// result is then `HandleFunc`'d. Gating on these markers (rather than
+// the import alone) avoids false-positives in every Go file that
+// happens to import net/http for an unrelated reason.
+func goFileUsesNetHTTPStdlib(content string) bool {
+	if goFileUsesGorillaMux(content) {
+		// gorilla/mux's HandleFunc shadows the stdlib one in the regex;
+		// let synthesizeGorillaMux handle this file exclusively.
+		return false
+	}
+	if !strings.Contains(content, `"net/http"`) {
+		return false
+	}
+	return strings.Contains(content, "http.HandleFunc(") ||
+		strings.Contains(content, "http.NewServeMux(") ||
+		strings.Contains(content, "ServeMux")
+}
+
+// synthesizeNetHTTPStdlib scans a Go file for net/http stdlib route
+// registrations and emits one synthetic http_endpoint per call. Handles
+// the Go 1.22+ "VERB /path" method-prefix syntax when present;
+// otherwise emits the endpoint with verb=ANY. The 1-based line number
+// of the .HandleFunc call is stamped on each synthetic so the resolver
+// rebind can stash it as `registration_start_line`.
+func synthesizeNetHTTPStdlib(content string, emit emitDefFn) {
+	if !goFileUsesNetHTTPStdlib(content) {
+		return
+	}
+	for _, m := range stdlibHandleFuncRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		pattern := content[m[2]:m[3]]
+		handler := content[m[4]:m[5]]
+		if i := strings.LastIndex(handler, "."); i >= 0 {
+			handler = handler[i+1:]
+		}
+		regLine := lineOfOffset(content, m[0])
+
+		verb := "ANY"
+		path := pattern
+		if mp := stdlibMethodPrefixRe.FindStringSubmatch(pattern); mp != nil {
+			verb = strings.ToUpper(mp[1])
+			path = strings.TrimSpace(mp[2])
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, path)
+		emit(verb, canonical, "nethttp", "Controller", handler, regLine)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// huma — issue #2686
+// ---------------------------------------------------------------------------
+
+// humaRegisterRe matches a huma.Register(...) call. The Operation
+// struct literal is matched with a non-greedy body; we then extract
+// Method and Path from the body in a second pass so field ordering
+// inside the struct doesn't matter.
+//
+// Example:
+//
+//	huma.Register(api, huma.Operation{
+//	    Method: http.MethodGet,
+//	    Path:   "/users/{id}",
+//	    Summary: "Get user",
+//	}, handleGetUser)
+//
+// Group 1 is the Operation{...} body text, group 2 is the handler
+// identifier (third argument to Register).
+var humaRegisterRe = regexp.MustCompile(
+	`\bhuma\s*\.\s*Register\s*\(\s*\w+\s*,\s*(?:&\s*)?huma\.Operation\s*\{([\s\S]*?)\}\s*,\s*([\w.]+)\s*\)`,
+)
+
+// humaMethodFieldRe extracts the Method field value from an Operation
+// struct body. Accepts both `Method: "GET"` and `Method: http.MethodGet`.
+var humaMethodFieldRe = regexp.MustCompile(
+	`\bMethod\s*:\s*(?:["` + "`" + `](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)["` + "`" + `]` +
+		`|http\.Method(Get|Post|Put|Patch|Delete|Head|Options))`,
+)
+
+// humaPathFieldRe extracts the Path field value from an Operation body.
+var humaPathFieldRe = regexp.MustCompile(
+	`\bPath\s*:\s*` + "`" + `?["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]` + "`" + `?`,
+)
+
+// goFileUsesHuma reports whether the file imports the huma library.
+// Both v1 (danielgtaylor/huma) and v2 (danielgtaylor/huma/v2) ship the
+// same huma.Register entry point with the Operation struct.
+func goFileUsesHuma(content string) bool {
+	return strings.Contains(content, "danielgtaylor/huma")
+}
+
+// synthesizeHuma scans a Go file for huma.Register(...) calls and emits
+// one synthetic http_endpoint per call. Operations missing either
+// Method or Path are skipped (they would fail at huma runtime too, so
+// they're not real endpoints). The 1-based line number of the
+// huma.Register(...) call is stamped on each synthetic so the resolver
+// rebind can stash it as `registration_start_line`.
+func synthesizeHuma(content string, emit emitDefFn) {
+	if !goFileUsesHuma(content) {
+		return
+	}
+	for _, m := range humaRegisterRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		opBody := content[m[2]:m[3]]
+		handler := content[m[4]:m[5]]
+		if i := strings.LastIndex(handler, "."); i >= 0 {
+			handler = handler[i+1:]
+		}
+		regLine := lineOfOffset(content, m[0])
+
+		verb := humaVerbFromBody(opBody)
+		if verb == "" {
+			continue
+		}
+		pathMatch := humaPathFieldRe.FindStringSubmatch(opBody)
+		if pathMatch == nil {
+			continue
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, pathMatch[1])
+		emit(verb, canonical, "huma", "Controller", handler, regLine)
+	}
+}
+
+// humaVerbFromBody parses the Method field out of an Operation struct
+// body. Returns "" when no recognizable Method field is present.
+func humaVerbFromBody(body string) string {
+	m := humaMethodFieldRe.FindStringSubmatch(body)
+	if m == nil {
+		return ""
+	}
+	switch {
+	case m[1] != "":
+		return strings.ToUpper(m[1])
+	case m[2] != "":
+		return strings.ToUpper(m[2])
+	}
+	return ""
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -385,6 +385,17 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 	case "go":
 		// Producer side: Gin / Echo / Chi route registrations. #722.
 		synthesizeGoRouters(string(content), emit)
+		// Producer side: gorilla/mux (#2684), net/http stdlib including
+		// Go 1.22 method-prefix patterns (#2685), and huma OpenAPI
+		// (#2686). Each synthesizer is independently import-guarded so
+		// it no-ops on files that don't use that framework. They use
+		// emitDef so the registration call's line number is stamped on
+		// each synthetic; the shared resolver then stashes that line as
+		// `registration_start_line` before rebinding StartLine to the
+		// handler def.
+		synthesizeGorillaMux(string(content), emitDef)
+		synthesizeNetHTTPStdlib(string(content), emitDef)
+		synthesizeHuma(string(content), emitDef)
 		// Consumer side (#721 wave 2a): net/http, resty, fasthttp.
 		synthesizeGoClientWithRuntime(string(content), emitClientRuntime)
 	case "kotlin":


### PR DESCRIPTION
## Summary

Three follow-up Go frameworks the #2678 audit identified as NOT_IMPLEMENTED are now synthesised into `http_endpoint_definition` entities, mirroring the chi/fiber pattern from #2682:

- **gorilla/mux** (#2684): `r.HandleFunc("/path", h).Methods("GET", "POST")` — each verb becomes a distinct synthetic; absent/empty `.Methods` emits an ANY-verb endpoint; `http.MethodGet`-style constants are recognised alongside string literals.
- **net/http stdlib** (#2685): `http.HandleFunc` / `mux.HandleFunc` on `*http.ServeMux`. Go 1.22+ `"VERB /path"` method-prefix patterns are parsed into `(verb, path)`; patterns without a verb prefix emit ANY. Gated to skip files importing gorilla/mux.
- **huma OpenAPI** (#2686): `huma.Register(api, huma.Operation{Method, Path, ...}, handler)`. Field-order-agnostic body parser; both huma v1 and v2 imports are recognised.

All three synthesisers use `emitDef` so the registration line is stamped on each synthetic before the shared resolver in `http_endpoint_resolve.go` rebinds `source_file` / `start_line` to the handler def and stashes `registration_source_file` + `registration_start_line` on the synthetic. No changes to the resolver were required.

Per-framework verdict update (#2678 follow-up):

| Framework   | Before                              | After |
|-------------|-------------------------------------|-------|
| gorilla/mux | NOT IMPLEMENTED — issue #2684       | FIXED |
| net/http    | NOT IMPLEMENTED — issue #2685       | FIXED |
| huma        | NOT IMPLEMENTED — issue #2686       | FIXED |

## Test plan

- [x] `go test ./cmd/archigraph -run TestGoTrio -count=1` — all three subtests pass (gorilla_mux: 5 endpoints, net_http_stdlib: 4 endpoints, huma: 2 endpoints; every endpoint rebinds to `handlers.go` with `registration_source_file=router.go` + positive `registration_start_line`).
- [x] `go test ./internal/engine/... -count=1` — no regressions.
- [x] `go build ./...` clean.

Closes #2684, #2685, #2686.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)