### PR TITLE
feat(multi): ASP.NET + Phoenix + Rocket endpoint synthesis (#2692)

### DIFF
--- a/cmd/archigraph/issue2692_other_trio_test.go
+++ b/cmd/archigraph/issue2692_other_trio_test.go
@@ -1,0 +1,189 @@
+// Issue #2692 — production-pipeline guards for ASP.NET Core, Elixir
+// Phoenix, and Rust Rocket endpoint synthesis + handler attribution.
+//
+// Each per-framework subtest runs the full Indexer.Run on a fixture under
+// testdata/audit2678_other_trio/<framework>/ and asserts:
+//
+//   - the expected http_endpoint_definition synthetics exist for the
+//     framework's representative endpoints (count check + presence check);
+//   - source_file of each definition points at the file containing the
+//     handler body (controller/handler source), NOT the routing /
+//     registration site (true for annotation-based frameworks by
+//     construction, and verified through ResolveHTTPEndpointHandlers'
+//     #2680 rebind for the cross-file Phoenix case);
+//   - source_line of each definition equals the 1-based line of the
+//     handler's `def` / method declaration, matching the convention
+//     established by #2677 (DRF) and #2678 (Flask, FastAPI, JS/TS, Go,
+//     PHP/Laravel).
+//
+// The fixtures live alongside this test file; keep the asserted line
+// numbers in sync with the source files in testdata/audit2678_other_trio.
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIssue2692_OtherTrio_EndpointAttribution_ASPNet runs the production
+// pipeline against the ASP.NET Core fixture and asserts the synthetic
+// endpoints attribute to WidgetsController.cs at the method declaration
+// lines.
+func TestIssue2692_OtherTrio_EndpointAttribution_ASPNet(t *testing.T) {
+	doc := runIndexerOn(t,
+		"testdata/audit2678_other_trio/aspnet",
+		"issue2692_aspnet", nil)
+
+	// Expected endpoints + the LINE of the method declaration in
+	// Controllers/WidgetsController.cs.
+	//
+	// The C# extractor anchors method_declaration entities at the start
+	// of the leading attribute_list (this is the tree-sitter convention
+	// and matches Spring/JAX-RS where the @-annotation line is the method
+	// entity's start_line). The resolver rebind (#2680) therefore lands
+	// the synthetic at the [Http...] attribute line, which is the
+	// conventional "method def line" for attribute-routed C#.
+	//
+	// [HttpGet]         on line 9  → method_declaration starts L9   (List)
+	// [HttpGet("{id}")] on line 15 → method_declaration starts L15  (Get)
+	// [HttpPost]        on line 21 → method_declaration starts L21  (Create)
+	cases := []struct {
+		id       string
+		wantLine int
+	}{
+		{"http:GET:/api/widgets", 9},
+		{"http:GET:/api/widgets/{id}", 15},
+		{"http:POST:/api/widgets", 21},
+	}
+	for _, tc := range cases {
+		found := false
+		for _, e := range doc.Entities {
+			if e.Kind != "http_endpoint_definition" && e.Kind != "http_endpoint" {
+				continue
+			}
+			if e.ID != tc.id && e.Name != tc.id {
+				continue
+			}
+			found = true
+			if !strings.HasSuffix(e.SourceFile, "WidgetsController.cs") {
+				t.Errorf("aspnet %s: source_file=%q, want suffix WidgetsController.cs", tc.id, e.SourceFile)
+			}
+			if e.StartLine != tc.wantLine {
+				t.Errorf("aspnet %s: start_line=%d, want %d (method def line)", tc.id, e.StartLine, tc.wantLine)
+			}
+			if e.Properties["framework"] != "aspnet_core" {
+				t.Errorf("aspnet %s: framework=%q, want aspnet_core", tc.id, e.Properties["framework"])
+			}
+		}
+		if !found {
+			t.Errorf("aspnet: missing http_endpoint_definition %s", tc.id)
+		}
+	}
+}
+
+// TestIssue2692_OtherTrio_EndpointAttribution_Phoenix runs the production
+// pipeline against the Phoenix fixture. Routes are declared in router.ex
+// but the handler bodies live in
+// controllers/user_controller.ex and controllers/widget_controller.ex.
+// The resolver rebind (#2680 + #2692 file-hint extension) must repoint
+// source_file/start_line to the controller file's `def <action>` line.
+func TestIssue2692_OtherTrio_EndpointAttribution_Phoenix(t *testing.T) {
+	doc := runIndexerOn(t,
+		"testdata/audit2678_other_trio/phoenix",
+		"issue2692_phoenix", nil)
+
+	// user_controller.ex:
+	//   def index   on line 4
+	//   def show    on line 8
+	//   def create  on line 12
+	// widget_controller.ex:
+	//   def index   on line 4
+	//   def show    on line 8
+	//   def create  on line 12
+	type want struct {
+		id       string
+		fileHint string
+		wantLine int
+	}
+	cases := []want{
+		{"http:GET:/api/users", "user_controller.ex", 4},
+		{"http:GET:/api/users/{id}", "user_controller.ex", 8},
+		{"http:POST:/api/users", "user_controller.ex", 12},
+		// resources "/widgets", WidgetController, only: [:index, :show, :create]
+		{"http:GET:/api/widgets", "widget_controller.ex", 4},
+		{"http:GET:/api/widgets/{id}", "widget_controller.ex", 8},
+		{"http:POST:/api/widgets", "widget_controller.ex", 12},
+	}
+	for _, tc := range cases {
+		found := false
+		for _, e := range doc.Entities {
+			if e.Kind != "http_endpoint_definition" && e.Kind != "http_endpoint" {
+				continue
+			}
+			if e.ID != tc.id && e.Name != tc.id {
+				continue
+			}
+			found = true
+			if !strings.HasSuffix(e.SourceFile, tc.fileHint) {
+				t.Errorf("phoenix %s: source_file=%q, want suffix %s (resolver should rebind from router.ex to controller file)", tc.id, e.SourceFile, tc.fileHint)
+			}
+			if e.StartLine != tc.wantLine {
+				t.Errorf("phoenix %s: start_line=%d, want %d (`def %s` line in controller)", tc.id, e.StartLine, tc.wantLine, tc.id)
+			}
+			fw := e.Properties["framework"]
+			if fw != "phoenix" && fw != "phoenix_resources" {
+				t.Errorf("phoenix %s: framework=%q, want phoenix/phoenix_resources", tc.id, fw)
+			}
+		}
+		if !found {
+			t.Errorf("phoenix: missing http_endpoint_definition %s", tc.id)
+		}
+	}
+}
+
+// TestIssue2692_OtherTrio_EndpointAttribution_Rocket runs the production
+// pipeline against the Rocket fixture. Rocket attribute macros sit on the
+// same `fn` they decorate, so source_file is correct by construction and
+// the resolver rebind populates start_line from the SCOPE.Operation entity.
+func TestIssue2692_OtherTrio_EndpointAttribution_Rocket(t *testing.T) {
+	doc := runIndexerOn(t,
+		"testdata/audit2678_other_trio/rocket",
+		"issue2692_rocket", nil)
+
+	// src/main.rs:
+	//   fn hello        line 5
+	//   fn show_user    line 10
+	//   fn create_user  line 15
+	cases := []struct {
+		id       string
+		wantLine int
+	}{
+		{"http:GET:/hello", 5},
+		{"http:GET:/users/{id}", 10},
+		{"http:POST:/users", 15},
+	}
+	for _, tc := range cases {
+		found := false
+		for _, e := range doc.Entities {
+			if e.Kind != "http_endpoint_definition" && e.Kind != "http_endpoint" {
+				continue
+			}
+			if e.ID != tc.id && e.Name != tc.id {
+				continue
+			}
+			found = true
+			if !strings.HasSuffix(e.SourceFile, "main.rs") {
+				t.Errorf("rocket %s: source_file=%q, want suffix main.rs", tc.id, e.SourceFile)
+			}
+			if e.StartLine != tc.wantLine {
+				t.Errorf("rocket %s: start_line=%d, want %d (`fn` line)", tc.id, e.StartLine, tc.wantLine)
+			}
+			if e.Properties["framework"] != "rocket" {
+				t.Errorf("rocket %s: framework=%q, want rocket", tc.id, e.Properties["framework"])
+			}
+		}
+		if !found {
+			t.Errorf("rocket: missing http_endpoint_definition %s", tc.id)
+		}
+	}
+}

--- a/cmd/archigraph/testdata/audit2678_other_trio/aspnet/Controllers/WidgetsController.cs
+++ b/cmd/archigraph/testdata/audit2678_other_trio/aspnet/Controllers/WidgetsController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TrioFixture.Aspnet.Controllers;
+
+[ApiController]
+[Route("/api/[controller]")]
+public class WidgetsController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult List()
+    {
+        return Ok(new[] { 1, 2, 3 });
+    }
+
+    [HttpGet("{id}")]
+    public IActionResult Get(int id)
+    {
+        return Ok(new { id });
+    }
+
+    [HttpPost]
+    public IActionResult Create([FromBody] object body)
+    {
+        return Created("/api/widgets", body);
+    }
+}

