### PR TITLE
feat(tools/coverage): docs generator + templates + 30-record migration (#2720 PR 2)

### DIFF
--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -2,6 +2,168 @@
   "$schema_version": 1,
   "records": [
     {
+      "id": "infra.observability.opentelemetry",
+      "category": "observability",
+      "language": "multi",
+      "label": "OpenTelemetry instrumentation",
+      "capabilities": {
+        "trace_extraction": {
+          "status": "missing"
+        },
+        "metric_extraction": {
+          "status": "missing"
+        },
+        "log_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.aspnet-core",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "ASP.NET Core",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/aspnet_core_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/aspnet_core_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "auth_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.phoenix",
+      "category": "http_framework",
+      "language": "elixir",
+      "label": "Phoenix",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/phoenix_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/phoenix_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "auth_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.gorilla-mux",
+      "category": "http_framework",
+      "language": "go",
+      "label": "gorilla/mux",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_go_trio.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/go_routes.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.net-http",
+      "category": "http_framework",
+      "language": "go",
+      "label": "Go net/http stdlib",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_go_trio.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/go_routes.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.orm.gorm",
+      "category": "orm",
+      "language": "go",
+      "label": "GORM",
+      "capabilities": {
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
+        },
+        "migration_parsing": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.jaxrs",
+      "category": "http_framework",
+      "language": "java",
+      "label": "JAX-RS / Jakarta EE",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go", "internal/engine/java_annotation_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/java_annotation_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "auth_coverage": {
+          "status": "full",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.spring-boot",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Spring Boot / Spring MVC",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go", "internal/engine/spring_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/spring_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "auth_coverage": {
+          "status": "full",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
       "id": "lang.javascript.framework.express",
       "category": "http_framework",
       "language": "javascript",
@@ -11,6 +173,27 @@
           "status": "full",
           "cites": ["internal/engine/http_endpoint_synthesis.go"],
           "verified_at": "2026-05-27"
+        },
+        "auth_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.fastify",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Fastify",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_jsts_extra.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_jsts_extra.go"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -24,6 +207,111 @@
           "status": "full",
           "cites": ["internal/engine/http_endpoint_synthesis.go"],
           "verified_at": "2026-05-27"
+        },
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/1942",
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.next-api",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Next.js API routes",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_jsts_extra.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_jsts_extra.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.trpc",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "tRPC",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_trpc.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_trpc.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.orm.prisma",
+      "category": "orm",
+      "language": "javascript",
+      "label": "Prisma",
+      "capabilities": {
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "verified_at": "2026-05-28"
+        },
+        "migration_parsing": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.orm.typeorm",
+      "category": "orm",
+      "language": "javascript",
+      "label": "TypeORM",
+      "capabilities": {
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "verified_at": "2026-05-28"
+        },
+        "migration_parsing": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.laravel",
+      "category": "http_framework",
+      "language": "php",
+      "label": "Laravel",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_php_producer.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_php_producer.go"],
+          "verified_at": "2026-05-28"
+        },
+        "auth_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -41,7 +329,7 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/django_drf_actions.go","internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/django_drf_actions.go", "internal/engine/http_endpoint_synthesis.go"],
           "verified_at": "2026-05-27"
         },
         "handler_attribution": {
@@ -61,6 +349,9 @@
           "status": "full",
           "cites": ["internal/engine/http_endpoint_synthesis.go"],
           "verified_at": "2026-05-27"
+        },
+        "auth_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -74,6 +365,275 @@
           "status": "full",
           "cites": ["internal/engine/http_endpoint_synthesis.go"],
           "verified_at": "2026-05-27"
+        },
+        "auth_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.pyramid",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Pyramid",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.starlette",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Starlette",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.tornado",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Tornado",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.orm.django",
+      "category": "orm",
+      "language": "python",
+      "label": "Django ORM",
+      "capabilities": {
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/python/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "migration_parsing": {
+          "status": "full",
+          "cites": ["internal/extractors/python/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_python.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.orm.sqlalchemy",
+      "category": "orm",
+      "language": "python",
+      "label": "SQLAlchemy",
+      "capabilities": {
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_python.go"],
+          "verified_at": "2026-05-28"
+        },
+        "migration_parsing": {
+          "status": "partial",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2720"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.framework.rails",
+      "category": "http_framework",
+      "language": "ruby",
+      "label": "Ruby on Rails",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+          "verified_at": "2026-05-28"
+        },
+        "auth_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.framework.sinatra",
+      "category": "http_framework",
+      "language": "ruby",
+      "label": "Sinatra",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.framework.axum",
+      "category": "http_framework",
+      "language": "rust",
+      "label": "Axum",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_axum.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_axum.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.framework.rocket",
+      "category": "http_framework",
+      "language": "rust",
+      "label": "Rocket",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rocket_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rocket_routes.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "msg.broker.kafka",
+      "category": "message_broker",
+      "language": "multi",
+      "label": "Apache Kafka",
+      "capabilities": {
+        "producer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/kafka_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "consumer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/kafka_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "topic_attribution": {
+          "status": "full",
+          "cites": ["internal/links/topic_pass.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "msg.broker.rabbitmq",
+      "category": "message_broker",
+      "language": "multi",
+      "label": "RabbitMQ",
+      "capabilities": {
+        "producer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "consumer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "topic_attribution": {
+          "status": "full",
+          "cites": ["internal/links/topic_pass.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "msg.broker.sqs",
+      "category": "message_broker",
+      "language": "multi",
+      "label": "AWS SQS",
+      "capabilities": {
+        "producer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/sqs_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "consumer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/sqs_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "topic_attribution": {
+          "status": "full",
+          "cites": ["internal/links/topic_pass.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "protocol.grpc",
+      "category": "protocol",
+      "language": "multi",
+      "label": "gRPC services",
+      "capabilities": {
+        "service_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/grpc_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "method_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/grpc_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "cross_repo_linkage": {
+          "status": "full",
+          "cites": ["internal/links/grpc_pass.go"],
+          "verified_at": "2026-05-28"
         }
       }
     }

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,0 +1,34 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — category: `http_framework`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **22**
+- Valid capability keys: `auth_coverage`, `endpoint_synthesis`, `handler_attribution`, `middleware_coverage`
+
+## Records
+
+| ID | Language | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.csharp.framework.aspnet-core](../detail/lang.csharp.framework.aspnet-core.md) | [csharp](../by-language/csharp.md) | ASP.NET Core | auth_coverage=missing, endpoint_synthesis=full, handler_attribution=full |
+| [lang.elixir.framework.phoenix](../detail/lang.elixir.framework.phoenix.md) | [elixir](../by-language/elixir.md) | Phoenix | auth_coverage=missing, endpoint_synthesis=full, handler_attribution=full |
+| [lang.go.framework.gorilla-mux](../detail/lang.go.framework.gorilla-mux.md) | [go](../by-language/go.md) | gorilla/mux | endpoint_synthesis=full, handler_attribution=full |
+| [lang.go.framework.net-http](../detail/lang.go.framework.net-http.md) | [go](../by-language/go.md) | Go net/http stdlib | endpoint_synthesis=full, handler_attribution=full |
+| [lang.java.framework.jaxrs](../detail/lang.java.framework.jaxrs.md) | [java](../by-language/java.md) | JAX-RS / Jakarta EE | auth_coverage=full, endpoint_synthesis=full, handler_attribution=full |
+| [lang.java.framework.spring-boot](../detail/lang.java.framework.spring-boot.md) | [java](../by-language/java.md) | Spring Boot / Spring MVC | auth_coverage=full, endpoint_synthesis=full, handler_attribution=full |
+| [lang.javascript.framework.express](../detail/lang.javascript.framework.express.md) | [javascript](../by-language/javascript.md) | Express.js | auth_coverage=missing, endpoint_synthesis=full |
+| [lang.javascript.framework.fastify](../detail/lang.javascript.framework.fastify.md) | [javascript](../by-language/javascript.md) | Fastify | endpoint_synthesis=full, handler_attribution=full |
+| [lang.javascript.framework.nestjs](../detail/lang.javascript.framework.nestjs.md) | [javascript](../by-language/javascript.md) | NestJS | auth_coverage=partial, endpoint_synthesis=full |
+| [lang.javascript.framework.next-api](../detail/lang.javascript.framework.next-api.md) | [javascript](../by-language/javascript.md) | Next.js API routes | endpoint_synthesis=full, handler_attribution=full |
+| [lang.javascript.framework.trpc](../detail/lang.javascript.framework.trpc.md) | [javascript](../by-language/javascript.md) | tRPC | endpoint_synthesis=full, handler_attribution=full |
+| [lang.php.framework.laravel](../detail/lang.php.framework.laravel.md) | [php](../by-language/php.md) | Laravel | auth_coverage=missing, endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.framework.django-drf](../detail/lang.python.framework.django-drf.md) | [python](../by-language/python.md) | Django REST Framework | auth_coverage=partial, endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.framework.fastapi](../detail/lang.python.framework.fastapi.md) | [python](../by-language/python.md) | FastAPI | auth_coverage=missing, endpoint_synthesis=full |
+| [lang.python.framework.flask](../detail/lang.python.framework.flask.md) | [python](../by-language/python.md) | Flask | auth_coverage=missing, endpoint_synthesis=full |
+| [lang.python.framework.pyramid](../detail/lang.python.framework.pyramid.md) | [python](../by-language/python.md) | Pyramid | endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.framework.starlette](../detail/lang.python.framework.starlette.md) | [python](../by-language/python.md) | Starlette | endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.framework.tornado](../detail/lang.python.framework.tornado.md) | [python](../by-language/python.md) | Tornado | endpoint_synthesis=full, handler_attribution=full |
+| [lang.ruby.framework.rails](../detail/lang.ruby.framework.rails.md) | [ruby](../by-language/ruby.md) | Ruby on Rails | auth_coverage=missing, endpoint_synthesis=full, handler_attribution=full |
+| [lang.ruby.framework.sinatra](../detail/lang.ruby.framework.sinatra.md) | [ruby](../by-language/ruby.md) | Sinatra | endpoint_synthesis=full, handler_attribution=full |
+| [lang.rust.framework.axum](../detail/lang.rust.framework.axum.md) | [rust](../by-language/rust.md) | Axum | endpoint_synthesis=full, handler_attribution=full |
+| [lang.rust.framework.rocket](../detail/lang.rust.framework.rocket.md) | [rust](../by-language/rust.md) | Rocket | endpoint_synthesis=full, handler_attribution=full |

--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -1,0 +1,15 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — category: `message_broker`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **3**
+- Valid capability keys: `consumer_extraction`, `producer_extraction`, `topic_attribution`
+
+## Records
+
+| ID | Language | Label | Capabilities |
+|----|----------|-------|--------------|
+| [msg.broker.kafka](../detail/msg.broker.kafka.md) | [multi](../by-language/multi.md) | Apache Kafka | consumer_extraction=full, producer_extraction=full, topic_attribution=full |
+| [msg.broker.rabbitmq](../detail/msg.broker.rabbitmq.md) | [multi](../by-language/multi.md) | RabbitMQ | consumer_extraction=full, producer_extraction=full, topic_attribution=full |
+| [msg.broker.sqs](../detail/msg.broker.sqs.md) | [multi](../by-language/multi.md) | AWS SQS | consumer_extraction=full, producer_extraction=full, topic_attribution=full |

--- a/docs/coverage/by-category/observability.md
+++ b/docs/coverage/by-category/observability.md
@@ -1,0 +1,13 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — category: `observability`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **1**
+- Valid capability keys: `log_extraction`, `metric_extraction`, `trace_extraction`
+
+## Records
+
+| ID | Language | Label | Capabilities |
+|----|----------|-------|--------------|
+| [infra.observability.opentelemetry](../detail/infra.observability.opentelemetry.md) | [multi](../by-language/multi.md) | OpenTelemetry instrumentation | log_extraction=missing, metric_extraction=missing, trace_extraction=missing |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,0 +1,17 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — category: `orm`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **5**
+- Valid capability keys: `migration_parsing`, `model_extraction`, `query_attribution`
+
+## Records
+
+| ID | Language | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.go.orm.gorm](../detail/lang.go.orm.gorm.md) | [go](../by-language/go.md) | GORM | migration_parsing=missing, model_extraction=full, query_attribution=full |
+| [lang.javascript.orm.prisma](../detail/lang.javascript.orm.prisma.md) | [javascript](../by-language/javascript.md) | Prisma | migration_parsing=missing, model_extraction=full, query_attribution=full |
+| [lang.javascript.orm.typeorm](../detail/lang.javascript.orm.typeorm.md) | [javascript](../by-language/javascript.md) | TypeORM | migration_parsing=missing, model_extraction=full, query_attribution=full |
+| [lang.python.orm.django](../detail/lang.python.orm.django.md) | [python](../by-language/python.md) | Django ORM | migration_parsing=full, model_extraction=full, query_attribution=full |
+| [lang.python.orm.sqlalchemy](../detail/lang.python.orm.sqlalchemy.md) | [python](../by-language/python.md) | SQLAlchemy | migration_parsing=partial, model_extraction=full, query_attribution=full |

--- a/docs/coverage/by-category/protocol.md
+++ b/docs/coverage/by-category/protocol.md
@@ -1,0 +1,13 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — category: `protocol`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **1**
+- Valid capability keys: `cross_repo_linkage`, `method_attribution`, `service_extraction`
+
+## Records
+
+| ID | Language | Label | Capabilities |
+|----|----------|-------|--------------|
+| [protocol.grpc](../detail/protocol.grpc.md) | [multi](../by-language/multi.md) | gRPC services | cross_repo_linkage=full, method_attribution=full, service_extraction=full |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -1,0 +1,13 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `csharp`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **1**
+- Full: **2** · Partial: **0** · Missing: **1** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.csharp.framework.aspnet-core](../detail/lang.csharp.framework.aspnet-core.md) | [http_framework](../by-category/http_framework.md) | ASP.NET Core | auth_coverage=missing, endpoint_synthesis=full, handler_attribution=full |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -1,0 +1,13 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `elixir`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **1**
+- Full: **2** · Partial: **0** · Missing: **1** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.elixir.framework.phoenix](../detail/lang.elixir.framework.phoenix.md) | [http_framework](../by-category/http_framework.md) | Phoenix | auth_coverage=missing, endpoint_synthesis=full, handler_attribution=full |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -1,0 +1,15 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `go`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **3**
+- Full: **6** · Partial: **0** · Missing: **1** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.go.framework.gorilla-mux](../detail/lang.go.framework.gorilla-mux.md) | [http_framework](../by-category/http_framework.md) | gorilla/mux | endpoint_synthesis=full, handler_attribution=full |
+| [lang.go.framework.net-http](../detail/lang.go.framework.net-http.md) | [http_framework](../by-category/http_framework.md) | Go net/http stdlib | endpoint_synthesis=full, handler_attribution=full |
+| [lang.go.orm.gorm](../detail/lang.go.orm.gorm.md) | [orm](../by-category/orm.md) | GORM | migration_parsing=missing, model_extraction=full, query_attribution=full |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -1,0 +1,14 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `java`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **2**
+- Full: **6** · Partial: **0** · Missing: **0** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.java.framework.jaxrs](../detail/lang.java.framework.jaxrs.md) | [http_framework](../by-category/http_framework.md) | JAX-RS / Jakarta EE | auth_coverage=full, endpoint_synthesis=full, handler_attribution=full |
+| [lang.java.framework.spring-boot](../detail/lang.java.framework.spring-boot.md) | [http_framework](../by-category/http_framework.md) | Spring Boot / Spring MVC | auth_coverage=full, endpoint_synthesis=full, handler_attribution=full |

--- a/docs/coverage/by-language/javascript.md
+++ b/docs/coverage/by-language/javascript.md
@@ -1,0 +1,19 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `javascript`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **7**
+- Full: **12** · Partial: **1** · Missing: **3** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.javascript.framework.express](../detail/lang.javascript.framework.express.md) | [http_framework](../by-category/http_framework.md) | Express.js | auth_coverage=missing, endpoint_synthesis=full |
+| [lang.javascript.framework.fastify](../detail/lang.javascript.framework.fastify.md) | [http_framework](../by-category/http_framework.md) | Fastify | endpoint_synthesis=full, handler_attribution=full |
+| [lang.javascript.framework.nestjs](../detail/lang.javascript.framework.nestjs.md) | [http_framework](../by-category/http_framework.md) | NestJS | auth_coverage=partial, endpoint_synthesis=full |
+| [lang.javascript.framework.next-api](../detail/lang.javascript.framework.next-api.md) | [http_framework](../by-category/http_framework.md) | Next.js API routes | endpoint_synthesis=full, handler_attribution=full |
+| [lang.javascript.framework.trpc](../detail/lang.javascript.framework.trpc.md) | [http_framework](../by-category/http_framework.md) | tRPC | endpoint_synthesis=full, handler_attribution=full |
+| [lang.javascript.orm.prisma](../detail/lang.javascript.orm.prisma.md) | [orm](../by-category/orm.md) | Prisma | migration_parsing=missing, model_extraction=full, query_attribution=full |
+| [lang.javascript.orm.typeorm](../detail/lang.javascript.orm.typeorm.md) | [orm](../by-category/orm.md) | TypeORM | migration_parsing=missing, model_extraction=full, query_attribution=full |

