### PR TITLE
feat(extractor/jsts): resolve template-literal var bindings in HTTP paths (#2704)

### DIFF
--- a/cmd/archigraph/audit_template_var_resolve_test.go
+++ b/cmd/archigraph/audit_template_var_resolve_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAudit2704_TemplateVarResolve is the integration guard for #2704.
+//
+// It indexes a fixture containing JS HTTP client calls whose path is a
+// template literal whose leading interpolation references a same-file
+// string-literal const (`const path = "things"`). The extractor must
+// substitute the constant value, producing concrete paths like
+// `/things/{id}` rather than the pre-fix `{param}/{id}` placeholder.
+//
+// Scope of the check (matches the issue acceptance criteria):
+//
+//   - Leading `${path}` resolves to `/things`.
+//   - Trailing `${id}` / `${nestedId}` remain as `{id}` / `{nestedId}`
+//     placeholders (those are real path params, not constants).
+//   - No emitted endpoint retains the leading `{param}` / `{path}` shape.
+func TestAudit2704_TemplateVarResolve(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/audit_template_var_resolve", "audit2704", nil)
+
+	// Collect consumer-side synthetics (http_endpoint_call) for this fixture
+	// — that's what client-side HTTP wrappers emit.
+	endpoints := make([]*struct {
+		Verb string
+		Path string
+	}, 0, 8)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind != "http_endpoint_call" && e.Kind != "http_endpoint" && e.Kind != "http_endpoint_definition" {
+			continue
+		}
+		if e.Properties == nil {
+			continue
+		}
+		endpoints = append(endpoints, &struct {
+			Verb string
+			Path string
+		}{Verb: e.Properties["verb"], Path: e.Properties["path"]})
+	}
+	if len(endpoints) == 0 {
+		t.Fatalf("audit_template_var_resolve: no http_endpoint(_call) entities emitted")
+	}
+
+	findBySuffix := func(verb, suffix string) bool {
+		verb = strings.ToUpper(verb)
+		for _, e := range endpoints {
+			if strings.ToUpper(e.Verb) != verb {
+				continue
+			}
+			if e.Path == suffix || strings.HasSuffix(e.Path, suffix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Expected (verb, path) pairs after constant folding of `${path}`.
+	cases := []struct {
+		verb string
+		path string
+	}{
+		{"GET", "/things/{id}"},
+		{"PATCH", "/things/{id}"},
+		{"DELETE", "/things/{id}/items/{nestedId}"},
+	}
+	for _, tc := range cases {
+		if !findBySuffix(tc.verb, tc.path) {
+			var seen []string
+			for _, e := range endpoints {
+				seen = append(seen, e.Verb+" "+e.Path)
+			}
+			t.Errorf("audit2704: missing %s %s; saw: %v", tc.verb, tc.path, seen)
+		}
+	}
+
+	// Negative check: no endpoint should retain the `{param}` / `{path}`
+	// leading-placeholder shape after constant folding.
+	for _, e := range endpoints {
+		p := e.Path
+		if strings.HasPrefix(p, "/{param}") || strings.HasPrefix(p, "{param}") ||
+			strings.HasPrefix(p, "/{path}") || strings.HasPrefix(p, "{path}") {
+			t.Errorf("audit2704: endpoint kept unresolved leading placeholder: %s %s",
+				e.Verb, p)
+		}
+	}
+}

--- a/cmd/archigraph/testdata/audit_template_var_resolve/package.json
+++ b/cmd/archigraph/testdata/audit_template_var_resolve/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "audit-template-var-resolve-fixture",
+  "version": "0.0.1",
+  "private": true
+}

--- a/cmd/archigraph/testdata/audit_template_var_resolve/services/thingsService.js
+++ b/cmd/archigraph/testdata/audit_template_var_resolve/services/thingsService.js
@@ -1,0 +1,26 @@
+// Fixture for #2704 — template-literal variable resolution in HTTP paths.
+//
+// The leading interpolation of each call below is a bare identifier (`path`)
+// whose binding is a same-file string-literal const. The extractor must
+// substitute the literal value, producing `/things/{id}` rather than the
+// pre-fix `{param}/{id}` / `{path}/{id}` placeholder shape.
+
+import apiClient from "./client";
+
+const path = "things";
+
+export async function listThings() {
+    return apiClient.get(`${path}/`);
+}
+
+export async function getThing(id) {
+    return apiClient.get(`${path}/${id}`);
+}
+
+export async function updateThing(id, body) {
+    return apiClient.patch(`${path}/${id}`, body);
+}
+
+export async function nestedThing(id, nestedId) {
+    return apiClient.delete(`${path}/${id}/items/${nestedId}`);
+}

--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -433,6 +433,12 @@ func isEnvVarStyleExpr(expr string) bool {
 func canonicalizeTemplateLiteral(tmpl string, syms map[string]string) (string, bool) {
 	// Whether the FIRST substitution was an env-var prefix (to be stripped).
 	firstSubst := true
+	// #2704 — Track whether the template begins with a ${var} interpolation
+	// that resolved to a same-file constant string (variable-binding resolution).
+	// When it does and the resolved value lacks a leading slash, we prepend
+	// one so the path validates as URL-absolute (e.g. `${path}/${id}` with
+	// `const path = "companies"` → `/companies/{id}` instead of being rejected).
+	leadingConstResolved := false
 
 	// Replace each ${expr} with its constant value or a named placeholder.
 	result := templateSubstRe.ReplaceAllStringFunc(tmpl, func(match string) string {
@@ -448,11 +454,17 @@ func canonicalizeTemplateLiteral(tmpl string, syms map[string]string) (string, b
 		// For member expressions (e.g. `obj.field`), try the full expr
 		// first, then the leading identifier.
 		if val, ok := syms[inner]; ok {
+			if isFirst {
+				leadingConstResolved = true
+			}
 			return val
 		}
 		// Try just the leading identifier of a dotted expression.
 		if dot := strings.IndexByte(inner, '.'); dot > 0 {
 			if val, ok := syms[inner[:dot]]; ok {
+				if isFirst {
+					leadingConstResolved = true
+				}
 				return val
 			}
 		}
@@ -483,6 +495,16 @@ func canonicalizeTemplateLiteral(tmpl string, syms map[string]string) (string, b
 
 	// Strip host prefix for absolute URLs.
 	result = stripURLHost(result)
+
+	// #2704 — When the leading interpolation resolved to a same-file const
+	// string without a leading slash (e.g. `${path}/${id}` with `const path =
+	// "companies"` → `companies/{id}`), prepend one so the path validates
+	// as URL-absolute. Guarded by `leadingConstResolved` so we don't accept
+	// bogus template literals like `not-a-path-${name}` whose leading literal
+	// chunk was never a constant reference.
+	if leadingConstResolved && len(result) > 0 && result[0] != '/' && result[0] != '{' {
+		result = "/" + result
+	}
 
 	// Validate that this looks like a URL path (absolute) or a
 	// template-parameter-prefixed path (starts with {<name>}).


### PR DESCRIPTION
## Summary
- When a JS/TS HTTP-client template literal's leading `${ident}` resolves to a same-file string-literal const (e.g. `const path = "things"; apiClient.get(\`${path}/${id}\`)`), `canonicalizeTemplateLiteral` already substituted the value but the result was silently rejected because it lacked a leading slash — emitting no endpoint at all. Track this case and prepend `/` before the URL-path validator.
- Scope guards match #2704: simple `const|let|var <ident> = "literal"` bindings only. Function-call interpolations (`${getPath()}`) and subscript expressions (`${MAP[key]}`) remain out of scope and keep their existing `{param}` / `{name}` placeholder behaviour. Bogus templates like `not-a-path-${name}` are unaffected — the `/` is only prepended when the leading chunk actually came from a resolved const reference.
- New integration fixture `cmd/archigraph/testdata/audit_template_var_resolve/` + `TestAudit2704_TemplateVarResolve` covers GET/PATCH/DELETE on `/things/{id}` resolved paths and asserts no endpoint keeps a leading `{param}` / `{path}` placeholder.

## Real-data note
On the upvate-core-frontend repo, the orphans with `{param}` leading shape (23 total) come from out-of-scope interpolations — `${base(companyType, companyId)}` (arrow-function call in branchService.js), `${COMPANY_TYPE_MAPPING[companyType]}` (subscript expression in companyServiceV2.js), `${queryParams.toString()}` (method call in devicesService.js). The fix is correctly scoped to the issue's narrow contract and unlocks the simple `const ident = "literal"` substitution path that was latent-broken. Resolving the arrow-function / subscript variants would require expanding scope beyond #2704 (out of scope per the issue's guards).

## Test plan
- [x] `go test ./internal/engine/` — all existing tests pass, including `TestSynth_TemplateLiteral_NonURLRejected` (verifies bogus templates still rejected).
- [x] `go test ./cmd/archigraph/` — new `TestAudit2704_TemplateVarResolve` passes with the fix and fails without it (confirmed by stashing the engine change).
- [x] `go test ./internal/extractors/javascript/` — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)