--- a/cmd/archigraph/testdata/audit2678_other_trio/phoenix/lib/my_app_web/controllers/user_controller.ex
+++ b/cmd/archigraph/testdata/audit2678_other_trio/phoenix/lib/my_app_web/controllers/user_controller.ex
@@ -1,0 +1,15 @@
+defmodule MyAppWeb.UserController do
+  use Phoenix.Controller
+
+  def index(conn, _params) do
+    json(conn, %{users: []})
+  end
+
+  def show(conn, %{"id" => id}) do
+    json(conn, %{id: id})
+  end
+
+  def create(conn, params) do
+    json(conn, %{created: params})
+  end
+end

--- a/cmd/archigraph/testdata/audit2678_other_trio/phoenix/lib/my_app_web/controllers/widget_controller.ex
+++ b/cmd/archigraph/testdata/audit2678_other_trio/phoenix/lib/my_app_web/controllers/widget_controller.ex
@@ -1,0 +1,15 @@
+defmodule MyAppWeb.WidgetController do
+  use Phoenix.Controller
+
+  def index(conn, _params) do
+    json(conn, %{widgets: []})
+  end
+
+  def show(conn, %{"id" => id}) do
+    json(conn, %{id: id})
+  end
+
+  def create(conn, params) do
+    json(conn, %{created: params})
+  end
+end

--- a/cmd/archigraph/testdata/audit2678_other_trio/phoenix/lib/my_app_web/router.ex
+++ b/cmd/archigraph/testdata/audit2678_other_trio/phoenix/lib/my_app_web/router.ex
@@ -1,0 +1,17 @@
+defmodule MyAppWeb.Router do
+  use Phoenix.Router
+
+  pipeline :api do
+    plug :accepts, ["json"]
+  end
+
+  scope "/api", MyAppWeb do
+    pipe_through :api
+
+    get "/users", UserController, :index
+    get "/users/:id", UserController, :show
+    post "/users", UserController, :create
+
+    resources "/widgets", WidgetController, only: [:index, :show, :create]
+  end
+end

--- a/cmd/archigraph/testdata/audit2678_other_trio/rocket/src/main.rs
+++ b/cmd/archigraph/testdata/audit2678_other_trio/rocket/src/main.rs
@@ -1,0 +1,22 @@
+#[macro_use]
+extern crate rocket;
+
+#[get("/hello")]
+fn hello() -> &'static str {
+    "Hello, world!"
+}
+
+#[get("/users/<id>")]
+fn show_user(id: u32) -> String {
+    format!("user {}", id)
+}
+
+#[post("/users", data = "<body>")]
+fn create_user(body: String) -> String {
+    format!("created: {}", body)
+}
+
+#[launch]
+fn rocket() -> _ {
+    rocket::build().mount("/", routes![hello, show_user, create_user])
+}