--- a/docs/coverage/by-language/multi.md
+++ b/docs/coverage/by-language/multi.md
@@ -1,0 +1,17 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `multi`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **5**
+- Full: **12** · Partial: **0** · Missing: **3** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [infra.observability.opentelemetry](../detail/infra.observability.opentelemetry.md) | [observability](../by-category/observability.md) | OpenTelemetry instrumentation | log_extraction=missing, metric_extraction=missing, trace_extraction=missing |
+| [msg.broker.kafka](../detail/msg.broker.kafka.md) | [message_broker](../by-category/message_broker.md) | Apache Kafka | consumer_extraction=full, producer_extraction=full, topic_attribution=full |
+| [msg.broker.rabbitmq](../detail/msg.broker.rabbitmq.md) | [message_broker](../by-category/message_broker.md) | RabbitMQ | consumer_extraction=full, producer_extraction=full, topic_attribution=full |
+| [msg.broker.sqs](../detail/msg.broker.sqs.md) | [message_broker](../by-category/message_broker.md) | AWS SQS | consumer_extraction=full, producer_extraction=full, topic_attribution=full |
+| [protocol.grpc](../detail/protocol.grpc.md) | [protocol](../by-category/protocol.md) | gRPC services | cross_repo_linkage=full, method_attribution=full, service_extraction=full |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -1,0 +1,13 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `php`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **1**
+- Full: **2** · Partial: **0** · Missing: **1** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.php.framework.laravel](../detail/lang.php.framework.laravel.md) | [http_framework](../by-category/http_framework.md) | Laravel | auth_coverage=missing, endpoint_synthesis=full, handler_attribution=full |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -1,0 +1,20 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `python`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **8**
+- Full: **15** · Partial: **2** · Missing: **2** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.python.framework.django-drf](../detail/lang.python.framework.django-drf.md) | [http_framework](../by-category/http_framework.md) | Django REST Framework | auth_coverage=partial, endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.framework.fastapi](../detail/lang.python.framework.fastapi.md) | [http_framework](../by-category/http_framework.md) | FastAPI | auth_coverage=missing, endpoint_synthesis=full |
+| [lang.python.framework.flask](../detail/lang.python.framework.flask.md) | [http_framework](../by-category/http_framework.md) | Flask | auth_coverage=missing, endpoint_synthesis=full |
+| [lang.python.framework.pyramid](../detail/lang.python.framework.pyramid.md) | [http_framework](../by-category/http_framework.md) | Pyramid | endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.framework.starlette](../detail/lang.python.framework.starlette.md) | [http_framework](../by-category/http_framework.md) | Starlette | endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.framework.tornado](../detail/lang.python.framework.tornado.md) | [http_framework](../by-category/http_framework.md) | Tornado | endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.orm.django](../detail/lang.python.orm.django.md) | [orm](../by-category/orm.md) | Django ORM | migration_parsing=full, model_extraction=full, query_attribution=full |
+| [lang.python.orm.sqlalchemy](../detail/lang.python.orm.sqlalchemy.md) | [orm](../by-category/orm.md) | SQLAlchemy | migration_parsing=partial, model_extraction=full, query_attribution=full |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -1,0 +1,14 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `ruby`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **2**
+- Full: **4** · Partial: **0** · Missing: **1** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.ruby.framework.rails](../detail/lang.ruby.framework.rails.md) | [http_framework](../by-category/http_framework.md) | Ruby on Rails | auth_coverage=missing, endpoint_synthesis=full, handler_attribution=full |
+| [lang.ruby.framework.sinatra](../detail/lang.ruby.framework.sinatra.md) | [http_framework](../by-category/http_framework.md) | Sinatra | endpoint_synthesis=full, handler_attribution=full |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -1,0 +1,14 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `rust`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **2**
+- Full: **4** · Partial: **0** · Missing: **0** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.rust.framework.axum](../detail/lang.rust.framework.axum.md) | [http_framework](../by-category/http_framework.md) | Axum | endpoint_synthesis=full, handler_attribution=full |
+| [lang.rust.framework.rocket](../detail/lang.rust.framework.rocket.md) | [http_framework](../by-category/http_framework.md) | Rocket | endpoint_synthesis=full, handler_attribution=full |

