### PR TITLE
feat(tools/coverage): registry foundation — schema + CLI + validate (#2720 PR 1)

### DIFF
--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -1,0 +1,81 @@
+{
+  "$schema_version": 1,
+  "records": [
+    {
+      "id": "lang.javascript.framework.express",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Express.js",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.nestjs",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "NestJS",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.django-drf",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Django REST Framework",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/django_drf_actions.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/1942",
+          "verified_at": "2026-05-27"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/django_drf_actions.go","internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/django_drf_actions.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.fastapi",
+      "category": "http_framework",
+      "language": "python",
+      "label": "FastAPI",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.flask",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Flask",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    }
+  ]
+}

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -1,0 +1,350 @@
+// Command coverage maintains the archigraph capabilities registry at
+// docs/coverage.json. It is a standalone dev tool with zero imports
+// from internal/ packages; pure file I/O only.
+//
+// See issue #2720 for the full spec and docs/coverage/summary.md for
+// the rendered registry.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+// run dispatches subcommands. It is split out from main so tests can
+// drive it with custom argv and capture stdout/stderr.
+func run(argv []string, stdout, stderr io.Writer) error {
+	if len(argv) == 0 {
+		printUsage(stderr)
+		return fmt.Errorf("no subcommand")
+	}
+	sub, rest := argv[0], argv[1:]
+	switch sub {
+	case "list":
+		return cmdList(rest, stdout)
+	case "get":
+		return cmdGet(rest, stdout)
+	case "add":
+		return cmdAdd(rest, stdout)
+	case "update":
+		return cmdUpdate(rest, stdout)
+	case "remove":
+		return cmdRemove(rest, stdout)
+	case "gaps":
+		return cmdGaps(rest, stdout)
+	case "stats":
+		return cmdStats(rest, stdout)
+	case "validate":
+		return cmdValidate(rest, stdout, stderr)
+	case "help", "-h", "--help":
+		printUsage(stdout)
+		return nil
+	default:
+		printUsage(stderr)
+		return fmt.Errorf("unknown subcommand %q", sub)
+	}
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, `usage: go run ./tools/coverage <subcommand> [flags]
+
+subcommands:
+  list      list records (filters: --status, --by-language, --by-category, --stale-days, --json)
+  get       show one record by id (--json)
+  add       insert a new record (--id, --category, --language, --label)
+  update    update one capability cell (id positional, --capability, --status, --cites, --verified-now, --issue)
+  remove    delete a record by id
+  gaps      list missing/partial records (--language, --category, --json)
+  stats     counters across the registry (--json)
+  validate  schema + cite-exists + duplicate-id + stale checks`)
+}
+
+// registryFlag adds a shared --file flag for overriding the registry
+// path (handy for tests). Returns a getter for the resolved path.
+func registryFlag(fs *flag.FlagSet) *string {
+	return fs.String("file", defaultRegistryPath, "path to coverage.json")
+}
+
+func cmdList(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	path := registryFlag(fs)
+	status := fs.String("status", "", "filter by capability status (full|partial|missing|not_applicable)")
+	lang := fs.String("by-language", "", "filter by language")
+	cat := fs.String("by-category", "", "filter by category")
+	stale := fs.Int("stale-days", 0, "filter to records with any capability verified more than N days ago")
+	asJSON := fs.Bool("json", false, "JSON output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	recs := listRecords(reg, ListFilter{Status: *status, Language: *lang, Category: *cat, StaleDays: *stale})
+	if *asJSON {
+		return printJSON(out, recs)
+	}
+	printRecordsText(out, recs)
+	return nil
+}
+
+func cmdGet(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("get", flag.ContinueOnError)
+	path := registryFlag(fs)
+	asJSON := fs.Bool("json", false, "JSON output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("get: expected exactly one ID argument")
+	}
+	id := fs.Arg(0)
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	rec := findRecord(reg, id)
+	if rec == nil {
+		return fmt.Errorf("get: id %q not found", id)
+	}
+	if *asJSON {
+		return printJSON(out, rec)
+	}
+	printRecordsText(out, []Record{*rec})
+	return nil
+}
+
+func cmdAdd(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("add", flag.ContinueOnError)
+	path := registryFlag(fs)
+	id := fs.String("id", "", "record ID (required)")
+	cat := fs.String("category", "", "category (required)")
+	lang := fs.String("language", "", "language (required)")
+	label := fs.String("label", "", "human-readable label (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *id == "" || *cat == "" || *lang == "" || *label == "" {
+		return fmt.Errorf("add: --id, --category, --language, --label are all required")
+	}
+	if err := validateID(*id); err != nil {
+		return err
+	}
+	if _, ok := categoryCapabilities[*cat]; !ok {
+		return fmt.Errorf("add: unknown category %q (known: %v)", *cat, knownCategories())
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	if findRecord(reg, *id) != nil {
+		return fmt.Errorf("add: id %q already exists", *id)
+	}
+	reg.Records = append(reg.Records, Record{
+		ID:           *id,
+		Category:     *cat,
+		Language:     *lang,
+		Label:        *label,
+		Capabilities: map[string]Capability{},
+	})
+	if err := saveRegistry(*path, reg); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "added %s\n", *id)
+	return nil
+}
+
+func cmdUpdate(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	path := registryFlag(fs)
+	cap := fs.String("capability", "", "capability key (required)")
+	status := fs.String("status", "", "status: full|partial|missing|not_applicable (required)")
+	cites := fs.String("cites", "", "comma-separated repo-relative paths")
+	verifiedNow := fs.Bool("verified-now", false, "set verified_at to today")
+	issue := fs.String("issue", "", "tracking issue URL")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("update: expected exactly one ID argument")
+	}
+	id := fs.Arg(0)
+	if *cap == "" || *status == "" {
+		return fmt.Errorf("update: --capability and --status are required")
+	}
+	if _, ok := validStatuses[*status]; !ok {
+		return fmt.Errorf("update: invalid status %q", *status)
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	rec := findRecord(reg, id)
+	if rec == nil {
+		return fmt.Errorf("update: id %q not found", id)
+	}
+	if !validCapabilityKey(rec.Category, *cap) {
+		return fmt.Errorf("update: capability %q not valid for category %q", *cap, rec.Category)
+	}
+	if rec.Capabilities == nil {
+		rec.Capabilities = map[string]Capability{}
+	}
+	cell := rec.Capabilities[*cap]
+	cell.Status = *status
+	if *cites != "" {
+		parts := strings.Split(*cites, ",")
+		clean := make([]string, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				clean = append(clean, p)
+			}
+		}
+		cell.Cites = clean
+	}
+	if *issue != "" {
+		cell.Issue = *issue
+	}
+	if *verifiedNow {
+		cell.VerifiedAt = time.Now().UTC().Format("2006-01-02")
+	}
+	rec.Capabilities[*cap] = cell
+	if err := saveRegistry(*path, reg); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "updated %s.%s -> %s\n", id, *cap, *status)
+	return nil
+}
+
+func cmdRemove(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("remove", flag.ContinueOnError)
+	path := registryFlag(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("remove: expected exactly one ID argument")
+	}
+	id := fs.Arg(0)
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	idx := -1
+	for i, rec := range reg.Records {
+		if rec.ID == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("remove: id %q not found", id)
+	}
+	reg.Records = append(reg.Records[:idx], reg.Records[idx+1:]...)
+	if err := saveRegistry(*path, reg); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "removed %s\n", id)
+	return nil
+}
+
+func cmdGaps(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("gaps", flag.ContinueOnError)
+	path := registryFlag(fs)
+	lang := fs.String("language", "", "filter by language")
+	cat := fs.String("category", "", "filter by category")
+	asJSON := fs.Bool("json", false, "JSON output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	recs := gapsRecords(reg, *lang, *cat)
+	if *asJSON {
+		return printJSON(out, recs)
+	}
+	printRecordsText(out, recs)
+	return nil
+}
+
+func cmdStats(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("stats", flag.ContinueOnError)
+	path := registryFlag(fs)
+	asJSON := fs.Bool("json", false, "JSON output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	s := computeStats(reg)
+	if *asJSON {
+		return printJSON(out, s)
+	}
+	fmt.Fprintf(out, "total records:    %d\n", s.Total)
+	fmt.Fprintf(out, "total capabilities: %d\n", s.Capabilities)
+	fmt.Fprintln(out, "by status:")
+	for _, k := range []string{StatusFull, StatusPartial, StatusMissing, StatusNotApplicable} {
+		fmt.Fprintf(out, "  %-16s  %d\n", k, s.ByStatus[k])
+	}
+	fmt.Fprintln(out, "by language:")
+	langs := make([]string, 0, len(s.ByLanguage))
+	for k := range s.ByLanguage {
+		langs = append(langs, k)
+	}
+	sortStrings(langs)
+	for _, l := range langs {
+		ls := s.ByLanguage[l]
+		fmt.Fprintf(out, "  %-14s records=%d full=%d partial=%d missing=%d n/a=%d\n", l, ls.Records, ls.Full, ls.Partial, ls.Missing, ls.NotAppl)
+	}
+	return nil
+}
+
+func cmdValidate(args []string, out, errw io.Writer) error {
+	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+	path := registryFlag(fs)
+	repoRoot := fs.String("repo-root", ".", "repository root used to resolve cite paths")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	res := validateRegistry(reg, *repoRoot)
+	for _, w := range res.Warnings {
+		fmt.Fprintf(errw, "warning: %s\n", w)
+	}
+	for _, e := range res.Errors {
+		fmt.Fprintf(errw, "error: %s\n", e)
+	}
+	if res.HasErrors() {
+		return fmt.Errorf("validation failed: %d error(s)", len(res.Errors))
+	}
+	fmt.Fprintf(out, "ok: %d record(s), %d warning(s)\n", len(reg.Records), len(res.Warnings))
+	return nil
+}
+
+// sortStrings is a tiny local helper to avoid pulling sort into main.go
+// at the top of the file (keeps the imports list minimal).
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/tools/coverage/main_test.go
+++ b/tools/coverage/main_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// repoRoot returns the repository root, assuming tests run from
+// tools/coverage/.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// tools/coverage -> ../../
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}
+
+// fixturePath returns the absolute path to testdata/fixture.json.
+func fixturePath(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Join(wd, "testdata", "fixture.json")
+}
+
+// copyFixture copies the fixture into a temp file so write subcommands
+// don't mutate the checked-in testdata.
+func copyFixture(t *testing.T) string {
+	t.Helper()
+	src := fixturePath(t)
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "coverage.json")
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	return dst
+}
+
+func runCmd(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	err := run(args, &stdout, &stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func TestList(t *testing.T) {
+	out, _, err := runCmd(t, "list", "--file", fixturePath(t))
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out, "lang.python.framework.django-drf") {
+		t.Errorf("expected django-drf in output, got:\n%s", out)
+	}
+}
+
+func TestListFilterByLanguage(t *testing.T) {
+	out, _, err := runCmd(t, "list", "--file", fixturePath(t), "--by-language", "python")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if strings.Contains(out, "javascript") {
+		t.Errorf("expected no javascript records when filtering by python, got:\n%s", out)
+	}
+	if !strings.Contains(out, "lang.python.framework.fastapi") {
+		t.Errorf("expected fastapi in output, got:\n%s", out)
+	}
+}
+
+func TestGet(t *testing.T) {
+	out, _, err := runCmd(t, "get", "--file", fixturePath(t), "lang.python.framework.flask")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !strings.Contains(out, "Flask") {
+		t.Errorf("expected Flask label, got:\n%s", out)
+	}
+}
+
+func TestGetMissing(t *testing.T) {
+	_, _, err := runCmd(t, "get", "--file", fixturePath(t), "no.such.id")
+	if err == nil {
+		t.Fatal("expected error for missing id")
+	}
+}
+
+func TestGetJSON(t *testing.T) {
+	out, _, err := runCmd(t, "get", "--file", fixturePath(t), "--json", "lang.python.framework.flask")
+	if err != nil {
+		t.Fatalf("get json: %v", err)
+	}
+	if !strings.Contains(out, "\"id\": \"lang.python.framework.flask\"") {
+		t.Errorf("expected JSON id field, got:\n%s", out)
+	}
+}
+
+func TestAddAndRemove(t *testing.T) {
+	tmp := copyFixture(t)
+	if _, _, err := runCmd(t, "add", "--file", tmp,
+		"--id", "lang.go.framework.chi",
+		"--category", "http_framework",
+		"--language", "go",
+		"--label", "Chi"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	out, _, err := runCmd(t, "get", "--file", tmp, "lang.go.framework.chi")
+	if err != nil {
+		t.Fatalf("get after add: %v", err)
+	}
+	if !strings.Contains(out, "Chi") {
+		t.Errorf("expected Chi after add")
+	}
+	if _, _, err := runCmd(t, "remove", "--file", tmp, "lang.go.framework.chi"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, _, err := runCmd(t, "get", "--file", tmp, "lang.go.framework.chi"); err == nil {
+		t.Fatal("expected error after remove")
+	}
+}
+
+func TestAddDuplicate(t *testing.T) {
+	tmp := copyFixture(t)
+	_, _, err := runCmd(t, "add", "--file", tmp,
+		"--id", "lang.python.framework.flask",
+		"--category", "http_framework",
+		"--language", "python",
+		"--label", "dup")
+	if err == nil {
+		t.Fatal("expected duplicate-id error")
+	}
+}
+
+func TestAddInvalidID(t *testing.T) {
+	tmp := copyFixture(t)
+	_, _, err := runCmd(t, "add", "--file", tmp,
+		"--id", "BadID",
+		"--category", "http_framework",
+		"--language", "go",
+		"--label", "x")
+	if err == nil {
+		t.Fatal("expected invalid-id error")
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	tmp := copyFixture(t)
+	if _, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "middleware_coverage",
+		"--status", "missing",
+		"--issue", "https://example.com/i/1",
+		"lang.python.framework.flask"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	out, _, err := runCmd(t, "get", "--file", tmp, "--json", "lang.python.framework.flask")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !strings.Contains(out, "middleware_coverage") {
+		t.Errorf("expected middleware_coverage in record, got:\n%s", out)
+	}
+}
+
+func TestUpdateInvalidCapability(t *testing.T) {
+	tmp := copyFixture(t)
+	_, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "not_a_real_key",
+		"--status", "missing",
+		"lang.python.framework.flask")
+	if err == nil {
+		t.Fatal("expected error for invalid capability key")
+	}
+}
+
+func TestGaps(t *testing.T) {
+	out, _, err := runCmd(t, "gaps", "--file", fixturePath(t))
+	if err != nil {
+		t.Fatalf("gaps: %v", err)
+	}
+	if !strings.Contains(out, "django-drf") {
+		t.Errorf("expected django-drf (has partial auth_coverage) in gaps, got:\n%s", out)
+	}
+	if strings.Contains(out, "fastapi") {
+		t.Errorf("fastapi has no gaps, should not appear")
+	}
+}
+
+func TestStats(t *testing.T) {
+	out, _, err := runCmd(t, "stats", "--file", fixturePath(t))
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if !strings.Contains(out, "total records:    5") {
+		t.Errorf("expected 5 total records, got:\n%s", out)
+	}
+}
+
+func TestStatsJSON(t *testing.T) {
+	out, _, err := runCmd(t, "stats", "--file", fixturePath(t), "--json")
+	if err != nil {
+		t.Fatalf("stats json: %v", err)
+	}
+	if !strings.Contains(out, "\"total\": 5") {
+		t.Errorf("expected total=5 in JSON, got:\n%s", out)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	_, errout, err := runCmd(t, "validate", "--file", fixturePath(t), "--repo-root", repoRoot(t))
+	if err != nil {
+		t.Fatalf("validate: %v\nstderr:\n%s", err, errout)
+	}
+}
+
+func TestValidateRejectsBadCite(t *testing.T) {
+	tmp := copyFixture(t)
+	// Inject a bogus cite via update.
+	if _, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "endpoint_synthesis",
+		"--status", "full",
+		"--cites", "this/file/does/not/exist.go",
+		"lang.python.framework.flask"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	_, _, err := runCmd(t, "validate", "--file", tmp, "--repo-root", repoRoot(t))
+	if err == nil {
+		t.Fatal("expected validate to fail on missing cite path")
+	}
+}
+
+func TestSaveIsDeterministic(t *testing.T) {
+	// Load, save twice, compare bytes.
+	src := fixturePath(t)
+	reg, err := loadRegistry(src)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	a := filepath.Join(t.TempDir(), "a.json")
+	b := filepath.Join(t.TempDir(), "b.json")
+	if err := saveRegistry(a, reg); err != nil {
+		t.Fatalf("save a: %v", err)
+	}
+	if err := saveRegistry(b, reg); err != nil {
+		t.Fatalf("save b: %v", err)
+	}
+	da, _ := os.ReadFile(a)
+	db, _ := os.ReadFile(b)
+	if !bytes.Equal(da, db) {
+		t.Errorf("save output is non-deterministic")
+	}
+}
+
+func TestUnknownSubcommand(t *testing.T) {
+	_, _, err := runCmd(t, "nonsense")
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand")
+	}
+}

--- a/tools/coverage/schema.go
+++ b/tools/coverage/schema.go
@@ -1,0 +1,153 @@
+// Package main implements the coverage registry CLI.
+//
+// The schema mirrors docs/coverage.json. Keep this file in sync with
+// the documented schema in issue #2720. Pure value types: zero imports
+// from internal/ packages.
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+// SchemaVersion is the current registry schema version. Bump when the
+// on-disk JSON shape changes incompatibly.
+const SchemaVersion = 1
+
+// Status enum values for a capability cell.
+const (
+	StatusFull          = "full"
+	StatusPartial       = "partial"
+	StatusMissing       = "missing"
+	StatusNotApplicable = "not_applicable"
+)
+
+// validStatuses lists the allowed status enum values.
+var validStatuses = map[string]struct{}{
+	StatusFull:          {},
+	StatusPartial:       {},
+	StatusMissing:       {},
+	StatusNotApplicable: {},
+}
+
+// idPattern matches stable dotted slug IDs:
+//
+//	lang.python.framework.django-drf
+var idPattern = regexp.MustCompile(`^[a-z0-9-]+(\.[a-z0-9-]+)+$`)
+
+// Registry is the root JSON document persisted at docs/coverage.json.
+type Registry struct {
+	SchemaVersion int      `json:"$schema_version"`
+	Records       []Record `json:"records"`
+}
+
+// Record is a single coverage row keyed by Record.ID.
+type Record struct {
+	ID           string                `json:"id"`
+	Category     string                `json:"category"`
+	Language     string                `json:"language"`
+	Label        string                `json:"label"`
+	Capabilities map[string]Capability `json:"capabilities"`
+}
+
+// Capability is a single capability cell on a record.
+type Capability struct {
+	Status      string   `json:"status"`
+	Cites       []string `json:"cites,omitempty"`
+	VerifiedAt  string   `json:"verified_at,omitempty"`
+	VerifiedSHA string   `json:"verified_sha,omitempty"`
+	Issue       string   `json:"issue,omitempty"`
+}
+
+// categoryCapabilities maps each registry category to the set of
+// capability keys that are valid for that category. The validate
+// subcommand rejects unknown keys per category.
+var categoryCapabilities = map[string][]string{
+	"language": {
+		"call_line_precision",
+		"discriminates_on",
+		"navigates_to",
+		"core_extraction",
+	},
+	"http_framework": {
+		"endpoint_synthesis",
+		"handler_attribution",
+		"auth_coverage",
+		"middleware_coverage",
+	},
+	"orm": {
+		"model_extraction",
+		"query_attribution",
+		"migration_parsing",
+	},
+	"message_broker": {
+		"producer_extraction",
+		"consumer_extraction",
+		"topic_attribution",
+	},
+	"observability": {
+		"trace_extraction",
+		"metric_extraction",
+		"log_extraction",
+	},
+	"build_system": {
+		"target_extraction",
+		"dependency_graph",
+	},
+	"package_manager": {
+		"manifest_parsing",
+		"lockfile_parsing",
+	},
+	"infrastructure": {
+		"resource_extraction",
+		"dependency_attribution",
+	},
+	"security": {
+		"auth_policy",
+		"secret_detection",
+		"sql_injection",
+	},
+	"protocol": {
+		"service_extraction",
+		"method_attribution",
+		"cross_repo_linkage",
+	},
+	"configuration": {
+		"file_parsing",
+		"env_resolution",
+	},
+}
+
+// validCapabilityKey reports whether key is declared for category.
+func validCapabilityKey(category, key string) bool {
+	keys, ok := categoryCapabilities[category]
+	if !ok {
+		return false
+	}
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// knownCategories returns sorted category names. Used by views and
+// validation error messages.
+func knownCategories() []string {
+	out := make([]string, 0, len(categoryCapabilities))
+	for k := range categoryCapabilities {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// validateID returns nil if id matches the stable-slug pattern.
+func validateID(id string) error {
+	if !idPattern.MatchString(id) {
+		return fmt.Errorf("invalid id %q: must match %s", id, idPattern.String())
+	}
+	return nil
+}

--- a/tools/coverage/store.go
+++ b/tools/coverage/store.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// defaultRegistryPath is the canonical on-disk location of the registry.
+const defaultRegistryPath = "docs/coverage.json"
+
+// loadRegistry reads and decodes the registry from path.
+func loadRegistry(path string) (*Registry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var reg Registry
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&reg); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	if reg.SchemaVersion == 0 {
+		reg.SchemaVersion = SchemaVersion
+	}
+	return &reg, nil
+}
+
+// saveRegistry sorts records and persists the registry atomically using
+// a temp file + rename. Output is deterministic: records sorted by ID,
+// capability maps marshalled in sorted-key order, 2-space indent,
+// trailing newline.
+func saveRegistry(path string, reg *Registry) error {
+	reg.SchemaVersion = SchemaVersion
+	sortRegistry(reg)
+	buf, err := marshalRegistry(reg)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".coverage.json.*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(buf); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// sortRegistry sorts records by ID and also sorts each record's cites
+// slice deterministically. Capability map ordering is handled at
+// marshal time.
+func sortRegistry(reg *Registry) {
+	sort.Slice(reg.Records, func(i, j int) bool {
+		return reg.Records[i].ID < reg.Records[j].ID
+	})
+	for i := range reg.Records {
+		for k, cap := range reg.Records[i].Capabilities {
+			sort.Strings(cap.Cites)
+			reg.Records[i].Capabilities[k] = cap
+		}
+	}
+}
+
+// marshalRegistry produces deterministic JSON bytes: records sorted,
+// capability map keys sorted, 2-space indent, trailing newline.
+func marshalRegistry(reg *Registry) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString("{\n")
+	fmt.Fprintf(&buf, "  \"$schema_version\": %d,\n", reg.SchemaVersion)
+	buf.WriteString("  \"records\": [")
+	for i, rec := range reg.Records {
+		if i == 0 {
+			buf.WriteString("\n")
+		}
+		if err := writeRecord(&buf, rec, "    "); err != nil {
+			return nil, err
+		}
+		if i < len(reg.Records)-1 {
+			buf.WriteString(",\n")
+		} else {
+			buf.WriteString("\n  ")
+		}
+	}
+	buf.WriteString("]\n")
+	buf.WriteString("}\n")
+	return buf.Bytes(), nil
+}
+
+// writeRecord writes a single record with sorted capability keys.
+func writeRecord(buf *bytes.Buffer, rec Record, indent string) error {
+	buf.WriteString(indent + "{\n")
+	inner := indent + "  "
+	if err := writeJSONField(buf, inner, "id", rec.ID, false); err != nil {
+		return err
+	}
+	if err := writeJSONField(buf, inner, "category", rec.Category, false); err != nil {
+		return err
+	}
+	if err := writeJSONField(buf, inner, "language", rec.Language, false); err != nil {
+		return err
+	}
+	if err := writeJSONField(buf, inner, "label", rec.Label, false); err != nil {
+		return err
+	}
+	buf.WriteString(inner + "\"capabilities\": {")
+	keys := sortedCapKeys(rec.Capabilities)
+	if len(keys) > 0 {
+		buf.WriteString("\n")
+	}
+	for i, k := range keys {
+		cap := rec.Capabilities[k]
+		if err := writeCapability(buf, inner+"  ", k, cap); err != nil {
+			return err
+		}
+		if i < len(keys)-1 {
+			buf.WriteString(",\n")
+		} else {
+			buf.WriteString("\n" + inner)
+		}
+	}
+	buf.WriteString("}\n")
+	buf.WriteString(indent + "}")
+	return nil
+}
+
+// writeJSONField writes a "key": value pair using encoding/json for
+// proper string escaping. last controls trailing comma+newline.
+func writeJSONField(buf *bytes.Buffer, indent, key, value string, last bool) error {
+	encKey, err := json.Marshal(key)
+	if err != nil {
+		return err
+	}
+	encVal, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	buf.WriteString(indent)
+	buf.Write(encKey)
+	buf.WriteString(": ")
+	buf.Write(encVal)
+	if last {
+		buf.WriteString("\n")
+	} else {
+		buf.WriteString(",\n")
+	}
+	return nil
+}
+
+// writeCapability serialises a capability cell with sorted, omit-empty
+// semantics matching the struct json tags.
+func writeCapability(buf *bytes.Buffer, indent, key string, cap Capability) error {
+	encKey, err := json.Marshal(key)
+	if err != nil {
+		return err
+	}
+	buf.WriteString(indent)
+	buf.Write(encKey)
+	buf.WriteString(": {\n")
+	inner := indent + "  "
+
+	type field struct {
+		name string
+		val  any
+		emit bool
+	}
+	fields := []field{
+		{"status", cap.Status, true},
+		{"cites", cap.Cites, len(cap.Cites) > 0},
+		{"issue", cap.Issue, cap.Issue != ""},
+		{"verified_at", cap.VerifiedAt, cap.VerifiedAt != ""},
+		{"verified_sha", cap.VerifiedSHA, cap.VerifiedSHA != ""},
+	}
+	first := true
+	for _, f := range fields {
+		if !f.emit {
+			continue
+		}
+		if !first {
+			buf.WriteString(",\n")
+		}
+		first = false
+		encName, err := json.Marshal(f.name)
+		if err != nil {
+			return err
+		}
+		encVal, err := json.Marshal(f.val)
+		if err != nil {
+			return err
+		}
+		buf.WriteString(inner)
+		buf.Write(encName)
+		buf.WriteString(": ")
+		buf.Write(encVal)
+	}
+	buf.WriteString("\n" + indent + "}")
+	return nil
+}
+
+// sortedCapKeys returns capability map keys in lexical order.
+func sortedCapKeys(m map[string]Capability) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/tools/coverage/testdata/fixture.json
+++ b/tools/coverage/testdata/fixture.json
@@ -1,0 +1,81 @@
+{
+  "$schema_version": 1,
+  "records": [
+    {
+      "id": "lang.javascript.framework.express",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Express.js",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.nestjs",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "NestJS",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.django-drf",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Django REST Framework",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/django_drf_actions.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/1942",
+          "verified_at": "2026-05-27"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/django_drf_actions.go","internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/django_drf_actions.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.fastapi",
+      "category": "http_framework",
+      "language": "python",
+      "label": "FastAPI",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.flask",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Flask",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-27"
+        }
+      }
+    }
+  ]
+}

--- a/tools/coverage/validate.go
+++ b/tools/coverage/validate.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// staleDays is the threshold beyond which a capability cell triggers a
+// stale-verification warning.
+const staleDays = 90
+
+// ValidationResult collects errors (block) and warnings (advisory).
+type ValidationResult struct {
+	Errors   []string
+	Warnings []string
+}
+
+// HasErrors reports whether validation failed.
+func (r *ValidationResult) HasErrors() bool { return len(r.Errors) > 0 }
+
+// validateRegistry runs schema, cite-exists, duplicate-id, capability-key,
+// stale-verification, and missing-issue checks against reg. repoRoot is
+// used to resolve cite paths.
+func validateRegistry(reg *Registry, repoRoot string) *ValidationResult {
+	res := &ValidationResult{}
+	if reg.SchemaVersion != SchemaVersion {
+		res.Errors = append(res.Errors, fmt.Sprintf("schema_version %d unsupported (want %d)", reg.SchemaVersion, SchemaVersion))
+	}
+
+	seen := map[string]int{}
+	for i, rec := range reg.Records {
+		prefix := fmt.Sprintf("records[%d] (%s)", i, rec.ID)
+		if err := validateID(rec.ID); err != nil {
+			res.Errors = append(res.Errors, prefix+": "+err.Error())
+		}
+		if prev, ok := seen[rec.ID]; ok {
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: duplicate id (also at records[%d])", prefix, prev))
+		}
+		seen[rec.ID] = i
+
+		if rec.Category == "" {
+			res.Errors = append(res.Errors, prefix+": category is empty")
+		} else if _, ok := categoryCapabilities[rec.Category]; !ok {
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: unknown category %q (known: %v)", prefix, rec.Category, knownCategories()))
+		}
+		if rec.Language == "" {
+			res.Errors = append(res.Errors, prefix+": language is empty")
+		}
+		if rec.Label == "" {
+			res.Errors = append(res.Errors, prefix+": label is empty")
+		}
+
+		// Capabilities: sort keys for deterministic error ordering.
+		keys := sortedCapKeys(rec.Capabilities)
+		for _, k := range keys {
+			cap := rec.Capabilities[k]
+			capPrefix := fmt.Sprintf("%s.capabilities[%s]", prefix, k)
+			if !validCapabilityKey(rec.Category, k) {
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid capability key for category %q", capPrefix, rec.Category))
+			}
+			if _, ok := validStatuses[cap.Status]; !ok {
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid status %q", capPrefix, cap.Status))
+			}
+			for _, cite := range cap.Cites {
+				full := filepath.Join(repoRoot, cite)
+				if _, err := os.Stat(full); err != nil {
+					res.Errors = append(res.Errors, fmt.Sprintf("%s: cite %q not found on disk", capPrefix, cite))
+				}
+			}
+			if cap.VerifiedAt != "" {
+				t, err := time.Parse("2006-01-02", cap.VerifiedAt)
+				if err != nil {
+					res.Errors = append(res.Errors, fmt.Sprintf("%s: verified_at %q not a valid ISO date", capPrefix, cap.VerifiedAt))
+				} else if time.Since(t) > staleDays*24*time.Hour {
+					res.Warnings = append(res.Warnings, fmt.Sprintf("%s: verified_at %s is older than %d days", capPrefix, cap.VerifiedAt, staleDays))
+				}
+			}
+			if (cap.Status == StatusMissing || cap.Status == StatusPartial) && cap.Issue == "" {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %s capability has no tracking issue", capPrefix, cap.Status))
+			}
+		}
+	}
+
+	sort.Strings(res.Errors)
+	sort.Strings(res.Warnings)
+	return res
+}

--- a/tools/coverage/views.go
+++ b/tools/coverage/views.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+)
+
+// ListFilter narrows the result of the list subcommand.
+type ListFilter struct {
+	Status    string
+	Language  string
+	Category  string
+	StaleDays int
+}
+
+// listRecords returns records matching f, in stable ID order.
+func listRecords(reg *Registry, f ListFilter) []Record {
+	out := make([]Record, 0, len(reg.Records))
+	cutoff := time.Time{}
+	if f.StaleDays > 0 {
+		cutoff = time.Now().AddDate(0, 0, -f.StaleDays)
+	}
+	for _, rec := range reg.Records {
+		if f.Language != "" && rec.Language != f.Language {
+			continue
+		}
+		if f.Category != "" && rec.Category != f.Category {
+			continue
+		}
+		if f.Status != "" {
+			match := false
+			for _, cap := range rec.Capabilities {
+				if cap.Status == f.Status {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+		if f.StaleDays > 0 {
+			stale := false
+			for _, cap := range rec.Capabilities {
+				if cap.VerifiedAt == "" {
+					continue
+				}
+				t, err := time.Parse("2006-01-02", cap.VerifiedAt)
+				if err == nil && t.Before(cutoff) {
+					stale = true
+					break
+				}
+			}
+			if !stale {
+				continue
+			}
+		}
+		out = append(out, rec)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// findRecord returns the record with the given ID, or nil.
+func findRecord(reg *Registry, id string) *Record {
+	for i := range reg.Records {
+		if reg.Records[i].ID == id {
+			return &reg.Records[i]
+		}
+	}
+	return nil
+}
+
+// Stats summarises status counts across the registry.
+type Stats struct {
+	Total       int                       `json:"total"`
+	ByStatus    map[string]int            `json:"by_status"`
+	ByLanguage  map[string]LanguageStats  `json:"by_language"`
+	ByCategory  map[string]int            `json:"by_category"`
+	Capabilities int                      `json:"capabilities"`
+}
+
+// LanguageStats aggregates per-language status counts.
+type LanguageStats struct {
+	Records    int `json:"records"`
+	Full       int `json:"full"`
+	Partial    int `json:"partial"`
+	Missing    int `json:"missing"`
+	NotAppl    int `json:"not_applicable"`
+}
+
+// computeStats aggregates counters across the registry.
+func computeStats(reg *Registry) Stats {
+	s := Stats{
+		Total:      len(reg.Records),
+		ByStatus:   map[string]int{},
+		ByLanguage: map[string]LanguageStats{},
+		ByCategory: map[string]int{},
+	}
+	for _, rec := range reg.Records {
+		s.ByCategory[rec.Category]++
+		ls := s.ByLanguage[rec.Language]
+		ls.Records++
+		for _, cap := range rec.Capabilities {
+			s.Capabilities++
+			s.ByStatus[cap.Status]++
+			switch cap.Status {
+			case StatusFull:
+				ls.Full++
+			case StatusPartial:
+				ls.Partial++
+			case StatusMissing:
+				ls.Missing++
+			case StatusNotApplicable:
+				ls.NotAppl++
+			}
+		}
+		s.ByLanguage[rec.Language] = ls
+	}
+	return s
+}
+
+// gapsRecords returns records that contain at least one missing or
+// partial capability. Filters by language/category like listRecords.
+func gapsRecords(reg *Registry, language, category string) []Record {
+	out := make([]Record, 0)
+	for _, rec := range reg.Records {
+		if language != "" && rec.Language != language {
+			continue
+		}
+		if category != "" && rec.Category != category {
+			continue
+		}
+		hit := false
+		for _, cap := range rec.Capabilities {
+			if cap.Status == StatusMissing || cap.Status == StatusPartial {
+				hit = true
+				break
+			}
+		}
+		if hit {
+			out = append(out, rec)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// printRecordsText writes a human-readable table to w.
+func printRecordsText(w io.Writer, recs []Record) {
+	for _, rec := range recs {
+		fmt.Fprintf(w, "%-50s  %-18s  %-12s  %s\n", rec.ID, rec.Category, rec.Language, rec.Label)
+		keys := sortedCapKeys(rec.Capabilities)
+		for _, k := range keys {
+			cap := rec.Capabilities[k]
+			fmt.Fprintf(w, "    %-30s  %s\n", k, cap.Status)
+		}
+	}
+}
+
+// printJSON emits v as indented JSON with deterministic key ordering.
+func printJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}


### PR DESCRIPTION
PR 1 of 3 for #2720 — Coverage Registry tooling.

## Summary
- New \`tools/coverage/\` standalone Go tool — zero imports from \`internal/daemon\`, \`internal/store\`, \`internal/links\`. Pure file I/O on \`docs/coverage.json\` so it works when the daemon is down.
- CLI subcommands: \`list\`, \`get\`, \`add\`, \`update\`, \`remove\`, \`gaps\`, \`stats\`, \`validate\` (all with \`--json\` where it makes sense). Stdlib \`flag\` only.
- Atomic save (temp + rename), sorted records, sorted capability-map keys → deterministic JSON the PR 2 \`gen\` can rely on.
- Validation enforces id pattern, duplicate-id, status enum, per-category capability keys, cite-exists; warnings for >90-day stale \`verified_at\` and missing-issue on partial/missing cells.
- \`docs/coverage.json\` seeded with 5 records (Django REST Framework, FastAPI, Flask, Express, NestJS) all citing real repo files; \`go run ./tools/coverage validate\` exits 0.
- \`tools/coverage/main_test.go\` covers every subcommand against \`testdata/fixture.json\`, plus a determinism assertion on \`saveRegistry\`.

## Deferred
- \`gen\` subcommand + \`templates/\` + generated \`docs/coverage/*.md\` → **PR 2**
- \`.github/workflows/coverage-docs.yml\` + Makefile + full migration of records from \`docs/coverage.md\` → **PR 3**
- Optional pre-commit hook → PR 3 (will skip if install machinery doesn't fit cleanly, noted as follow-up).

## Test plan
- [x] \`go build ./tools/coverage/\`
- [x] \`go vet ./tools/coverage/\`
- [x] \`go test ./tools/coverage/\` (all subcommand integration tests + determinism)
- [x] \`go run ./tools/coverage validate\` → ok, 0 warnings
- [ ] Reviewer: \`go run ./tools/coverage stats\` / \`list\` / \`gaps\` for sanity