--- a/internal/engine/aspnet_core_routes.go
+++ b/internal/engine/aspnet_core_routes.go
@@ -1,0 +1,199 @@
+// http_endpoint_aspnet_core.go — ASP.NET Core attribute-routing → http_endpoint_definition synthesis.
+//
+// ASP.NET Core uses class-level `[Route("/api/[controller]")]` (and the
+// `[ApiController]` marker) on a `*Controller` class together with
+// per-action verb attributes `[HttpGet("...")]` / `[HttpPost("...")]` /
+// `[HttpPut/Patch/Delete/Head/Options("...")]`. The action method may
+// appear on the line immediately after the verb attribute (or after a
+// stack of intermediate attributes such as `[ProducesResponseType]`,
+// `[Authorize]`, etc.). All artefacts live in the same `.cs` file, so
+// this synthesizer is single-file and same-file is the dominant case.
+//
+// Token substitution:
+//
+//	[Route("/api/[controller]")]  on  class WidgetsController
+//	      → "/api/widgets"
+//
+// The `[controller]` token expands to the controller class name with the
+// trailing "Controller" suffix stripped and lowercased — matching the
+// canonical ASP.NET Core convention. `[action]` is similarly supported
+// (expanded to the lowercased method name).
+//
+// Handler attribution is wired through ResolveHTTPEndpointHandlers via a
+// `source_handler=SCOPE.Operation:<Class>.<Method>` property. The C#
+// extractor names methods inside a class as `<Class>.<Method>` (see
+// internal/extractors/csharp/csharp.go buildOperation), so the resolver
+// can rebind source_file / start_line to the action method without the
+// cross-file globalIdx fallback needing to fire. For controllers split
+// from their routing site the same rebind still applies via globalIdx.
+//
+// Refs #2692.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// aspnetVerbAttrRe captures a method-level HTTP verb attribute and the
+// following method name. The route argument is optional (e.g. `[HttpGet]`
+// on its own pairs with the class-level `[Route]` for `GET /api/widgets`).
+//
+// We allow intervening attributes (`[ProducesResponseType(...)]`,
+// `[Authorize]`, etc.) and access / modifier keywords between the verb
+// attribute and the method declaration. The method-return-type chunk
+// `[\w<>\[\],.\s?]+?` matches `IActionResult`, `Task<ActionResult<Foo>>`,
+// `ValueTask<IEnumerable<Bar>>`, etc.
+//
+// Capture groups:
+//
+//	1 = HTTP verb (Get / Post / Put / Patch / Delete / Head / Options)
+//	2 = optional route argument (the string literal contents)
+//	3 = method name
+var aspnetVerbAttrRe = regexp.MustCompile(
+	`\[\s*Http(Get|Post|Put|Patch|Delete|Head|Options)\s*` +
+		`(?:\(\s*(?:"([^"\r\n]*)")?[^)]*\))?\s*\]` +
+		`\s*(?:[\r\n]+(?:\s*\[[^\]\r\n]+\]\s*[\r\n]+)*)?\s*` +
+		`(?:public|protected|private|internal|static|virtual|override|sealed|async|\s)+` +
+		`[\w<>\[\],.\s?]+?\s+([A-Za-z_]\w*)\s*\(`,
+)
+
+// aspnetClassRouteRe captures the class-level `[Route("...")]` value and
+// the controller class name (allowing intervening attributes between the
+// `[Route]` line and the `class` declaration).
+//
+// Capture groups:
+//
+//	1 = route argument
+//	2 = class name
+var aspnetClassRouteRe = regexp.MustCompile(
+	`\[\s*Route\s*\(\s*"([^"\r\n]*)"\s*\)\s*\]` +
+		`\s*[\r\n]+(?:\s*\[[^\]\r\n]+\]\s*[\r\n]+)*` +
+		`\s*(?:public|internal|sealed|abstract|partial|static|\s)*` +
+		`class\s+([A-Za-z_]\w*)`,
+)
+
+// aspnetControllerClassRe matches every Controller class declaration in
+// the file (with or without a class-level `[Route]`). Used to recover the
+// class name when the only route prefix lives implicitly in `[Route]`.
+//
+// Capture group 1 = class name.
+var aspnetControllerClassRe = regexp.MustCompile(
+	`(?m)^\s*(?:public|internal|sealed|abstract|partial|static|\s)*` +
+		`class\s+([A-Za-z_]\w*Controller)\b`,
+)
+
+// aspnetHasAttributeRouting returns true when the file shows any sign of
+// ASP.NET Core attribute routing. Used as a fast pre-filter so the regex
+// machinery doesn't run on every C# file in the index.
+func aspnetHasAttributeRouting(content string) bool {
+	if !strings.Contains(content, "[Http") && !strings.Contains(content, "[Route") {
+		return false
+	}
+	// Cheap shape check: at least one HTTP verb attribute is present.
+	return strings.Contains(content, "[HttpGet") ||
+		strings.Contains(content, "[HttpPost") ||
+		strings.Contains(content, "[HttpPut") ||
+		strings.Contains(content, "[HttpPatch") ||
+		strings.Contains(content, "[HttpDelete") ||
+		strings.Contains(content, "[HttpHead") ||
+		strings.Contains(content, "[HttpOptions")
+}
+
+// aspnetControllerToken converts a controller class name to the lower-case
+// token that `[controller]` substitutes to. Strips the trailing "Controller"
+// suffix per the canonical ASP.NET Core convention.
+//
+//	WidgetsController -> "widgets"
+//	UsersController   -> "users"
+//	HomeController    -> "home"
+//	Misc              -> "misc"  (no suffix to strip)
+func aspnetControllerToken(class string) string {
+	name := strings.TrimSuffix(class, "Controller")
+	return strings.ToLower(name)
+}
+
+// aspnetSubstituteTokens expands `[controller]` and `[action]` tokens in a
+// route template using the controller class name and method name.
+func aspnetSubstituteTokens(template, controllerClass, method string) string {
+	out := template
+	if controllerClass != "" {
+		token := aspnetControllerToken(controllerClass)
+		out = strings.ReplaceAll(out, "[controller]", token)
+	}
+	if method != "" {
+		out = strings.ReplaceAll(out, "[action]", strings.ToLower(method))
+	}
+	return out
+}
+
+// synthesizeASPNetCore scans a C# source file for ASP.NET Core attribute
+// routing patterns and calls emit for each (verb, canonical-path,
+// framework, handlerKind, handlerName) tuple discovered.
+//
+// The class-level `[Route(...)]` prefix is applied to every per-method
+// verb attribute. When a method-level attribute provides an absolute path
+// (one starting with `/`), it replaces the class prefix entirely, matching
+// the ASP.NET Core routing precedence rules.
+func synthesizeASPNetCore(content string, emit emitFn) {
+	if !aspnetHasAttributeRouting(content) {
+		return
+	}
+
+	// Resolve the (single) controller class name + class-level prefix for
+	// this file. ASP.NET Core overwhelmingly uses one controller per file;
+	// when the file declares multiple controllers we still pick the first
+	// `[Route(...)]`-anchored class as the prefix anchor and attribute all
+	// actions to it (acceptable for the same reasons NestJS does).
+	classPrefix := ""
+	className := ""
+	if m := aspnetClassRouteRe.FindStringSubmatch(content); len(m) >= 3 {
+		classPrefix = m[1]
+		className = m[2]
+	}
+	// Fallback: no class-level [Route], but a *Controller class exists —
+	// the empty prefix is fine, but we still want className for
+	// `[controller]` token expansion in method-level attributes.
+	if className == "" {
+		if m := aspnetControllerClassRe.FindStringSubmatch(content); len(m) >= 2 {
+			className = m[1]
+		}
+	}
+
+	for _, m := range aspnetVerbAttrRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		methodPath := m[2]
+		methodName := m[3]
+
+		var raw string
+		switch {
+		case methodPath == "":
+			raw = classPrefix
+		case strings.HasPrefix(methodPath, "/"):
+			// Absolute method-level path overrides the class prefix.
+			raw = methodPath
+		default:
+			raw = joinPathFragments(classPrefix, methodPath)
+		}
+		raw = aspnetSubstituteTokens(raw, className, methodName)
+
+		canonical := httproutes.Canonicalize(httproutes.FrameworkASPNetCore, raw)
+		if canonical == "" {
+			continue
+		}
+		// SCOPE.Operation:<Class>.<Method> matches the C# extractor's
+		// convention (buildOperation in internal/extractors/csharp/csharp.go).
+		// The resolver rebinds source_file / start_line to the method
+		// declaration via the #2680 mechanism.
+		refName := methodName
+		if className != "" {
+			refName = className + "." + methodName
+		}
+		emit(verb, canonical, "aspnet_core", "SCOPE.Operation", refName)
+	}
+}

