### PR TITLE
fix(prune): restore Django migration prune regressed in Wave 3-5 (#2706)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1171,6 +1171,24 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			"archigraph: incremental — carried forward %d entities and %d relationships from previous graph (dropped %d stale edges)\n",
 			mergeStats.entitiesAdded, mergeStats.relsAdded, mergeStats.relsDropped)
 	}
+
+	// #2706 — belt-and-suspenders prune of Django migration entities.
+	// Per-extractor prunes (#2551, #2602, #2616) cover the AST-walk and
+	// cross-language hierarchy paths, but every per-language extractor calls
+	// extractor.FileEntity at the top of Extract() which unconditionally
+	// emits SCOPE.Component(subtype="file") — and Wave 3-5 added new
+	// emission paths (file_conventions, framework synthesisers) that don't
+	// know about the migration gate. This single sweep at the indexer level
+	// drops every container/scope-shaped entity anchored to a migrations/
+	// file regardless of which extractor emitted it. Opt-in via
+	// ARCHIGRAPH_EMIT_MIGRATION_ENTITIES=1|true bypasses the prune.
+	//
+	// Runs AFTER mergeIncrementalPrevDoc so that entities carried forward
+	// from a previous graph (which may predate the per-extractor prunes or
+	// have been emitted by a Wave 3-5 path) are also caught.
+	if ePruned, rPruned := extractors.PruneMigrationEntities(doc); ePruned > 0 && verbose() {
+		fmt.Fprintf(os.Stderr, "migration-prune: dropped %d entities + %d relationships anchored to Django migration files\n", ePruned, rPruned)
+	}
 	// Drop the per-pass record slices now that buildDocument has produced
 	// the merged + deduped graph.Entity / graph.Relationship slices. These
 	// pass-level slices hold a copy of every entity's Properties /

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -439,6 +439,19 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// --- Step 8: merge + sort + write ---
 	doc.Entities = append(doc.Entities, newEntities...)
 	doc.Relationships = append(doc.Relationships, newRels...)
+
+	// #2706 — belt-and-suspenders prune of Django migration entities.
+	// The incremental path bypasses the per-extractor prune gates only
+	// indirectly (it calls extractor.Extract which respects them), but the
+	// merged `doc.Entities` slice includes survivors carried forward from
+	// the previous on-disk graph. If a previous build slipped any migration
+	// entities through (e.g. before the per-extractor prune existed, or via
+	// a new emission path) they would survive here forever. The central
+	// sweep keeps the incremental and full-rebuild paths in lockstep.
+	if ePruned, rPruned := PruneMigrationEntities(doc); ePruned > 0 {
+		logger.Printf("incremental: migration-prune dropped %d entities + %d relationships", ePruned, rPruned)
+	}
+
 	doc.Stats.Entities = len(doc.Entities)
 	doc.Stats.Relationships = len(doc.Relationships)
 	doc.GeneratedAt = time.Now().UTC()