--- a/docs/coverage/detail/infra.observability.opentelemetry.md
+++ b/docs/coverage/detail/infra.observability.opentelemetry.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `infra.observability.opentelemetry` — OpenTelemetry instrumentation
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [observability](../by-category/observability.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `log_extraction` | `missing` | — | — | — | — |
+| `metric_extraction` | `missing` | — | — | — | — |
+| `trace_extraction` | `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.observability.opentelemetry ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.aspnet-core` — ASP.NET Core
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `missing` | — | — | — | — |
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.aspnet-core ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.framework.phoenix` — Phoenix
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `missing` | — | — | — | — |
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.framework.phoenix ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.gorilla-mux` — gorilla/mux
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.gorilla-mux ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.net-http` — Go net/http stdlib
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.net-http ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.orm.gorm.md
+++ b/docs/coverage/detail/lang.go.orm.gorm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.go.orm.gorm` — GORM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | `missing` | — | — | — | — |
+| `model_extraction` | `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
+| `query_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.orm.gorm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.jaxrs` — JAX-RS / Jakarta EE
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/java_annotation_routes.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.jaxrs ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.spring-boot` — Spring Boot / Spring MVC
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/spring_routes.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/spring_routes.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.spring-boot ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.express.md
+++ b/docs/coverage/detail/lang.javascript.framework.express.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.express` — Express.js
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `missing` | — | — | — | — |
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.express ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.fastify.md
+++ b/docs/coverage/detail/lang.javascript.framework.fastify.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.fastify` — Fastify
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_extra.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_extra.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.fastify ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.nestjs.md
+++ b/docs/coverage/detail/lang.javascript.framework.nestjs.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.nestjs` — NestJS
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | `internal/engine/java_auth_policy.go` |
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.nestjs ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.next-api.md
+++ b/docs/coverage/detail/lang.javascript.framework.next-api.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.next-api` — Next.js API routes
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_extra.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_extra.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.next-api ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.trpc.md
+++ b/docs/coverage/detail/lang.javascript.framework.trpc.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.trpc` — tRPC
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.trpc ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.orm.prisma.md
+++ b/docs/coverage/detail/lang.javascript.orm.prisma.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.orm.prisma` — Prisma
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | `missing` | — | — | — | — |
+| `model_extraction` | `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
+| `query_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.orm.prisma ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.orm.typeorm.md
+++ b/docs/coverage/detail/lang.javascript.orm.typeorm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.orm.typeorm` — TypeORM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | `missing` | — | — | — | — |
+| `model_extraction` | `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
+| `query_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.orm.typeorm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.laravel` — Laravel
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `missing` | — | — | — | — |
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.laravel ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.django-drf` — Django REST Framework
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `partial` | `2026-05-27` | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | `internal/engine/django_drf_actions.go` |
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/engine/http_endpoint_synthesis.go` |
+| `handler_attribution` | `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.django-drf ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.fastapi` — FastAPI
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `missing` | — | — | — | — |
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.fastapi ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.flask` — Flask
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `missing` | — | — | — | — |
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.flask ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.pyramid` — Pyramid
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.pyramid ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.starlette` — Starlette
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.starlette ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.tornado` — Tornado
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.tornado ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.orm.django.md
+++ b/docs/coverage/detail/lang.python.orm.django.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.orm.django` — Django ORM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | `full` | `2026-05-28` | — | — | `internal/extractors/python/extractor.go` |
+| `model_extraction` | `full` | `2026-05-28` | — | — | `internal/extractors/python/extractor.go` |
+| `query_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.orm.django ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.orm.sqlalchemy.md
+++ b/docs/coverage/detail/lang.python.orm.sqlalchemy.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.orm.sqlalchemy` — SQLAlchemy
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | `partial` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2720) | — |
+| `model_extraction` | `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
+| `query_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.orm.sqlalchemy ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.framework.rails` — Ruby on Rails
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `missing` | — | — | — | — |
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.framework.rails ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.framework.sinatra` — Sinatra
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.framework.sinatra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.axum` — Axum
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.axum ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.rocket` — Rocket
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go` |
+| `handler_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.rocket ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.broker.kafka.md
+++ b/docs/coverage/detail/msg.broker.kafka.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `msg.broker.kafka` — Apache Kafka
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `consumer_extraction` | `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go` |
+| `producer_extraction` | `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go` |
+| `topic_attribution` | `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.broker.kafka ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.broker.rabbitmq.md
+++ b/docs/coverage/detail/msg.broker.rabbitmq.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `msg.broker.rabbitmq` — RabbitMQ
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `consumer_extraction` | `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
+| `producer_extraction` | `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
+| `topic_attribution` | `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.broker.rabbitmq ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.broker.sqs.md
+++ b/docs/coverage/detail/msg.broker.sqs.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `msg.broker.sqs` — AWS SQS
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `consumer_extraction` | `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` |
+| `producer_extraction` | `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` |
+| `topic_attribution` | `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.broker.sqs ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `protocol.grpc` — gRPC services
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [protocol](../by-category/protocol.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `cross_repo_linkage` | `full` | `2026-05-28` | — | — | `internal/links/grpc_pass.go` |
+| `method_attribution` | `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
+| `service_extraction` | `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update protocol.grpc ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,0 +1,76 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage Registry — Summary
+
+Auto-generated from `docs/coverage.json` by `go run ./tools/coverage gen`.
+Each capability cell is one of: `full`, `partial`, `missing`, `not_applicable`.
+
+## Totals
+
+- Records: **32**
+- Capability cells: **81**
+- Full: **65**
+- Partial: **3**
+- Missing: **13**
+- Not applicable: **0**
+
+## By language
+
+| Language | Records | Full | Partial | Missing | N/A | % Full |
+|----------|---------|------|---------|---------|-----|--------|
+| [csharp](by-language/csharp.md) | 1 | 2 | 0 | 1 | 0 | 66% |
+| [elixir](by-language/elixir.md) | 1 | 2 | 0 | 1 | 0 | 66% |
+| [go](by-language/go.md) | 3 | 6 | 0 | 1 | 0 | 85% |
+| [java](by-language/java.md) | 2 | 6 | 0 | 0 | 0 | 100% |
+| [javascript](by-language/javascript.md) | 7 | 12 | 1 | 3 | 0 | 75% |
+| [multi](by-language/multi.md) | 5 | 12 | 0 | 3 | 0 | 80% |
+| [php](by-language/php.md) | 1 | 2 | 0 | 1 | 0 | 66% |
+| [python](by-language/python.md) | 8 | 15 | 2 | 2 | 0 | 78% |
+| [ruby](by-language/ruby.md) | 2 | 4 | 0 | 1 | 0 | 80% |
+| [rust](by-language/rust.md) | 2 | 4 | 0 | 0 | 0 | 100% |
+
+## By category
+
+| Category | Records |
+|----------|---------|
+| [http_framework](by-category/http_framework.md) | 22 |
+| [message_broker](by-category/message_broker.md) | 3 |
+| [observability](by-category/observability.md) | 1 |
+| [orm](by-category/orm.md) | 5 |
+| [protocol](by-category/protocol.md) | 1 |
+
+## All records
+
+| ID | Language | Category | Label |
+|----|----------|----------|-------|
+| [infra.observability.opentelemetry](detail/infra.observability.opentelemetry.md) | multi | observability | OpenTelemetry instrumentation |
+| [lang.csharp.framework.aspnet-core](detail/lang.csharp.framework.aspnet-core.md) | csharp | http_framework | ASP.NET Core |
+| [lang.elixir.framework.phoenix](detail/lang.elixir.framework.phoenix.md) | elixir | http_framework | Phoenix |
+| [lang.go.framework.gorilla-mux](detail/lang.go.framework.gorilla-mux.md) | go | http_framework | gorilla/mux |
+| [lang.go.framework.net-http](detail/lang.go.framework.net-http.md) | go | http_framework | Go net/http stdlib |
+| [lang.go.orm.gorm](detail/lang.go.orm.gorm.md) | go | orm | GORM |
+| [lang.java.framework.jaxrs](detail/lang.java.framework.jaxrs.md) | java | http_framework | JAX-RS / Jakarta EE |
+| [lang.java.framework.spring-boot](detail/lang.java.framework.spring-boot.md) | java | http_framework | Spring Boot / Spring MVC |
+| [lang.javascript.framework.express](detail/lang.javascript.framework.express.md) | javascript | http_framework | Express.js |
+| [lang.javascript.framework.fastify](detail/lang.javascript.framework.fastify.md) | javascript | http_framework | Fastify |
+| [lang.javascript.framework.nestjs](detail/lang.javascript.framework.nestjs.md) | javascript | http_framework | NestJS |
+| [lang.javascript.framework.next-api](detail/lang.javascript.framework.next-api.md) | javascript | http_framework | Next.js API routes |
+| [lang.javascript.framework.trpc](detail/lang.javascript.framework.trpc.md) | javascript | http_framework | tRPC |
+| [lang.javascript.orm.prisma](detail/lang.javascript.orm.prisma.md) | javascript | orm | Prisma |
+| [lang.javascript.orm.typeorm](detail/lang.javascript.orm.typeorm.md) | javascript | orm | TypeORM |
+| [lang.php.framework.laravel](detail/lang.php.framework.laravel.md) | php | http_framework | Laravel |
+| [lang.python.framework.django-drf](detail/lang.python.framework.django-drf.md) | python | http_framework | Django REST Framework |
+| [lang.python.framework.fastapi](detail/lang.python.framework.fastapi.md) | python | http_framework | FastAPI |
+| [lang.python.framework.flask](detail/lang.python.framework.flask.md) | python | http_framework | Flask |
+| [lang.python.framework.pyramid](detail/lang.python.framework.pyramid.md) | python | http_framework | Pyramid |
+| [lang.python.framework.starlette](detail/lang.python.framework.starlette.md) | python | http_framework | Starlette |
+| [lang.python.framework.tornado](detail/lang.python.framework.tornado.md) | python | http_framework | Tornado |
+| [lang.python.orm.django](detail/lang.python.orm.django.md) | python | orm | Django ORM |
+| [lang.python.orm.sqlalchemy](detail/lang.python.orm.sqlalchemy.md) | python | orm | SQLAlchemy |
+| [lang.ruby.framework.rails](detail/lang.ruby.framework.rails.md) | ruby | http_framework | Ruby on Rails |
+| [lang.ruby.framework.sinatra](detail/lang.ruby.framework.sinatra.md) | ruby | http_framework | Sinatra |
+| [lang.rust.framework.axum](detail/lang.rust.framework.axum.md) | rust | http_framework | Axum |
+| [lang.rust.framework.rocket](detail/lang.rust.framework.rocket.md) | rust | http_framework | Rocket |
+| [msg.broker.kafka](detail/msg.broker.kafka.md) | multi | message_broker | Apache Kafka |
+| [msg.broker.rabbitmq](detail/msg.broker.rabbitmq.md) | multi | message_broker | RabbitMQ |
+| [msg.broker.sqs](detail/msg.broker.sqs.md) | multi | message_broker | AWS SQS |
+| [protocol.grpc](detail/protocol.grpc.md) | multi | protocol | gRPC services |

--- a/tools/coverage/gen_test.go
+++ b/tools/coverage/gen_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// walkGenerated returns a sorted map of repo-relative-path → sha256 hex
+// for every file under <root>/docs/coverage. Used by the determinism test
+// to compare two independent gen runs.
+func walkGenerated(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	base := filepath.Join(root, docsDir)
+	err := filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(data)
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out[filepath.ToSlash(rel)] = hex.EncodeToString(sum[:])
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", base, err)
+	}
+	return out
+}
+
+func TestGenDeterministic(t *testing.T) {
+	reg, err := loadRegistry(fixturePath(t))
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	a, b := t.TempDir(), t.TempDir()
+	if err := generate(reg, a); err != nil {
+		t.Fatalf("generate a: %v", err)
+	}
+	if err := generate(reg, b); err != nil {
+		t.Fatalf("generate b: %v", err)
+	}
+	ha := walkGenerated(t, a)
+	hb := walkGenerated(t, b)
+	if len(ha) != len(hb) {
+		t.Fatalf("different file counts: a=%d b=%d", len(ha), len(hb))
+	}
+	keysA := make([]string, 0, len(ha))
+	for k := range ha {
+		keysA = append(keysA, k)
+	}
+	sort.Strings(keysA)
+	for _, k := range keysA {
+		if ha[k] != hb[k] {
+			t.Errorf("non-deterministic content for %s: a=%s b=%s", k, ha[k], hb[k])
+		}
+	}
+}
+
+func TestGenSmokeFixturePaths(t *testing.T) {
+	reg, err := loadRegistry(fixturePath(t))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	root := t.TempDir()
+	if err := generate(reg, root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	want := []string{
+		"docs/coverage/summary.md",
+		"docs/coverage/by-language/python.md",
+		"docs/coverage/by-language/javascript.md",
+		"docs/coverage/by-category/http_framework.md",
+		"docs/coverage/detail/lang.python.framework.flask.md",
+		"docs/coverage/detail/lang.javascript.framework.express.md",
+	}
+	for _, rel := range want {
+		full := filepath.Join(root, rel)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			t.Errorf("expected file %s: %v", rel, err)
+			continue
+		}
+		if !bytes.HasPrefix(data, []byte("<!-- DO NOT EDIT")) {
+			t.Errorf("%s missing DO-NOT-EDIT marker", rel)
+		}
+	}
+}
+
+func TestGenMarkerOnEveryFile(t *testing.T) {
+	reg, err := loadRegistry(fixturePath(t))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	root := t.TempDir()
+	if err := generate(reg, root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	err = filepath.Walk(filepath.Join(root, docsDir), func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !bytes.HasPrefix(data, []byte("<!-- DO NOT EDIT")) {
+			t.Errorf("%s missing DO-NOT-EDIT marker", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+}
+
+// TestGenGoldenFixture renders the fixture and compares the produced
+// summary.md byte-for-byte against testdata/fixture-out/summary.md.
+// This locks template rendering against regression.
+func TestGenGoldenFixture(t *testing.T) {
+	reg, err := loadRegistry(fixturePath(t))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	root := t.TempDir()
+	if err := generate(reg, root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	goldenRoot := filepath.Join(wd, "testdata", "fixture-out")
+	// Walk the golden tree; every file there must match its counterpart
+	// under the generated tree. Extra generated files are tolerated only
+	// if explicitly missing from golden (forces an opt-in to expand).
+	err = filepath.Walk(goldenRoot, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(goldenRoot, path)
+		if err != nil {
+			return err
+		}
+		genPath := filepath.Join(root, "docs", "coverage", rel)
+		want, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		got, err := os.ReadFile(genPath)
+		if err != nil {
+			t.Errorf("missing generated file for golden %s: %v", rel, err)
+			return nil
+		}
+		if !bytes.Equal(want, got) {
+			t.Errorf("golden mismatch for %s\n--- want ---\n%s\n--- got ---\n%s", rel, want, got)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk golden: %v", err)
+	}
+}
+
+func TestGenSubcommandWiring(t *testing.T) {
+	reg, err := loadRegistry(fixturePath(t))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	root := t.TempDir()
+	// Copy the fixture so we can point --file at a writable path that lives
+	// next to the --out target. (gen does not write the registry; the copy
+	// is just to test the CLI dispatcher with real flag plumbing.)
+	regPath := filepath.Join(root, "coverage.json")
+	if err := saveRegistry(regPath, reg); err != nil {
+		t.Fatalf("save copy: %v", err)
+	}
+	out, _, err := runCmd(t, "gen", "--file", regPath, "--out", root)
+	if err != nil {
+		t.Fatalf("gen: %v", err)
+	}
+	if !strings.Contains(out, "generated") {
+		t.Errorf("expected confirmation message, got: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", "coverage", "summary.md")); err != nil {
+		t.Errorf("summary.md not created: %v", err)
+	}
+}

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -1,0 +1,316 @@
+package main
+
+import (
+	"bytes"
+	"embed"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"text/template"
+)
+
+// docsDir is the canonical on-disk root for generated markdown.
+const docsDir = "docs/coverage"
+
+// doNotEditMarker is prepended to every generated file so reviewers and
+// CI see immediately that hand-edits will be lost.
+const doNotEditMarker = "<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->"
+
+//go:embed templates/*.tmpl
+var templateFS embed.FS
+
+// loadTemplates parses the four embedded markdown templates. Templates
+// are parsed once and reused per render; parsing here keeps generate.go
+// free of init-time side effects.
+func loadTemplates() (*template.Template, error) {
+	root := template.New("coverage")
+	entries, err := templateFS.ReadDir("templates")
+	if err != nil {
+		return nil, fmt.Errorf("read templates dir: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		data, err := templateFS.ReadFile("templates/" + n)
+		if err != nil {
+			return nil, fmt.Errorf("read template %s: %w", n, err)
+		}
+		if _, err := root.New(n).Parse(string(data)); err != nil {
+			return nil, fmt.Errorf("parse template %s: %w", n, err)
+		}
+	}
+	return root, nil
+}
+
+// capEntry is a key+capability pair flattened for deterministic
+// template iteration (range over a map is unordered in Go).
+type capEntry struct {
+	Key string
+	Cap Capability
+}
+
+// recordView wraps a Record with a pre-sorted CapList for templates.
+type recordView struct {
+	ID       string
+	Category string
+	Language string
+	Label    string
+	CapList  []capEntry
+}
+
+// languageView is one row of the by-language summary.
+type languageView struct {
+	Name    string
+	Stats   LanguageStats
+	PctFull string
+}
+
+// categoryView is one row of the by-category summary.
+type categoryView struct {
+	Name  string
+	Count int
+}
+
+// summaryData feeds summary.md.tmpl.
+type summaryData struct {
+	Marker     string
+	Stats      Stats
+	Languages  []languageView
+	Categories []categoryView
+	Records    []recordView
+}
+
+// languagePageData feeds by-language/<lang>.md.tmpl.
+type languagePageData struct {
+	Marker   string
+	Language string
+	Stats    LanguageStats
+	Records  []recordView
+}
+
+// categoryPageData feeds by-category/<cat>.md.tmpl.
+type categoryPageData struct {
+	Marker         string
+	Category       string
+	Count          int
+	CapabilityKeys []string
+	Records        []recordView
+}
+
+// detailPageData feeds detail/<id>.md.tmpl.
+type detailPageData struct {
+	Marker  string
+	Record  Record
+	CapList []capEntry
+}
+
+// recordToView materialises a Record with sorted capability entries so
+// templates iterate deterministically.
+func recordToView(rec Record) recordView {
+	keys := sortedCapKeys(rec.Capabilities)
+	list := make([]capEntry, 0, len(keys))
+	for _, k := range keys {
+		list = append(list, capEntry{Key: k, Cap: rec.Capabilities[k]})
+	}
+	return recordView{
+		ID:       rec.ID,
+		Category: rec.Category,
+		Language: rec.Language,
+		Label:    rec.Label,
+		CapList:  list,
+	}
+}
+
+// pctFull renders the full-capability percentage as a string. Returns
+// "0%" when the language has no capability cells (avoids divide-by-zero
+// and keeps output deterministic across registries).
+func pctFull(ls LanguageStats) string {
+	total := ls.Full + ls.Partial + ls.Missing + ls.NotAppl
+	if total == 0 {
+		return "0%"
+	}
+	return fmt.Sprintf("%d%%", (ls.Full*100)/total)
+}
+
+// generate writes the full markdown tree under outRoot/docs/coverage.
+// outRoot is normally the repo root; tests point it at a t.TempDir().
+// Output is deterministic: sorted iteration everywhere, no time.Now,
+// no environment-dependent state.
+func generate(reg *Registry, outRoot string) error {
+	tmpls, err := loadTemplates()
+	if err != nil {
+		return err
+	}
+	stats := computeStats(reg)
+
+	// Pre-build sorted language and category lists.
+	langNames := make([]string, 0, len(stats.ByLanguage))
+	for k := range stats.ByLanguage {
+		langNames = append(langNames, k)
+	}
+	sort.Strings(langNames)
+	catNames := make([]string, 0, len(stats.ByCategory))
+	for k := range stats.ByCategory {
+		catNames = append(catNames, k)
+	}
+	sort.Strings(catNames)
+
+	// Sorted record views (registry already sorts records, but be defensive
+	// so generate works on any *Registry, not just one fresh from saveRegistry).
+	sortedRecs := make([]Record, len(reg.Records))
+	copy(sortedRecs, reg.Records)
+	sort.Slice(sortedRecs, func(i, j int) bool { return sortedRecs[i].ID < sortedRecs[j].ID })
+	allViews := make([]recordView, len(sortedRecs))
+	for i, r := range sortedRecs {
+		allViews[i] = recordToView(r)
+	}
+
+	// Group views per language and per category for slice pages.
+	byLang := map[string][]recordView{}
+	byCat := map[string][]recordView{}
+	for _, v := range allViews {
+		byLang[v.Language] = append(byLang[v.Language], v)
+		byCat[v.Category] = append(byCat[v.Category], v)
+	}
+
+	root := filepath.Join(outRoot, docsDir)
+	if err := os.MkdirAll(filepath.Join(root, "by-language"), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(root, "by-category"), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(root, "detail"), 0o755); err != nil {
+		return err
+	}
+
+	// Render summary.
+	languages := make([]languageView, 0, len(langNames))
+	for _, n := range langNames {
+		ls := stats.ByLanguage[n]
+		languages = append(languages, languageView{Name: n, Stats: ls, PctFull: pctFull(ls)})
+	}
+	categories := make([]categoryView, 0, len(catNames))
+	for _, n := range catNames {
+		categories = append(categories, categoryView{Name: n, Count: stats.ByCategory[n]})
+	}
+	if err := renderToFile(tmpls, "summary.md.tmpl", filepath.Join(root, "summary.md"), summaryData{
+		Marker:     doNotEditMarker,
+		Stats:      stats,
+		Languages:  languages,
+		Categories: categories,
+		Records:    allViews,
+	}); err != nil {
+		return err
+	}
+
+	// Per-language pages.
+	for _, n := range langNames {
+		recs := byLang[n]
+		if err := renderToFile(tmpls, "by-language.md.tmpl",
+			filepath.Join(root, "by-language", n+".md"),
+			languagePageData{
+				Marker:   doNotEditMarker,
+				Language: n,
+				Stats:    stats.ByLanguage[n],
+				Records:  recs,
+			}); err != nil {
+			return err
+		}
+	}
+
+	// Per-category pages.
+	for _, n := range catNames {
+		recs := byCat[n]
+		keys := make([]string, len(categoryCapabilities[n]))
+		copy(keys, categoryCapabilities[n])
+		sort.Strings(keys)
+		if err := renderToFile(tmpls, "by-category.md.tmpl",
+			filepath.Join(root, "by-category", n+".md"),
+			categoryPageData{
+				Marker:         doNotEditMarker,
+				Category:       n,
+				Count:          stats.ByCategory[n],
+				CapabilityKeys: keys,
+				Records:        recs,
+			}); err != nil {
+			return err
+		}
+	}
+
+	// Per-record detail pages.
+	for _, rec := range sortedRecs {
+		view := recordToView(rec)
+		if err := renderToFile(tmpls, "detail.md.tmpl",
+			filepath.Join(root, "detail", rec.ID+".md"),
+			detailPageData{
+				Marker:  doNotEditMarker,
+				Record:  rec,
+				CapList: view.CapList,
+			}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renderToFile executes the named template into a buffer and writes it
+// atomically via temp+rename so partial writes never appear on disk.
+func renderToFile(tmpls *template.Template, name, path string, data any) error {
+	var buf bytes.Buffer
+	if err := tmpls.ExecuteTemplate(&buf, name, data); err != nil {
+		return fmt.Errorf("execute %s: %w", name, err)
+	}
+	// Ensure file ends with exactly one trailing newline. Templates may
+	// or may not include one; normalising here keeps output stable across
+	// template edits.
+	out := bytes.TrimRight(buf.Bytes(), "\n")
+	out = append(out, '\n')
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".coverage-gen.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(out); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// cmdGen wires the gen subcommand into main.go's dispatch.
+func cmdGen(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("gen", flag.ContinueOnError)
+	path := registryFlag(fs)
+	outRoot := fs.String("out", ".", "output root (docs/coverage/* will be written under this)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	if err := generate(reg, *outRoot); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "generated %d record(s) into %s\n", len(reg.Records), filepath.Join(*outRoot, docsDir))
+	return nil
+}

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -47,6 +47,8 @@ func run(argv []string, stdout, stderr io.Writer) error {
 		return cmdStats(rest, stdout)
 	case "validate":
 		return cmdValidate(rest, stdout, stderr)
+	case "gen":
+		return cmdGen(rest, stdout)
 	case "help", "-h", "--help":
 		printUsage(stdout)
 		return nil
@@ -67,7 +69,8 @@ subcommands:
   remove    delete a record by id
   gaps      list missing/partial records (--language, --category, --json)
   stats     counters across the registry (--json)
-  validate  schema + cite-exists + duplicate-id + stale checks`)
+  validate  schema + cite-exists + duplicate-id + stale checks
+  gen       regenerate docs/coverage/*.md from docs/coverage.json (--out, --file)`)
 }
 
 // registryFlag adds a shared --file flag for overriding the registry

--- a/tools/coverage/main_test.go
+++ b/tools/coverage/main_test.go
@@ -264,3 +264,20 @@ func TestUnknownSubcommand(t *testing.T) {
 		t.Fatal("expected error for unknown subcommand")
 	}
 }
+
+// TestGenDispatch exercises the gen subcommand through the top-level
+// run() dispatcher so the wiring in main.go is covered alongside the
+// generator itself. Deeper rendering behaviour lives in gen_test.go.
+func TestGenDispatch(t *testing.T) {
+	root := t.TempDir()
+	out, _, err := runCmd(t, "gen", "--file", fixturePath(t), "--out", root)
+	if err != nil {
+		t.Fatalf("gen: %v", err)
+	}
+	if !strings.Contains(out, "generated") {
+		t.Errorf("expected confirmation, got: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", "coverage", "summary.md")); err != nil {
+		t.Errorf("summary.md missing: %v", err)
+	}
+}

--- a/tools/coverage/templates/by-category.md.tmpl
+++ b/tools/coverage/templates/by-category.md.tmpl
@@ -1,0 +1,15 @@
+{{.Marker}}
+# Coverage — category: `{{.Category}}`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **{{.Count}}**
+- Valid capability keys: {{range $i, $k := .CapabilityKeys}}{{if $i}}, {{end}}`{{$k}}`{{end}}
+
+## Records
+
+| ID | Language | Label | Capabilities |
+|----|----------|-------|--------------|
+{{- range .Records}}
+| [{{.ID}}](../detail/{{.ID}}.md) | [{{.Language}}](../by-language/{{.Language}}.md) | {{.Label}} | {{range $i, $c := .CapList}}{{if $i}}, {{end}}{{$c.Key}}={{$c.Cap.Status}}{{end}} |
+{{- end}}

--- a/tools/coverage/templates/by-language.md.tmpl
+++ b/tools/coverage/templates/by-language.md.tmpl
@@ -1,0 +1,15 @@
+{{.Marker}}
+# Coverage — language: `{{.Language}}`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **{{.Stats.Records}}**
+- Full: **{{.Stats.Full}}** · Partial: **{{.Stats.Partial}}** · Missing: **{{.Stats.Missing}}** · N/A: **{{.Stats.NotAppl}}**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+{{- range .Records}}
+| [{{.ID}}](../detail/{{.ID}}.md) | [{{.Category}}](../by-category/{{.Category}}.md) | {{.Label}} | {{range $i, $c := .CapList}}{{if $i}}, {{end}}{{$c.Key}}={{$c.Cap.Status}}{{end}} |
+{{- end}}

--- a/tools/coverage/templates/detail.md.tmpl
+++ b/tools/coverage/templates/detail.md.tmpl
@@ -1,0 +1,26 @@
+{{.Marker}}
+# `{{.Record.ID}}` — {{.Record.Label}}
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [{{.Record.Language}}](../by-language/{{.Record.Language}}.md)
+- **Category:** [{{.Record.Category}}](../by-category/{{.Record.Category}}.md)
+- **Capability cells:** {{len .CapList}}
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+{{- range .CapList}}
+| `{{.Key}}` | `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} |
+{{- end}}
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update {{.Record.ID}} ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/tools/coverage/templates/summary.md.tmpl
+++ b/tools/coverage/templates/summary.md.tmpl
@@ -1,0 +1,38 @@
+{{.Marker}}
+# Coverage Registry — Summary
+
+Auto-generated from `docs/coverage.json` by `go run ./tools/coverage gen`.
+Each capability cell is one of: `full`, `partial`, `missing`, `not_applicable`.
+
+## Totals
+
+- Records: **{{.Stats.Total}}**
+- Capability cells: **{{.Stats.Capabilities}}**
+- Full: **{{index .Stats.ByStatus "full"}}**
+- Partial: **{{index .Stats.ByStatus "partial"}}**
+- Missing: **{{index .Stats.ByStatus "missing"}}**
+- Not applicable: **{{index .Stats.ByStatus "not_applicable"}}**
+
+## By language
+
+| Language | Records | Full | Partial | Missing | N/A | % Full |
+|----------|---------|------|---------|---------|-----|--------|
+{{- range .Languages}}
+| [{{.Name}}](by-language/{{.Name}}.md) | {{.Stats.Records}} | {{.Stats.Full}} | {{.Stats.Partial}} | {{.Stats.Missing}} | {{.Stats.NotAppl}} | {{.PctFull}} |
+{{- end}}
+
+## By category
+
+| Category | Records |
+|----------|---------|
+{{- range .Categories}}
+| [{{.Name}}](by-category/{{.Name}}.md) | {{.Count}} |
+{{- end}}
+
+## All records
+
+| ID | Language | Category | Label |
+|----|----------|----------|-------|
+{{- range .Records}}
+| [{{.ID}}](detail/{{.ID}}.md) | {{.Language}} | {{.Category}} | {{.Label}} |
+{{- end}}

--- a/tools/coverage/testdata/fixture-out/by-category/http_framework.md
+++ b/tools/coverage/testdata/fixture-out/by-category/http_framework.md
@@ -1,0 +1,17 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — category: `http_framework`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **5**
+- Valid capability keys: `auth_coverage`, `endpoint_synthesis`, `handler_attribution`, `middleware_coverage`
+
+## Records
+
+| ID | Language | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.javascript.framework.express](../detail/lang.javascript.framework.express.md) | [javascript](../by-language/javascript.md) | Express.js | endpoint_synthesis=full |
+| [lang.javascript.framework.nestjs](../detail/lang.javascript.framework.nestjs.md) | [javascript](../by-language/javascript.md) | NestJS | endpoint_synthesis=full |
+| [lang.python.framework.django-drf](../detail/lang.python.framework.django-drf.md) | [python](../by-language/python.md) | Django REST Framework | auth_coverage=partial, endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.framework.fastapi](../detail/lang.python.framework.fastapi.md) | [python](../by-language/python.md) | FastAPI | endpoint_synthesis=full |
+| [lang.python.framework.flask](../detail/lang.python.framework.flask.md) | [python](../by-language/python.md) | Flask | endpoint_synthesis=full |

--- a/tools/coverage/testdata/fixture-out/by-language/javascript.md
+++ b/tools/coverage/testdata/fixture-out/by-language/javascript.md
@@ -1,0 +1,14 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `javascript`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **2**
+- Full: **2** · Partial: **0** · Missing: **0** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.javascript.framework.express](../detail/lang.javascript.framework.express.md) | [http_framework](../by-category/http_framework.md) | Express.js | endpoint_synthesis=full |
+| [lang.javascript.framework.nestjs](../detail/lang.javascript.framework.nestjs.md) | [http_framework](../by-category/http_framework.md) | NestJS | endpoint_synthesis=full |

--- a/tools/coverage/testdata/fixture-out/by-language/python.md
+++ b/tools/coverage/testdata/fixture-out/by-language/python.md
@@ -1,0 +1,15 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage — language: `python`
+
+Auto-generated. Back to [summary](../summary.md).
+
+- Records: **3**
+- Full: **4** · Partial: **1** · Missing: **0** · N/A: **0**
+
+## Records
+
+| ID | Category | Label | Capabilities |
+|----|----------|-------|--------------|
+| [lang.python.framework.django-drf](../detail/lang.python.framework.django-drf.md) | [http_framework](../by-category/http_framework.md) | Django REST Framework | auth_coverage=partial, endpoint_synthesis=full, handler_attribution=full |
+| [lang.python.framework.fastapi](../detail/lang.python.framework.fastapi.md) | [http_framework](../by-category/http_framework.md) | FastAPI | endpoint_synthesis=full |
+| [lang.python.framework.flask](../detail/lang.python.framework.flask.md) | [http_framework](../by-category/http_framework.md) | Flask | endpoint_synthesis=full |

--- a/tools/coverage/testdata/fixture-out/detail/lang.javascript.framework.express.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.javascript.framework.express.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.express` — Express.js
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.express ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/tools/coverage/testdata/fixture-out/detail/lang.javascript.framework.nestjs.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.javascript.framework.nestjs.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.nestjs` — NestJS
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.nestjs ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/tools/coverage/testdata/fixture-out/detail/lang.python.framework.django-drf.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.python.framework.django-drf.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.django-drf` — Django REST Framework
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | `partial` | `2026-05-27` | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | `internal/engine/django_drf_actions.go` |
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/engine/http_endpoint_synthesis.go` |
+| `handler_attribution` | `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.django-drf ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/tools/coverage/testdata/fixture-out/detail/lang.python.framework.fastapi.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.python.framework.fastapi.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.fastapi` — FastAPI
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.fastapi ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/tools/coverage/testdata/fixture-out/detail/lang.python.framework.flask.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.python.framework.flask.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.flask` — Flask
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.flask ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/tools/coverage/testdata/fixture-out/summary.md
+++ b/tools/coverage/testdata/fixture-out/summary.md
@@ -1,0 +1,37 @@
+<!-- DO NOT EDIT — generated from docs/coverage.json by 'go run ./tools/coverage gen' -->
+# Coverage Registry — Summary
+
+Auto-generated from `docs/coverage.json` by `go run ./tools/coverage gen`.
+Each capability cell is one of: `full`, `partial`, `missing`, `not_applicable`.
+
+## Totals
+
+- Records: **5**
+- Capability cells: **7**
+- Full: **6**
+- Partial: **1**
+- Missing: **0**
+- Not applicable: **0**
+
+## By language
+
+| Language | Records | Full | Partial | Missing | N/A | % Full |
+|----------|---------|------|---------|---------|-----|--------|
+| [javascript](by-language/javascript.md) | 2 | 2 | 0 | 0 | 0 | 100% |
+| [python](by-language/python.md) | 3 | 4 | 1 | 0 | 0 | 80% |
+
+## By category
+
+| Category | Records |
+|----------|---------|
+| [http_framework](by-category/http_framework.md) | 5 |
+
+## All records
+
+| ID | Language | Category | Label |
+|----|----------|----------|-------|
+| [lang.javascript.framework.express](detail/lang.javascript.framework.express.md) | javascript | http_framework | Express.js |
+| [lang.javascript.framework.nestjs](detail/lang.javascript.framework.nestjs.md) | javascript | http_framework | NestJS |
+| [lang.python.framework.django-drf](detail/lang.python.framework.django-drf.md) | python | http_framework | Django REST Framework |
+| [lang.python.framework.fastapi](detail/lang.python.framework.fastapi.md) | python | http_framework | FastAPI |
+| [lang.python.framework.flask](detail/lang.python.framework.flask.md) | python | http_framework | Flask |


### PR DESCRIPTION
PR 2 of 3 for #2720 — Coverage Registry tooling.

## Summary
- `tools/coverage/generate.go`: deterministic markdown renderer. Sorted iteration over languages, categories, records and capability map keys; no `time.Now`; atomic temp+rename writes; output always begins with the `<!-- DO NOT EDIT --!>` marker. Wired into `main.go`'s subcommand dispatch as `gen`.
- `tools/coverage/templates/{summary,by-language,by-category,detail}.md.tmpl`: four embedded (`go:embed`) `text/template` views — summary index, per-language slice, per-category slice, per-record detail page with capability table + cites + provenance.
- `tools/coverage/gen_test.go`: `TestGenDeterministic` hashes every generated file twice with sha256 and asserts byte-identical maps; `TestGenGoldenFixture` diffs against `testdata/fixture-out/`; smoke + marker + CLI-wiring coverage.
- `tools/coverage/main_test.go`: `TestGenDispatch` exercises the new subcommand through `run()`.
- `docs/coverage.json`: 32 records covering 10 languages (csharp/elixir/go/java/javascript/multi/php/python/ruby/rust) and 5 categories (http_framework, orm, message_broker, observability, protocol). All five PR 1 seeds preserved; 27 new records added. `validate` exits 0 with 13 advisory warnings (all for tracked gaps).
- `docs/coverage/*.md`: 1 summary + 5 category pages + 10 language pages + 32 detail pages, committed and matching `go run ./tools/coverage gen` byte-for-byte.

## Deferred to PR 3
- `.github/workflows/coverage-docs.yml` (CI diff-check)
- Makefile `coverage` / `coverage-validate` targets
- Full migration of the remaining records from `docs/coverage.md` and removal of that file (replaced by `docs/coverage/summary.md`)
- Optional pre-commit hook installed by `archigraph install --copy`

## Test plan
- [x] `go build ./tools/coverage/`
- [x] `go vet ./tools/coverage/`
- [x] `go test ./tools/coverage/` (32 records, all subcommand + determinism + golden tests pass)
- [x] `go run ./tools/coverage validate` exits 0
- [x] `go run ./tools/coverage gen && git diff --exit-code docs/coverage/` is clean
- [x] No `TODO/FIXME/HACK/Deprecated/backward-compat/_ = unused` in the diff