--- a/internal/engine/aspnet_core_routes_test.go
+++ b/internal/engine/aspnet_core_routes_test.go
@@ -1,0 +1,128 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestASPNetCore_Basic covers class-level [Route] + per-method verb
+// attributes — the dominant ASP.NET Core pattern.
+func TestASPNetCore_Basic(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("/api/widgets")]
+public class WidgetsController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult List() { return Ok(); }
+
+    [HttpGet("{id}")]
+    public IActionResult Get(int id) { return Ok(); }
+
+    [HttpPost]
+    public IActionResult Create() { return Ok(); }
+}
+`
+	ids, _ := runDetect(t, "csharp", "WidgetsController.cs", src)
+	want := []string{
+		"http:GET:/api/widgets",
+		"http:GET:/api/widgets/{id}",
+		"http:POST:/api/widgets",
+	}
+	requireContains(t, ids, want, "aspnet-basic")
+}
+
+// TestASPNetCore_ControllerTokenSubstitution verifies the `[controller]`
+// token expands to the lower-cased controller class name (minus the
+// "Controller" suffix).
+func TestASPNetCore_ControllerTokenSubstitution(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("/api/[controller]")]
+public class WidgetsController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult List() { return Ok(); }
+
+    [HttpGet("{id}")]
+    public IActionResult Get(int id) { return Ok(); }
+}
+`
+	ids, _ := runDetect(t, "csharp", "WidgetsController.cs", src)
+	want := []string{
+		"http:GET:/api/widgets",
+		"http:GET:/api/widgets/{id}",
+	}
+	requireContains(t, ids, want, "aspnet-controller-token")
+}
+
+// TestASPNetCore_AllVerbs covers get/post/put/patch/delete/head/options.
+func TestASPNetCore_AllVerbs(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.Mvc;
+
+[Route("/res")]
+public class ResController : ControllerBase
+{
+    [HttpGet] public IActionResult G() { return Ok(); }
+    [HttpPost] public IActionResult P() { return Ok(); }
+    [HttpPut("{id}")] public IActionResult U(int id) { return Ok(); }
+    [HttpPatch("{id}")] public IActionResult Pa(int id) { return Ok(); }
+    [HttpDelete("{id}")] public IActionResult D(int id) { return Ok(); }
+    [HttpHead] public IActionResult H() { return Ok(); }
+    [HttpOptions] public IActionResult O() { return Ok(); }
+}
+`
+	ids, _ := runDetect(t, "csharp", "ResController.cs", src)
+	want := []string{
+		"http:GET:/res",
+		"http:POST:/res",
+		"http:PUT:/res/{id}",
+		"http:PATCH:/res/{id}",
+		"http:DELETE:/res/{id}",
+		"http:HEAD:/res",
+		"http:OPTIONS:/res",
+	}
+	requireContains(t, ids, want, "aspnet-all-verbs")
+}
+
+// TestASPNetCore_MethodLevelAbsolutePath covers a method-level attribute
+// whose path starts with `/` and therefore OVERRIDES the class prefix
+// (matching ASP.NET Core routing semantics).
+func TestASPNetCore_MethodLevelAbsolutePath(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.Mvc;
+
+[Route("/api/[controller]")]
+public class HealthController : ControllerBase
+{
+    [HttpGet("/healthz")]
+    public IActionResult Healthz() { return Ok(); }
+}
+`
+	ids, _ := runDetect(t, "csharp", "HealthController.cs", src)
+	want := []string{"http:GET:/healthz"}
+	requireContains(t, ids, want, "aspnet-method-absolute")
+}
+
+// TestASPNetCore_RouteConstraintStripped verifies that the `:int`
+// route-constraint suffix on `{id:int}` is dropped during canonicalisation
+// so producer and consumer sides agree on the same synthetic ID.
+func TestASPNetCore_RouteConstraintStripped(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.Mvc;
+
+[Route("/api/widgets")]
+public class WidgetsController : ControllerBase
+{
+    [HttpGet("{id:int}")]
+    public IActionResult Get(int id) { return Ok(); }
+}
+`
+	ids, _ := runDetect(t, "csharp", "WidgetsController.cs", src)
+	want := []string{"http:GET:/api/widgets/{id}"}
+	requireContains(t, ids, want, "aspnet-route-constraint")
+}

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -136,6 +136,13 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 	// can locate and scan the actual handler body.
 	type knKey struct{ kind, name string }
 	globalIdx := make(map[knKey]int, len(merged))
+	// #2692 — multi-match index for the Phoenix-style `name@file_hint`
+	// resolution path. Routes-file frameworks (Phoenix router) declare
+	// handlers by short action name (`index`, `show`) that collides
+	// repo-wide. The synthesizer encodes the controller-module basename
+	// as a hint suffix; the resolver uses this list to pick the candidate
+	// whose source_file matches.
+	globalMulti := make(map[knKey][]int, len(merged))
 	// #1217: migrate legacy http_endpoint entities to the new split kinds
 	// based on their pattern_type property. Graphs indexed before this
 	// release may still carry the old kind string; we rewrite it in-place
@@ -169,6 +176,7 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 		if _, ok := globalIdx[gk]; !ok {
 			globalIdx[gk] = i
 		}
+		globalMulti[gk] = append(globalMulti[gk], i)
 	}
 
 	// Build an index of definitions by canonical Name (= synthetic ID)
@@ -322,14 +330,37 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 		// of `index` / `show` / `create` methods) BEFORE the global
 		// (kind, name) fallback picks the first arbitrary match.
 		lookupFile := r.SourceFile
+		handlerFileHint := ""
 		if r.Properties != nil {
 			if hf := r.Properties["handler_file"]; hf != "" {
 				lookupFile = hf
+				handlerFileHint = hf
 			}
 		}
 		// Prefer same-file match (handlers and route synthetics are
 		// often emitted from the same file by Phase 1 construction).
 		handlerIdx, found := idx[key{hk, hn, lookupFile}]
+		// #2692 — Phoenix-style cross-file hint: the synthesizer cannot
+		// know the full controller file path because Phoenix repos
+		// arrange them differently (lib/myapp_web/controllers/, web/,
+		// etc.). When the exact-file lookup misses and a `handler_file`
+		// hint is set, use it as a SUBSTRING match against every
+		// candidate entity with the right (kind, name).
+		if !found && handlerFileHint != "" {
+			candidateKinds := append([]string{hk}, resolverKindEquivalents[hk]...)
+			for _, ck := range candidateKinds {
+				for _, ci := range globalMulti[knKey{ck, hn}] {
+					if strings.Contains(merged[ci].SourceFile, handlerFileHint) {
+						handlerIdx = ci
+						found = true
+						break
+					}
+				}
+				if found {
+					break
+				}
+			}
+		}
 		if !found {
 			// Cross-file fallback (#753). Django composed routes record
 			// a `View:<ViewSet>` handler reference whose entity lives in
@@ -566,6 +597,7 @@ func splitHandlerRef(ref string) (kind, name string, ok bool) {
 	}
 	return ref[:i], ref[i+1:], true
 }
+
 
 // resolveCallerToFetchesEdge attempts to resolve a consumer synthetic's
 // `source_caller` property into a real caller entity in the same file

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -409,11 +409,17 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Consumer side (#721 wave 2b): Net::HTTP, Faraday, HTTParty, RestClient.
 		synthesizeRubyClientWithRuntime(string(content), emitClientRuntime)
 	case "csharp":
+		// Producer side (#2692): ASP.NET Core attribute routing —
+		// [HttpGet/Post/...] + class-level [Route("/api/[controller]")].
+		synthesizeASPNetCore(string(content), emit)
 		// Consumer side (#721 wave 2b): HttpClient, RestSharp, Refit, WebClient.
 		synthesizeCSharpClientWithRuntime(string(content), emitClientRuntime)
 	case "rust":
 		// Producer side (#1420): axum Router::new().route(...) registrations.
 		synthesizeAxumRoutes(string(content), emit)
+		// Producer side (#2692): Rocket attribute macros
+		// (#[get("/path")], #[post("/path")], ...).
+		synthesizeRocket(string(content), emit)
 		// Consumer side (#721 wave 2c): reqwest, hyper, ureq, surf.
 		synthesizeRustClientWithRuntime(string(content), emitClientRuntime)
 	case "php":
@@ -423,6 +429,24 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// WordPress HTTP API, Laravel Http facade.
 		synthesizePHPClientWithRuntime(string(content), emitClientRuntime)
 	case "elixir":
+		// Producer side (#2692): Phoenix router file scope/verb/resources.
+		// The synth supplies a controller-module snake_case file hint
+		// (e.g. `user_controller`); we stamp it as `handler_file` on the
+		// just-emitted synthetic so the resolver substring-matches it
+		// against candidate handler entities (#2692 extension of the
+		// #2691 Rails handler_file mechanism).
+		synthesizePhoenix(string(content), func(method, canonicalPath, framework, refKind, refName, fileHint string) {
+			before := len(entities)
+			emit(method, canonicalPath, framework, refKind, refName)
+			if fileHint == "" || len(entities) == before {
+				return
+			}
+			last := &entities[len(entities)-1]
+			if last.Properties == nil {
+				last.Properties = map[string]string{}
+			}
+			last.Properties["handler_file"] = fileHint
+		})
 		// Consumer side (#1483): Finch.build(:verb, url) + HTTPoison.<verb>(url).
 		synthesizeElixirHTTPClients(string(content), emitClient)
 	}

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -48,6 +48,17 @@ const (
 	// function sees the path, so canonicalisation here is identity +
 	// normaliseSlashes (default case).
 	FrameworkTornado = "tornado"
+	// FrameworkASPNetCore (#2692) — ASP.NET Core `[Route("/api/{id}")]` and
+	// `[HttpGet("/path/{id:int}")]` use the same curly-brace syntax as Spring
+	// (and accept the optional `:type` route-constraint suffix). Canonicalisation
+	// reuses canonicalizeCurlyBraces which strips the constraint suffix.
+	FrameworkASPNetCore = "aspnet_core"
+	// FrameworkPhoenix (#2692) — Elixir Phoenix routers use `:name` colon-prefixed
+	// path parameters (`get "/users/:id", ...`), identical to Express/Rails/Gin.
+	FrameworkPhoenix = "phoenix"
+	// FrameworkRocket (#2692) — Rust Rocket attribute macros use `<name>` angle-
+	// bracket path parameters (`#[get("/users/<id>")]`), like Django/Flask.
+	FrameworkRocket = "rocket"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -67,7 +78,7 @@ func Canonicalize(framework, raw string) string {
 
 	var out string
 	switch framework {
-	case FrameworkDjango, FrameworkFlask:
+	case FrameworkDjango, FrameworkFlask, FrameworkRocket:
 		// #2669 — Django re_path and DRF @action(url_path=…) frequently embed
 		// Python named-group regex `(?P<name>charclass)` inside the URL. Pre-strip
 		// these to `<name>` so the angle-bracket walker can canonicalise them
@@ -77,7 +88,7 @@ func Canonicalize(framework, raw string) string {
 		out = stripPythonNamedGroups(raw)
 		out = canonicalizeAngleBrackets(out)
 	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS, FrameworkAxum,
-		FrameworkStarlette, FrameworkPyramid:
+		FrameworkStarlette, FrameworkPyramid, FrameworkASPNetCore:
 		out = canonicalizeCurlyBraces(raw)
 	case FrameworkTornado:
 		// Tornado paths arrive already pre-processed by the synthesizer
@@ -85,7 +96,7 @@ func Canonicalize(framework, raw string) string {
 		// strips any stray `:regex` constraints, mirroring the other
 		// curly-brace frameworks.
 		out = canonicalizeCurlyBraces(raw)
-	case FrameworkExpress, FrameworkGin, FrameworkEcho, FrameworkChi:
+	case FrameworkExpress, FrameworkGin, FrameworkEcho, FrameworkChi, FrameworkPhoenix:
 		out = canonicalizeColonParams(raw)
 	default:
 		// Unknown framework: pass through but still normalise slashes.

--- a/internal/engine/phoenix_routes.go
+++ b/internal/engine/phoenix_routes.go
@@ -1,0 +1,342 @@
+// http_endpoint_phoenix.go — Elixir Phoenix router → http_endpoint_definition synthesis.
+//
+// Phoenix declares routes in a `router.ex` file as a block of `scope` /
+// `pipe_through` / verb / `resources` calls:
+//
+//	scope "/api", MyAppWeb do
+//	    pipe_through :api
+//	    get "/users", UserController, :index
+//	    post "/users", UserController, :create
+//	    resources "/widgets", WidgetController
+//	end
+//
+// The action functions (`def index(...)`, `def create(...)`, ...) live in
+// the matching controller file, e.g. `controllers/user_controller.ex`,
+// inside `defmodule MyAppWeb.UserController do`. The Elixir extractor
+// emits each `def` as `SCOPE.Operation:<func>` (no module qualification),
+// so a naive (kind, name) cross-file lookup would resolve `index` to the
+// FIRST `def index` found anywhere in the merged set — which collides
+// across controllers in any non-trivial app.
+//
+// Disambiguation: we stamp the controller module's snake_case basename
+// (e.g. `user_controller`) on the synthetic as a `handler_file` property
+// hint. The shared resolver (http_endpoint_resolve.go) consumes the hint
+// as a SUBSTRING match against every candidate handler's source_file when
+// the exact-file lookup misses — the #2692 extension of the #2691 Rails
+// `handler_file` mechanism, generalised to bare-basename hints.
+//
+// Coverage:
+//
+//   - `get|post|put|patch|delete|head|options "/path", MyController, :action`
+//   - `resources "/widgets", WidgetController`               — 7 CRUD verbs
+//   - `resources "/widgets", WidgetController, only: [:index, :show]`
+//   - `resources "/widgets", WidgetController, except: [:delete]`
+//   - `scope "/prefix", MyAppWeb do ... end` — prefix is prepended; the
+//     module alias on the scope line is recorded so unqualified
+//     `MyController` references in the body can be resolved against it
+//     (not currently needed — we only consume the basename).
+//   - Nested scopes — prefixes compose by string concatenation.
+//
+// Out of scope (phase 1):
+//
+//   - `forward "/admin", AdminPlug`                       — Plug forwards
+//   - `live "/path", LiveView, :live_action`              — Phoenix LiveView
+//   - `pipe_through` semantics — informational only; we do not gate
+//     synthesis on pipeline membership.
+//
+// Refs #2692.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// phoenixVerbRouteRe matches `<verb> "/path", MyController, :action`
+// (with optional trailing kwargs).
+//
+// Capture groups:
+//
+//	1 = verb
+//	2 = path
+//	3 = controller module (may be qualified with `.` like MyAppWeb.UserController)
+//	4 = action atom name
+var phoenixVerbRouteRe = regexp.MustCompile(
+	`(?m)^\s*(get|post|put|patch|delete|head|options)\s+` +
+		`"([^"\r\n]+)"\s*,\s*` +
+		`([A-Za-z_][\w.]*)\s*,\s*` +
+		`:([A-Za-z_]\w*)`,
+)
+
+// phoenixResourcesRe matches `resources "/path", MyController` with
+// optional kwargs. The `only:` / `except:` lists are extracted from the
+// kwargs blob captured in group 3 by parsePhoenixResourceFilter.
+//
+// Capture groups:
+//
+//	1 = path
+//	2 = controller module
+//	3 = trailing args (may be empty or contain `only:` / `except:` / `do` etc.)
+var phoenixResourcesRe = regexp.MustCompile(
+	`(?m)^\s*resources\s+"([^"\r\n]+)"\s*,\s*([A-Za-z_][\w.]*)([^\r\n]*)`,
+)
+
+// phoenixScopeRe matches `scope "/prefix", MaybeModule do` and `scope MaybeModule do`.
+//
+// Capture groups:
+//
+//	1 = optional quoted prefix (may be empty when only the module form is used)
+var phoenixScopeRe = regexp.MustCompile(
+	`(?m)^\s*scope\s+(?:"([^"\r\n]*)"|[A-Za-z_][\w.]*)` +
+		`(?:\s*,\s*[A-Za-z_][\w.]*)?` +
+		`(?:\s*,\s*\[[^\]]*\])?\s*do\b`,
+)
+
+// phoenixEndRe matches a bare `end` keyword at the start of a line. We use
+// it to close `scope ... do` blocks for prefix composition.
+var phoenixEndRe = regexp.MustCompile(`(?m)^\s*end\s*$`)
+
+// phoenixResourceCRUDActions enumerates the 7 standard actions
+// `resources` generates plus the verb + path-suffix each implies.
+// The action name doubles as the disambiguation hint when looking up the
+// controller-module's `def <action>` entity.
+var phoenixResourceCRUDActions = []struct{ action, verb, suffix string }{
+	{"index", "GET", ""},
+	{"new", "GET", "/new"},
+	{"create", "POST", ""},
+	{"show", "GET", "/{id}"},
+	{"edit", "GET", "/{id}/edit"},
+	{"update", "PUT", "/{id}"},
+	{"delete", "DELETE", "/{id}"},
+}
+
+// phoenixHasRouter is a fast pre-filter: any non-router file lacks both
+// `Phoenix.Router` and the `scope` / verb / `resources` macros.
+func phoenixHasRouter(content string) bool {
+	if !strings.Contains(content, "Phoenix.Router") &&
+		!strings.Contains(content, "use Phoenix.Router") &&
+		!strings.Contains(content, "scope ") {
+		return false
+	}
+	return strings.Contains(content, "get ") || strings.Contains(content, "post ") ||
+		strings.Contains(content, "put ") || strings.Contains(content, "patch ") ||
+		strings.Contains(content, "delete ") || strings.Contains(content, "resources ") ||
+		strings.Contains(content, "head ") || strings.Contains(content, "options ")
+}
+
+// phoenixControllerHint converts a Phoenix controller module reference
+// (possibly qualified with `MyAppWeb.`) into the snake_case basename the
+// matching controller file uses. Example:
+//
+//	MyAppWeb.UserController        → user_controller
+//	WidgetController               → widget_controller
+//	MyAppWeb.Admin.UserController  → user_controller
+//
+// The trailing `Controller` suffix is preserved (Phoenix file naming
+// convention includes it) and the camel-cased prefix is converted to
+// snake_case with an underscore before every capital except the first.
+func phoenixControllerHint(modRef string) string {
+	last := modRef
+	if i := strings.LastIndexByte(modRef, '.'); i >= 0 {
+		last = modRef[i+1:]
+	}
+	return camelToSnake(last)
+}
+
+// camelToSnake converts CamelCase / PascalCase to snake_case. Consecutive
+// upper-case letters (e.g. "HTTPServer") are preserved as a single run with
+// a single leading underscore (`http_server`). Non-letter characters are
+// passed through verbatim.
+func camelToSnake(s string) string {
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 4)
+	runes := []rune(s)
+	for i, r := range runes {
+		isUpper := r >= 'A' && r <= 'Z'
+		if isUpper && i > 0 {
+			prev := runes[i-1]
+			prevUpper := prev >= 'A' && prev <= 'Z'
+			// Insert an underscore on every uppercase boundary except
+			// inside an all-caps run (HTTPServer → http_server).
+			if !prevUpper {
+				b.WriteByte('_')
+			} else if i+1 < len(runes) {
+				next := runes[i+1]
+				if next >= 'a' && next <= 'z' {
+					// "HTTPServer" — emit underscore before the start of the
+					// next word's leading capital ('S' before 'erver').
+					b.WriteByte('_')
+				}
+			}
+		}
+		if isUpper {
+			b.WriteRune(r + ('a' - 'A'))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// parsePhoenixResourceFilter inspects the trailing kwargs blob of a
+// `resources "...", Ctrl, only: [:show, :index]` declaration and returns
+// the filter set + filter mode:
+//
+//	mode "only"   — emit only the listed actions
+//	mode "except" — emit all actions except the listed ones
+//	mode ""       — no filter, emit all 7
+//
+// The returned set contains action atoms (without the leading colon).
+func parsePhoenixResourceFilter(args string) (mode string, set map[string]bool) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return "", nil
+	}
+	for _, kw := range []string{"only", "except"} {
+		needle := kw + ":"
+		idx := strings.Index(args, needle)
+		if idx < 0 {
+			continue
+		}
+		tail := args[idx+len(needle):]
+		open := strings.IndexByte(tail, '[')
+		close := strings.IndexByte(tail, ']')
+		if open < 0 || close < 0 || close <= open {
+			continue
+		}
+		body := tail[open+1 : close]
+		out := map[string]bool{}
+		for _, tok := range strings.Split(body, ",") {
+			tok = strings.TrimSpace(tok)
+			tok = strings.TrimPrefix(tok, ":")
+			if tok != "" {
+				out[tok] = true
+			}
+		}
+		return kw, out
+	}
+	return "", nil
+}
+
+// phoenixScopePrefixAt returns the active scope prefix that should be
+// prepended to a route declaration at byte offset `off`. We walk every
+// `scope ... do` opener and `end` closer in the file and maintain a
+// running prefix stack. The current stack at `off` is concatenated.
+//
+// This is a single linear scan over the file content — O(n) regardless
+// of how many routes the file declares.
+func phoenixScopePrefixAt(content string, off int) string {
+	type evt struct {
+		offset int
+		open   bool
+		prefix string
+	}
+	var events []evt
+	for _, m := range phoenixScopeRe.FindAllStringSubmatchIndex(content, -1) {
+		prefix := ""
+		if len(m) >= 4 && m[2] >= 0 {
+			prefix = content[m[2]:m[3]]
+		}
+		events = append(events, evt{offset: m[0], open: true, prefix: prefix})
+	}
+	for _, m := range phoenixEndRe.FindAllStringIndex(content, -1) {
+		events = append(events, evt{offset: m[0], open: false})
+	}
+	// Sort by offset.
+	for i := 1; i < len(events); i++ {
+		for j := i; j > 0 && events[j-1].offset > events[j].offset; j-- {
+			events[j-1], events[j] = events[j], events[j-1]
+		}
+	}
+	var stack []string
+	for _, e := range events {
+		if e.offset >= off {
+			break
+		}
+		if e.open {
+			stack = append(stack, e.prefix)
+		} else if len(stack) > 0 {
+			stack = stack[:len(stack)-1]
+		}
+	}
+	var b strings.Builder
+	for _, p := range stack {
+		b.WriteString(p)
+	}
+	return b.String()
+}
+
+// phoenixEmitFn extends emitFn with the controller-module file hint so
+// the synth can stamp `handler_file` on the synthetic without coupling
+// to the dispatch-internal emitFile closure shape. The dispatch wraps
+// emit to set the property after emission.
+type phoenixEmitFn func(method, canonicalPath, framework, refKind, refName, fileHint string)
+
+// synthesizePhoenix scans an Elixir router file for Phoenix route
+// declarations and calls emit for each (verb, canonical-path, framework,
+// handlerKind, handlerName, fileHint) tuple. The resolver consumes
+// fileHint via the `handler_file` property to cross-file-rebind
+// source_file / start_line to the matching `def <action>` (#2680, #2692).
+func synthesizePhoenix(content string, emit phoenixEmitFn) {
+	if !phoenixHasRouter(content) {
+		return
+	}
+
+	// --- Explicit verb routes ---
+	for _, m := range phoenixVerbRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := content[m[4]:m[5]]
+		modRef := content[m[6]:m[7]]
+		action := content[m[8]:m[9]]
+
+		prefix := phoenixScopePrefixAt(content, m[0])
+		full := joinPathFragments(prefix, raw)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkPhoenix, full)
+		if canonical == "" {
+			continue
+		}
+		emit(verb, canonical, "phoenix", "SCOPE.Operation", action, phoenixControllerHint(modRef))
+	}
+
+	// --- resources → up to 7 CRUD endpoints ---
+	for _, m := range phoenixResourcesRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		raw := content[m[2]:m[3]]
+		modRef := content[m[4]:m[5]]
+		args := content[m[6]:m[7]]
+
+		mode, filter := parsePhoenixResourceFilter(args)
+		prefix := phoenixScopePrefixAt(content, m[0])
+		base := joinPathFragments(prefix, raw)
+		hint := phoenixControllerHint(modRef)
+
+		for _, r := range phoenixResourceCRUDActions {
+			switch mode {
+			case "only":
+				if !filter[r.action] {
+					continue
+				}
+			case "except":
+				if filter[r.action] {
+					continue
+				}
+			}
+			path := base + r.suffix
+			canonical := httproutes.Canonicalize(httproutes.FrameworkPhoenix, path)
+			if canonical == "" {
+				continue
+			}
+			emit(r.verb, canonical, "phoenix_resources", "SCOPE.Operation", r.action, hint)
+		}
+	}
+}

--- a/internal/engine/phoenix_routes_test.go
+++ b/internal/engine/phoenix_routes_test.go
@@ -1,0 +1,131 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestPhoenix_VerbInScope covers `scope "/api", MyAppWeb do ... get "/users", UserController, :index end`.
+func TestPhoenix_VerbInScope(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  use Phoenix.Router
+
+  scope "/api", MyAppWeb do
+    get "/users", UserController, :index
+    post "/users", UserController, :create
+    get "/users/:id", UserController, :show
+  end
+end
+`
+	ids, _ := runDetect(t, "elixir", "router.ex", src)
+	want := []string{
+		"http:GET:/api/users",
+		"http:POST:/api/users",
+		"http:GET:/api/users/{id}",
+	}
+	requireContains(t, ids, want, "phoenix-verb-in-scope")
+}
+
+// TestPhoenix_Resources covers `resources "/widgets", WidgetController` →
+// 7 standard CRUD endpoints.
+func TestPhoenix_Resources(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  use Phoenix.Router
+  scope "/api", MyAppWeb do
+    resources "/widgets", WidgetController
+  end
+end
+`
+	ids, _ := runDetect(t, "elixir", "router.ex", src)
+	want := []string{
+		"http:GET:/api/widgets",
+		"http:GET:/api/widgets/new",
+		"http:POST:/api/widgets",
+		"http:GET:/api/widgets/{id}",
+		"http:GET:/api/widgets/{id}/edit",
+		"http:PUT:/api/widgets/{id}",
+		"http:DELETE:/api/widgets/{id}",
+	}
+	requireContains(t, ids, want, "phoenix-resources")
+}
+
+// TestPhoenix_ResourcesOnly verifies `only: [:index, :show]` restricts the
+// emitted CRUD set.
+func TestPhoenix_ResourcesOnly(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  use Phoenix.Router
+  scope "/api", MyAppWeb do
+    resources "/widgets", WidgetController, only: [:index, :show]
+  end
+end
+`
+	ids, _ := runDetect(t, "elixir", "router.ex", src)
+	want := []string{
+		"http:GET:/api/widgets",
+		"http:GET:/api/widgets/{id}",
+	}
+	requireContains(t, ids, want, "phoenix-resources-only")
+	// Spot-check that the create/update/delete variants are NOT emitted.
+	for _, bad := range []string{
+		"http:POST:/api/widgets",
+		"http:PUT:/api/widgets/{id}",
+		"http:DELETE:/api/widgets/{id}",
+	} {
+		for _, g := range ids {
+			if g == bad {
+				t.Errorf("phoenix-resources-only: unexpected endpoint %s emitted (only: filter not respected)", bad)
+			}
+		}
+	}
+}
+
+// TestPhoenix_NestedScope covers `scope "/api" do; scope "/v1" do; ... end; end`.
+func TestPhoenix_NestedScope(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  use Phoenix.Router
+  scope "/api", MyAppWeb do
+    scope "/v1" do
+      get "/health", HealthController, :index
+    end
+  end
+end
+`
+	ids, _ := runDetect(t, "elixir", "router.ex", src)
+	want := []string{"http:GET:/api/v1/health"}
+	requireContains(t, ids, want, "phoenix-nested-scope")
+}
+
+// TestPhoenix_ControllerHandlerRef verifies the synthesizer stamps the
+// controller-module snake_case basename as the `handler_file` property
+// (used by the resolver for cross-file substring disambiguation) and
+// keeps the source_handler ref bare (no `@<hint>` encoding leaks).
+func TestPhoenix_ControllerHandlerRef(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  use Phoenix.Router
+  scope "/api", MyAppWeb do
+    get "/users", UserController, :index
+  end
+end
+`
+	_, res := runDetect(t, "elixir", "router.ex", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.ID != "http:GET:/api/users" {
+			continue
+		}
+		if e.Properties["source_handler"] != "SCOPE.Operation:index" {
+			t.Errorf("phoenix-handler-ref: source_handler=%q, want SCOPE.Operation:index", e.Properties["source_handler"])
+		}
+		if e.Properties["handler_file"] != "user_controller" {
+			t.Errorf("phoenix-handler-ref: handler_file=%q, want user_controller", e.Properties["handler_file"])
+		}
+		found = true
+	}
+	if !found {
+		t.Errorf("phoenix-handler-ref: missing http:GET:/api/users synthetic")
+	}
+}

--- a/internal/engine/rocket_routes.go
+++ b/internal/engine/rocket_routes.go
@@ -1,0 +1,101 @@
+// http_endpoint_rocket.go — Rust Rocket attribute macros → http_endpoint_definition synthesis.
+//
+// Rocket uses attribute macros on handler functions in the same file:
+//
+//	#[get("/hello")]
+//	fn hello() -> &'static str { "world" }
+//
+//	#[post("/users/<id>", data = "<user>")]
+//	fn create_user(id: u32, user: Json<User>) -> Status { Status::Ok }
+//
+// Path parameters use angle-bracket syntax (`<id>`) identical to Django /
+// Flask; canonicalisation reuses the angle-bracket walker via
+// FrameworkRocket. Trailing macro arguments (`data = "..."`,
+// `format = "..."`, `rank = N`) are tolerated.
+//
+// Rocket also requires `rocket::routes![handler1, handler2, ...]` (or the
+// `#[launch]` builder) to be registered for the route to actually fire,
+// but for the static endpoint catalogue we treat the attribute macro
+// itself as authoritative. Unused handlers behind the attribute are rare
+// and never harmful to surface.
+//
+// Same-file by construction: the function definition follows the attribute
+// on the next line, so source_file is already correct on the synthetic.
+// The ResolveHTTPEndpointHandlers rebind (#2680) populates start_line by
+// looking up the resolved handler entity.
+//
+// Refs #2692.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// rocketRouteAttrRe matches a Rocket HTTP verb attribute and the function
+// it decorates. We allow trailing macro arguments (any combination of
+// `data="..."`, `format="..."`, `rank=N`) and intervening attributes
+// (`#[cfg(...)]`, etc.) between the verb attribute and the `fn` keyword.
+//
+// Capture groups:
+//
+//	1 = verb (get / post / put / patch / delete / head / options)
+//	2 = path string
+//	3 = function name
+var rocketRouteAttrRe = regexp.MustCompile(
+	`#\[\s*(get|post|put|patch|delete|head|options)\s*\(\s*"([^"\r\n]+)"[^)]*\)\s*\]` +
+		`\s*(?:[\r\n]+(?:\s*#\[[^\]\r\n]*\]\s*[\r\n]+)*)?\s*` +
+		`(?:pub(?:\s*\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)\s*\(`,
+)
+
+// rocketHasRoutes is a fast pre-filter: returns true when the file
+// references Rocket or its attribute macros.
+func rocketHasRoutes(content string) bool {
+	if !strings.Contains(content, "rocket") &&
+		!strings.Contains(content, "Rocket") {
+		// Some downstream files may only contain `#[get(...)]` without an
+		// explicit `rocket` import (it's pulled in by the crate-level
+		// `#[macro_use] extern crate rocket;`). Fall back to the verb
+		// attribute shape itself.
+		if !strings.Contains(content, "#[get(") &&
+			!strings.Contains(content, "#[post(") &&
+			!strings.Contains(content, "#[put(") &&
+			!strings.Contains(content, "#[patch(") &&
+			!strings.Contains(content, "#[delete(") &&
+			!strings.Contains(content, "#[head(") &&
+			!strings.Contains(content, "#[options(") {
+			return false
+		}
+	}
+	return true
+}
+
+// synthesizeRocket scans a Rust source file for Rocket route-attribute
+// macros and calls emit for each (verb, canonical-path, framework,
+// handlerKind, handlerName) tuple.
+//
+// The handler-kind is "Controller" to reuse the resolverKindEquivalents
+// fallback that maps to the Rust extractor's SCOPE.Operation kind (the
+// same convention synthesizeAxumRoutes uses, see http_endpoint_axum.go).
+// This keeps the handler-resolution path identical between the two Rust
+// frameworks.
+func synthesizeRocket(content string, emit emitFn) {
+	if !rocketHasRoutes(content) {
+		return
+	}
+	for _, m := range rocketRouteAttrRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		raw := m[2]
+		handler := m[3]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkRocket, raw)
+		if canonical == "" {
+			continue
+		}
+		emit(verb, canonical, "rocket", "Controller", handler)
+	}
+}

--- a/internal/engine/rocket_routes_test.go
+++ b/internal/engine/rocket_routes_test.go
@@ -1,0 +1,111 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestRocket_Basic covers the canonical Rocket attribute-macro form.
+func TestRocket_Basic(t *testing.T) {
+	src := `
+#[macro_use] extern crate rocket;
+
+#[get("/hello")]
+fn hello() -> &'static str { "world" }
+
+#[post("/users")]
+fn create_user() -> &'static str { "{}" }
+`
+	ids, _ := runDetect(t, "rust", "main.rs", src)
+	want := []string{
+		"http:GET:/hello",
+		"http:POST:/users",
+	}
+	requireContains(t, ids, want, "rocket-basic")
+}
+
+// TestRocket_AngleBracketParam covers Rocket's `<id>` path parameter
+// syntax and verifies it canonicalises to `{id}`.
+func TestRocket_AngleBracketParam(t *testing.T) {
+	src := `
+#[macro_use] extern crate rocket;
+
+#[get("/users/<id>")]
+fn show(id: u32) -> String { format!("{}", id) }
+
+#[delete("/users/<id>")]
+fn destroy(id: u32) {}
+`
+	ids, _ := runDetect(t, "rust", "users.rs", src)
+	want := []string{
+		"http:GET:/users/{id}",
+		"http:DELETE:/users/{id}",
+	}
+	requireContains(t, ids, want, "rocket-angle-bracket")
+}
+
+// TestRocket_AllVerbs covers get/post/put/patch/delete/head/options.
+func TestRocket_AllVerbs(t *testing.T) {
+	src := `
+#[macro_use] extern crate rocket;
+
+#[get("/r")]     fn g()  {}
+#[post("/r")]    fn p()  {}
+#[put("/r/<id>")]    fn u(id: u32) {}
+#[patch("/r/<id>")]  fn pa(id: u32) {}
+#[delete("/r/<id>")] fn d(id: u32) {}
+#[head("/r")]    fn h()  {}
+#[options("/r")] fn o()  {}
+`
+	ids, _ := runDetect(t, "rust", "main.rs", src)
+	want := []string{
+		"http:GET:/r",
+		"http:POST:/r",
+		"http:PUT:/r/{id}",
+		"http:PATCH:/r/{id}",
+		"http:DELETE:/r/{id}",
+		"http:HEAD:/r",
+		"http:OPTIONS:/r",
+	}
+	requireContains(t, ids, want, "rocket-all-verbs")
+}
+
+// TestRocket_TrailingMacroArgs covers macros with trailing kwargs such as
+// `data = "..."` and `format = "..."`.
+func TestRocket_TrailingMacroArgs(t *testing.T) {
+	src := `
+#[macro_use] extern crate rocket;
+
+#[post("/users", data = "<body>")]
+fn create_user(body: String) -> String { body }
+
+#[get("/items", format = "json")]
+fn list_items() -> &'static str { "[]" }
+`
+	ids, _ := runDetect(t, "rust", "main.rs", src)
+	want := []string{
+		"http:POST:/users",
+		"http:GET:/items",
+	}
+	requireContains(t, ids, want, "rocket-trailing-args")
+}
+
+// TestRocket_HandlerRef verifies source_handler property carries the
+// function name (compatible with the resolverKindEquivalents fallback).
+func TestRocket_HandlerRef(t *testing.T) {
+	src := `
+#[macro_use] extern crate rocket;
+
+#[post("/quote")]
+fn quote() -> &'static str { "{}" }
+`
+	_, res := runDetect(t, "rust", "pricing.rs", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.ID == "http:POST:/quote" && e.Properties["source_handler"] == "Controller:quote" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("rocket-handler-ref: expected http:POST:/quote with source_handler=Controller:quote")
+	}
+}


### PR DESCRIPTION
## Summary

Producer-side `http_endpoint_definition` synthesis for three more frameworks, completing the multi-language audit started by #2690 / #2691.

- **ASP.NET Core (C#)** — annotation-based, same-file. `[HttpGet/Post/Put/Patch/Delete/Head/Options(...)]` action attributes + class-level `[Route(\"/api/[controller]\")]` with `[controller]` and `[action]` token substitution. Method-level absolute paths (`[HttpGet(\"/healthz\")]`) override the class prefix per ASP.NET semantics.
- **Elixir Phoenix** — routes-file pattern with cross-file attribution. Router declares verb / `resources` macros under `scope \"/api\", MyAppWeb`; handler bodies live in `controllers/<name>_controller.ex`. Synth stamps a `handler_file` snake-case basename hint; resolver substring-matches it against `SCOPE.Operation:<action>` candidates. `resources` expands to the standard 7 CRUD set and honours `only:` / `except:`. Nested scopes compose.
- **Rust Rocket** — attribute macros on handler functions: `#[get/post/put/patch/delete/head/options(\"/path\", data = ..., format = ...)]`. Same-file by construction; mirrors the existing Axum synthesizer.

## Cross-cutting findings

- Generalised the `handler_file` property mechanism (introduced by #2691 for Rails). Where Rails supplies a full path (`app/controllers/users_controller.rb`), Phoenix needs only a substring hint (`user_controller`). One extra fallback in `ResolveHTTPEndpointHandlers` consumes the hint as a SUBSTRING match against a new `globalMulti` index when the exact-file lookup misses — same property surface, more general matcher.
- Three new framework constants in `httproutes`: `FrameworkASPNetCore` (curly-brace + `:type` constraint), `FrameworkPhoenix` (colon-prefix params), `FrameworkRocket` (angle-bracket params).
- All three synthesisers compose with the #2680 resolver rebind so `source_file` and `start_line` always land at the handler body.

## Test plan

- [x] `go test ./internal/engine/... -run 'TestASPNetCore|TestPhoenix|TestRocket'` — 15 unit tests covering basic patterns, token substitution, all 7 verbs, path-parameter shapes, resources filters, nested scopes, trailing macro args, handler-ref encoding.
- [x] `go test ./cmd/archigraph/ -run 'TestIssue2692_'` — three integration subtests run the production `Indexer.Run` on `testdata/audit2678_other_trio/{aspnet,phoenix,rocket}` and assert per-endpoint `source_file` + `start_line` + framework.
- [x] `go test ./internal/engine/... ./internal/engine/httproutes/` — no regressions across the existing engine suite.
- [x] Pre-existing failures on `origin/main` (`TestAudit2678Go_GinEchoAttribution`, one `internal/mcp` session-meta test) are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)