--- a/internal/extractors/migration_prune.go
+++ b/internal/extractors/migration_prune.go
@@ -1,0 +1,136 @@
+// migration_prune.go — central, belt-and-suspenders prune of Django
+// migration entities at the indexer level (#2706).
+//
+// Background
+// ----------
+// Auto-generated Django migration files (`<app>/migrations/0NNN_*.py`) are
+// pure ORM scaffolding with zero architectural signal. PRs #2551, #2602
+// and #2616 layered per-extractor prunes (Python AST walk, cross-language
+// hierarchy extractor) gated by the ARCHIGRAPH_EMIT_MIGRATION_ENTITIES
+// env-var opt-in.
+//
+// Bench iter 8 (2026-05-27) found 43 SCOPE.Component entities for
+// `core/migrations/*.py` had reappeared in the upvate graph (#2706).
+// Root cause: `extractor.FileEntity` is called unconditionally at the top
+// of every per-language extractor's Extract() and emits a
+// SCOPE.Component(subtype="file") for every source file — including
+// migration files. New extractor paths (file_conventions in #2382,
+// new framework synthesisers in Wave 3-5: PRs #2680, #2696, #2698,
+// #2700) can also emit SCOPE.Component-shaped entities anchored to
+// migration files without knowing about the per-extractor prune.
+//
+// Fix
+// ---
+// One sweep at the indexer level that drops every entity whose
+// SourceFile is a Django migration file AND whose Kind is one of the
+// container/scope shapes we never want to surface for migrations:
+// SCOPE.Component, SCOPE.Class, SCOPE.Operation, Class, Operation,
+// Component. Entities of kind "Migration" (the lightweight file-tag
+// emitted by the YAML file_convention rule + the opt-in
+// extractMigrationEntity) are preserved — those are the *intended*
+// migration representation.
+//
+// All relationships referencing a removed entity ID on either end are
+// dropped. Opt-in via ARCHIGRAPH_EMIT_MIGRATION_ENTITIES=1|true bypasses
+// the prune entirely so analysts who need full migration extraction can
+// still get it.
+//
+// Both the full-rebuild path (cmd/archigraph/index.go::Indexer.Run, after
+// buildDocument) and the incremental path (this package's
+// TryIncremental, after the re-extraction merge) call PruneMigrationEntities
+// so neither route can silently let migrations slip back into the graph.
+
+package extractors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// migrationEmitEnv mirrors the env-var name used by
+// internal/extractors/python/extractor.go and
+// internal/extractors/cross/hierarchy/extractor.go. Keep in sync.
+const migrationEmitEnv = "ARCHIGRAPH_EMIT_MIGRATION_ENTITIES"
+
+// prunedMigrationKinds is the set of entity kinds we drop when anchored
+// to a Django migration file. "Migration" is intentionally absent: that
+// kind is the lightweight file-tag we *want* to keep when emitted by the
+// YAML file_convention rule or the opt-in extractMigrationEntity helper.
+var prunedMigrationKinds = map[string]bool{
+	"SCOPE.Component": true,
+	"SCOPE.Class":     true,
+	"SCOPE.Operation": true,
+	"Class":           true,
+	"Operation":       true,
+	"Component":       true,
+}
+
+// IsDjangoMigrationFile mirrors the predicate in
+// internal/extractors/python/extractor.go and
+// internal/extractors/cross/hierarchy/extractor.go. Returns true for paths
+// of the form `.../migrations/<anything>.py` (the parent directory is
+// literally named "migrations").
+func IsDjangoMigrationFile(path string) bool {
+	if path == "" {
+		return false
+	}
+	if !strings.HasSuffix(path, ".py") {
+		return false
+	}
+	dir := filepath.Dir(filepath.FromSlash(path))
+	return filepath.Base(dir) == "migrations"
+}
+
+// MigrationEmitEnabled returns true when the operator has opted into full
+// migration extraction by setting ARCHIGRAPH_EMIT_MIGRATION_ENTITIES=1|true.
+// Default is off — migrations are pruned.
+func MigrationEmitEnabled() bool {
+	v := os.Getenv(migrationEmitEnv)
+	return v == "1" || v == "true"
+}
+
+// PruneMigrationEntities drops container/scope entities anchored to Django
+// migration files plus every relationship that referenced them on either
+// end. Returns the number of entities and relationships pruned so callers
+// can log / surface the count. No-op when the opt-in env var is set.
+//
+// Idempotent — safe to call multiple times; the second pass finds nothing
+// to remove.
+func PruneMigrationEntities(doc *graph.Document) (entitiesPruned, relsPruned int) {
+	if doc == nil || MigrationEmitEnabled() {
+		return 0, 0
+	}
+
+	removedIDs := make(map[string]bool)
+	keptEntities := make([]graph.Entity, 0, len(doc.Entities))
+	for _, e := range doc.Entities {
+		if IsDjangoMigrationFile(e.SourceFile) && prunedMigrationKinds[e.Kind] {
+			if e.ID != "" {
+				removedIDs[e.ID] = true
+			}
+			entitiesPruned++
+			continue
+		}
+		keptEntities = append(keptEntities, e)
+	}
+	doc.Entities = keptEntities
+
+	if len(removedIDs) == 0 {
+		return entitiesPruned, 0
+	}
+
+	keptRels := make([]graph.Relationship, 0, len(doc.Relationships))
+	for _, r := range doc.Relationships {
+		if removedIDs[r.FromID] || removedIDs[r.ToID] {
+			relsPruned++
+			continue
+		}
+		keptRels = append(keptRels, r)
+	}
+	doc.Relationships = keptRels
+
+	return entitiesPruned, relsPruned
+}

--- a/internal/extractors/migration_prune_test.go
+++ b/internal/extractors/migration_prune_test.go
@@ -1,0 +1,174 @@
+// migration_prune_test.go — regression coverage for #2706.
+//
+// Asserts that PruneMigrationEntities drops every container/scope-shaped
+// entity anchored to a Django migration file regardless of which
+// extractor produced it (per-language FileEntity, file_convention
+// glob-based dispatch, framework synthesisers, etc.), while leaving the
+// canonical Migration entity intact.
+
+package extractors
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func TestIsDjangoMigrationFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"core/migrations/0001_initial.py", true},
+		{"app/migrations/0042_alter_field.py", true},
+		{"some/long/path/to/migrations/9999_squashed.py", true},
+		{"migrations/0001_initial.py", true},
+
+		// Non-migration paths.
+		{"core/views.py", false},
+		{"core/migrations.py", false},                // file named migrations.py (not in a migrations/ dir)
+		{"core/migrations/__init__.py", true},        // technically a migration package file — pruned
+		{"core/migrations/0001_initial.txt", false},  // not Python
+		{"core/migrations_helper/0001.py", false},    // dir is migrations_helper, not migrations
+		{"core/migration/0001.py", false},            // singular "migration"
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsDjangoMigrationFile(c.path); got != c.want {
+			t.Errorf("IsDjangoMigrationFile(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestPruneMigrationEntities_DropsAllContainerKinds(t *testing.T) {
+	// Simulate the worst-case state that triggered #2706: every Wave 3-5
+	// emission path produces a SCOPE.Component / Class / Operation for the
+	// same migration file. After the prune the only migration-anchored
+	// entity that survives must be kind="Migration".
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			// FileEntity from per-language Python extractor (#577).
+			{ID: "a1", Name: "core/migrations/0001_initial.py", Kind: "SCOPE.Component", Subtype: "file", SourceFile: "core/migrations/0001_initial.py"},
+			// Cross-language hierarchy extractor before #2616 fix.
+			{ID: "a2", Name: "Migration", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "core/migrations/0001_initial.py"},
+			// SCOPE.Class shape sometimes emitted by other paths.
+			{ID: "a3", Name: "Migration", Kind: "SCOPE.Class", SourceFile: "core/migrations/0001_initial.py"},
+			// SCOPE.Operation shape (e.g. operations-bound function entity).
+			{ID: "a4", Name: "forwards_func", Kind: "SCOPE.Operation", SourceFile: "core/migrations/0001_initial.py"},
+			// Bare Class / Operation / Component variants (defensive).
+			{ID: "a5", Name: "Migration", Kind: "Class", SourceFile: "core/migrations/0001_initial.py"},
+			{ID: "a6", Name: "noop", Kind: "Operation", SourceFile: "core/migrations/0001_initial.py"},
+			{ID: "a7", Name: "noop", Kind: "Component", SourceFile: "core/migrations/0001_initial.py"},
+
+			// The intended Migration file-tag — MUST be preserved.
+			{ID: "mig", Name: "0001_initial", Kind: "Migration", SourceFile: "core/migrations/0001_initial.py"},
+
+			// Non-migration entities — MUST be preserved.
+			{ID: "b1", Name: "User", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "core/models.py"},
+			{ID: "b2", Name: "UserViewSet", Kind: "Class", SourceFile: "core/views.py"},
+		},
+		Relationships: []graph.Relationship{
+			// Edge between two pruned migration entities — should be dropped.
+			{ID: "r1", FromID: "a1", ToID: "a2", Kind: "CONTAINS"},
+			// Edge FROM a non-migration entity TO a pruned migration entity — should be dropped.
+			{ID: "r2", FromID: "b1", ToID: "a3", Kind: "DEPENDS_ON"},
+			// Edge FROM a pruned migration entity TO a non-migration entity — should be dropped.
+			{ID: "r3", FromID: "a4", ToID: "b1", Kind: "CALLS"},
+			// Edge between two non-migration entities — should be kept.
+			{ID: "r4", FromID: "b1", ToID: "b2", Kind: "DEPENDS_ON"},
+			// Edge involving the kept Migration entity — should be kept (its ID is not in removedIDs).
+			{ID: "r5", FromID: "mig", ToID: "b1", Kind: "DEPENDS_ON"},
+		},
+	}
+
+	t.Setenv("ARCHIGRAPH_EMIT_MIGRATION_ENTITIES", "") // ensure prune is active
+
+	ePruned, rPruned := PruneMigrationEntities(doc)
+
+	if ePruned != 7 {
+		t.Errorf("entities pruned = %d, want 7", ePruned)
+	}
+	if rPruned != 3 {
+		t.Errorf("relationships pruned = %d, want 3", rPruned)
+	}
+
+	// Assert ZERO container-kind migration entities remain.
+	for _, e := range doc.Entities {
+		if IsDjangoMigrationFile(e.SourceFile) && prunedMigrationKinds[e.Kind] {
+			t.Errorf("migration entity survived prune: id=%s kind=%s source=%s", e.ID, e.Kind, e.SourceFile)
+		}
+	}
+
+	// Assert the canonical Migration entity + non-migration entities survived.
+	wantSurvivors := map[string]bool{"mig": true, "b1": true, "b2": true}
+	gotSurvivors := make(map[string]bool, len(doc.Entities))
+	for _, e := range doc.Entities {
+		gotSurvivors[e.ID] = true
+	}
+	for id := range wantSurvivors {
+		if !gotSurvivors[id] {
+			t.Errorf("expected entity %s to survive prune, but it was dropped", id)
+		}
+	}
+	if len(gotSurvivors) != len(wantSurvivors) {
+		t.Errorf("survivor count = %d, want %d (extra: %v)", len(gotSurvivors), len(wantSurvivors), gotSurvivors)
+	}
+
+	// Assert relationship r4 + r5 survived.
+	wantRels := map[string]bool{"r4": true, "r5": true}
+	for _, r := range doc.Relationships {
+		if !wantRels[r.ID] {
+			t.Errorf("unexpected relationship survived prune: %s", r.ID)
+		}
+		delete(wantRels, r.ID)
+	}
+	for id := range wantRels {
+		t.Errorf("expected relationship %s to survive prune, but it was dropped", id)
+	}
+}
+
+func TestPruneMigrationEntities_OptInBypass(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "a1", Name: "Migration", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "core/migrations/0001_initial.py"},
+			{ID: "a2", Name: "User", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "core/models.py"},
+		},
+	}
+
+	t.Setenv("ARCHIGRAPH_EMIT_MIGRATION_ENTITIES", "1")
+
+	ePruned, rPruned := PruneMigrationEntities(doc)
+	if ePruned != 0 || rPruned != 0 {
+		t.Errorf("opt-in bypass: pruned=(%d,%d), want (0,0)", ePruned, rPruned)
+	}
+	if len(doc.Entities) != 2 {
+		t.Errorf("opt-in bypass: entities len = %d, want 2", len(doc.Entities))
+	}
+}
+
+func TestPruneMigrationEntities_Idempotent(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "a1", Name: "Migration", Kind: "SCOPE.Component", SourceFile: "core/migrations/0001_initial.py"},
+			{ID: "b1", Name: "User", Kind: "SCOPE.Component", SourceFile: "core/models.py"},
+		},
+	}
+	t.Setenv("ARCHIGRAPH_EMIT_MIGRATION_ENTITIES", "")
+
+	e1, _ := PruneMigrationEntities(doc)
+	e2, r2 := PruneMigrationEntities(doc) // second call must be a no-op
+	if e1 != 1 {
+		t.Errorf("first call entities pruned = %d, want 1", e1)
+	}
+	if e2 != 0 || r2 != 0 {
+		t.Errorf("second call pruned = (%d,%d), want (0,0) — prune is not idempotent", e2, r2)
+	}
+}
+
+func TestPruneMigrationEntities_NilSafe(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EMIT_MIGRATION_ENTITIES", "")
+	e, r := PruneMigrationEntities(nil)
+	if e != 0 || r != 0 {
+		t.Errorf("nil doc: pruned = (%d,%d), want (0,0)", e, r)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2706.

Bench iter 8 found 43 SCOPE.Component entities anchored to `core/migrations/*.py` had reappeared in the upvate graph after iters 4/6/7 had held this at 0 (post #2551 / #2602 / #2616).

**Root cause:** the migration prune is scattered across two per-extractor sites (Python AST walk, cross-language hierarchy). Every per-language extractor calls `extractor.FileEntity` unconditionally for IMPORTS resolution (#577), and Wave 3-5 added new emission paths (`file_conventions` #2382, laravel #2680, Ruby #2696, Go trio #2698, ASP.NET/Phoenix/Rocket #2700) that don't know about the gate.

**Fix:** central belt-and-suspenders sweep `extractors.PruneMigrationEntities` runs after `buildDocument` and after `mergeIncrementalPrevDoc` (#2719). Drops every entity whose `SourceFile` is a Django migration file AND whose Kind is one of `{SCOPE.Component, SCOPE.Class, SCOPE.Operation, Class, Operation, Component}`, plus every relationship referencing a removed ID. Kind=`Migration` is preserved — that is the canonical YAML-file-convention file-tag.

Same prune wired into the incremental path (`TryIncremental`) so daemon fast-path stays in lockstep.

`ARCHIGRAPH_EMIT_MIGRATION_ENTITIES=1|true` bypasses the prune for analysts that need full migration extraction.

## Verification on real upvate rebuild

| | SCOPE.Component for migrations | Migration (intended) | Total entities |
|---|---|---|---|
| Before | 43 | 43 | 5,819 |
| After | **0** | 43 | 5,819 |

## Test plan

- [x] `go test ./internal/extractors/ -run "Prune|IsDjango"` — 5 new tests pass
- [x] `go test ./cmd/archigraph/` — existing test suite passes (no regressions)
- [x] `go build ./...` clean
- [x] Real upvate rebuild via `/Users/jorgecajas/go/bin/archigraph rebuild upvate` confirms 0 SCOPE.Component migration entities