### PR TITLE
research(tools/coverage): comprehensive ecosystem inventory (#2726)

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -1,13 +1,88 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # build_system
 
-**Total**: 4 records · **multi**: 4
+**Total**: 79 records · **csharp**: 6 · **elixir**: 4 · **go**: 7 · **groovy**: 1 · **java**: 8 · **javascript**: 20 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 5 · **scala**: 2
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
 | Language | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|---|
+| [csharp](../by-language/csharp.md) | [FluentAssertions](../detail/test.fluentassertions.md) | ❌ | — | — | ❌ | |
+| [csharp](../by-language/csharp.md) | [MSTest](../detail/test.mstest.md) | ⚠️ | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [NUnit](../detail/test.nunit.md) | ⚠️ | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [NuGet](../detail/build.nuget.md) | ⚠️ | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | — | — | ✅ | |
+| [csharp](../by-language/csharp.md) | [xUnit](../detail/test.xunit.md) | ⚠️ | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [ExUnit](../detail/test.exunit.md) | ✅ | — | — | ✅ | |
+| [elixir](../by-language/elixir.md) | [Hex](../detail/build.hex.md) | ⚠️ | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | ✅ | |
+| [elixir](../by-language/elixir.md) | [StreamData (property tests)](../detail/test.streamdata.md) | ❌ | — | — | ❌ | |
+| [go](../by-language/go.md) | [Ginkgo](../detail/test.ginkgo.md) | ❌ | — | — | ❌ | |
+| [go](../by-language/go.md) | [Gomega](../detail/test.gomega.md) | ❌ | — | — | ❌ | |
+| [go](../by-language/go.md) | [Mage](../detail/build.mage.md) | ❌ | — | — | ❌ | |
+| [go](../by-language/go.md) | [Task (taskfile.dev)](../detail/build.task.md) | ❌ | — | — | ❌ | |
+| [go](../by-language/go.md) | [go modules (go.mod / go.sum)](../detail/build.go-modules.md) | ✅ | — | — | ✅ | |
+| [go](../by-language/go.md) | [go testing (stdlib)](../detail/test.go-testing.md) | ✅ | — | — | ✅ | |
+| [go](../by-language/go.md) | [testify](../detail/test.testify.md) | ⚠️ | — | — | ⚠️ | |
+| [groovy](../by-language/groovy.md) | [Spock](../detail/test.spock.md) | ❌ | — | — | ❌ | |
+| [java](../by-language/java.md) | [AssertJ](../detail/test.assertj.md) | ❌ | — | — | ❌ | |
+| [java](../by-language/java.md) | [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | — | — | ✅ | |
+| [java](../by-language/java.md) | [JUnit 4](../detail/test.junit4.md) | ⚠️ | — | — | ⚠️ | |
+| [java](../by-language/java.md) | [JUnit 5](../detail/test.junit5.md) | ✅ | — | — | ✅ | |
+| [java](../by-language/java.md) | [Maven (pom.xml)](../detail/build.maven.md) | ✅ | — | — | ✅ | |
+| [java](../by-language/java.md) | [Mockito](../detail/test.mockito.md) | ❌ | — | — | ❌ | |
+| [java](../by-language/java.md) | [REST-assured](../detail/test.restassured.md) | ❌ | — | — | ❌ | |
+| [java](../by-language/java.md) | [TestNG](../detail/test.testng.md) | ❌ | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [AVA](../detail/test.ava.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [Bun (runtime + manager)](../detail/build.bun.md) | ⚠️ | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [Cypress](../detail/test.cypress.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [Jasmine](../detail/test.jasmine.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [Jest](../detail/test.jest.md) | ✅ | — | — | ✅ | |
+| [javascript](../by-language/javascript.md) | [Lerna](../detail/build.lerna.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [Mocha](../detail/test.mocha.md) | ⚠️ | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [Nx (monorepo)](../detail/build.nx.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [Parcel](../detail/build.parcel.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [Playwright](../detail/test.playwright.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [Rollup](../detail/build.rollup.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [Turborepo](../detail/build.turborepo.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [Vite](../detail/build.vite.md) | ❌ | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [Vitest](../detail/test.vitest.md) | ⚠️ | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [Webpack](../detail/build.webpack.md) | ❌ | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [Yarn](../detail/build.yarn.md) | ✅ | — | — | ✅ | |
+| [javascript](../by-language/javascript.md) | [esbuild](../detail/build.esbuild.md) | ❌ | — | — | ❌ | |
+| [javascript](../by-language/javascript.md) | [npm](../detail/build.npm.md) | ✅ | — | — | ✅ | |
+| [javascript](../by-language/javascript.md) | [pnpm](../detail/build.pnpm.md) | ✅ | — | — | ✅ | |
+| [javascript](../by-language/javascript.md) | [tap / node:test](../detail/test.tap.md) | ❌ | — | — | ❌ | |
 | [multi](../by-language/multi.md) | [Bazel / BUCK / WORKSPACE](../detail/build.bazel.md) | ✅ | — | — | ✅ | |
 | [multi](../by-language/multi.md) | [Dockerfile](../detail/build.dockerfile.md) | ✅ | — | — | ✅ | |
 | [multi](../by-language/multi.md) | [Justfile](../detail/build.justfile.md) | ✅ | — | — | ✅ | |
 | [multi](../by-language/multi.md) | [Makefile](../detail/build.makefile.md) | ❌ | — | — | ⚠️ | |
+| [php](../by-language/php.md) | [Behat](../detail/test.behat.md) | ❌ | — | — | ❌ | |
+| [php](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | ❌ | — | — | ❌ | |
+| [php](../by-language/php.md) | [Composer](../detail/build.composer.md) | ✅ | — | — | ✅ | |
+| [php](../by-language/php.md) | [PHPUnit](../detail/test.phpunit.md) | ✅ | — | — | ✅ | |
+| [php](../by-language/php.md) | [Pest](../detail/test.pest.md) | ❌ | — | — | ❌ | |
+| [python](../by-language/python.md) | [Flit](../detail/build.flit.md) | ❌ | — | — | ❌ | |
+| [python](../by-language/python.md) | [Hatch](../detail/build.hatch.md) | ❌ | — | — | ❌ | |
+| [python](../by-language/python.md) | [Hypothesis (property tests)](../detail/test.hypothesis.md) | ❌ | — | — | ❌ | |
+| [python](../by-language/python.md) | [Pipenv](../detail/build.pipenv.md) | ⚠️ | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [Poetry](../detail/build.poetry.md) | ✅ | — | — | ✅ | |
+| [python](../by-language/python.md) | [doctest (stdlib)](../detail/test.doctest.md) | ❌ | — | — | ❌ | |
+| [python](../by-language/python.md) | [nose2](../detail/test.nose2.md) | ❌ | — | — | ❌ | |
+| [python](../by-language/python.md) | [pip (requirements.txt)](../detail/build.pip.md) | ✅ | — | — | ✅ | |
+| [python](../by-language/python.md) | [pytest](../detail/test.pytest.md) | ✅ | — | — | ✅ | |
+| [python](../by-language/python.md) | [setuptools / setup.py](../detail/build.setuptools.md) | ⚠️ | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [unittest (stdlib)](../detail/test.unittest.md) | ⚠️ | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [uv (Astral)](../detail/build.uv.md) | ⚠️ | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [Bundler (Gemfile)](../detail/build.bundler.md) | ✅ | — | — | ✅ | |
+| [ruby](../by-language/ruby.md) | [Cucumber](../detail/test.cucumber.md) | ❌ | — | — | ❌ | |
+| [ruby](../by-language/ruby.md) | [Minitest](../detail/test.minitest.md) | ⚠️ | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [RSpec](../detail/test.rspec.md) | ✅ | — | — | ✅ | |
+| [ruby](../by-language/ruby.md) | [Rake](../detail/build.rake.md) | ❌ | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | — | — | ✅ | |
+| [rust](../by-language/rust.md) | [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | — | — | ✅ | |
+| [rust](../by-language/rust.md) | [criterion (benchmark)](../detail/test.criterion.md) | ❌ | — | — | ❌ | |
+| [rust](../by-language/rust.md) | [mockall](../detail/test.mockall.md) | ❌ | — | — | ❌ | |
+| [rust](../by-language/rust.md) | [proptest](../detail/test.proptest.md) | ❌ | — | — | ❌ | |
+| [scala](../by-language/scala.md) | [Mill](../detail/build.mill.md) | ❌ | — | — | ❌ | |
+| [scala](../by-language/scala.md) | [SBT](../detail/build.sbt.md) | ✅ | — | — | ✅ | |

--- a/docs/coverage/by-category/configuration.md
+++ b/docs/coverage/by-category/configuration.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # configuration
 
-**Total**: 10 records · **java**: 1 · **javascript**: 1 · **multi**: 8
+**Total**: 19 records · **java**: 1 · **javascript**: 1 · **multi**: 17
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -13,7 +13,16 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [.ini / setup.cfg / flake8 / mypy / pytest.ini](../detail/config.ini.md) | — | ⚠️ | ⚠️ | |
 | [multi](../by-language/multi.md) | [.toml](../detail/config.toml.md) | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [.yaml / .yml](../detail/config.yaml.md) | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Azure Pipelines](../detail/ci.azure-pipelines.md) | ⚠️ | ✅ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Bitbucket Pipelines](../detail/ci.bitbucket.md) | ⚠️ | ✅ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Buildkite](../detail/ci.buildkite.md) | ⚠️ | ✅ | ⚠️ | |
+| [multi](../by-language/multi.md) | [CircleCI](../detail/ci.circleci.md) | ⚠️ | ✅ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Drone CI](../detail/ci.drone.md) | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [GitHub Actions](../detail/ci.github-actions.md) | ⚠️ | ✅ | ⚠️ | |
 | [multi](../by-language/multi.md) | [GitHub Actions workflows](../detail/config.github-actions.md) | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [GitLab CI](../detail/ci.gitlab.md) | ⚠️ | ✅ | ⚠️ | |
 | [multi](../by-language/multi.md) | [GitLab CI](../detail/config.gitlab-ci.md) | — | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Jenkins (Jenkinsfile)](../detail/ci.jenkins.md) | ❌ | ⚠️ | ❌ | |
 | [multi](../by-language/multi.md) | [Jenkinsfile / Jenkins Pipeline DSL](../detail/config.jenkins.md) | — | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [Travis CI](../detail/ci.travis.md) | ⚠️ | ✅ | ⚠️ | |
 | [multi](../by-language/multi.md) | [docker-compose.yml](../detail/config.docker-compose.md) | — | ✅ | ✅ | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,71 +1,174 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 62 records · **csharp**: 3 · **elixir**: 2 · **go**: 8 · **java**: 6 · **javascript**: 13 · **kotlin**: 3 · **lua**: 2 · **php**: 3 · **python**: 12 · **ruby**: 4 · **rust**: 5 · **swift**: 1
+**Total**: 165 records · **csharp**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **javascript**: 30 · **kotlin**: 12 · **lua**: 2 · **php**: 12 · **python**: 20 · **ruby**: 8 · **rust**: 11 · **scala**: 9 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|---|
-| [csharp](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | — | |
-| [csharp](../by-language/csharp.md) | [ASP.NET MVC (attribute-route subset)](../detail/lang.csharp.framework.aspnet-mvc.md) | — | ⚠️ | ⚠️ | — | |
+| [csharp](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | — | — | ⚠️ | — | |
+| [csharp](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ | ✅ | ✅ | ❌ | |
+| [csharp](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | — | — | ⚠️ | — | |
 | [csharp](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | — | ❌ | — | — | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ | ✅ | ✅ | — | |
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView (pages indexed; lifecycle hooks not surfaced)](../detail/lang.elixir.framework.phoenix-liveview.md) | — | ⚠️ | ⚠️ | — | |
-| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | — | ❌ | — | — | |
-| [go](../by-language/go.md) | [Go net/http stdlib](../detail/lang.go.framework.net-http.md) | — | ✅ | ✅ | — | |
-| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | — | ✅ | ✅ | — | |
-| [go](../by-language/go.md) | [gin-gonic/gin](../detail/lang.go.framework.gin.md) | — | ✅ | ✅ | — | |
-| [go](../by-language/go.md) | [go-chi/chi](../detail/lang.go.framework.chi.md) | — | ✅ | ✅ | — | |
-| [go](../by-language/go.md) | [gofiber/fiber](../detail/lang.go.framework.fiber.md) | — | ✅ | ✅ | — | |
-| [go](../by-language/go.md) | [gorilla/mux](../detail/lang.go.framework.gorilla-mux.md) | — | ✅ | ✅ | — | |
-| [go](../by-language/go.md) | [labstack/echo](../detail/lang.go.framework.echo.md) | — | ✅ | ✅ | — | |
-| [java](../by-language/java.md) | [Dropwizard (JAX-RS subset)](../detail/lang.java.framework.dropwizard.md) | — | ⚠️ | ⚠️ | — | |
-| [java](../by-language/java.md) | [JAX-RS / Jakarta EE](../detail/lang.java.framework.jaxrs.md) | ✅ | ✅ | ✅ | — | |
-| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | — | ❌ | — | — | |
-| [java](../by-language/java.md) | [Quarkus (JAX-RS-backed)](../detail/lang.java.framework.quarkus.md) | ✅ | ✅ | ✅ | — | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ | ✅ | ✅ | — | |
-| [java](../by-language/java.md) | [Spring WebFlux](../detail/lang.java.framework.spring-webflux.md) | ⚠️ | ✅ | ✅ | — | |
-| [javascript](../by-language/javascript.md) | [Angular](../detail/lang.javascript.framework.angular.md) | — | ❌ | — | — | |
-| [javascript](../by-language/javascript.md) | [Astro](../detail/lang.javascript.framework.astro.md) | — | ❌ | — | — | |
-| [javascript](../by-language/javascript.md) | [Express.js](../detail/lang.javascript.framework.express.md) | ❌ | ✅ | — | — | |
-| [javascript](../by-language/javascript.md) | [Fastify](../detail/lang.javascript.framework.fastify.md) | — | ✅ | ✅ | — | |
-| [javascript](../by-language/javascript.md) | [GraphQL resolvers (Apollo / Yoga)](../detail/lang.javascript.framework.graphql-resolvers.md) | — | ✅ | ✅ | — | |
-| [javascript](../by-language/javascript.md) | [Hono](../detail/lang.javascript.framework.hono.md) | — | ❌ | — | — | |
-| [javascript](../by-language/javascript.md) | [Koa](../detail/lang.javascript.framework.koa.md) | — | ❌ | — | — | |
-| [javascript](../by-language/javascript.md) | [NestJS](../detail/lang.javascript.framework.nestjs.md) | ⚠️ | ✅ | ✅ | — | |
-| [javascript](../by-language/javascript.md) | [Next.js API routes](../detail/lang.javascript.framework.next-api.md) | — | ✅ | ✅ | — | |
-| [javascript](../by-language/javascript.md) | [Nuxt](../detail/lang.javascript.framework.nuxt.md) | — | ❌ | — | — | |
-| [javascript](../by-language/javascript.md) | [Remix](../detail/lang.javascript.framework.remix.md) | — | ❌ | — | — | |
-| [javascript](../by-language/javascript.md) | [Svelte / SvelteKit](../detail/lang.javascript.framework.sveltekit.md) | — | ❌ | — | — | |
-| [javascript](../by-language/javascript.md) | [tRPC](../detail/lang.javascript.framework.trpc.md) | — | ✅ | ✅ | — | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | — | ❌ | — | — | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ | ✅ | ✅ | — | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | — | ❌ | — | — | |
+| [csharp](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | — | — | ⚠️ | — | |
+| [csharp](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ | ❌ | ❌ | ❌ | |
+| [csharp](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ | ❌ | ❌ | ❌ | |
+| [csharp](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ | ❌ | ❌ | ❌ | |
+| [csharp](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ | ❌ | ❌ | ❌ | |
+| [csharp](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | — | — | ⚠️ | — | |
+| [csharp](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | — | — | ⚠️ | — | |
+| [csharp](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | — | — | ⚠️ | — | |
+| [csharp](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | — | — | ⚠️ | — | |
+| [csharp](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ | ❌ | ❌ | ❌ | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ | ❌ | ❌ | ❌ | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | — | — | ⚠️ | — | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | — | — | ⚠️ | — | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ | ✅ | ✅ | ❌ | |
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ | ✅ | ✅ | ❌ | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ | ❌ | ❌ | ❌ | |
+| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ❌ | ✅ | ✅ | ❌ | |
+| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ❌ | ✅ | ✅ | ❌ | |
+| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | ❌ | ✅ | ✅ | ❌ | |
+| [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | — | — | ⚠️ | — | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ❌ | ✅ | ✅ | ❌ | |
+| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ❌ | ✅ | ✅ | ❌ | |
+| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | ❌ | ✅ | ✅ | ❌ | |
+| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | ❌ | ✅ | ✅ | ❌ | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | — | — | ⚠️ | — | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ❌ | ✅ | ✅ | ❌ | |
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ | ❌ | ❌ | ❌ | |
+| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | — | — | ⚠️ | — | |
+| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | — | — | ⚠️ | — | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ | ✅ | ✅ | ❌ | |
+| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ❌ | ❌ | ❌ | ❌ | |
+| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ | ❌ | ❌ | ❌ | |
+| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | — | — | ⚠️ | — | |
+| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ | ✅ | ✅ | ⚠️ | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [javascript](../by-language/javascript.md) | [AdonisJS](../detail/lang.javascript.framework.adonisjs.md) | ❌ | ❌ | ❌ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Angular](../detail/lang.javascript.framework.angular.md) | — | — | ✅ | — | |
+| [javascript](../by-language/javascript.md) | [Astro](../detail/lang.javascript.framework.astro.md) | ❌ | ✅ | ✅ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Electron](../detail/lang.javascript.framework.electron.md) | — | — | ⚠️ | — | |
+| [javascript](../by-language/javascript.md) | [Expo](../detail/lang.javascript.framework.expo.md) | — | — | ⚠️ | — | |
+| [javascript](../by-language/javascript.md) | [Express](../detail/lang.javascript.framework.express.md) | ❌ | ✅ | ✅ | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [Fastify](../detail/lang.javascript.framework.fastify.md) | ❌ | ✅ | ✅ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Feathers](../detail/lang.javascript.framework.feathers.md) | ❌ | ❌ | ❌ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Gatsby](../detail/lang.javascript.framework.gatsby.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [javascript](../by-language/javascript.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.javascript.framework.graphql-resolvers.md) | ❌ | ✅ | ✅ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Hapi](../detail/lang.javascript.framework.hapi.md) | ❌ | ❌ | ❌ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Hono](../detail/lang.javascript.framework.hono.md) | ❌ | ✅ | ✅ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Ionic](../detail/lang.javascript.framework.ionic.md) | — | — | ⚠️ | — | |
+| [javascript](../by-language/javascript.md) | [Koa](../detail/lang.javascript.framework.koa.md) | ❌ | ✅ | ✅ | ❌ | |
+| [javascript](../by-language/javascript.md) | [LangChain.js](../detail/lang.javascript.framework.langchain.md) | — | — | ⚠️ | — | |
+| [javascript](../by-language/javascript.md) | [Marble.js](../detail/lang.javascript.framework.marblejs.md) | ❌ | ❌ | ❌ | ❌ | |
+| [javascript](../by-language/javascript.md) | [NativeScript](../detail/lang.javascript.framework.nativescript.md) | — | — | ⚠️ | — | |
+| [javascript](../by-language/javascript.md) | [NestJS](../detail/lang.javascript.framework.nestjs.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [Next.js API Routes / App Router](../detail/lang.javascript.framework.next-api.md) | ❌ | ✅ | ✅ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Nuxt](../detail/lang.javascript.framework.nuxt.md) | ❌ | ✅ | ✅ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Polka](../detail/lang.javascript.framework.polka.md) | ❌ | ❌ | ❌ | ❌ | |
+| [javascript](../by-language/javascript.md) | [React](../detail/lang.javascript.framework.react.md) | — | — | ⚠️ | — | |
+| [javascript](../by-language/javascript.md) | [React Native](../detail/lang.javascript.framework.react-native.md) | — | — | ⚠️ | — | |
+| [javascript](../by-language/javascript.md) | [Remix](../detail/lang.javascript.framework.remix.md) | ❌ | ✅ | ✅ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Restify](../detail/lang.javascript.framework.restify.md) | ❌ | ❌ | ❌ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Sails](../detail/lang.javascript.framework.sails.md) | ❌ | ❌ | ❌ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Svelte](../detail/lang.javascript.framework.svelte.md) | — | — | ⚠️ | — | |
+| [javascript](../by-language/javascript.md) | [SvelteKit](../detail/lang.javascript.framework.sveltekit.md) | ❌ | ✅ | ✅ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Vue](../detail/lang.javascript.framework.vue.md) | — | — | ⚠️ | — | |
+| [javascript](../by-language/javascript.md) | [tRPC](../detail/lang.javascript.framework.trpc.md) | ❌ | ✅ | ✅ | ❌ | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | — | — | ⚠️ | — | |
+| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | — | — | ⚠️ | — | |
+| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | — | — | ⚠️ | — | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ | ❌ | ❌ | ❌ | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | — | — | ⚠️ | — | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | — | — | ⚠️ | — | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ | ✅ | ✅ | ❌ | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | — | — | ⚠️ | — | |
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | — | ❌ | — | — | |
 | [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | — | ❌ | — | — | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ❌ | ✅ | ✅ | — | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | — | ❌ | — | — | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | — | ❌ | — | — | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | — | ❌ | — | — | |
-| [python](../by-language/python.md) | [Django (URLconf)](../detail/lang.python.framework.django.md) | ⚠️ | ✅ | ✅ | — | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | — | |
-| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ❌ | ✅ | — | — | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ❌ | ✅ | — | — | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | — | ❌ | — | — | |
-| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | — | ✅ | ✅ | — | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | — | ❌ | — | — | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | — | ❌ | — | — | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | — | ✅ | ✅ | — | |
-| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | — | ✅ | ✅ | — | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | — | ❌ | — | — | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | — | ❌ | — | — | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | — | ❌ | — | — | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ | ✅ | ✅ | — | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | — | ✅ | ✅ | — | |
-| [rust](../by-language/rust.md) | [Actix](../detail/lang.rust.framework.actix.md) | — | ❌ | — | — | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | — | ✅ | ✅ | — | |
-| [rust](../by-language/rust.md) | [Hyper](../detail/lang.rust.framework.hyper.md) | — | ❌ | — | — | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | — | ✅ | ✅ | — | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | — | ❌ | — | — | |
+| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ❌ | ✅ | ✅ | ❌ | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ | ❌ | ❌ | ❌ | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ | ❌ | ❌ | ❌ | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ❌ | ✅ | ✅ | ❌ | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ | ✅ | ✅ | ❌ | |
+| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | — | — | ✅ | — | |
+| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ | ❌ | ❌ | ❌ | |
+| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | — | — | ⚠️ | — | |
+| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ | ❌ | ❌ | ❌ | |
+| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ❌ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ | ❌ | ❌ | ❌ | |
+| [python](../by-language/python.md) | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | — | — | ⚠️ | — | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ❌ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ❌ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ | ❌ | ❌ | ❌ | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ❌ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ❌ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ❌ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ❌ | ✅ | ✅ | ❌ | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ | ✅ | ✅ | ❌ | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ | ❌ | ❌ | ❌ | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ | ✅ | ✅ | ❌ | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ | ✅ | ✅ | ❌ | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ | ✅ | ✅ | ❌ | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ❌ | ✅ | ✅ | ❌ | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | — | — | ⚠️ | — | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ❌ | ✅ | ✅ | ❌ | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ❌ | ✅ | ✅ | ❌ | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ❌ | ✅ | ✅ | ❌ | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ | ❌ | ❌ | ❌ | |
+| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | — | — | ⚠️ | — | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ | ❌ | ❌ | ❌ | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ❌ | ✅ | ✅ | ❌ | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ | ❌ | ❌ | ❌ | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | — | — | ⚠️ | — | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | — | ❌ | — | — | |

--- a/docs/coverage/by-category/infrastructure.md
+++ b/docs/coverage/by-category/infrastructure.md
@@ -1,15 +1,38 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # infrastructure
 
-**Total**: 6 records · **multi**: 6
+**Total**: 29 records · **multi**: 29
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
 | Language | Name | dependency_attribution | resource_extraction | Status | Notes |
 |---|---|---|---|---|---|
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | ⚠️ | ⚠️ | ⚠️ | |
 | [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ⚠️ | ✅ | ⚠️ | |
 | [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | — | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [AWS DynamoDB](../detail/db.dynamodb.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Apache Cassandra (schema)](../detail/db.cassandra.md) | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [ClickHouse](../detail/db.clickhouse.md) | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [Dockerfile](../detail/infra.container.dockerfile.md) | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Elasticsearch (indices)](../detail/db.elasticsearch.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Helm charts](../detail/infra.container.helm.md) | ⚠️ | ⚠️ | ⚠️ | |
 | [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [MongoDB (collections)](../detail/db.mongodb.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [MySQL / MariaDB (schema)](../detail/db.mysql.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Neo4j](../detail/db.neo4j.md) | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [PostgreSQL (schema)](../detail/db.postgres.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | ⚠️ | ⚠️ | ⚠️ | |
 | [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Redis (keys)](../detail/db.redis.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [SQLite (schema)](../detail/db.sqlite.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Snowflake](../detail/db.snowflake.md) | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [docker-compose.yml](../detail/infra.container.docker-compose.md) | ✅ | ✅ | ✅ | |

--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -1,31 +1,33 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # message_broker
 
-**Total**: 23 records · **javascript**: 1 · **multi**: 18 · **python**: 3 · **ruby**: 1
+**Total**: 25 records · **javascript**: 1 · **multi**: 20 · **python**: 3 · **ruby**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
 | Language | Name | consumer_extraction | producer_extraction | topic_attribution | Status | Notes |
 |---|---|---|---|---|---|---|
 | [javascript](../by-language/javascript.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
-| [multi](../by-language/multi.md) | [AWS EventBridge](../detail/msg.broker.eventbridge.md) | ✅ | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [AWS SNS (IaC-declared)](../detail/msg.broker.sns.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [AMQP (generic)](../detail/msg.broker.amqp.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [AWS EventBridge](../detail/msg.broker.eventbridge.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [AWS SNS](../detail/msg.broker.sns.md) | ✅ | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [AWS SQS](../detail/msg.broker.sqs.md) | ✅ | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Apache Kafka](../detail/msg.broker.kafka.md) | ✅ | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Apache Pulsar](../detail/msg.broker.pulsar.md) | ✅ | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Azure Event Grid](../detail/msg.broker.eventgrid.md) | ✅ | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [CloudEvents](../detail/msg.broker.cloudevents.md) | ✅ | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Debezium / Kafka Connect CDC](../detail/msg.broker.debezium.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
-| [multi](../by-language/multi.md) | [GCP Pub/Sub](../detail/msg.broker.gcp-pubsub.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Apache Pulsar](../detail/msg.broker.pulsar.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Azure Event Grid](../detail/msg.broker.eventgrid.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Azure Service Bus](../detail/msg.broker.azure-service-bus.md) | ❌ | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [CloudEvents](../detail/msg.broker.cloudevents.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Debezium (CDC)](../detail/msg.broker.debezium.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [GCP Pub/Sub](../detail/msg.broker.gcp-pubsub.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | |
 | [multi](../by-language/multi.md) | [GraphQL subscriptions](../detail/msg.graphql-subscriptions.md) | ✅ | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Kafka Streams / Faust](../detail/msg.kafka-streams.md) | ❌ | ❌ | — | ❌ | |
-| [multi](../by-language/multi.md) | [MQTT](../detail/msg.broker.mqtt.md) | ❌ | ❌ | — | ❌ | |
+| [multi](../by-language/multi.md) | [MQTT](../detail/msg.broker.mqtt.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | |
 | [multi](../by-language/multi.md) | [NATS](../detail/msg.broker.nats.md) | ✅ | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [RabbitMQ](../detail/msg.broker.rabbitmq.md) | ✅ | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Redis pub/sub + Streams](../detail/msg.broker.redis.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [Redis pub/sub & streams](../detail/msg.broker.redis.md) | ✅ | ✅ | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Server-Sent Events](../detail/msg.sse.md) | ✅ | ✅ | — | ✅ | |
-| [multi](../by-language/multi.md) | [WebSocket channels](../detail/msg.websocket.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
-| [multi](../by-language/multi.md) | [Webhook inbound (Stripe, GitHub, Twilio, Slack, SendGrid, Mailgun, ...)](../detail/msg.webhook.md) | ✅ | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [WebSocket](../detail/msg.websocket.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Webhooks](../detail/msg.webhook.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
 | [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | ✅ | ✅ | |
 | [python](../by-language/python.md) | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
 | [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ❌ | ❌ | — | ❌ | |

--- a/docs/coverage/by-category/observability.md
+++ b/docs/coverage/by-category/observability.md
@@ -1,15 +1,18 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # observability
 
-**Total**: 6 records · **multi**: 6
+**Total**: 9 records · **multi**: 9
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
 | Language | Name | log_extraction | metric_extraction | trace_extraction | Status | Notes |
 |---|---|---|---|---|---|---|
-| [multi](../by-language/multi.md) | [Datadog APM / StatsD](../detail/infra.observability.datadog.md) | — | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [Datadog](../detail/infra.observability.datadog.md) | ❌ | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [Elastic APM](../detail/infra.observability.elastic-apm.md) | ❌ | ❌ | ❌ | ❌ | |
 | [multi](../by-language/multi.md) | [Generic logging-config extractor (Python logging, Go slog, Node winston/pino, .NET NLog/Serilog, log4j/logback)](../detail/infra.observability.logging-config.md) | ✅ | — | — | ✅ | |
-| [multi](../by-language/multi.md) | [New Relic](../detail/infra.observability.newrelic.md) | — | ❌ | ❌ | ❌ | |
-| [multi](../by-language/multi.md) | [OpenTelemetry instrumentation](../detail/infra.observability.opentelemetry.md) | ❌ | ❌ | ❌ | ❌ | |
-| [multi](../by-language/multi.md) | [Prometheus client libraries](../detail/infra.observability.prometheus.md) | — | ❌ | — | ❌ | |
-| [multi](../by-language/multi.md) | [Sentry SDK](../detail/infra.observability.sentry.md) | — | — | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [Grafana Loki](../detail/infra.observability.grafana-loki.md) | ❌ | — | — | ❌ | |
+| [multi](../by-language/multi.md) | [Honeycomb](../detail/infra.observability.honeycomb.md) | ❌ | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [New Relic](../detail/infra.observability.newrelic.md) | ❌ | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [OpenTelemetry (OTEL)](../detail/infra.observability.opentelemetry.md) | ❌ | ⚠️ | ✅ | ❌ | |
+| [multi](../by-language/multi.md) | [Prometheus](../detail/infra.observability.prometheus.md) | — | ⚠️ | — | ⚠️ | |
+| [multi](../by-language/multi.md) | [Sentry](../detail/infra.observability.sentry.md) | ❌ | ❌ | ❌ | ❌ | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,29 +1,152 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 20 records · **csharp**: 1 · **elixir**: 1 · **go**: 2 · **java**: 2 · **javascript**: 5 · **php**: 2 · **python**: 6 · **ruby**: 1
+**Total**: 143 records · **csharp**: 14 · **elixir**: 10 · **go**: 17 · **java**: 13 · **javascript**: 18 · **kotlin**: 7 · **php**: 14 · **python**: 17 · **ruby**: 13 · **rust**: 14 · **scala**: 6
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
 | Language | Name | migration_parsing | model_extraction | query_attribution | Notes |
 |---|---|---|---|---|---|
-| [csharp](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ | ⚠️ | ❌ | |
-| [elixir](../by-language/elixir.md) | [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ | ✅ | ❌ | |
+| [csharp](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ | ⚠️ | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ | ✅ | ✅ | |
+| [csharp](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ | ⚠️ | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ | ❌ | ❌ | |
+| [csharp](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ | ⚠️ | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | — | — | ⚠️ | |
+| [csharp](../by-language/csharp.md) | [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ | ✅ | ✅ | |
+| [elixir](../by-language/elixir.md) | [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [MyXQL](../detail/lang.elixir.driver.myxql.md) | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [Postgrex](../detail/lang.elixir.driver.postgrex.md) | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [Redix](../detail/lang.elixir.driver.redix.md) | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ | ⚠️ | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | — | — | ⚠️ | |
+| [elixir](../by-language/elixir.md) | [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ | ⚠️ | ⚠️ | |
 | [go](../by-language/go.md) | [GORM](../detail/lang.go.orm.gorm.md) | ❌ | ✅ | ✅ | |
-| [go](../by-language/go.md) | [ent](../detail/lang.go.orm.ent.md) | — | ❌ | ❌ | |
-| [java](../by-language/java.md) | [Hibernate / JPA](../detail/lang.java.orm.hibernate.md) | — | ✅ | ⚠️ | |
-| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | — | ✅ | ⚠️ | |
-| [javascript](../by-language/javascript.md) | [Drizzle ORM](../detail/lang.javascript.orm.drizzle.md) | — | ❌ | ❌ | |
-| [javascript](../by-language/javascript.md) | [Mongoose](../detail/lang.javascript.orm.mongoose.md) | — | ⚠️ | ✅ | |
-| [javascript](../by-language/javascript.md) | [Prisma](../detail/lang.javascript.orm.prisma.md) | ❌ | ✅ | ✅ | |
-| [javascript](../by-language/javascript.md) | [Sequelize](../detail/lang.javascript.orm.sequelize.md) | — | ✅ | ✅ | |
+| [go](../by-language/go.md) | [ent (Facebook)](../detail/lang.go.orm.ent.md) | ❌ | ✅ | ✅ | |
+| [go](../by-language/go.md) | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | ❌ | ❌ | ❌ | |
+| [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | ⚠️ | — | — | |
+| [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | — | — | ⚠️ | |
+| [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ | ⚠️ | ⚠️ | |
+| [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | ❌ | ❌ | ❌ | |
+| [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | — | ⚠️ | ⚠️ | |
+| [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ | ❌ | ❌ | |
+| [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ | ❌ | ❌ | |
+| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ | ✅ | ✅ | |
+| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ | ✅ | ⚠️ | |
+| [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ | ⚠️ | ⚠️ | |
+| [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ | ⚠️ | ⚠️ | |
+| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ | ⚠️ | ⚠️ | |
+| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ | ⚠️ | ⚠️ | |
+| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ | ✅ | ✅ | |
+| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ | ⚠️ | ⚠️ | |
+| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ | ⚠️ | ⚠️ | |
+| [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ | ⚠️ | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [@elastic/elasticsearch](../detail/lang.javascript.driver.elastic.md) | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [AWS SDK DynamoDB (JS)](../detail/lang.javascript.driver.dynamodb.md) | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [Drizzle](../detail/lang.javascript.orm.drizzle.md) | ❌ | ✅ | ✅ | |
+| [javascript](../by-language/javascript.md) | [Knex (query builder)](../detail/lang.javascript.orm.knex.md) | ❌ | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [MikroORM](../detail/lang.javascript.orm.mikro-orm.md) | ❌ | ⚠️ | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [MongoDB Node.js driver](../detail/lang.javascript.driver.mongodb.md) | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [Mongoose](../detail/lang.javascript.orm.mongoose.md) | — | ✅ | ✅ | |
+| [javascript](../by-language/javascript.md) | [Objection.js](../detail/lang.javascript.orm.objection.md) | ❌ | ❌ | ❌ | |
+| [javascript](../by-language/javascript.md) | [Prisma](../detail/lang.javascript.orm.prisma.md) | ⚠️ | ✅ | ✅ | |
+| [javascript](../by-language/javascript.md) | [Sequelize](../detail/lang.javascript.orm.sequelize.md) | ❌ | ✅ | ✅ | |
 | [javascript](../by-language/javascript.md) | [TypeORM](../detail/lang.javascript.orm.typeorm.md) | ❌ | ✅ | ✅ | |
-| [php](../by-language/php.md) | [Doctrine](../detail/lang.php.orm.doctrine.md) | — | ❌ | ❌ | |
-| [php](../by-language/php.md) | [Eloquent (Laravel ActiveRecord)](../detail/lang.php.orm.eloquent.md) | — | ⚠️ | ❌ | |
+| [javascript](../by-language/javascript.md) | [better-sqlite3 / sqlite3](../detail/lang.javascript.driver.sqlite.md) | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [cassandra-driver (JS)](../detail/lang.javascript.driver.cassandra.md) | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [ioredis / node-redis](../detail/lang.javascript.driver.redis.md) | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [mysql / mysql2](../detail/lang.javascript.driver.mysql.md) | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [neo4j-driver (JS)](../detail/lang.javascript.driver.neo4j.md) | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [node-postgres / pg](../detail/lang.javascript.driver.postgres.md) | — | — | ⚠️ | |
+| [javascript](../by-language/javascript.md) | [supabase-js](../detail/lang.javascript.driver.supabase.md) | — | — | ⚠️ | |
+| [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | ❌ | ✅ | ✅ | |
+| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ | ⚠️ | ⚠️ | |
+| [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ | ⚠️ | ⚠️ | |
+| [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | — | ⚠️ | ⚠️ | |
+| [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ | ⚠️ | ⚠️ | |
+| [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ | ⚠️ | ⚠️ | |
+| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ | ⚠️ | ⚠️ | |
+| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | — | — | ⚠️ | |
+| [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | ❌ | ❌ | ❌ | |
+| [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | ❌ | ✅ | ✅ | |
+| [php](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | ❌ | ✅ | ✅ | |
+| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | — | — | ⚠️ | |
+| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | — | — | ⚠️ | |
+| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | — | — | ⚠️ | |
+| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | ❌ | ⚠️ | ⚠️ | |
+| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ | ⚠️ | ⚠️ | |
+| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | — | — | ⚠️ | |
+| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | — | — | ⚠️ | |
+| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | — | — | ⚠️ | |
+| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | — | — | ⚠️ | |
+| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ⚠️ | — | — | |
+| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | — | ⚠️ | ⚠️ | |
 | [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ | ✅ | ✅ | |
-| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | — | ❌ | ❌ | |
-| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | — | ❌ | ✅ | |
+| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | — | ⚠️ | ⚠️ | |
+| [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ | ⚠️ | ⚠️ | |
+| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ | ⚠️ | ⚠️ | |
 | [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ | ✅ | ✅ | |
-| [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | — | ❌ | ⚠️ | |
-| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | — | ❌ | ✅ | |
-| [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | — | ✅ | ✅ | |
+| [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ | ✅ | ✅ | |
+| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ | ✅ | ⚠️ | |
+| [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [redis-py](../detail/lang.python.driver.redis.md) | — | — | ⚠️ | |
+| [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ❌ | ✅ | ✅ | |
+| [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ | ⚠️ | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | — | ⚠️ | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ | ⚠️ | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ | ⚠️ | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | — | — | ⚠️ | |
+| [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | ❌ | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | ❌ | ❌ | ❌ | |
+| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | ❌ | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [neo4rs](../detail/lang.rust.driver.neo4j.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [redis-rs](../detail/lang.rust.driver.redis.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | — | — | ⚠️ | |
+| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ | ⚠️ | ⚠️ | |
+| [rust](../by-language/rust.md) | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | — | — | ⚠️ | |
+| [scala](../by-language/scala.md) | [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ | ⚠️ | ⚠️ | |
+| [scala](../by-language/scala.md) | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | — | ⚠️ | ⚠️ | |
+| [scala](../by-language/scala.md) | [Quill](../detail/lang.scala.orm.quill.md) | ❌ | ⚠️ | ⚠️ | |
+| [scala](../by-language/scala.md) | [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ | ⚠️ | ⚠️ | |
+| [scala](../by-language/scala.md) | [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | — | ⚠️ | ⚠️ | |
+| [scala](../by-language/scala.md) | [Slick](../detail/lang.scala.orm.slick.md) | ❌ | ⚠️ | ⚠️ | |

--- a/docs/coverage/by-category/protocol.md
+++ b/docs/coverage/by-category/protocol.md
@@ -1,13 +1,15 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # protocol
 
-**Total**: 4 records · **multi**: 4
+**Total**: 6 records · **multi**: 6
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
 | Language | Name | cross_repo_linkage | method_attribution | service_extraction | Status | Notes |
 |---|---|---|---|---|---|---|
-| [multi](../by-language/multi.md) | [GraphQL SDL (Query/Mutation/Subscription)](../detail/protocol.graphql.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
-| [multi](../by-language/multi.md) | [OpenAPI / Swagger spec](../detail/protocol.openapi.md) | ✅ | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Protocol Buffers (.proto)](../detail/protocol.protobuf.md) | ✅ | ✅ | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [gRPC services](../detail/protocol.grpc.md) | ✅ | ✅ | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [GraphQL](../detail/protocol.graphql.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
+| [multi](../by-language/multi.md) | [JSON-RPC](../detail/protocol.jsonrpc.md) | ❌ | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [OpenAPI / Swagger](../detail/protocol.openapi.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
+| [multi](../by-language/multi.md) | [Protocol Buffers](../detail/protocol.protobuf.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
+| [multi](../by-language/multi.md) | [SOAP / WSDL](../detail/protocol.soap.md) | ❌ | ❌ | ❌ | ❌ | |
+| [multi](../by-language/multi.md) | [gRPC](../detail/protocol.grpc.md) | ✅ | ✅ | ✅ | ✅ | |

--- a/docs/coverage/by-category/security.md
+++ b/docs/coverage/by-category/security.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # security
 
-**Total**: 5 records · **java**: 1 · **multi**: 4
+**Total**: 11 records · **java**: 1 · **multi**: 10
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -10,5 +10,11 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [java](../by-language/java.md) | [Auth policy resolver (Java/Kotlin — Phase 1 of #1942)](../detail/security.auth-java.md) | ✅ | — | — | ✅ | |
 | [multi](../by-language/multi.md) | [Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)](../detail/security.auth-other.md) | ❌ | — | — | ❌ | |
 | [multi](../by-language/multi.md) | [CSRF heuristic detector](../detail/security.csrf.md) | ✅ | — | — | ✅ | |
+| [multi](../by-language/multi.md) | [HTTP Basic Auth](../detail/security.auth.basic.md) | ⚠️ | ❌ | — | ❌ | |
+| [multi](../by-language/multi.md) | [JWT](../detail/security.auth.jwt.md) | ⚠️ | ❌ | — | ❌ | |
+| [multi](../by-language/multi.md) | [OAuth2](../detail/security.auth.oauth2.md) | ⚠️ | ❌ | — | ❌ | |
+| [multi](../by-language/multi.md) | [OIDC (OpenID Connect)](../detail/security.auth.oidc.md) | ⚠️ | ❌ | — | ❌ | |
+| [multi](../by-language/multi.md) | [SAML](../detail/security.auth.saml.md) | ❌ | ❌ | — | ❌ | |
 | [multi](../by-language/multi.md) | [SQL injection heuristic (f-string / .format() / % interpolation into SQL)](../detail/security.sql-injection.md) | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Secret material extraction (Phase 1 security audit)](../detail/security.secrets.md) | — | ✅ | — | ✅ | |
+| [multi](../by-language/multi.md) | [Session cookies](../detail/security.auth.session.md) | ⚠️ | ❌ | — | ❌ | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # csharp
 
-**Frameworks**: 3 · **Tools**: 1 · **ORMs**: 1 · **Other**: 1
+**Frameworks**: 15 · **Tools**: 7 · **ORMs**: 14 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -9,21 +9,52 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | — | |
-| [ASP.NET MVC (attribute-route subset)](../detail/lang.csharp.framework.aspnet-mvc.md) | — | ⚠️ | ⚠️ | — | |
+| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | — | — | ⚠️ | — | |
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | ⚠️ | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | — | — | ⚠️ | — | |
 | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | — | ❌ | — | — | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | — | — | ⚠️ | — | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ | ❌ | ❌ | ❌ | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ | ❌ | ❌ | ❌ | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ | ❌ | ❌ | ❌ | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Uno Platform](../detail/lang.csharp.framework.uno.md) | — | — | ⚠️ | — | |
+| [WPF](../detail/lang.csharp.framework.wpf.md) | — | — | ⚠️ | — | |
+| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | — | — | ⚠️ | — | |
+| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | — | — | ⚠️ | — | |
+| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
 | [.csproj / packages.config](../detail/pkg.csproj.md) | — | ❌ | ❌ | — | |
+| [FluentAssertions](../detail/test.fluentassertions.md) | ❌ | — | — | ❌ | |
+| [MSTest](../detail/test.mstest.md) | ⚠️ | — | — | ⚠️ | |
+| [NUnit](../detail/test.nunit.md) | ⚠️ | — | — | ⚠️ | |
+| [NuGet](../detail/build.nuget.md) | ⚠️ | — | — | ⚠️ | |
+| [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | — | — | ✅ | |
+| [xUnit](../detail/test.xunit.md) | ⚠️ | — | — | ⚠️ | |
 
 ## ORMs
 
 | Name | migration_parsing | model_extraction | query_attribution | Notes |
 |---|---|---|---|---|
-| [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ | ⚠️ | ❌ | |
+| [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | — | — | ⚠️ | |
+| [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | — | — | ⚠️ | |
+| [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ | ⚠️ | ⚠️ | |
+| [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ | ✅ | ✅ | |
+| [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ | ⚠️ | ⚠️ | |
+| [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ | ❌ | ❌ | |
+| [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | — | — | ⚠️ | |
+| [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | — | — | ⚠️ | |
+| [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | — | — | ⚠️ | |
+| [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | — | — | ⚠️ | |
+| [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ | ⚠️ | ⚠️ | |
+| [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | — | — | ⚠️ | |
+| [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | — | — | ⚠️ | |
+| [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | — | — | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # elixir
 
-**Frameworks**: 2 · **Tools**: 1 · **ORMs**: 1 · **Other**: 1
+**Frameworks**: 9 · **Tools**: 5 · **ORMs**: 10 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -9,20 +9,40 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ | ✅ | ✅ | — | |
-| [Phoenix LiveView (pages indexed; lifecycle hooks not surfaced)](../detail/lang.elixir.framework.phoenix-liveview.md) | — | ⚠️ | ⚠️ | — | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | — | — | ⚠️ | — | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | — | — | ⚠️ | — | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ | ❌ | ❌ | ❌ | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
+| [ExUnit](../detail/test.exunit.md) | ✅ | — | — | ✅ | |
+| [Hex](../detail/build.hex.md) | ⚠️ | — | — | ⚠️ | |
+| [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | ✅ | |
+| [StreamData (property tests)](../detail/test.streamdata.md) | ❌ | — | — | ❌ | |
 | [mix.exs](../detail/pkg.mix.md) | — | — | ❌ | — | |
 
 ## ORMs
 
 | Name | migration_parsing | model_extraction | query_attribution | Notes |
 |---|---|---|---|---|
-| [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ | ✅ | ❌ | |
+| [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ | ✅ | ✅ | |
+| [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | — | — | ⚠️ | |
+| [MyXQL](../detail/lang.elixir.driver.myxql.md) | — | — | ⚠️ | |
+| [Postgrex](../detail/lang.elixir.driver.postgrex.md) | — | — | ⚠️ | |
+| [Redix](../detail/lang.elixir.driver.redix.md) | — | — | ⚠️ | |
+| [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | — | — | ⚠️ | |
+| [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | — | — | ⚠️ | |
+| [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ | ⚠️ | ⚠️ | |
+| [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | — | — | ⚠️ | |
+| [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | — | — | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # go
 
-**Frameworks**: 8 · **Tools**: 1 · **ORMs**: 2 · **Other**: 1
+**Frameworks**: 17 · **Tools**: 8 · **ORMs**: 17 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -9,27 +9,58 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [Beego](../detail/lang.go.framework.beego.md) | — | ❌ | — | — | |
-| [Go net/http stdlib](../detail/lang.go.framework.net-http.md) | — | ✅ | ✅ | — | |
-| [Huma](../detail/lang.go.framework.huma.md) | — | ✅ | ✅ | — | |
-| [gin-gonic/gin](../detail/lang.go.framework.gin.md) | — | ✅ | ✅ | — | |
-| [go-chi/chi](../detail/lang.go.framework.chi.md) | — | ✅ | ✅ | — | |
-| [gofiber/fiber](../detail/lang.go.framework.fiber.md) | — | ✅ | ✅ | — | |
-| [gorilla/mux](../detail/lang.go.framework.gorilla-mux.md) | — | ✅ | ✅ | — | |
-| [labstack/echo](../detail/lang.go.framework.echo.md) | — | ✅ | ✅ | — | |
+| [Beego](../detail/lang.go.framework.beego.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Buffalo](../detail/lang.go.framework.buffalo.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Echo](../detail/lang.go.framework.echo.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Fiber](../detail/lang.go.framework.fiber.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | — | — | ⚠️ | — | |
+| [Gin](../detail/lang.go.framework.gin.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Huma](../detail/lang.go.framework.huma.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Iris](../detail/lang.go.framework.iris.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Revel](../detail/lang.go.framework.revel.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [chi](../detail/lang.go.framework.chi.md) | ❌ | ✅ | ✅ | ❌ | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [go-zero](../detail/lang.go.framework.go-zero.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | — | — | ⚠️ | — | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ❌ | ✅ | ✅ | ❌ | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
+| [Ginkgo](../detail/test.ginkgo.md) | ❌ | — | — | ❌ | |
+| [Gomega](../detail/test.gomega.md) | ❌ | — | — | ❌ | |
+| [Mage](../detail/build.mage.md) | ❌ | — | — | ❌ | |
+| [Task (taskfile.dev)](../detail/build.task.md) | ❌ | — | — | ❌ | |
+| [go modules (go.mod / go.sum)](../detail/build.go-modules.md) | ✅ | — | — | ✅ | |
+| [go testing (stdlib)](../detail/test.go-testing.md) | ✅ | — | — | ✅ | |
 | [go.mod](../detail/pkg.go-mod.md) | — | ⚠️ | ✅ | — | |
+| [testify](../detail/test.testify.md) | ⚠️ | — | — | ⚠️ | |
 
 ## ORMs
 
 | Name | migration_parsing | model_extraction | query_attribution | Notes |
 |---|---|---|---|---|
+| [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | — | — | ⚠️ | |
+| [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ | ⚠️ | ⚠️ | |
 | [GORM](../detail/lang.go.orm.gorm.md) | ❌ | ✅ | ✅ | |
-| [ent](../detail/lang.go.orm.ent.md) | — | ❌ | ❌ | |
+| [ent (Facebook)](../detail/lang.go.orm.ent.md) | ❌ | ✅ | ✅ | |
+| [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | ❌ | ❌ | ❌ | |
+| [go-elasticsearch](../detail/lang.go.driver.elastic.md) | — | — | ⚠️ | |
+| [go-redis](../detail/lang.go.driver.redis.md) | — | — | ⚠️ | |
+| [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | — | — | ⚠️ | |
+| [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | — | — | ⚠️ | |
+| [golang-migrate](../detail/lang.go.orm.migrate.md) | ⚠️ | — | — | |
+| [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | — | — | ⚠️ | |
+| [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | — | — | ⚠️ | |
+| [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | — | — | ⚠️ | |
+| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | — | — | ⚠️ | |
+| [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ⚠️ | ⚠️ | ⚠️ | |
+| [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ | ⚠️ | ⚠️ | |
+| [xo (codegen)](../detail/lang.go.orm.xo.md) | ❌ | ❌ | ❌ | |
 
 ## Other
 

--- a/docs/coverage/by-language/groovy.md
+++ b/docs/coverage/by-language/groovy.md
@@ -1,9 +1,15 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # groovy
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 1
+**Frameworks**: 0 · **Tools**: 1 · **ORMs**: 0 · **Other**: 1
 
 Back to [summary](../summary.md).
+
+## Tools
+
+| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+|---|---|---|---|---|---|
+| [Spock](../detail/test.spock.md) | ❌ | — | — | ❌ | |
 
 ## Other
 

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # java
 
-**Frameworks**: 6 · **Tools**: 2 · **ORMs**: 2 · **Other**: 3
+**Frameworks**: 19 · **Tools**: 10 · **ORMs**: 13 · **Other**: 3
 
 Back to [summary](../summary.md).
 
@@ -9,17 +9,38 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [Dropwizard (JAX-RS subset)](../detail/lang.java.framework.dropwizard.md) | — | ⚠️ | ⚠️ | — | |
-| [JAX-RS / Jakarta EE](../detail/lang.java.framework.jaxrs.md) | ✅ | ✅ | ✅ | — | |
-| [Micronaut](../detail/lang.java.framework.micronaut.md) | — | ❌ | — | — | |
-| [Quarkus (JAX-RS-backed)](../detail/lang.java.framework.quarkus.md) | ✅ | ✅ | ✅ | — | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ | ✅ | ✅ | — | |
-| [Spring WebFlux](../detail/lang.java.framework.spring-webflux.md) | ⚠️ | ✅ | ✅ | — | |
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | — | — | ⚠️ | — | |
+| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | — | — | ⚠️ | — | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Helidon](../detail/lang.java.framework.helidon.md) | ❌ | ❌ | ❌ | ❌ | |
+| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ | ❌ | ❌ | ❌ | |
+| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | — | — | ⚠️ | — | |
+| [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [Play Framework](../detail/lang.java.framework.play.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ | ✅ | ✅ | ⚠️ | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
+| [AssertJ](../detail/test.assertj.md) | ❌ | — | — | ❌ | |
+| [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | — | — | ✅ | |
+| [JUnit 4](../detail/test.junit4.md) | ⚠️ | — | — | ⚠️ | |
+| [JUnit 5](../detail/test.junit5.md) | ✅ | — | — | ✅ | |
+| [Maven (pom.xml)](../detail/build.maven.md) | ✅ | — | — | ✅ | |
+| [Mockito](../detail/test.mockito.md) | ❌ | — | — | ❌ | |
+| [REST-assured](../detail/test.restassured.md) | ❌ | — | — | ❌ | |
+| [TestNG](../detail/test.testng.md) | ❌ | — | — | ⚠️ | |
 | [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | ❌ | ❌ | — | |
 | [pom.xml](../detail/pkg.pom.md) | — | — | ✅ | — | |
 
@@ -27,8 +48,19 @@ Back to [summary](../summary.md).
 
 | Name | migration_parsing | model_extraction | query_attribution | Notes |
 |---|---|---|---|---|
-| [Hibernate / JPA](../detail/lang.java.orm.hibernate.md) | — | ✅ | ⚠️ | |
-| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | — | ✅ | ⚠️ | |
+| [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | — | ⚠️ | ⚠️ | |
+| [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ | ❌ | ❌ | |
+| [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ | ❌ | ❌ | |
+| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ | ✅ | ✅ | |
+| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ | ✅ | ⚠️ | |
+| [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ | ⚠️ | ⚠️ | |
+| [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ | ⚠️ | ⚠️ | |
+| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ | ⚠️ | ⚠️ | |
+| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ | ⚠️ | ⚠️ | |
+| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ | ✅ | ✅ | |
+| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ | ⚠️ | ⚠️ | |
+| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ | ⚠️ | ⚠️ | |
+| [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ | ⚠️ | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/by-language/javascript.md
+++ b/docs/coverage/by-language/javascript.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # javascript
 
-**Frameworks**: 13 · **Tools**: 1 · **ORMs**: 5 · **Other**: 3
+**Frameworks**: 30 · **Tools**: 21 · **ORMs**: 18 · **Other**: 3
 
 Back to [summary](../summary.md).
 
@@ -9,35 +9,85 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [Angular](../detail/lang.javascript.framework.angular.md) | — | ❌ | — | — | |
-| [Astro](../detail/lang.javascript.framework.astro.md) | — | ❌ | — | — | |
-| [Express.js](../detail/lang.javascript.framework.express.md) | ❌ | ✅ | — | — | |
-| [Fastify](../detail/lang.javascript.framework.fastify.md) | — | ✅ | ✅ | — | |
-| [GraphQL resolvers (Apollo / Yoga)](../detail/lang.javascript.framework.graphql-resolvers.md) | — | ✅ | ✅ | — | |
-| [Hono](../detail/lang.javascript.framework.hono.md) | — | ❌ | — | — | |
-| [Koa](../detail/lang.javascript.framework.koa.md) | — | ❌ | — | — | |
-| [NestJS](../detail/lang.javascript.framework.nestjs.md) | ⚠️ | ✅ | ✅ | — | |
-| [Next.js API routes](../detail/lang.javascript.framework.next-api.md) | — | ✅ | ✅ | — | |
-| [Nuxt](../detail/lang.javascript.framework.nuxt.md) | — | ❌ | — | — | |
-| [Remix](../detail/lang.javascript.framework.remix.md) | — | ❌ | — | — | |
-| [Svelte / SvelteKit](../detail/lang.javascript.framework.sveltekit.md) | — | ❌ | — | — | |
-| [tRPC](../detail/lang.javascript.framework.trpc.md) | — | ✅ | ✅ | — | |
+| [AdonisJS](../detail/lang.javascript.framework.adonisjs.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Angular](../detail/lang.javascript.framework.angular.md) | — | — | ✅ | — | |
+| [Astro](../detail/lang.javascript.framework.astro.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Electron](../detail/lang.javascript.framework.electron.md) | — | — | ⚠️ | — | |
+| [Expo](../detail/lang.javascript.framework.expo.md) | — | — | ⚠️ | — | |
+| [Express](../detail/lang.javascript.framework.express.md) | ❌ | ✅ | ✅ | ⚠️ | |
+| [Fastify](../detail/lang.javascript.framework.fastify.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Feathers](../detail/lang.javascript.framework.feathers.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Gatsby](../detail/lang.javascript.framework.gatsby.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.javascript.framework.graphql-resolvers.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Hapi](../detail/lang.javascript.framework.hapi.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Hono](../detail/lang.javascript.framework.hono.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Ionic](../detail/lang.javascript.framework.ionic.md) | — | — | ⚠️ | — | |
+| [Koa](../detail/lang.javascript.framework.koa.md) | ❌ | ✅ | ✅ | ❌ | |
+| [LangChain.js](../detail/lang.javascript.framework.langchain.md) | — | — | ⚠️ | — | |
+| [Marble.js](../detail/lang.javascript.framework.marblejs.md) | ❌ | ❌ | ❌ | ❌ | |
+| [NativeScript](../detail/lang.javascript.framework.nativescript.md) | — | — | ⚠️ | — | |
+| [NestJS](../detail/lang.javascript.framework.nestjs.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
+| [Next.js API Routes / App Router](../detail/lang.javascript.framework.next-api.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Nuxt](../detail/lang.javascript.framework.nuxt.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Polka](../detail/lang.javascript.framework.polka.md) | ❌ | ❌ | ❌ | ❌ | |
+| [React](../detail/lang.javascript.framework.react.md) | — | — | ⚠️ | — | |
+| [React Native](../detail/lang.javascript.framework.react-native.md) | — | — | ⚠️ | — | |
+| [Remix](../detail/lang.javascript.framework.remix.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Restify](../detail/lang.javascript.framework.restify.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Sails](../detail/lang.javascript.framework.sails.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Svelte](../detail/lang.javascript.framework.svelte.md) | — | — | ⚠️ | — | |
+| [SvelteKit](../detail/lang.javascript.framework.sveltekit.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Vue](../detail/lang.javascript.framework.vue.md) | — | — | ⚠️ | — | |
+| [tRPC](../detail/lang.javascript.framework.trpc.md) | ❌ | ✅ | ✅ | ❌ | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
+| [AVA](../detail/test.ava.md) | ❌ | — | — | ❌ | |
+| [Bun (runtime + manager)](../detail/build.bun.md) | ⚠️ | — | — | ⚠️ | |
+| [Cypress](../detail/test.cypress.md) | ❌ | — | — | ❌ | |
+| [Jasmine](../detail/test.jasmine.md) | ❌ | — | — | ❌ | |
+| [Jest](../detail/test.jest.md) | ✅ | — | — | ✅ | |
+| [Lerna](../detail/build.lerna.md) | ❌ | — | — | ❌ | |
+| [Mocha](../detail/test.mocha.md) | ⚠️ | — | — | ⚠️ | |
+| [Nx (monorepo)](../detail/build.nx.md) | ❌ | — | — | ❌ | |
+| [Parcel](../detail/build.parcel.md) | ❌ | — | — | ❌ | |
+| [Playwright](../detail/test.playwright.md) | ❌ | — | — | ❌ | |
+| [Rollup](../detail/build.rollup.md) | ❌ | — | — | ❌ | |
+| [Turborepo](../detail/build.turborepo.md) | ❌ | — | — | ❌ | |
+| [Vite](../detail/build.vite.md) | ❌ | — | — | ⚠️ | |
+| [Vitest](../detail/test.vitest.md) | ⚠️ | — | — | ⚠️ | |
+| [Webpack](../detail/build.webpack.md) | ❌ | — | — | ⚠️ | |
+| [Yarn](../detail/build.yarn.md) | ✅ | — | — | ✅ | |
+| [esbuild](../detail/build.esbuild.md) | ❌ | — | — | ❌ | |
+| [npm](../detail/build.npm.md) | ✅ | — | — | ✅ | |
 | [package.json (npm/yarn/pnpm)](../detail/pkg.npm.md) | — | ❌ | ✅ | — | |
+| [pnpm](../detail/build.pnpm.md) | ✅ | — | — | ✅ | |
+| [tap / node:test](../detail/test.tap.md) | ❌ | — | — | ❌ | |
 
 ## ORMs
 
 | Name | migration_parsing | model_extraction | query_attribution | Notes |
 |---|---|---|---|---|
-| [Drizzle ORM](../detail/lang.javascript.orm.drizzle.md) | — | ❌ | ❌ | |
-| [Mongoose](../detail/lang.javascript.orm.mongoose.md) | — | ⚠️ | ✅ | |
-| [Prisma](../detail/lang.javascript.orm.prisma.md) | ❌ | ✅ | ✅ | |
-| [Sequelize](../detail/lang.javascript.orm.sequelize.md) | — | ✅ | ✅ | |
+| [@elastic/elasticsearch](../detail/lang.javascript.driver.elastic.md) | — | — | ⚠️ | |
+| [AWS SDK DynamoDB (JS)](../detail/lang.javascript.driver.dynamodb.md) | — | — | ⚠️ | |
+| [Drizzle](../detail/lang.javascript.orm.drizzle.md) | ❌ | ✅ | ✅ | |
+| [Knex (query builder)](../detail/lang.javascript.orm.knex.md) | ❌ | — | ⚠️ | |
+| [MikroORM](../detail/lang.javascript.orm.mikro-orm.md) | ❌ | ⚠️ | ⚠️ | |
+| [MongoDB Node.js driver](../detail/lang.javascript.driver.mongodb.md) | — | — | ⚠️ | |
+| [Mongoose](../detail/lang.javascript.orm.mongoose.md) | — | ✅ | ✅ | |
+| [Objection.js](../detail/lang.javascript.orm.objection.md) | ❌ | ❌ | ❌ | |
+| [Prisma](../detail/lang.javascript.orm.prisma.md) | ⚠️ | ✅ | ✅ | |
+| [Sequelize](../detail/lang.javascript.orm.sequelize.md) | ❌ | ✅ | ✅ | |
 | [TypeORM](../detail/lang.javascript.orm.typeorm.md) | ❌ | ✅ | ✅ | |
+| [better-sqlite3 / sqlite3](../detail/lang.javascript.driver.sqlite.md) | — | — | ⚠️ | |
+| [cassandra-driver (JS)](../detail/lang.javascript.driver.cassandra.md) | — | — | ⚠️ | |
+| [ioredis / node-redis](../detail/lang.javascript.driver.redis.md) | — | — | ⚠️ | |
+| [mysql / mysql2](../detail/lang.javascript.driver.mysql.md) | — | — | ⚠️ | |
+| [neo4j-driver (JS)](../detail/lang.javascript.driver.neo4j.md) | — | — | ⚠️ | |
+| [node-postgres / pg](../detail/lang.javascript.driver.postgres.md) | — | — | ⚠️ | |
+| [supabase-js](../detail/lang.javascript.driver.supabase.md) | — | — | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # kotlin
 
-**Frameworks**: 3 · **Tools**: 0 · **ORMs**: 0 · **Other**: 1
+**Frameworks**: 12 · **Tools**: 0 · **ORMs**: 7 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -9,9 +9,30 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | — | ❌ | — | — | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ | ✅ | ✅ | — | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | — | ❌ | — | — | |
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | — | — | ⚠️ | — | |
+| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | — | — | ⚠️ | — | |
+| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | — | — | ⚠️ | — | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | — | — | ⚠️ | — | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | — | — | ⚠️ | — | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | — | — | ⚠️ | — | |
+
+## ORMs
+
+| Name | migration_parsing | model_extraction | query_attribution | Notes |
+|---|---|---|---|---|
+| [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | ❌ | ✅ | ✅ | |
+| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ | ⚠️ | ⚠️ | |
+| [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ | ⚠️ | ⚠️ | |
+| [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | — | ⚠️ | ⚠️ | |
+| [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ | ⚠️ | ⚠️ | |
+| [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ | ⚠️ | ⚠️ | |
+| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ | ⚠️ | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/by-language/multi.md
+++ b/docs/coverage/by-language/multi.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # Uncategorized
 
-**Frameworks**: 0 · **Tools**: 4 · **ORMs**: 0 · **Other**: 46
+**Frameworks**: 0 · **Tools**: 4 · **ORMs**: 0 · **Other**: 91
 
 Back to [summary](../summary.md).
 
@@ -22,45 +22,90 @@ Back to [summary](../summary.md).
 | [.ini / setup.cfg / flake8 / mypy / pytest.ini](../detail/config.ini.md) | [configuration](../by-category/configuration.md) | ⚠️ | |
 | [.toml](../detail/config.toml.md) | [configuration](../by-category/configuration.md) | ✅ | |
 | [.yaml / .yml](../detail/config.yaml.md) | [configuration](../by-category/configuration.md) | ✅ | |
+| [AMQP (generic)](../detail/msg.broker.amqp.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
+| [AWS CDK](../detail/infra.iac.cdk.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
 | [AWS CDK](../detail/infra.resource.aws-cdk.md) | [infrastructure](../by-category/infrastructure.md) | ✅ | |
+| [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
 | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
-| [AWS EventBridge](../detail/msg.broker.eventbridge.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [AWS SNS (IaC-declared)](../detail/msg.broker.sns.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [AWS DynamoDB](../detail/db.dynamodb.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
+| [AWS EventBridge](../detail/msg.broker.eventbridge.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
+| [AWS SNS](../detail/msg.broker.sns.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
 | [AWS SQS](../detail/msg.broker.sqs.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [Ansible (playbooks)](../detail/infra.iac.ansible.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
+| [Apache Cassandra (schema)](../detail/db.cassandra.md) | [infrastructure](../by-category/infrastructure.md) | ❌ | |
 | [Apache Kafka](../detail/msg.broker.kafka.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Apache Pulsar](../detail/msg.broker.pulsar.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [Apache Pulsar](../detail/msg.broker.pulsar.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
 | [Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)](../detail/security.auth-other.md) | [security](../by-category/security.md) | ❌ | |
-| [Azure Event Grid](../detail/msg.broker.eventgrid.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [Azure Bicep](../detail/infra.iac.bicep.md) | [infrastructure](../by-category/infrastructure.md) | ❌ | |
+| [Azure Event Grid](../detail/msg.broker.eventgrid.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
+| [Azure Pipelines](../detail/ci.azure-pipelines.md) | [configuration](../by-category/configuration.md) | ⚠️ | |
+| [Azure Service Bus](../detail/msg.broker.azure-service-bus.md) | [message_broker](../by-category/message_broker.md) | ❌ | |
+| [Bitbucket Pipelines](../detail/ci.bitbucket.md) | [configuration](../by-category/configuration.md) | ⚠️ | |
+| [Buildkite](../detail/ci.buildkite.md) | [configuration](../by-category/configuration.md) | ⚠️ | |
 | [CSRF heuristic detector](../detail/security.csrf.md) | [security](../by-category/security.md) | ✅ | |
-| [CloudEvents](../detail/msg.broker.cloudevents.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Datadog APM / StatsD](../detail/infra.observability.datadog.md) | [observability](../by-category/observability.md) | ❌ | |
-| [Debezium / Kafka Connect CDC](../detail/msg.broker.debezium.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
-| [GCP Pub/Sub](../detail/msg.broker.gcp-pubsub.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [CircleCI](../detail/ci.circleci.md) | [configuration](../by-category/configuration.md) | ⚠️ | |
+| [ClickHouse](../detail/db.clickhouse.md) | [infrastructure](../by-category/infrastructure.md) | ❌ | |
+| [CloudEvents](../detail/msg.broker.cloudevents.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
+| [Datadog](../detail/infra.observability.datadog.md) | [observability](../by-category/observability.md) | ❌ | |
+| [Debezium (CDC)](../detail/msg.broker.debezium.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [Dockerfile](../detail/infra.container.dockerfile.md) | [infrastructure](../by-category/infrastructure.md) | ✅ | |
+| [Drone CI](../detail/ci.drone.md) | [configuration](../by-category/configuration.md) | ❌ | |
+| [Elastic APM](../detail/infra.observability.elastic-apm.md) | [observability](../by-category/observability.md) | ❌ | |
+| [Elasticsearch (indices)](../detail/db.elasticsearch.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
+| [GCP Pub/Sub](../detail/msg.broker.gcp-pubsub.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
 | [Generic logging-config extractor (Python logging, Go slog, Node winston/pino, .NET NLog/Serilog, log4j/logback)](../detail/infra.observability.logging-config.md) | [observability](../by-category/observability.md) | ✅ | |
+| [GitHub Actions](../detail/ci.github-actions.md) | [configuration](../by-category/configuration.md) | ⚠️ | |
 | [GitHub Actions workflows](../detail/config.github-actions.md) | [configuration](../by-category/configuration.md) | ✅ | |
+| [GitLab CI](../detail/ci.gitlab.md) | [configuration](../by-category/configuration.md) | ⚠️ | |
 | [GitLab CI](../detail/config.gitlab-ci.md) | [configuration](../by-category/configuration.md) | ⚠️ | |
-| [GraphQL SDL (Query/Mutation/Subscription)](../detail/protocol.graphql.md) | [protocol](../by-category/protocol.md) | ⚠️ | |
+| [Grafana Loki](../detail/infra.observability.grafana-loki.md) | [observability](../by-category/observability.md) | ❌ | |
+| [GraphQL](../detail/protocol.graphql.md) | [protocol](../by-category/protocol.md) | ⚠️ | |
 | [GraphQL subscriptions](../detail/msg.graphql-subscriptions.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [HTTP Basic Auth](../detail/security.auth.basic.md) | [security](../by-category/security.md) | ❌ | |
+| [Helm charts](../detail/infra.container.helm.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
 | [Helm charts](../detail/infra.resource.helm.md) | [infrastructure](../by-category/infrastructure.md) | ❌ | |
+| [Honeycomb](../detail/infra.observability.honeycomb.md) | [observability](../by-category/observability.md) | ❌ | |
+| [JSON-RPC](../detail/protocol.jsonrpc.md) | [protocol](../by-category/protocol.md) | ❌ | |
+| [JWT](../detail/security.auth.jwt.md) | [security](../by-category/security.md) | ❌ | |
+| [Jenkins (Jenkinsfile)](../detail/ci.jenkins.md) | [configuration](../by-category/configuration.md) | ❌ | |
 | [Jenkinsfile / Jenkins Pipeline DSL](../detail/config.jenkins.md) | [configuration](../by-category/configuration.md) | ❌ | |
 | [Kafka Streams / Faust](../detail/msg.kafka-streams.md) | [message_broker](../by-category/message_broker.md) | ❌ | |
+| [Kubernetes manifests](../detail/infra.container.kubernetes.md) | [infrastructure](../by-category/infrastructure.md) | ✅ | |
 | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | [infrastructure](../by-category/infrastructure.md) | ✅ | |
-| [MQTT](../detail/msg.broker.mqtt.md) | [message_broker](../by-category/message_broker.md) | ❌ | |
+| [Kustomize](../detail/infra.container.kustomize.md) | [infrastructure](../by-category/infrastructure.md) | ❌ | |
+| [MQTT](../detail/msg.broker.mqtt.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
+| [MongoDB (collections)](../detail/db.mongodb.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
+| [MySQL / MariaDB (schema)](../detail/db.mysql.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
 | [NATS](../detail/msg.broker.nats.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [Neo4j](../detail/db.neo4j.md) | [infrastructure](../by-category/infrastructure.md) | ❌ | |
 | [New Relic](../detail/infra.observability.newrelic.md) | [observability](../by-category/observability.md) | ❌ | |
-| [OpenAPI / Swagger spec](../detail/protocol.openapi.md) | [protocol](../by-category/protocol.md) | ✅ | |
-| [OpenTelemetry instrumentation](../detail/infra.observability.opentelemetry.md) | [observability](../by-category/observability.md) | ❌ | |
-| [Prometheus client libraries](../detail/infra.observability.prometheus.md) | [observability](../by-category/observability.md) | ❌ | |
-| [Protocol Buffers (.proto)](../detail/protocol.protobuf.md) | [protocol](../by-category/protocol.md) | ✅ | |
+| [OAuth2](../detail/security.auth.oauth2.md) | [security](../by-category/security.md) | ❌ | |
+| [OIDC (OpenID Connect)](../detail/security.auth.oidc.md) | [security](../by-category/security.md) | ❌ | |
+| [OpenAPI / Swagger](../detail/protocol.openapi.md) | [protocol](../by-category/protocol.md) | ⚠️ | |
+| [OpenTelemetry (OTEL)](../detail/infra.observability.opentelemetry.md) | [observability](../by-category/observability.md) | ❌ | |
+| [PostgreSQL (schema)](../detail/db.postgres.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
+| [Prometheus](../detail/infra.observability.prometheus.md) | [observability](../by-category/observability.md) | ⚠️ | |
+| [Protocol Buffers](../detail/protocol.protobuf.md) | [protocol](../by-category/protocol.md) | ⚠️ | |
+| [Pulumi](../detail/infra.iac.pulumi.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
 | [Pulumi](../detail/infra.resource.pulumi.md) | [infrastructure](../by-category/infrastructure.md) | ✅ | |
 | [RabbitMQ](../detail/msg.broker.rabbitmq.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Redis pub/sub + Streams](../detail/msg.broker.redis.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [Redis (keys)](../detail/db.redis.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
+| [Redis pub/sub & streams](../detail/msg.broker.redis.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [SAML](../detail/security.auth.saml.md) | [security](../by-category/security.md) | ❌ | |
+| [SOAP / WSDL](../detail/protocol.soap.md) | [protocol](../by-category/protocol.md) | ❌ | |
 | [SQL injection heuristic (f-string / .format() / % interpolation into SQL)](../detail/security.sql-injection.md) | [security](../by-category/security.md) | ✅ | |
+| [SQLite (schema)](../detail/db.sqlite.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
 | [Secret material extraction (Phase 1 security audit)](../detail/security.secrets.md) | [security](../by-category/security.md) | ✅ | |
-| [Sentry SDK](../detail/infra.observability.sentry.md) | [observability](../by-category/observability.md) | ❌ | |
+| [Sentry](../detail/infra.observability.sentry.md) | [observability](../by-category/observability.md) | ❌ | |
 | [Server-Sent Events](../detail/msg.sse.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [Serverless Framework](../detail/infra.iac.serverless-framework.md) | [infrastructure](../by-category/infrastructure.md) | ⚠️ | |
+| [Session cookies](../detail/security.auth.session.md) | [security](../by-category/security.md) | ❌ | |
+| [Snowflake](../detail/db.snowflake.md) | [infrastructure](../by-category/infrastructure.md) | ❌ | |
+| [Terraform (HCL)](../detail/infra.iac.terraform.md) | [infrastructure](../by-category/infrastructure.md) | ✅ | |
 | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | [infrastructure](../by-category/infrastructure.md) | ✅ | |
-| [WebSocket channels](../detail/msg.websocket.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
-| [Webhook inbound (Stripe, GitHub, Twilio, Slack, SendGrid, Mailgun, ...)](../detail/msg.webhook.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [Travis CI](../detail/ci.travis.md) | [configuration](../by-category/configuration.md) | ⚠️ | |
+| [WebSocket](../detail/msg.websocket.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
+| [Webhooks](../detail/msg.webhook.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
 | [docker-compose.yml](../detail/config.docker-compose.md) | [configuration](../by-category/configuration.md) | ✅ | |
-| [gRPC services](../detail/protocol.grpc.md) | [protocol](../by-category/protocol.md) | ✅ | |
+| [docker-compose.yml](../detail/infra.container.docker-compose.md) | [infrastructure](../by-category/infrastructure.md) | ✅ | |
+| [gRPC](../detail/protocol.grpc.md) | [protocol](../by-category/protocol.md) | ✅ | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # php
 
-**Frameworks**: 3 · **Tools**: 1 · **ORMs**: 2 · **Other**: 1
+**Frameworks**: 12 · **Tools**: 6 · **ORMs**: 14 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -9,22 +9,48 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [Laravel](../detail/lang.php.framework.laravel.md) | ❌ | ✅ | ✅ | — | |
-| [Slim](../detail/lang.php.framework.slim.md) | — | ❌ | — | — | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | — | ❌ | — | — | |
+| [CakePHP](../detail/lang.php.framework.cakephp.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Drupal](../detail/lang.php.framework.drupal.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Magento](../detail/lang.php.framework.magento.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Slim](../detail/lang.php.framework.slim.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | ❌ | ✅ | ✅ | ❌ | |
+| [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Yii](../detail/lang.php.framework.yii.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
+| [Behat](../detail/test.behat.md) | ❌ | — | — | ❌ | |
+| [Codeception](../detail/test.codeception.md) | ❌ | — | — | ❌ | |
+| [Composer](../detail/build.composer.md) | ✅ | — | — | ✅ | |
+| [PHPUnit](../detail/test.phpunit.md) | ✅ | — | — | ✅ | |
+| [Pest](../detail/test.pest.md) | ❌ | — | — | ❌ | |
 | [composer.json](../detail/pkg.composer.md) | — | ❌ | ❌ | — | |
 
 ## ORMs
 
 | Name | migration_parsing | model_extraction | query_attribution | Notes |
 |---|---|---|---|---|
-| [Doctrine](../detail/lang.php.orm.doctrine.md) | — | ❌ | ❌ | |
-| [Eloquent (Laravel ActiveRecord)](../detail/lang.php.orm.eloquent.md) | — | ⚠️ | ❌ | |
+| [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | — | — | ⚠️ | |
+| [CycleORM](../detail/lang.php.orm.cycleorm.md) | ❌ | ❌ | ❌ | |
+| [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | ❌ | ✅ | ✅ | |
+| [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | ❌ | ✅ | ✅ | |
+| [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | — | — | ⚠️ | |
+| [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | — | — | ⚠️ | |
+| [PDO SQLite](../detail/lang.php.driver.sqlite.md) | — | — | ⚠️ | |
+| [Propel](../detail/lang.php.orm.propel.md) | ❌ | ⚠️ | ⚠️ | |
+| [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ | ⚠️ | ⚠️ | |
+| [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | — | — | ⚠️ | |
+| [elasticsearch-php](../detail/lang.php.driver.elastic.md) | — | — | ⚠️ | |
+| [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | — | — | ⚠️ | |
+| [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | — | — | ⚠️ | |
+| [phpredis / Predis](../detail/lang.php.driver.redis.md) | — | — | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # python
 
-**Frameworks**: 12 · **Tools**: 3 · **ORMs**: 6 · **Other**: 4
+**Frameworks**: 20 · **Tools**: 15 · **ORMs**: 17 · **Other**: 4
 
 Back to [summary](../summary.md).
 
@@ -9,37 +9,68 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | — | ❌ | — | — | |
-| [Django (URLconf)](../detail/lang.python.framework.django.md) | ⚠️ | ✅ | ✅ | — | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | — | |
-| [FastAPI](../detail/lang.python.framework.fastapi.md) | ❌ | ✅ | — | — | |
-| [Flask](../detail/lang.python.framework.flask.md) | ❌ | ✅ | — | — | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | — | ❌ | — | — | |
-| [Pyramid](../detail/lang.python.framework.pyramid.md) | — | ✅ | ✅ | — | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | — | ❌ | — | — | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | — | ❌ | — | — | |
-| [Starlette](../detail/lang.python.framework.starlette.md) | — | ✅ | ✅ | — | |
-| [Tornado](../detail/lang.python.framework.tornado.md) | — | ✅ | ✅ | — | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | — | ❌ | — | — | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Celery (task queue)](../detail/lang.python.framework.celery.md) | — | — | ✅ | — | |
+| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Django](../detail/lang.python.framework.django.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | — | — | ⚠️ | — | |
+| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ | ❌ | ❌ | ❌ | |
+| [FastAPI](../detail/lang.python.framework.fastapi.md) | ⚠️ | ✅ | ✅ | ❌ | |
+| [Flask](../detail/lang.python.framework.flask.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Hug](../detail/lang.python.framework.hug.md) | ❌ | ❌ | ❌ | ❌ | |
+| [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | — | — | ⚠️ | — | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Pyramid](../detail/lang.python.framework.pyramid.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Quart](../detail/lang.python.framework.quart.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Tornado](../detail/lang.python.framework.tornado.md) | ❌ | ✅ | ✅ | ❌ | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ | ✅ | ✅ | ❌ | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
+| [Flit](../detail/build.flit.md) | ❌ | — | — | ❌ | |
+| [Hatch](../detail/build.hatch.md) | ❌ | — | — | ❌ | |
+| [Hypothesis (property tests)](../detail/test.hypothesis.md) | ❌ | — | — | ❌ | |
+| [Pipenv](../detail/build.pipenv.md) | ⚠️ | — | — | ⚠️ | |
 | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | ❌ | ❌ | — | |
+| [Poetry](../detail/build.poetry.md) | ✅ | — | — | ✅ | |
+| [doctest (stdlib)](../detail/test.doctest.md) | ❌ | — | — | ❌ | |
+| [nose2](../detail/test.nose2.md) | ❌ | — | — | ❌ | |
+| [pip (requirements.txt)](../detail/build.pip.md) | ✅ | — | — | ✅ | |
 | [pyproject.toml](../detail/pkg.pyproject.md) | — | ❌ | ✅ | — | |
+| [pytest](../detail/test.pytest.md) | ✅ | — | — | ✅ | |
 | [requirements.txt](../detail/pkg.requirements.md) | — | — | ✅ | — | |
+| [setuptools / setup.py](../detail/build.setuptools.md) | ⚠️ | — | — | ⚠️ | |
+| [unittest (stdlib)](../detail/test.unittest.md) | ⚠️ | — | — | ⚠️ | |
+| [uv (Astral)](../detail/build.uv.md) | ⚠️ | — | — | ⚠️ | |
 
 ## ORMs
 
 | Name | migration_parsing | model_extraction | query_attribution | Notes |
 |---|---|---|---|---|
+| [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ⚠️ | — | — | |
+| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | — | ⚠️ | ⚠️ | |
 | [Django ORM](../detail/lang.python.orm.django.md) | ✅ | ✅ | ✅ | |
-| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | — | ❌ | ❌ | |
-| [Peewee](../detail/lang.python.orm.peewee.md) | — | ❌ | ✅ | |
+| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | — | ⚠️ | ⚠️ | |
+| [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | — | — | ⚠️ | |
+| [Peewee](../detail/lang.python.orm.peewee.md) | ❌ | ⚠️ | ⚠️ | |
+| [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ | ⚠️ | ⚠️ | |
 | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ | ✅ | ✅ | |
-| [SQLModel](../detail/lang.python.orm.sqlmodel.md) | — | ❌ | ⚠️ | |
-| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | — | ❌ | ✅ | |
+| [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ | ✅ | ✅ | |
+| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ | ✅ | ⚠️ | |
+| [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | — | — | ⚠️ | |
+| [cassandra-driver](../detail/lang.python.driver.cassandra.md) | — | — | ⚠️ | |
+| [elasticsearch-py](../detail/lang.python.driver.elastic.md) | — | — | ⚠️ | |
+| [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | — | — | ⚠️ | |
+| [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | — | — | ⚠️ | |
+| [redis-py](../detail/lang.python.driver.redis.md) | — | — | ⚠️ | |
+| [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | — | — | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # ruby
 
-**Frameworks**: 4 · **Tools**: 1 · **ORMs**: 1 · **Other**: 2
+**Frameworks**: 8 · **Tools**: 6 · **ORMs**: 13 · **Other**: 2
 
 Back to [summary](../summary.md).
 
@@ -9,22 +9,43 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [Grape](../detail/lang.ruby.framework.grape.md) | — | ❌ | — | — | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | — | ❌ | — | — | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ | ✅ | ✅ | — | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | — | ✅ | ✅ | — | |
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ❌ | ✅ | ✅ | ❌ | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | — | — | ⚠️ | — | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
+| [Bundler (Gemfile)](../detail/build.bundler.md) | ✅ | — | — | ✅ | |
+| [Cucumber](../detail/test.cucumber.md) | ❌ | — | — | ❌ | |
 | [Gemfile](../detail/pkg.gemfile.md) | — | ❌ | ✅ | — | |
+| [Minitest](../detail/test.minitest.md) | ⚠️ | — | — | ⚠️ | |
+| [RSpec](../detail/test.rspec.md) | ✅ | — | — | ✅ | |
+| [Rake](../detail/build.rake.md) | ❌ | — | — | ⚠️ | |
 
 ## ORMs
 
 | Name | migration_parsing | model_extraction | query_attribution | Notes |
 |---|---|---|---|---|
-| [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | — | ✅ | ✅ | |
+| [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | — | — | ⚠️ | |
+| [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ❌ | ✅ | ✅ | |
+| [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ | ⚠️ | ⚠️ | |
+| [Mongoid](../detail/lang.ruby.orm.mongoid.md) | — | ⚠️ | ⚠️ | |
+| [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ | ⚠️ | ⚠️ | |
+| [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ | ⚠️ | ⚠️ | |
+| [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | — | — | ⚠️ | |
+| [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | — | — | ⚠️ | |
+| [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | — | — | ⚠️ | |
+| [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | — | — | ⚠️ | |
+| [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | — | — | ⚠️ | |
+| [redis-rb](../detail/lang.ruby.driver.redis.md) | — | — | ⚠️ | |
+| [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | — | — | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # rust
 
-**Frameworks**: 5 · **Tools**: 1 · **ORMs**: 0 · **Other**: 1
+**Frameworks**: 11 · **Tools**: 6 · **ORMs**: 14 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -9,17 +9,47 @@ Back to [summary](../summary.md).
 
 | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
 |---|---|---|---|---|---|
-| [Actix](../detail/lang.rust.framework.actix.md) | — | ❌ | — | — | |
-| [Axum](../detail/lang.rust.framework.axum.md) | — | ✅ | ✅ | — | |
-| [Hyper](../detail/lang.rust.framework.hyper.md) | — | ❌ | — | — | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | — | ✅ | ✅ | — | |
-| [Warp](../detail/lang.rust.framework.warp.md) | — | ❌ | — | — | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Axum](../detail/lang.rust.framework.axum.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Poem](../detail/lang.rust.framework.poem.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | ❌ | ✅ | ✅ | ❌ | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | — | — | ⚠️ | — | |
+| [Tide](../detail/lang.rust.framework.tide.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Warp](../detail/lang.rust.framework.warp.md) | ❌ | ✅ | ✅ | ❌ | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
+| [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | — | — | ✅ | |
 | [Cargo.toml](../detail/pkg.cargo.md) | — | ❌ | ✅ | — | |
+| [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | — | — | ✅ | |
+| [criterion (benchmark)](../detail/test.criterion.md) | ❌ | — | — | ❌ | |
+| [mockall](../detail/test.mockall.md) | ❌ | — | — | ❌ | |
+| [proptest](../detail/test.proptest.md) | ❌ | — | — | ❌ | |
+
+## ORMs
+
+| Name | migration_parsing | model_extraction | query_attribution | Notes |
+|---|---|---|---|---|
+| [Diesel](../detail/lang.rust.orm.diesel.md) | ❌ | ✅ | ✅ | |
+| [Rbatis](../detail/lang.rust.orm.rbatis.md) | ❌ | ❌ | ❌ | |
+| [SeaORM](../detail/lang.rust.orm.seaorm.md) | ❌ | ✅ | ✅ | |
+| [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | — | — | ⚠️ | |
+| [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | — | — | ⚠️ | |
+| [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | — | — | ⚠️ | |
+| [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | — | — | ⚠️ | |
+| [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | — | — | ⚠️ | |
+| [neo4rs](../detail/lang.rust.driver.neo4j.md) | — | — | ⚠️ | |
+| [redis-rs](../detail/lang.rust.driver.redis.md) | — | — | ⚠️ | |
+| [rusqlite](../detail/lang.rust.orm.rusqlite.md) | — | — | ⚠️ | |
+| [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | — | — | ⚠️ | |
+| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ | ⚠️ | ⚠️ | |
+| [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | — | — | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -1,15 +1,42 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # scala
 
-**Frameworks**: 0 · **Tools**: 1 · **ORMs**: 0 · **Other**: 1
+**Frameworks**: 9 · **Tools**: 3 · **ORMs**: 6 · **Other**: 1
 
 Back to [summary](../summary.md).
+
+## Frameworks
+
+| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+|---|---|---|---|---|---|
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Cask](../detail/lang.scala.framework.cask.md) | ❌ | ❌ | ❌ | ❌ | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | — | — | ⚠️ | — | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 
 ## Tools
 
 | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
 |---|---|---|---|---|---|
+| [Mill](../detail/build.mill.md) | ❌ | — | — | ❌ | |
+| [SBT](../detail/build.sbt.md) | ✅ | — | — | ✅ | |
 | [build.sbt](../detail/pkg.sbt.md) | — | — | ❌ | — | |
+
+## ORMs
+
+| Name | migration_parsing | model_extraction | query_attribution | Notes |
+|---|---|---|---|---|
+| [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ | ⚠️ | ⚠️ | |
+| [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | — | ⚠️ | ⚠️ | |
+| [Quill](../detail/lang.scala.orm.quill.md) | ❌ | ⚠️ | ⚠️ | |
+| [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ | ⚠️ | ⚠️ | |
+| [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | — | ⚠️ | ⚠️ | |
+| [Slick](../detail/lang.scala.orm.slick.md) | ❌ | ⚠️ | ⚠️ | |
 
 ## Other
 

--- a/docs/coverage/detail/build.bun.md
+++ b/docs/coverage/detail/build.bun.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.bun` — Bun (runtime + manager)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.bun ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.bundler.md
+++ b/docs/coverage/detail/build.bundler.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.bundler` — Bundler (Gemfile)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.bundler ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.cargo.md
+++ b/docs/coverage/detail/build.cargo.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.cargo` — Cargo (Cargo.toml)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.cargo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.composer.md
+++ b/docs/coverage/detail/build.composer.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.composer` — Composer
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.composer ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.dotnet.md
+++ b/docs/coverage/detail/build.dotnet.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.dotnet` — dotnet CLI / MSBuild
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.dotnet ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.esbuild.md
+++ b/docs/coverage/detail/build.esbuild.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.esbuild` — esbuild
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.esbuild ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.flit.md
+++ b/docs/coverage/detail/build.flit.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.flit` — Flit
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.flit ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.go-modules.md
+++ b/docs/coverage/detail/build.go-modules.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.go-modules` — go modules (go.mod / go.sum)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/golang/gomod.go` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/build_tools.yaml`<br>`internal/extractors/golang/gomod.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.go-modules ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.gradle.md
+++ b/docs/coverage/detail/build.gradle.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.gradle` — Gradle (Groovy + Kotlin DSL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml`<br>`internal/engine/rules/kotlin/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.gradle ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.hatch.md
+++ b/docs/coverage/detail/build.hatch.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.hatch` — Hatch
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.hatch ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.hex.md
+++ b/docs/coverage/detail/build.hex.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.hex` — Hex
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.hex ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.lerna.md
+++ b/docs/coverage/detail/build.lerna.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.lerna` — Lerna
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.lerna ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.mage.md
+++ b/docs/coverage/detail/build.mage.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.mage` — Mage
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.mage ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.maven.md
+++ b/docs/coverage/detail/build.maven.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.maven` — Maven (pom.xml)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.maven ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.mill.md
+++ b/docs/coverage/detail/build.mill.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.mill` — Mill
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.mill ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.mix.md
+++ b/docs/coverage/detail/build.mix.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.mix` — Mix (mix.exs)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.mix ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.npm.md
+++ b/docs/coverage/detail/build.npm.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.npm` — npm
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.npm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.nuget.md
+++ b/docs/coverage/detail/build.nuget.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.nuget` — NuGet
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.nuget ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.nx.md
+++ b/docs/coverage/detail/build.nx.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.nx` — Nx (monorepo)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.nx ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.parcel.md
+++ b/docs/coverage/detail/build.parcel.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.parcel` — Parcel
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.parcel ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.pip.md
+++ b/docs/coverage/detail/build.pip.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.pip` — pip (requirements.txt)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.pip ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.pipenv.md
+++ b/docs/coverage/detail/build.pipenv.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.pipenv` — Pipenv
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.pipenv ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.pnpm.md
+++ b/docs/coverage/detail/build.pnpm.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.pnpm` — pnpm
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.pnpm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.poetry.md
+++ b/docs/coverage/detail/build.poetry.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.poetry` — Poetry
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.poetry ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.rake.md
+++ b/docs/coverage/detail/build.rake.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.rake` — Rake
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.rake ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.rollup.md
+++ b/docs/coverage/detail/build.rollup.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.rollup` — Rollup
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.rollup ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.sbt.md
+++ b/docs/coverage/detail/build.sbt.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.sbt` — SBT
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/scala/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/scala/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.sbt ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.setuptools.md
+++ b/docs/coverage/detail/build.setuptools.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.setuptools` — setuptools / setup.py
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.setuptools ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.task.md
+++ b/docs/coverage/detail/build.task.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.task` — Task (taskfile.dev)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.task ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.turborepo.md
+++ b/docs/coverage/detail/build.turborepo.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.turborepo` — Turborepo
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.turborepo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.uv.md
+++ b/docs/coverage/detail/build.uv.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.uv` — uv (Astral)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.uv ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.vite.md
+++ b/docs/coverage/detail/build.vite.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.vite` — Vite
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.vite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.webpack.md
+++ b/docs/coverage/detail/build.webpack.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.webpack` — Webpack
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.webpack ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.yarn.md
+++ b/docs/coverage/detail/build.yarn.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.yarn` — Yarn
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.yarn ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/ci.azure-pipelines.md
+++ b/docs/coverage/detail/ci.azure-pipelines.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `ci.azure-pipelines` — Azure Pipelines
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [configuration](../by-category/configuration.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/azure_pipelines.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update ci.azure-pipelines ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/ci.bitbucket.md
+++ b/docs/coverage/detail/ci.bitbucket.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `ci.bitbucket` — Bitbucket Pipelines
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [configuration](../by-category/configuration.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update ci.bitbucket ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/ci.buildkite.md
+++ b/docs/coverage/detail/ci.buildkite.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `ci.buildkite` — Buildkite
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [configuration](../by-category/configuration.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/buildkite.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update ci.buildkite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/ci.circleci.md
+++ b/docs/coverage/detail/ci.circleci.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `ci.circleci` — CircleCI
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [configuration](../by-category/configuration.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/circleci.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update ci.circleci ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/ci.drone.md
+++ b/docs/coverage/detail/ci.drone.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `ci.drone` — Drone CI
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [configuration](../by-category/configuration.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `env_resolution` | ❌ `missing` | — | — | — | — |
+| `file_parsing` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update ci.drone ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/ci.github-actions.md
+++ b/docs/coverage/detail/ci.github-actions.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `ci.github-actions` — GitHub Actions
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [configuration](../by-category/configuration.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/github_actions.yaml`<br>`internal/extractors/yaml/extractor.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update ci.github-actions ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/ci.gitlab.md
+++ b/docs/coverage/detail/ci.gitlab.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `ci.gitlab` — GitLab CI
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [configuration](../by-category/configuration.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/gitlab_ci.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update ci.gitlab ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/ci.jenkins.md
+++ b/docs/coverage/detail/ci.jenkins.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `ci.jenkins` — Jenkins (Jenkinsfile)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [configuration](../by-category/configuration.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `env_resolution` | ❌ `missing` | — | — | — | — |
+| `file_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/cicd/_manifest.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update ci.jenkins ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/ci.travis.md
+++ b/docs/coverage/detail/ci.travis.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `ci.travis` — Travis CI
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [configuration](../by-category/configuration.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/travis_ci.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update ci.travis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/config.toml.md
+++ b/docs/coverage/detail/config.toml.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/config/discover.go` |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go`<br>`internal/extractors/cross/manifest/extractor.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.yaml.md
+++ b/docs/coverage/detail/config.yaml.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go`<br>`internal/extractors/config/discover.go` |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go`<br>`internal/extractors/yaml/extractor.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.cassandra.md
+++ b/docs/coverage/detail/db.cassandra.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.cassandra` — Apache Cassandra (schema)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.cassandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.clickhouse.md
+++ b/docs/coverage/detail/db.clickhouse.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.clickhouse` — ClickHouse
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.clickhouse ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.dynamodb.md
+++ b/docs/coverage/detail/db.dynamodb.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.dynamodb` — AWS DynamoDB
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.elasticsearch.md
+++ b/docs/coverage/detail/db.elasticsearch.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.elasticsearch` — Elasticsearch (indices)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.elasticsearch ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.mongodb.md
+++ b/docs/coverage/detail/db.mongodb.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.mongodb` — MongoDB (collections)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.mongodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.mysql.md
+++ b/docs/coverage/detail/db.mysql.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.mysql` — MySQL / MariaDB (schema)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.mysql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.neo4j.md
+++ b/docs/coverage/detail/db.neo4j.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.neo4j` — Neo4j
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.postgres.md
+++ b/docs/coverage/detail/db.postgres.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.postgres` — PostgreSQL (schema)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.postgres ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.redis.md
+++ b/docs/coverage/detail/db.redis.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.redis` — Redis (keys)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.redis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.snowflake.md
+++ b/docs/coverage/detail/db.snowflake.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.snowflake` — Snowflake
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.snowflake ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/db.sqlite.md
+++ b/docs/coverage/detail/db.sqlite.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `db.sqlite` — SQLite (schema)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/sql` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update db.sqlite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.container.docker-compose.md
+++ b/docs/coverage/detail/infra.container.docker-compose.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.container.docker-compose` — docker-compose.yml
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/docker/frameworks/docker_compose.yaml`<br>`internal/extractors/yaml/extractor.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.container.docker-compose ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.container.dockerfile.md
+++ b/docs/coverage/detail/infra.container.dockerfile.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.container.dockerfile` — Dockerfile
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/dockerfile/dockerfile.go` |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/docker/frameworks/dockerfile.yaml`<br>`internal/extractors/dockerfile/dockerfile.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.container.dockerfile ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.container.helm.md
+++ b/docs/coverage/detail/infra.container.helm.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.container.helm` — Helm charts
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.container.helm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.container.kubernetes.md
+++ b/docs/coverage/detail/infra.container.kubernetes.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.container.kubernetes` — Kubernetes manifests
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml`<br>`internal/extractors/yaml/extractor.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.container.kubernetes ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.container.kustomize.md
+++ b/docs/coverage/detail/infra.container.kustomize.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.container.kustomize` — Kustomize
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.container.kustomize ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.iac.ansible.md
+++ b/docs/coverage/detail/infra.iac.ansible.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.iac.ansible` — Ansible (playbooks)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ansible/_manifest.yaml` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ansible/_manifest.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.iac.ansible ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.iac.bicep.md
+++ b/docs/coverage/detail/infra.iac.bicep.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.iac.bicep` — Azure Bicep
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.iac.bicep ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.iac.cdk.md
+++ b/docs/coverage/detail/infra.iac.cdk.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.iac.cdk` — AWS CDK
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/cdk/_manifest.yaml` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/cdk/_manifest.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.iac.cdk ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.iac.cloudformation.md
+++ b/docs/coverage/detail/infra.iac.cloudformation.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.iac.cloudformation` — AWS CloudFormation
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.iac.cloudformation ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.iac.pulumi.md
+++ b/docs/coverage/detail/infra.iac.pulumi.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.iac.pulumi` — Pulumi
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/pulumi/_manifest.yaml` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/pulumi/_manifest.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.iac.pulumi ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.iac.serverless-framework.md
+++ b/docs/coverage/detail/infra.iac.serverless-framework.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.iac.serverless-framework` — Serverless Framework
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/serverless_edges.go` |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/serverless_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.iac.serverless-framework ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.iac.terraform.md
+++ b/docs/coverage/detail/infra.iac.terraform.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.iac.terraform` — Terraform (HCL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [infrastructure](../by-category/infrastructure.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl` |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.iac.terraform ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.observability.datadog.md
+++ b/docs/coverage/detail/infra.observability.datadog.md
@@ -1,16 +1,17 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `infra.observability.datadog` — Datadog APM / StatsD
+# `infra.observability.datadog` — Datadog
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [observability](../by-category/observability.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — |
 | `metric_extraction` | ❌ `missing` | — | — | — | — |
 | `trace_extraction` | ❌ `missing` | — | — | — | — |
 

--- a/docs/coverage/detail/infra.observability.elastic-apm.md
+++ b/docs/coverage/detail/infra.observability.elastic-apm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.observability.elastic-apm` — Elastic APM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [observability](../by-category/observability.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.observability.elastic-apm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.observability.grafana-loki.md
+++ b/docs/coverage/detail/infra.observability.grafana-loki.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.observability.grafana-loki` — Grafana Loki
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [observability](../by-category/observability.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — |
+| `metric_extraction` | — `not_applicable` | — | — | — | — |
+| `trace_extraction` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.observability.grafana-loki ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.observability.honeycomb.md
+++ b/docs/coverage/detail/infra.observability.honeycomb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.observability.honeycomb` — Honeycomb
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [observability](../by-category/observability.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.observability.honeycomb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/infra.observability.newrelic.md
+++ b/docs/coverage/detail/infra.observability.newrelic.md
@@ -5,12 +5,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [observability](../by-category/observability.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — |
 | `metric_extraction` | ❌ `missing` | — | — | — | — |
 | `trace_extraction` | ❌ `missing` | — | — | — | — |
 

--- a/docs/coverage/detail/infra.observability.opentelemetry.md
+++ b/docs/coverage/detail/infra.observability.opentelemetry.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `infra.observability.opentelemetry` — OpenTelemetry instrumentation
+# `infra.observability.opentelemetry` — OpenTelemetry (OTEL)
 
 Auto-generated. Back to [summary](../summary.md).
 
@@ -12,8 +12,8 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `log_extraction` | ❌ `missing` | — | — | — | — |
-| `metric_extraction` | ❌ `missing` | — | — | — | — |
-| `trace_extraction` | ❌ `missing` | — | — | — | — |
+| `metric_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| `trace_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/event_flow.go`<br>`internal/engine/process_flow.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.prometheus.md
+++ b/docs/coverage/detail/infra.observability.prometheus.md
@@ -1,17 +1,19 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `infra.observability.prometheus` — Prometheus client libraries
+# `infra.observability.prometheus` — Prometheus
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [observability](../by-category/observability.md)
-- **Capability cells:** 1
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `metric_extraction` | ❌ `missing` | — | — | — | — |
+| `log_extraction` | — `not_applicable` | — | — | — | — |
+| `metric_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/_engine/comment_marker_extractor.yaml` |
+| `trace_extraction` | — `not_applicable` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.sentry.md
+++ b/docs/coverage/detail/infra.observability.sentry.md
@@ -1,16 +1,18 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `infra.observability.sentry` — Sentry SDK
+# `infra.observability.sentry` — Sentry
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [observability](../by-category/observability.md)
-- **Capability cells:** 1
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | — | — |
 | `trace_extraction` | ❌ `missing` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.csharp.driver.cassandra.md
+++ b/docs/coverage/detail/lang.csharp.driver.cassandra.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.driver.cassandra` — CassandraCSharpDriver
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/cassandra_csharp.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.driver.cassandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.dynamodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.driver.dynamodb` — AWSSDK.DynamoDBv2
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/dynamodb_csharp.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.driver.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.driver.elastic.md
+++ b/docs/coverage/detail/lang.csharp.driver.elastic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.driver.elastic` — NEST (Elasticsearch .NET)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/nest_elasticsearch.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.driver.elastic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.driver.mongodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.mongodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.driver.mongodb` — MongoDB.Driver (C#)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/mongodb_csharp.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.driver.mongodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.driver.mysql.md
+++ b/docs/coverage/detail/lang.csharp.driver.mysql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.driver.mysql` — MySQL.Data / MySqlConnector
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/mysql_csharp.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.driver.mysql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.driver.neo4j.md
+++ b/docs/coverage/detail/lang.csharp.driver.neo4j.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.driver.neo4j` — Neo4j.Driver (C#)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/neo4j.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.driver.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.driver.npgsql.md
+++ b/docs/coverage/detail/lang.csharp.driver.npgsql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.driver.npgsql` — Npgsql (PostgreSQL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/npgsql.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.driver.npgsql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.driver.redis.md
+++ b/docs/coverage/detail/lang.csharp.driver.redis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.driver.redis` — StackExchange.Redis
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/redis_stackexchange.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.driver.redis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.driver.sqlite.md
+++ b/docs/coverage/detail/lang.csharp.driver.sqlite.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.driver.sqlite` — Microsoft.Data.Sqlite
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/sqlite_csharp.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.driver.sqlite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -5,15 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [csharp](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go`<br>`internal/engine/rules/csharp/frameworks/asp_net_core.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` |
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.csharp.framework.aspnet-mvc` — ASP.NET MVC (attribute-route subset)
+# `lang.csharp.framework.aspnet-mvc` — ASP.NET MVC (legacy)
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [csharp](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.blazor-server` — Blazor Server
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/blazor_server.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.blazor-server ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.blazor-wasm` — Blazor WebAssembly
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.blazor-wasm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.carter` — Carter
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.carter ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.fastendpoints` — FastEndpoints
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.fastendpoints ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.grpc-net` — grpc-dotnet
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go`<br>`internal/engine/rules/csharp/frameworks/grpc_net.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/grpc_net.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.grpc-net ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.nancyfx` — NancyFX
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.nancyfx ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.net-maui.md
+++ b/docs/coverage/detail/lang.csharp.framework.net-maui.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.net-maui` — .NET MAUI
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/net_maui.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.net-maui ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.servicestack` — ServiceStack
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.servicestack ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.uno.md
+++ b/docs/coverage/detail/lang.csharp.framework.uno.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.uno` — Uno Platform
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/uno_platform.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.uno ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.winforms.md
+++ b/docs/coverage/detail/lang.csharp.framework.winforms.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.winforms` — Windows Forms
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/winforms.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.winforms ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.wpf.md
+++ b/docs/coverage/detail/lang.csharp.framework.wpf.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.wpf` — WPF
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/wpf.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.wpf ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.framework.xamarin.md
+++ b/docs/coverage/detail/lang.csharp.framework.xamarin.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.xamarin` — Xamarin
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/xamarin.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.xamarin ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.orm.dapper.md
+++ b/docs/coverage/detail/lang.csharp.orm.dapper.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.orm.dapper` — Dapper
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/dapper.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/dapper.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.orm.dapper ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.orm.efcore.md
+++ b/docs/coverage/detail/lang.csharp.orm.efcore.md
@@ -12,8 +12,8 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/_engine/column_schema_extractor.yaml` |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/entity_framework_core.yaml`<br>`internal/engine/rules/csharp/orms/entity_framework_core.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
+++ b/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.orm.linq-to-sql` — LINQ to SQL
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.orm.linq-to-sql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.orm.linqtodb.md
+++ b/docs/coverage/detail/lang.csharp.orm.linqtodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.orm.linqtodb` — LinqToDB
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.orm.linqtodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.orm.nhibernate.md
+++ b/docs/coverage/detail/lang.csharp.orm.nhibernate.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.orm.nhibernate` — NHibernate
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.orm.nhibernate ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.dynamodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.driver.dynamodb` — ExAws DynamoDB
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.driver.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.driver.elastic.md
+++ b/docs/coverage/detail/lang.elixir.driver.elastic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.driver.elastic` — elasticsearch-elixir
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.driver.elastic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.driver.mongodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.mongodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.driver.mongodb` — mongodb (Elixir driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.driver.mongodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.driver.myxql.md
+++ b/docs/coverage/detail/lang.elixir.driver.myxql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.driver.myxql` — MyXQL
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/myxql.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.driver.myxql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.driver.neo4j.md
+++ b/docs/coverage/detail/lang.elixir.driver.neo4j.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.driver.neo4j` — bolt_sips (Neo4j)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/orms/neo4j.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.driver.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.driver.postgrex.md
+++ b/docs/coverage/detail/lang.elixir.driver.postgrex.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.driver.postgrex` — Postgrex
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/postgrex.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.driver.postgrex ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.driver.redix.md
+++ b/docs/coverage/detail/lang.elixir.driver.redix.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.driver.redix` — Redix
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/redix.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.driver.redix ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.driver.xandra.md
+++ b/docs/coverage/detail/lang.elixir.driver.xandra.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.driver.xandra` — Xandra (Cassandra)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/xandra.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.driver.xandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.framework.absinthe` — Absinthe (GraphQL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml`<br>`internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.framework.absinthe ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.framework.ash` — Ash Framework
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.framework.ash ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.framework.bandit` — Bandit
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.framework.bandit ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.framework.cowboy` — Cowboy
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.framework.cowboy ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.framework.nerves` — Nerves (embedded)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/nerves.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.framework.nerves ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.framework.oban` — Oban (job queue)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/oban.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.framework.oban ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.elixir.framework.phoenix-liveview` — Phoenix LiveView (pages indexed; lifecycle hooks not surfaced)
+# `lang.elixir.framework.phoenix-liveview` — Phoenix LiveView
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -5,15 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go`<br>`internal/engine/rules/elixir/frameworks/phoenix.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.framework.plug` — Plug
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.framework.plug ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elixir.orm.ecto-sqlite3` — ecto_sqlite3
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elixir.orm.ecto-sqlite3 ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elixir.orm.ecto.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto.md
@@ -12,8 +12,8 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ecto_standalone.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.cassandra.md
+++ b/docs/coverage/detail/lang.go.driver.cassandra.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.driver.cassandra` — gocql (Cassandra)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/cassandra_go.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.driver.cassandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.go.driver.dynamodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.driver.dynamodb` — AWS SDK DynamoDB (Go)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/dynamodb_go.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.driver.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.driver.elastic.md
+++ b/docs/coverage/detail/lang.go.driver.elastic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.driver.elastic` — go-elasticsearch
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/elasticsearch_go.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.driver.elastic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.driver.mongodb.md
+++ b/docs/coverage/detail/lang.go.driver.mongodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.driver.mongodb` — mongo-go-driver
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/mongo_driver.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.driver.mongodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.driver.mysql.md
+++ b/docs/coverage/detail/lang.go.driver.mysql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.driver.mysql` — go-sql-driver/mysql
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/mysql_go.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.driver.mysql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.driver.neo4j.md
+++ b/docs/coverage/detail/lang.go.driver.neo4j.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.driver.neo4j` — neo4j-go-driver
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/neo4j.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.driver.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.driver.redis.md
+++ b/docs/coverage/detail/lang.go.driver.redis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.driver.redis` — go-redis
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/go_redis.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.driver.redis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.driver.sqlite.md
+++ b/docs/coverage/detail/lang.go.driver.sqlite.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.driver.sqlite` — mattn/go-sqlite3
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlite_go.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.driver.sqlite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/beego.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/beego.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.buffalo` — Buffalo
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/buffalo.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/buffalo.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.buffalo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.go.framework.chi` — go-chi/chi
+# `lang.go.framework.chi` — chi
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/chi.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.go.framework.echo` — labstack/echo
+# `lang.go.framework.echo` — Echo
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/echo.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.fasthttp` — fasthttp
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.fasthttp ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.go.framework.fiber` — gofiber/fiber
+# `lang.go.framework.fiber` — Fiber
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/fiber.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.fyne.md
+++ b/docs/coverage/detail/lang.go.framework.fyne.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.fyne` — Fyne (desktop GUI)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fyne.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.fyne ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.go.framework.gin` — gin-gonic/gin
+# `lang.go.framework.gin` — Gin
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gin.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.go-zero` — go-zero
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/go_zero.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/go_zero.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.go-zero ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.gomobile.md
+++ b/docs/coverage/detail/lang.go.framework.gomobile.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.gomobile` — gomobile (mobile bindings)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/gomobile.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.gomobile ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.go.framework.gorilla-mux` — gorilla/mux
+# `lang.go.framework.gorilla-mux` — Gorilla Mux
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gorilla_mux.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.hertz` — Hertz (CloudWeGo)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/hertz.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/hertz.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.hertz ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.iris` — Iris
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/iris.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/iris.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.iris ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.kratos` — Kratos (Bilibili)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/kratos.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/kratos.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.kratos ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.go.framework.net-http` — Go net/http stdlib
+# `lang.go.framework.net-http` — net/http (stdlib)
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/net_http_stdlib.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.framework.revel` — Revel
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/revel.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/revel.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.framework.revel ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.orm.bun.md
+++ b/docs/coverage/detail/lang.go.orm.bun.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.orm.bun` — Bun (uptrace)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/bun.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/bun.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.orm.bun ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.orm.ent.md
+++ b/docs/coverage/detail/lang.go.orm.ent.md
@@ -1,18 +1,19 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.go.orm.ent` — ent
+# `lang.go.orm.ent` — ent (Facebook)
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/ent.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.gen.md
+++ b/docs/coverage/detail/lang.go.orm.gen.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.orm.gen` — gen (gentleman / GORM gen)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.orm.gen ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.orm.gorm.md
+++ b/docs/coverage/detail/lang.go.orm.gorm.md
@@ -12,8 +12,8 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/go/frameworks/gorm.yaml`<br>`internal/engine/rules/go/orms/gorm.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.migrate.md
+++ b/docs/coverage/detail/lang.go.orm.migrate.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.orm.migrate` — golang-migrate
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/golang_migrate.yaml` |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.orm.migrate ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.orm.pgx.md
+++ b/docs/coverage/detail/lang.go.orm.pgx.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.orm.pgx` — pgx (PostgreSQL driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/pgx.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.orm.pgx ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.orm.sqlc.md
+++ b/docs/coverage/detail/lang.go.orm.sqlc.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.orm.sqlc` — sqlc (codegen)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlc.yaml` |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlc.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlc.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.orm.sqlc ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.orm.sqlx.md
+++ b/docs/coverage/detail/lang.go.orm.sqlx.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.orm.sqlx` — sqlx
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlx.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlx.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.orm.sqlx ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.go.orm.xo.md
+++ b/docs/coverage/detail/lang.go.orm.xo.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.go.orm.xo` — xo (codegen)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.go.orm.xo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.akka-http` — Akka HTTP (Java DSL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.akka-http ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.android-jetpack.md
+++ b/docs/coverage/detail/lang.java.framework.android-jetpack.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.android-jetpack` — Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/android_jetpack_compose.yaml`<br>`internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.android-jetpack ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.android-sdk.md
+++ b/docs/coverage/detail/lang.java.framework.android-sdk.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.android-sdk` — Android SDK (Activity/Fragment routing)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/android_sdk.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.android-sdk ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.java.framework.dropwizard` — Dropwizard (JAX-RS subset)
+# `lang.java.framework.dropwizard` — Dropwizard
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/dropwizard.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.gwt.md
+++ b/docs/coverage/detail/lang.java.framework.gwt.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.gwt` — Google Web Toolkit (GWT)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.gwt ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.helidon` — Helidon
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.helidon ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.jakarta-ee` — Jakarta EE (Servlet / EE Platform)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.jakarta-ee ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.javalin` — Javalin
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.javalin ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -1,19 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.java.framework.jaxrs` — JAX-RS / Jakarta EE
+# `lang.java.framework.jaxrs` — JAX-RS / Jakarta REST
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/java_annotation_routes.go` |
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/jakarta_ee.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.langchain4j.md
+++ b/docs/coverage/detail/lang.java.framework.langchain4j.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.langchain4j` — LangChain4J (LLM agent framework)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/langchain4j.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.langchain4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/micronaut.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.microprofile` — Eclipse MicroProfile
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.microprofile ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.play.md
+++ b/docs/coverage/detail/lang.java.framework.play.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.play` — Play Framework
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/play_framework.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/play_framework.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.play ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -1,19 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.java.framework.quarkus` — Quarkus (JAX-RS-backed)
+# `lang.java.framework.quarkus` — Quarkus
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/quarkus.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -5,15 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/spring_routes.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/java/frameworks/spring_boot.yaml`<br>`internal/engine/rules/java/frameworks/spring_mvc.yaml`<br>`internal/engine/spring_routes.go` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` |
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_annotation_params.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -1,19 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.java.framework.spring-webflux` — Spring WebFlux
+# `lang.java.framework.spring-webflux` — Spring WebFlux (reactive)
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/spring_webflux.yaml`<br>`internal/engine/spring_routes.go` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.struts` — Apache Struts
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.struts ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.vaadin.md
+++ b/docs/coverage/detail/lang.java.framework.vaadin.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.vaadin` — Vaadin (UI-as-server)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vaadin.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vaadin.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.vaadin ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.framework.vertx` — Vert.x
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.framework.vertx ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.dynamodb.md
+++ b/docs/coverage/detail/lang.java.orm.dynamodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.dynamodb` — AWS SDK DynamoDB (Java)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.ebean.md
+++ b/docs/coverage/detail/lang.java.orm.ebean.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.ebean` — Ebean ORM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.ebean ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.eclipselink.md
+++ b/docs/coverage/detail/lang.java.orm.eclipselink.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.eclipselink` — EclipseLink
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.eclipselink ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.hibernate.md
+++ b/docs/coverage/detail/lang.java.orm.hibernate.md
@@ -1,18 +1,19 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.java.orm.hibernate` — Hibernate / JPA
+# `lang.java.orm.hibernate` — Hibernate ORM
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/hibernate_core.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.jooq.md
+++ b/docs/coverage/detail/lang.java.orm.jooq.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.jooq` — jOOQ
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/jooq.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/jooq.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.jooq ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.jpa.md
+++ b/docs/coverage/detail/lang.java.orm.jpa.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.jpa` — JPA / Jakarta Persistence API
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.jpa ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.mybatis.md
+++ b/docs/coverage/detail/lang.java.orm.mybatis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.mybatis` — MyBatis
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/mybatis.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/mybatis.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.mybatis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.neo4j.md
+++ b/docs/coverage/detail/lang.java.orm.neo4j.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.neo4j` — Neo4j (Java driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/neo4j.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/neo4j.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.spring-data-cassandra` — Spring Data Cassandra
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.spring-data-cassandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.spring-data-elastic` — Spring Data Elasticsearch
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.spring-data-elastic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
@@ -5,14 +5,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/spring_data_jpa.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.spring-data-mongo` — Spring Data MongoDB
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.spring-data-mongo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.java.orm.spring-data-redis.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-redis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.spring-data-redis` — Spring Data Redis
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.spring-data-redis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.cassandra.md
+++ b/docs/coverage/detail/lang.javascript.driver.cassandra.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.cassandra` — cassandra-driver (JS)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.cassandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.javascript.driver.dynamodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.dynamodb` — AWS SDK DynamoDB (JS)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.elastic.md
+++ b/docs/coverage/detail/lang.javascript.driver.elastic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.elastic` — @elastic/elasticsearch
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.elastic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.mongodb.md
+++ b/docs/coverage/detail/lang.javascript.driver.mongodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.mongodb` — MongoDB Node.js driver
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.mongodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.mysql.md
+++ b/docs/coverage/detail/lang.javascript.driver.mysql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.mysql` — mysql / mysql2
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mysql_js.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.mysql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.neo4j.md
+++ b/docs/coverage/detail/lang.javascript.driver.neo4j.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.neo4j` — neo4j-driver (JS)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/neo4j.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.postgres.md
+++ b/docs/coverage/detail/lang.javascript.driver.postgres.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.postgres` — node-postgres / pg
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.postgres ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.redis.md
+++ b/docs/coverage/detail/lang.javascript.driver.redis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.redis` — ioredis / node-redis
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/redis_js.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.redis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.sqlite.md
+++ b/docs/coverage/detail/lang.javascript.driver.sqlite.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.sqlite` — better-sqlite3 / sqlite3
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.sqlite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.driver.supabase.md
+++ b/docs/coverage/detail/lang.javascript.driver.supabase.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.driver.supabase` — supabase-js
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/supabase_js.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.driver.supabase ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.javascript.framework.adonisjs.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.adonisjs` — AdonisJS
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.adonisjs ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.angular.md
+++ b/docs/coverage/detail/lang.javascript.framework.angular.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/angular.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.astro.md
+++ b/docs/coverage/detail/lang.javascript.framework.astro.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.electron.md
+++ b/docs/coverage/detail/lang.javascript.framework.electron.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.electron` — Electron
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/electron.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.electron ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.expo.md
+++ b/docs/coverage/detail/lang.javascript.framework.expo.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.expo` — Expo
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.expo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.express.md
+++ b/docs/coverage/detail/lang.javascript.framework.express.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.javascript.framework.express` — Express.js
+# `lang.javascript.framework.express` — Express
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml` |
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.fastify.md
+++ b/docs/coverage/detail/lang.javascript.framework.fastify.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_extra.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_extra.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.feathers.md
+++ b/docs/coverage/detail/lang.javascript.framework.feathers.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.feathers` — Feathers
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.feathers ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.gatsby.md
+++ b/docs/coverage/detail/lang.javascript.framework.gatsby.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.gatsby` — Gatsby
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.gatsby ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.javascript.framework.graphql-resolvers.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.javascript.framework.graphql-resolvers` — GraphQL resolvers (Apollo / Yoga)
+# `lang.javascript.framework.graphql-resolvers` — GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.hapi.md
+++ b/docs/coverage/detail/lang.javascript.framework.hapi.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.hapi` — Hapi
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.hapi ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.hono.md
+++ b/docs/coverage/detail/lang.javascript.framework.hono.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.ionic.md
+++ b/docs/coverage/detail/lang.javascript.framework.ionic.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.ionic` — Ionic
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/ionic.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.ionic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.koa.md
+++ b/docs/coverage/detail/lang.javascript.framework.koa.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.langchain.md
+++ b/docs/coverage/detail/lang.javascript.framework.langchain.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.langchain` — LangChain.js
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.langchain ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.marblejs.md
+++ b/docs/coverage/detail/lang.javascript.framework.marblejs.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.marblejs` — Marble.js
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.marblejs ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.nativescript.md
+++ b/docs/coverage/detail/lang.javascript.framework.nativescript.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.nativescript` — NativeScript
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nativescript.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.nativescript ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.nestjs.md
+++ b/docs/coverage/detail/lang.javascript.framework.nestjs.md
@@ -5,15 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.next-api.md
+++ b/docs/coverage/detail/lang.javascript.framework.next-api.md
@@ -1,18 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.javascript.framework.next-api` — Next.js API routes
+# `lang.javascript.framework.next-api` — Next.js API Routes / App Router
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_extra.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_extra.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.nuxt.md
+++ b/docs/coverage/detail/lang.javascript.framework.nuxt.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.polka.md
+++ b/docs/coverage/detail/lang.javascript.framework.polka.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.polka` — Polka
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.polka ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.react-native.md
+++ b/docs/coverage/detail/lang.javascript.framework.react-native.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.react-native` — React Native
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.react-native ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.react.md
+++ b/docs/coverage/detail/lang.javascript.framework.react.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.react` — React
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.react ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.remix.md
+++ b/docs/coverage/detail/lang.javascript.framework.remix.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.restify.md
+++ b/docs/coverage/detail/lang.javascript.framework.restify.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.restify` — Restify
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.restify ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.sails.md
+++ b/docs/coverage/detail/lang.javascript.framework.sails.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.sails` — Sails
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.sails ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.svelte.md
+++ b/docs/coverage/detail/lang.javascript.framework.svelte.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.svelte` — Svelte
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/svelte.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.svelte ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.javascript.framework.sveltekit.md
@@ -1,17 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.javascript.framework.sveltekit` — Svelte / SvelteKit
+# `lang.javascript.framework.sveltekit` — SvelteKit
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.trpc.md
+++ b/docs/coverage/detail/lang.javascript.framework.trpc.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.framework.vue.md
+++ b/docs/coverage/detail/lang.javascript.framework.vue.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.framework.vue` — Vue
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/vue.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.framework.vue ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.orm.drizzle.md
+++ b/docs/coverage/detail/lang.javascript.orm.drizzle.md
@@ -1,18 +1,19 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.javascript.orm.drizzle` — Drizzle ORM
+# `lang.javascript.orm.drizzle` — Drizzle
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/drizzle.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.javascript.orm.knex.md
+++ b/docs/coverage/detail/lang.javascript.orm.knex.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.orm.knex` — Knex (query builder)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/knex.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.orm.knex ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.orm.mikro-orm.md
+++ b/docs/coverage/detail/lang.javascript.orm.mikro-orm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.orm.mikro-orm` — MikroORM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.orm.mikro-orm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.orm.mongoose.md
+++ b/docs/coverage/detail/lang.javascript.orm.mongoose.md
@@ -5,13 +5,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mongoose.yaml` |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
 
 ## Provenance

--- a/docs/coverage/detail/lang.javascript.orm.objection.md
+++ b/docs/coverage/detail/lang.javascript.orm.objection.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.javascript.orm.objection` — Objection.js
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.javascript.orm.objection ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.javascript.orm.prisma.md
+++ b/docs/coverage/detail/lang.javascript.orm.prisma.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/prisma/_manifest.yaml` |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/prisma.yaml`<br>`internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml`<br>`internal/engine/rules/prisma/_manifest.yaml` |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
 
 ## Provenance

--- a/docs/coverage/detail/lang.javascript.orm.sequelize.md
+++ b/docs/coverage/detail/lang.javascript.orm.sequelize.md
@@ -5,13 +5,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [javascript](../by-language/javascript.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/sequelize.yaml` |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
 
 ## Provenance

--- a/docs/coverage/detail/lang.javascript.orm.typeorm.md
+++ b/docs/coverage/detail/lang.javascript.orm.typeorm.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/typeorm.yaml` |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.arrow` — Arrow (functional Kotlin)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.arrow ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.compose-desktop` — Compose Desktop
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/compose_desktop.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.compose-desktop ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.compose-multiplatform` — Compose Multiplatform
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/compose_multiplatform.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.compose-multiplatform ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.compose` — Jetpack Compose (Android UI)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.compose ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.coroutines` — kotlinx.coroutines (structured concurrency)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.coroutines ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.javalin` — Javalin (Kotlin)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.javalin ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.kmp` — Kotlin Multiplatform (KMP / KMM)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/kmp.yaml`<br>`internal/engine/rules/kotlin/frameworks/kotlin_multiplatform_kmp_kmm.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.kmp ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.micronaut` — Micronaut (Kotlin)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.micronaut ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.quarkus` — Quarkus (Kotlin)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.quarkus ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -5,15 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes_kotlin.go` |
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml`<br>`internal/engine/spring_routes_kotlin.go` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes_kotlin.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.exposed.md
+++ b/docs/coverage/detail/lang.kotlin.orm.exposed.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.orm.exposed` — Exposed (JetBrains)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/exposed.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/exposed.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.orm.exposed ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.orm.hibernate.md
+++ b/docs/coverage/detail/lang.kotlin.orm.hibernate.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.orm.hibernate` — Hibernate (Kotlin)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.orm.hibernate ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.orm.ktorm.md
+++ b/docs/coverage/detail/lang.kotlin.orm.ktorm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.orm.ktorm` — Ktorm
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.orm.ktorm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.orm.mongodb.md
+++ b/docs/coverage/detail/lang.kotlin.orm.mongodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.orm.mongodb` — MongoDB (Kotlin driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.orm.mongodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.orm.room.md
+++ b/docs/coverage/detail/lang.kotlin.orm.room.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.orm.room` — Room (Android)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/room_android.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/room_android.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.orm.room ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.orm.spring-data.md
+++ b/docs/coverage/detail/lang.kotlin.orm.spring-data.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.orm.spring-data` — Spring Data (Kotlin)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.orm.spring-data ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
+++ b/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.orm.sqldelight` — SQLDelight
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.orm.sqldelight ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.driver.cassandra.md
+++ b/docs/coverage/detail/lang.php.driver.cassandra.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.driver.cassandra` — datastax/php-driver (Cassandra)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/cassandra_php.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.driver.cassandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.php.driver.dynamodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.driver.dynamodb` — AWS SDK DynamoDB (PHP)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/dynamodb_php.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.driver.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.driver.elastic.md
+++ b/docs/coverage/detail/lang.php.driver.elastic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.driver.elastic` — elasticsearch-php
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/elasticsearch_php.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.driver.elastic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.driver.mongodb.md
+++ b/docs/coverage/detail/lang.php.driver.mongodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.driver.mongodb` — mongodb (PHP driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/mongodb_php.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.driver.mongodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.driver.mysql.md
+++ b/docs/coverage/detail/lang.php.driver.mysql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.driver.mysql` — PDO MySQL / mysqli
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/mysql_php.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.driver.mysql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.driver.neo4j.md
+++ b/docs/coverage/detail/lang.php.driver.neo4j.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.driver.neo4j` — neo4j-php-client
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/neo4j.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.driver.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.driver.postgres.md
+++ b/docs/coverage/detail/lang.php.driver.postgres.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.driver.postgres` — PDO PostgreSQL
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/postgresql_php.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.driver.postgres ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.driver.redis.md
+++ b/docs/coverage/detail/lang.php.driver.redis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.driver.redis` — phpredis / Predis
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/redis_php.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.driver.redis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.driver.sqlite.md
+++ b/docs/coverage/detail/lang.php.driver.sqlite.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.driver.sqlite` — PDO SQLite
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/sqlite_php.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.driver.sqlite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.cakephp` — CakePHP
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/cakephp.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/cakephp.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.cakephp ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.codeigniter` — CodeIgniter
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.codeigniter ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.drupal` — Drupal
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/drupal.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/drupal.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.drupal ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.laminas` — Laminas (formerly Zend)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/laminas.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/laminas.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.laminas ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -5,15 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/laravel.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.lumen` — Lumen
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.lumen ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.magento` — Magento
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/magento.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/magento.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.magento ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.phalcon` — Phalcon
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.phalcon ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/slim.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/slim.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2717) | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/symfony.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.wordpress` — WordPress
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/wordpress.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/wordpress.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.wordpress ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.yii` — Yii
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/yii.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/yii.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.yii ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.orm.cycleorm.md
+++ b/docs/coverage/detail/lang.php.orm.cycleorm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.orm.cycleorm` — CycleORM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.orm.cycleorm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.orm.doctrine.md
+++ b/docs/coverage/detail/lang.php.orm.doctrine.md
@@ -1,18 +1,19 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.php.orm.doctrine` — Doctrine
+# `lang.php.orm.doctrine` — Doctrine ORM
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/doctrine_orm.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.eloquent.md
+++ b/docs/coverage/detail/lang.php.orm.eloquent.md
@@ -1,18 +1,19 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.php.orm.eloquent` — Eloquent (Laravel ActiveRecord)
+# `lang.php.orm.eloquent` — Eloquent (Laravel)
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/php/eloquent.go` |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/eloquent_laravel_orm.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.propel.md
+++ b/docs/coverage/detail/lang.php.orm.propel.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.orm.propel` — Propel
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/propel.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/propel.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.orm.propel ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.php.orm.redbeanphp.md
+++ b/docs/coverage/detail/lang.php.orm.redbeanphp.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.orm.redbeanphp` — RedBeanPHP
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/redbeanphp.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/redbeanphp.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.orm.redbeanphp ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.driver.cassandra.md
+++ b/docs/coverage/detail/lang.python.driver.cassandra.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.driver.cassandra` — cassandra-driver
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/cassandra_py.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.driver.cassandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.python.driver.dynamodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.driver.dynamodb` — boto3 DynamoDB
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/dynamodb_py.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.driver.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.driver.elastic.md
+++ b/docs/coverage/detail/lang.python.driver.elastic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.driver.elastic` — elasticsearch-py
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/elasticsearch_py.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.driver.elastic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.driver.mysql.md
+++ b/docs/coverage/detail/lang.python.driver.mysql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.driver.mysql` — MySQL (PyMySQL / mysqlclient)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/mysql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.driver.mysql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.driver.neo4j.md
+++ b/docs/coverage/detail/lang.python.driver.neo4j.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.driver.neo4j` — neo4j (Python driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/neo4j.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.driver.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.driver.postgres.md
+++ b/docs/coverage/detail/lang.python.driver.postgres.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.driver.postgres` — psycopg / asyncpg (PostgreSQL drivers)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/postgresql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.driver.postgres ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.driver.redis.md
+++ b/docs/coverage/detail/lang.python.driver.redis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.driver.redis` — redis-py
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/redis_py.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.driver.redis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.driver.sqlite.md
+++ b/docs/coverage/detail/lang.python.driver.sqlite.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.driver.sqlite` — sqlite3 (stdlib)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/sqlite_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.driver.sqlite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/bottle.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/bottle.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.celery.md
+++ b/docs/coverage/detail/lang.python.framework.celery.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.celery` — Celery (task queue)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/celery.yaml`<br>`internal/extractors/python/celery.go` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.celery ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.cherrypy` — CherryPy
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.cherrypy ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -5,15 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-27` | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | `internal/engine/django_drf_actions.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/engine/http_endpoint_synthesis.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go` |
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/django_drf_actions.go` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/drf_serializer_fields.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -1,19 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.python.framework.django` — Django (URLconf)
+# `lang.python.framework.django` — Django
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_routes.go`<br>`internal/engine/django_urlconf_nested.go`<br>`internal/engine/http_endpoint_synthesis.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go` |
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_routes.go`<br>`internal/engine/django_urlconf_nested.go`<br>`internal/engine/rules/python/frameworks/django.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_admin_routes.go`<br>`internal/engine/django_routes.go` |
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_imports_rewrite.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.dramatiq.md
+++ b/docs/coverage/detail/lang.python.framework.dramatiq.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.dramatiq` — Dramatiq (task queue)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/dramatiq.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.dramatiq ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.falcon` — Falcon
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.falcon ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/fastapi.yaml` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/fastapi.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/fastapi.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/flask.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/flask.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.hug` — Hug
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.hug ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.langchain.md
+++ b/docs/coverage/detail/lang.python.framework.langchain.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.langchain` — LangChain (LLM agent framework)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/langchain.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.langchain ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/litestar.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/litestar.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pyramid.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pyramid.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.quart` — Quart
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.quart ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/robyn.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/robyn.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/sanic.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/sanic.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/starlette.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/starlette.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.framework.strawberry-graphql` — Strawberry GraphQL
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/strawberry_python.yaml`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/strawberry_graphql.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.framework.strawberry-graphql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/tornado.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/tornado.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.alembic.md
+++ b/docs/coverage/detail/lang.python.orm.alembic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.orm.alembic` — Alembic (migration tool)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/alembic.yaml` |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.orm.alembic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.orm.beanie` — Beanie (async MongoDB ODM)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/beanie.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/beanie.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.orm.beanie ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.orm.django.md
+++ b/docs/coverage/detail/lang.python.orm.django.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/python/django_migration.go` |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/python/django_relational.go`<br>`internal/extractors/python/extractor.go` |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/django_orm.yaml`<br>`internal/extractors/python/django_relational.go` |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
 
 ## Provenance

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -5,14 +5,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/mongoengine.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/mongoengine.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.peewee.md
+++ b/docs/coverage/detail/lang.python.orm.peewee.md
@@ -5,14 +5,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/peewee.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/peewee.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.pony.md
+++ b/docs/coverage/detail/lang.python.orm.pony.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.python.orm.pony` — Pony ORM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/pony_orm.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/pony_orm.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.python.orm.pony ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.python.orm.sqlalchemy.md
+++ b/docs/coverage/detail/lang.python.orm.sqlalchemy.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ⚠️ `partial` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2720) | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/alembic.yaml` |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/python/orms/sqlalchemy.yaml` |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
 
 ## Provenance

--- a/docs/coverage/detail/lang.python.orm.sqlmodel.md
+++ b/docs/coverage/detail/lang.python.orm.sqlmodel.md
@@ -5,14 +5,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/sqlmodel.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.tortoise.md
+++ b/docs/coverage/detail/lang.python.orm.tortoise.md
@@ -5,14 +5,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/tortoise_orm.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.cassandra.md
+++ b/docs/coverage/detail/lang.ruby.driver.cassandra.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.driver.cassandra` — cassandra-driver (Ruby)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/cassandra_ruby.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.driver.cassandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.ruby.driver.dynamodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.driver.dynamodb` — AWS SDK DynamoDB (Ruby)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/dynamodb_ruby.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.driver.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.driver.elastic.md
+++ b/docs/coverage/detail/lang.ruby.driver.elastic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.driver.elastic` — elasticsearch-ruby
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.driver.elastic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.driver.mysql.md
+++ b/docs/coverage/detail/lang.ruby.driver.mysql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.driver.mysql` — mysql2 (Ruby driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/mysql_ruby.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.driver.mysql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.driver.neo4j.md
+++ b/docs/coverage/detail/lang.ruby.driver.neo4j.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.driver.neo4j` — neo4j-ruby-driver
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/neo4j.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.driver.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.driver.postgres.md
+++ b/docs/coverage/detail/lang.ruby.driver.postgres.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.driver.postgres` — pg (Ruby driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/pg_ruby.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.driver.postgres ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.driver.redis.md
+++ b/docs/coverage/detail/lang.ruby.driver.redis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.driver.redis` — redis-rb
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/redis_rb.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.driver.redis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.driver.sqlite.md
+++ b/docs/coverage/detail/lang.ruby.driver.sqlite.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.driver.sqlite` — sqlite3 (Ruby driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/sqlite_ruby.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.driver.sqlite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.framework.cuba` — Cuba
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.framework.cuba ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.framework.dry-rb` — dry-rb (ecosystem)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/dry_rb.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.framework.dry-rb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/grape.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/grape.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.framework.padrino` — Padrino
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.framework.padrino ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -5,15 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.framework.roda` — Roda
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/roda.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/roda.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.framework.roda ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/sinatra.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.activerecord.md
+++ b/docs/coverage/detail/lang.ruby.orm.activerecord.md
@@ -5,14 +5,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/ormlink/extractor.go` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/activerecord.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.datamapper.md
+++ b/docs/coverage/detail/lang.ruby.orm.datamapper.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.orm.datamapper` — DataMapper / Hanami Model (legacy)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.orm.datamapper ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.orm.mongoid.md
+++ b/docs/coverage/detail/lang.ruby.orm.mongoid.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.orm.mongoid` — Mongoid
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/mongoid.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/mongoid.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.orm.mongoid ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.orm.rom-rb.md
+++ b/docs/coverage/detail/lang.ruby.orm.rom-rb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.orm.rom-rb` — ROM (Ruby Object Mapper)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml`<br>`internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.orm.rom-rb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ruby.orm.sequel.md
+++ b/docs/coverage/detail/lang.ruby.orm.sequel.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ruby.orm.sequel` — Sequel
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/sequel.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/sequel.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ruby.orm.sequel ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.driver.cassandra.md
+++ b/docs/coverage/detail/lang.rust.driver.cassandra.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.driver.cassandra` — cdrs / scylla-rust-driver
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/cassandra_rust.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.driver.cassandra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.rust.driver.dynamodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.driver.dynamodb` — aws-sdk-dynamodb (Rust)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/dynamodb_rust.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.driver.dynamodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.driver.elastic.md
+++ b/docs/coverage/detail/lang.rust.driver.elastic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.driver.elastic` — elasticsearch-rs
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/elasticsearch_rs.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.driver.elastic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.driver.mongodb.md
+++ b/docs/coverage/detail/lang.rust.driver.mongodb.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.driver.mongodb` — mongodb (Rust driver)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/mongodb_mongodb.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.driver.mongodb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.driver.mysql.md
+++ b/docs/coverage/detail/lang.rust.driver.mysql.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.driver.mysql` — mysql / mysql_async
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/mysql_rust.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.driver.mysql ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.driver.neo4j.md
+++ b/docs/coverage/detail/lang.rust.driver.neo4j.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.driver.neo4j` — neo4rs
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/neo4j.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.driver.neo4j ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.driver.postgres.md
+++ b/docs/coverage/detail/lang.rust.driver.postgres.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.driver.postgres` — tokio-postgres / postgres
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/postgresql_rust.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.driver.postgres ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.driver.redis.md
+++ b/docs/coverage/detail/lang.rust.driver.redis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.driver.redis` — redis-rs
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/redis_redis_rs.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.driver.redis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.driver.sqlite.md
+++ b/docs/coverage/detail/lang.rust.driver.sqlite.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.driver.sqlite` — sqlite (Rust)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/sqlite_rust.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.driver.sqlite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -1,17 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.rust.framework.actix` — Actix
+# `lang.rust.framework.actix` — Actix Web
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go`<br>`internal/engine/rules/rust/frameworks/axum.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.gotham` — Gotham
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/gotham.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/gotham.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.gotham ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -1,17 +1,20 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.rust.framework.hyper` — Hyper
+# `lang.rust.framework.hyper` — hyper
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/hyper.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/hyper.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.poem` — Poem
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/poem.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/poem.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.poem ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -5,14 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 2
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go` |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go`<br>`internal/engine/rules/rust/frameworks/rocket.yaml` |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.salvo` — Salvo
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.salvo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.tauri.md
+++ b/docs/coverage/detail/lang.rust.framework.tauri.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.tauri` — Tauri (desktop)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tauri.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.tauri ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.tide` — Tide
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tide.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tide.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.tide ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.tower` — Tower (service abstraction)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.tower ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -5,13 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Capability cells:** 4
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/warp.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/warp.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.diesel.md
+++ b/docs/coverage/detail/lang.rust.orm.diesel.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.orm.diesel` — Diesel
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/diesel.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/diesel.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.orm.diesel ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.orm.rbatis.md
+++ b/docs/coverage/detail/lang.rust.orm.rbatis.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.orm.rbatis` — Rbatis
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.orm.rbatis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.orm.rusqlite.md
+++ b/docs/coverage/detail/lang.rust.orm.rusqlite.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.orm.rusqlite` — rusqlite
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/rusqlite.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.orm.rusqlite ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.orm.seaorm.md
+++ b/docs/coverage/detail/lang.rust.orm.seaorm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.orm.seaorm` — SeaORM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/seaorm.yaml` |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/seaorm.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.orm.seaorm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.orm.sqlx.md
+++ b/docs/coverage/detail/lang.rust.orm.sqlx.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.orm.sqlx` — sqlx (Rust)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/sqlx.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/sqlx.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.orm.sqlx ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.akka-http` — Akka HTTP / Pekko HTTP
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.akka-http ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.cask` — Cask
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.cask ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.cats-effect` — Cats Effect (concurrency runtime)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/cats_effect.yaml` |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.cats-effect ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.finatra` — Finatra (Twitter Finagle)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.finatra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.http4s` — http4s
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.http4s ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.lagom` — Lagom
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.lagom ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.play.md
+++ b/docs/coverage/detail/lang.scala.framework.play.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.play` — Play Framework (Scala)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/play_framework.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/play_framework.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.play ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.scalatra` — Scalatra
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.scalatra ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.zio-http` — ZIO HTTP / ZIO
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Capability cells:** 4
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.zio-http ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.orm.doobie.md
+++ b/docs/coverage/detail/lang.scala.orm.doobie.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.orm.doobie` — Doobie
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/doobie.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/doobie.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.orm.doobie ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.orm.elastic4s.md
+++ b/docs/coverage/detail/lang.scala.orm.elastic4s.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.orm.elastic4s` — Elastic4s
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/elastic4s.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/elastic4s.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.orm.elastic4s ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.orm.quill.md
+++ b/docs/coverage/detail/lang.scala.orm.quill.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.orm.quill` — Quill
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/quill.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/quill.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.orm.quill ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.orm.scalikejdbc.md
+++ b/docs/coverage/detail/lang.scala.orm.scalikejdbc.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.orm.scalikejdbc` — ScalikeJDBC
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.orm.scalikejdbc ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.orm.scanamo.md
+++ b/docs/coverage/detail/lang.scala.orm.scanamo.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.orm.scanamo` — Scanamo (DynamoDB)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scanamo.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scanamo.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.orm.scanamo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.orm.slick.md
+++ b/docs/coverage/detail/lang.scala.orm.slick.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.orm.slick` — Slick
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/slick.yaml` |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/slick.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.orm.slick ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.broker.amqp.md
+++ b/docs/coverage/detail/msg.broker.amqp.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `msg.broker.amqp` — AMQP (generic)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.broker.amqp ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.broker.azure-service-bus.md
+++ b/docs/coverage/detail/msg.broker.azure-service-bus.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `msg.broker.azure-service-bus` — Azure Service Bus
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `consumer_extraction` | ❌ `missing` | — | — | — | — |
+| `producer_extraction` | ❌ `missing` | — | — | — | — |
+| `topic_attribution` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.broker.azure-service-bus ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.broker.cloudevents.md
+++ b/docs/coverage/detail/msg.broker.cloudevents.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.debezium.md
+++ b/docs/coverage/detail/msg.broker.debezium.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `msg.broker.debezium` — Debezium / Kafka Connect CDC
+# `msg.broker.debezium` — Debezium (CDC)
 
 Auto-generated. Back to [summary](../summary.md).
 
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|
 | `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` |
 | `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.eventbridge.md
+++ b/docs/coverage/detail/msg.broker.eventbridge.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.eventgrid.md
+++ b/docs/coverage/detail/msg.broker.eventgrid.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.gcp-pubsub.md
+++ b/docs/coverage/detail/msg.broker.gcp-pubsub.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.kafka.md
+++ b/docs/coverage/detail/msg.broker.kafka.md
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|
 | `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go` |
 | `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go`<br>`internal/engine/kafka_wrapper_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.mqtt.md
+++ b/docs/coverage/detail/msg.broker.mqtt.md
@@ -5,14 +5,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ❌ `missing` | — | — | — | — |
-| `producer_extraction` | ❌ `missing` | — | — | — | — |
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.nats.md
+++ b/docs/coverage/detail/msg.broker.nats.md
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|
 | `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/nats_edges.go` |
 | `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/nats_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/nats_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.pulsar.md
+++ b/docs/coverage/detail/msg.broker.pulsar.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.rabbitmq.md
+++ b/docs/coverage/detail/msg.broker.rabbitmq.md
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|
 | `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
 | `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.redis.md
+++ b/docs/coverage/detail/msg.broker.redis.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `msg.broker.redis` — Redis pub/sub + Streams
+# `msg.broker.redis` — Redis pub/sub & streams
 
 Auto-generated. Back to [summary](../summary.md).
 
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|
 | `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
 | `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.sns.md
+++ b/docs/coverage/detail/msg.broker.sns.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `msg.broker.sns` — AWS SNS (IaC-declared)
+# `msg.broker.sns` — AWS SNS
 
 Auto-generated. Back to [summary](../summary.md).
 
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|
 | `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` |
 | `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.sqs.md
+++ b/docs/coverage/detail/msg.broker.sqs.md
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|
 | `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` |
 | `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.sse.md
+++ b/docs/coverage/detail/msg.sse.md
@@ -5,7 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -13,6 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|
 | `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sse_edges.go` |
 | `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sse_edges.go` |
+| `topic_attribution` | — `not_applicable` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.webhook.md
+++ b/docs/coverage/detail/msg.webhook.md
@@ -1,11 +1,11 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `msg.webhook` — Webhook inbound (Stripe, GitHub, Twilio, Slack, SendGrid, Mailgun, ...)
+# `msg.webhook` — Webhooks
 
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [multi](../by-language/multi.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
-- **Capability cells:** 2
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -13,6 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|
 | `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/webhooks_edges.go` |
 | `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/webhooks_edges.go` |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/webhooks_edges.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.websocket.md
+++ b/docs/coverage/detail/msg.websocket.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `msg.websocket` — WebSocket channels
+# `msg.websocket` — WebSocket
 
 Auto-generated. Back to [summary](../summary.md).
 

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `protocol.graphql` — GraphQL SDL (Query/Mutation/Subscription)
+# `protocol.graphql` — GraphQL
 
 Auto-generated. Back to [summary](../summary.md).
 
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ⚠️ `partial` | — | — | — | — |
+| `cross_repo_linkage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/http_endpoint_match.go` |
 | `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go` |
-| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/graphql/graphql.go` |
+| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go`<br>`internal/engine/rules/graphql/frameworks/graphql_schema.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `protocol.grpc` — gRPC services
+# `protocol.grpc` — gRPC
 
 Auto-generated. Back to [summary](../summary.md).
 
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/links/grpc_pass.go` |
+| `cross_repo_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
 | `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
 | `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
 

--- a/docs/coverage/detail/protocol.jsonrpc.md
+++ b/docs/coverage/detail/protocol.jsonrpc.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `protocol.jsonrpc` — JSON-RPC
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [protocol](../by-category/protocol.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `cross_repo_linkage` | ❌ `missing` | — | — | — | — |
+| `method_attribution` | ❌ `missing` | — | — | — | — |
+| `service_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update protocol.jsonrpc ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/protocol.openapi.md
+++ b/docs/coverage/detail/protocol.openapi.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `protocol.openapi` — OpenAPI / Swagger spec
+# `protocol.openapi` — OpenAPI / Swagger
 
 Auto-generated. Back to [summary](../summary.md).
 
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/links/openapi_pass.go` |
-| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/openapi_pass.go` |
-| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/links/openapi_pass.go` |
+| `cross_repo_linkage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/http_endpoint_match.go` |
+| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/openapi/language.yaml` |
+| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/openapi/language.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.protobuf.md
+++ b/docs/coverage/detail/protocol.protobuf.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `protocol.protobuf` — Protocol Buffers (.proto)
+# `protocol.protobuf` — Protocol Buffers
 
 Auto-generated. Back to [summary](../summary.md).
 
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
-| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/proto/proto.go` |
-| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/proto/proto.go` |
+| `cross_repo_linkage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
+| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/proto` |
+| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/protobuf/_manifest.yaml`<br>`internal/extractors/proto` |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.soap.md
+++ b/docs/coverage/detail/protocol.soap.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `protocol.soap` — SOAP / WSDL
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [protocol](../by-category/protocol.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `cross_repo_linkage` | ❌ `missing` | — | — | — | — |
+| `method_attribution` | ❌ `missing` | — | — | — | — |
+| `service_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update protocol.soap ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/security.auth.basic.md
+++ b/docs/coverage/detail/security.auth.basic.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `security.auth.basic` — HTTP Basic Auth
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [security](../by-category/security.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `secret_detection` | ❌ `missing` | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update security.auth.basic ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/security.auth.jwt.md
+++ b/docs/coverage/detail/security.auth.jwt.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `security.auth.jwt` — JWT
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [security](../by-category/security.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `secret_detection` | ❌ `missing` | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update security.auth.jwt ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/security.auth.oauth2.md
+++ b/docs/coverage/detail/security.auth.oauth2.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `security.auth.oauth2` — OAuth2
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [security](../by-category/security.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `secret_detection` | ❌ `missing` | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update security.auth.oauth2 ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/security.auth.oidc.md
+++ b/docs/coverage/detail/security.auth.oidc.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `security.auth.oidc` — OIDC (OpenID Connect)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [security](../by-category/security.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `secret_detection` | ❌ `missing` | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update security.auth.oidc ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/security.auth.saml.md
+++ b/docs/coverage/detail/security.auth.saml.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `security.auth.saml` — SAML
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [security](../by-category/security.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_policy` | ❌ `missing` | — | — | — | — |
+| `secret_detection` | ❌ `missing` | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update security.auth.saml ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/security.auth.session.md
+++ b/docs/coverage/detail/security.auth.session.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `security.auth.session` — Session cookies
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [security](../by-category/security.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| `secret_detection` | ❌ `missing` | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update security.auth.session ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.assertj.md
+++ b/docs/coverage/detail/test.assertj.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.assertj` — AssertJ
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.assertj ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.ava.md
+++ b/docs/coverage/detail/test.ava.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.ava` — AVA
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.ava ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.behat.md
+++ b/docs/coverage/detail/test.behat.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.behat` — Behat
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.behat ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.cargo-test.md
+++ b/docs/coverage/detail/test.cargo-test.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.cargo-test` — cargo test (stdlib)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.cargo-test ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.codeception.md
+++ b/docs/coverage/detail/test.codeception.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.codeception` — Codeception
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.codeception ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.criterion.md
+++ b/docs/coverage/detail/test.criterion.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.criterion` — criterion (benchmark)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.criterion ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.cucumber.md
+++ b/docs/coverage/detail/test.cucumber.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.cucumber` — Cucumber
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.cucumber ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.cypress.md
+++ b/docs/coverage/detail/test.cypress.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.cypress` — Cypress
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.cypress ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.doctest.md
+++ b/docs/coverage/detail/test.doctest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.doctest` — doctest (stdlib)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.doctest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.exunit.md
+++ b/docs/coverage/detail/test.exunit.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.exunit` — ExUnit
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.exunit ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.fluentassertions.md
+++ b/docs/coverage/detail/test.fluentassertions.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.fluentassertions` — FluentAssertions
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.fluentassertions ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.ginkgo.md
+++ b/docs/coverage/detail/test.ginkgo.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.ginkgo` — Ginkgo
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.ginkgo ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.go-testing.md
+++ b/docs/coverage/detail/test.go-testing.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.go-testing` — go testing (stdlib)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.go-testing ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.gomega.md
+++ b/docs/coverage/detail/test.gomega.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.gomega` — Gomega
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.gomega ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.hypothesis.md
+++ b/docs/coverage/detail/test.hypothesis.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.hypothesis` — Hypothesis (property tests)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.hypothesis ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.jasmine.md
+++ b/docs/coverage/detail/test.jasmine.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.jasmine` — Jasmine
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.jasmine ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.jest.md
+++ b/docs/coverage/detail/test.jest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.jest` — Jest
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/jest.yaml`<br>`internal/engine/tests_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.jest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.junit4.md
+++ b/docs/coverage/detail/test.junit4.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.junit4` — JUnit 4
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/test_patterns.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.junit4 ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.junit5.md
+++ b/docs/coverage/detail/test.junit5.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.junit5` — JUnit 5
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/junit5.yaml`<br>`internal/engine/tests_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.junit5 ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.minitest.md
+++ b/docs/coverage/detail/test.minitest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.minitest` — Minitest
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/test_patterns.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.minitest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.mocha.md
+++ b/docs/coverage/detail/test.mocha.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.mocha` — Mocha
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/test_patterns.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.mocha ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.mockall.md
+++ b/docs/coverage/detail/test.mockall.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.mockall` — mockall
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.mockall ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.mockito.md
+++ b/docs/coverage/detail/test.mockito.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.mockito` — Mockito
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.mockito ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.mstest.md
+++ b/docs/coverage/detail/test.mstest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.mstest` — MSTest
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/test_patterns.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.mstest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.nose2.md
+++ b/docs/coverage/detail/test.nose2.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.nose2` — nose2
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.nose2 ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.nunit.md
+++ b/docs/coverage/detail/test.nunit.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.nunit` — NUnit
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/test_patterns.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.nunit ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.pest.md
+++ b/docs/coverage/detail/test.pest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.pest` — Pest
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.pest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.phpunit.md
+++ b/docs/coverage/detail/test.phpunit.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.phpunit` — PHPUnit
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.phpunit ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.playwright.md
+++ b/docs/coverage/detail/test.playwright.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.playwright` — Playwright
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.playwright ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.proptest.md
+++ b/docs/coverage/detail/test.proptest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.proptest` — proptest
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.proptest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.pytest.md
+++ b/docs/coverage/detail/test.pytest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.pytest` — pytest
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pytest.yaml`<br>`internal/engine/tests_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.pytest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.restassured.md
+++ b/docs/coverage/detail/test.restassured.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.restassured` — REST-assured
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.restassured ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.rspec.md
+++ b/docs/coverage/detail/test.rspec.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.rspec` — RSpec
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ruby](../by-language/ruby.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/rspec.yaml`<br>`internal/engine/tests_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.rspec ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.spock.md
+++ b/docs/coverage/detail/test.spock.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.spock` — Spock
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [groovy](../by-language/groovy.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.spock ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.streamdata.md
+++ b/docs/coverage/detail/test.streamdata.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.streamdata` — StreamData (property tests)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elixir](../by-language/elixir.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.streamdata ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.tap.md
+++ b/docs/coverage/detail/test.tap.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.tap` — tap / node:test
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.tap ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.testify.md
+++ b/docs/coverage/detail/test.testify.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.testify` — testify
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [go](../by-language/go.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/test_patterns.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.testify ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.testng.md
+++ b/docs/coverage/detail/test.testng.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.testng` — TestNG
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/test_patterns.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.testng ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.unittest.md
+++ b/docs/coverage/detail/test.unittest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.unittest` — unittest (stdlib)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [python](../by-language/python.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/test_patterns.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.unittest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.vitest.md
+++ b/docs/coverage/detail/test.vitest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.vitest` — Vitest
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [javascript](../by-language/javascript.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/test_patterns.yaml` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.vitest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.xunit.md
+++ b/docs/coverage/detail/test.xunit.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.xunit` — xUnit
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [csharp](../by-language/csharp.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.xunit ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -7,14 +7,86 @@
       "language": "multi",
       "label": "Bazel / BUCK / WORKSPACE",
       "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/extractors/bazel/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
         "target_extraction": {
           "status": "full",
           "cites": ["internal/extractors/bazel/parser.go"],
           "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.bun",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Bun (runtime + manager)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
         },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.bundler",
+      "category": "build_system",
+      "language": "ruby",
+      "label": "Bundler (Gemfile)",
+      "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/extractors/bazel/extractor.go"],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.cargo",
+      "category": "build_system",
+      "language": "rust",
+      "label": "Cargo (Cargo.toml)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.composer",
+      "category": "build_system",
+      "language": "php",
+      "label": "Composer",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/php/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/php/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -25,14 +97,128 @@
       "language": "multi",
       "label": "Dockerfile",
       "capabilities": {
-        "target_extraction": {
+        "dependency_graph": {
           "status": "full",
           "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         },
-        "dependency_graph": {
+        "target_extraction": {
           "status": "full",
           "cites": ["internal/extractors/dockerfile/dockerfile.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.dotnet",
+      "category": "build_system",
+      "language": "csharp",
+      "label": "dotnet CLI / MSBuild",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.esbuild",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "esbuild",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.flit",
+      "category": "build_system",
+      "language": "python",
+      "label": "Flit",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.go-modules",
+      "category": "build_system",
+      "language": "go",
+      "label": "go modules (go.mod / go.sum)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/extractors/golang/gomod.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/go/build_tools.yaml","internal/extractors/golang/gomod.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.gradle",
+      "category": "build_system",
+      "language": "java",
+      "label": "Gradle (Groovy + Kotlin DSL)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/java/build_tools.yaml","internal/engine/rules/kotlin/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.hatch",
+      "category": "build_system",
+      "language": "python",
+      "label": "Hatch",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.hex",
+      "category": "build_system",
+      "language": "elixir",
+      "label": "Hex",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -43,15 +229,43 @@
       "language": "multi",
       "label": "Justfile",
       "capabilities": {
-        "target_extraction": {
-          "status": "full",
-          "cites": ["internal/extractors/just/just.go"],
-          "verified_at": "2026-05-28"
-        },
         "dependency_graph": {
           "status": "full",
           "cites": ["internal/extractors/just/just.go"],
           "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/just/just.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.lerna",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Lerna",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.mage",
+      "category": "build_system",
+      "language": "go",
+      "label": "Mage",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
         }
       }
     },
@@ -61,13 +275,517 @@
       "language": "multi",
       "label": "Makefile",
       "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
         "target_extraction": {
           "status": "partial",
           "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.maven",
+      "category": "build_system",
+      "language": "java",
+      "label": "Maven (pom.xml)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
+          "verified_at": "2026-05-28"
         },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.mill",
+      "category": "build_system",
+      "language": "scala",
+      "label": "Mill",
+      "capabilities": {
         "dependency_graph": {
           "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.mix",
+      "category": "build_system",
+      "language": "elixir",
+      "label": "Mix (mix.exs)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.npm",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "npm",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.nuget",
+      "category": "build_system",
+      "language": "csharp",
+      "label": "NuGet",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.nx",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Nx (monorepo)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.parcel",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Parcel",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.pip",
+      "category": "build_system",
+      "language": "python",
+      "label": "pip (requirements.txt)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.pipenv",
+      "category": "build_system",
+      "language": "python",
+      "label": "Pipenv",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.pnpm",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "pnpm",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.poetry",
+      "category": "build_system",
+      "language": "python",
+      "label": "Poetry",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.rake",
+      "category": "build_system",
+      "language": "ruby",
+      "label": "Rake",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.rollup",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Rollup",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.sbt",
+      "category": "build_system",
+      "language": "scala",
+      "label": "SBT",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.setuptools",
+      "category": "build_system",
+      "language": "python",
+      "label": "setuptools / setup.py",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.task",
+      "category": "build_system",
+      "language": "go",
+      "label": "Task (taskfile.dev)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.turborepo",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Turborepo",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "build.uv",
+      "category": "build_system",
+      "language": "python",
+      "label": "uv (Astral)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.vite",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Vite",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.webpack",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Webpack",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "build.yarn",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Yarn",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "ci.azure-pipelines",
+      "category": "configuration",
+      "language": "multi",
+      "label": "Azure Pipelines",
+      "capabilities": {
+        "env_resolution": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "file_parsing": {
+          "status": "full",
+          "cites": ["internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "ci.bitbucket",
+      "category": "configuration",
+      "language": "multi",
+      "label": "Bitbucket Pipelines",
+      "capabilities": {
+        "env_resolution": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "file_parsing": {
+          "status": "full",
+          "cites": ["internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "ci.buildkite",
+      "category": "configuration",
+      "language": "multi",
+      "label": "Buildkite",
+      "capabilities": {
+        "env_resolution": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "file_parsing": {
+          "status": "full",
+          "cites": ["internal/engine/rules/cicd/frameworks/buildkite.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "ci.circleci",
+      "category": "configuration",
+      "language": "multi",
+      "label": "CircleCI",
+      "capabilities": {
+        "env_resolution": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "file_parsing": {
+          "status": "full",
+          "cites": ["internal/engine/rules/cicd/frameworks/circleci.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "ci.drone",
+      "category": "configuration",
+      "language": "multi",
+      "label": "Drone CI",
+      "capabilities": {
+        "env_resolution": {
+          "status": "missing"
+        },
+        "file_parsing": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "ci.github-actions",
+      "category": "configuration",
+      "language": "multi",
+      "label": "GitHub Actions",
+      "capabilities": {
+        "env_resolution": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "file_parsing": {
+          "status": "full",
+          "cites": ["internal/engine/rules/cicd/frameworks/github_actions.yaml","internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "ci.gitlab",
+      "category": "configuration",
+      "language": "multi",
+      "label": "GitLab CI",
+      "capabilities": {
+        "env_resolution": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "file_parsing": {
+          "status": "full",
+          "cites": ["internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "ci.jenkins",
+      "category": "configuration",
+      "language": "multi",
+      "label": "Jenkins (Jenkinsfile)",
+      "capabilities": {
+        "env_resolution": {
+          "status": "missing"
+        },
+        "file_parsing": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/cicd/_manifest.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "ci.travis",
+      "category": "configuration",
+      "language": "multi",
+      "label": "Travis CI",
+      "capabilities": {
+        "env_resolution": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "file_parsing": {
+          "status": "full",
+          "cites": ["internal/engine/rules/cicd/frameworks/travis_ci.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -90,12 +808,12 @@
       "language": "multi",
       "label": ".env (names-only — values stripped at extraction boundary)",
       "capabilities": {
-        "file_parsing": {
+        "env_resolution": {
           "status": "full",
           "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         },
-        "env_resolution": {
+        "file_parsing": {
           "status": "full",
           "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
@@ -173,7 +891,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go", "internal/extractors/config/discover.go"],
+          "cites": ["internal/extractors/config/discover.go","internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -199,7 +917,397 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go", "internal/extractors/config/discover.go"],
+          "cites": ["internal/extractors/config/discover.go","internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "db.cassandra",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Apache Cassandra (schema)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "missing"
+        },
+        "resource_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "db.clickhouse",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "ClickHouse",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "missing"
+        },
+        "resource_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "db.dynamodb",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "AWS DynamoDB",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/iac_sns_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "db.elasticsearch",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Elasticsearch (indices)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "db.mongodb",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "MongoDB (collections)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "db.mysql",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "MySQL / MariaDB (schema)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "db.neo4j",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Neo4j",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "missing"
+        },
+        "resource_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "db.postgres",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "PostgreSQL (schema)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "db.redis",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Redis (keys)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "db.snowflake",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Snowflake",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "missing"
+        },
+        "resource_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "db.sqlite",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "SQLite (schema)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/extractors/sql"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.container.docker-compose",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "docker-compose.yml",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "full",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/docker/frameworks/docker_compose.yaml","internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.container.dockerfile",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Dockerfile",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "full",
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/docker/frameworks/dockerfile.yaml","internal/extractors/dockerfile/dockerfile.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.container.helm",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Helm charts",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.container.kubernetes",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Kubernetes manifests",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "full",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml","internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.container.kustomize",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Kustomize",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "missing"
+        },
+        "resource_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "infra.iac.ansible",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Ansible (playbooks)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.iac.bicep",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Azure Bicep",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "missing"
+        },
+        "resource_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "infra.iac.cdk",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "AWS CDK",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.iac.cloudformation",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "AWS CloudFormation",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.iac.pulumi",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Pulumi",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.iac.serverless-framework",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Serverless Framework",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/serverless_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/serverless_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "infra.iac.terraform",
+      "category": "infrastructure",
+      "language": "multi",
+      "label": "Terraform (HCL)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "full",
+          "cites": ["internal/extractors/hcl"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/hcl"],
           "verified_at": "2026-05-28"
         }
       }
@@ -208,12 +1316,66 @@
       "id": "infra.observability.datadog",
       "category": "observability",
       "language": "multi",
-      "label": "Datadog APM / StatsD",
+      "label": "Datadog",
       "capabilities": {
-        "trace_extraction": {
+        "log_extraction": {
           "status": "missing"
         },
         "metric_extraction": {
+          "status": "missing"
+        },
+        "trace_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "infra.observability.elastic-apm",
+      "category": "observability",
+      "language": "multi",
+      "label": "Elastic APM",
+      "capabilities": {
+        "log_extraction": {
+          "status": "missing"
+        },
+        "metric_extraction": {
+          "status": "missing"
+        },
+        "trace_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "infra.observability.grafana-loki",
+      "category": "observability",
+      "language": "multi",
+      "label": "Grafana Loki",
+      "capabilities": {
+        "log_extraction": {
+          "status": "missing"
+        },
+        "metric_extraction": {
+          "status": "not_applicable"
+        },
+        "trace_extraction": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "infra.observability.honeycomb",
+      "category": "observability",
+      "language": "multi",
+      "label": "Honeycomb",
+      "capabilities": {
+        "log_extraction": {
+          "status": "missing"
+        },
+        "metric_extraction": {
+          "status": "missing"
+        },
+        "trace_extraction": {
           "status": "missing"
         }
       }
@@ -237,10 +1399,13 @@
       "language": "multi",
       "label": "New Relic",
       "capabilities": {
-        "trace_extraction": {
+        "log_extraction": {
           "status": "missing"
         },
         "metric_extraction": {
+          "status": "missing"
+        },
+        "trace_extraction": {
           "status": "missing"
         }
       }
@@ -249,16 +1414,20 @@
       "id": "infra.observability.opentelemetry",
       "category": "observability",
       "language": "multi",
-      "label": "OpenTelemetry instrumentation",
+      "label": "OpenTelemetry (OTEL)",
       "capabilities": {
-        "trace_extraction": {
+        "log_extraction": {
           "status": "missing"
         },
         "metric_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/event_bus_edges.go"],
+          "verified_at": "2026-05-28"
         },
-        "log_extraction": {
-          "status": "missing"
+        "trace_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/event_flow.go","internal/engine/process_flow.go"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -266,10 +1435,18 @@
       "id": "infra.observability.prometheus",
       "category": "observability",
       "language": "multi",
-      "label": "Prometheus client libraries",
+      "label": "Prometheus",
       "capabilities": {
+        "log_extraction": {
+          "status": "not_applicable"
+        },
         "metric_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "trace_extraction": {
+          "status": "not_applicable"
         }
       }
     },
@@ -277,8 +1454,14 @@
       "id": "infra.observability.sentry",
       "category": "observability",
       "language": "multi",
-      "label": "Sentry SDK",
+      "label": "Sentry",
       "capabilities": {
+        "log_extraction": {
+          "status": "missing"
+        },
+        "metric_extraction": {
+          "status": "missing"
+        },
         "trace_extraction": {
           "status": "missing"
         }
@@ -353,14 +1536,14 @@
       "language": "multi",
       "label": "Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint",
       "capabilities": {
-        "resource_extraction": {
-          "status": "full",
-          "cites": ["internal/extractors/hcl/extractor.go", "internal/extractors/hcl/relationships.go"],
-          "verified_at": "2026-05-28"
-        },
         "dependency_attribution": {
           "status": "full",
           "cites": ["internal/extractors/hcl/relationships.go"],
+          "verified_at": "2026-05-28"
+        },
+        "resource_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/hcl/extractor.go","internal/extractors/hcl/relationships.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -371,13 +1554,13 @@
       "language": "clojure",
       "label": "Clojure",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/clojure/clojure.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         },
         "discriminates_on": {
           "status": "missing"
@@ -390,13 +1573,13 @@
       "language": "cpp",
       "label": "C++",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/cpp/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         },
         "discriminates_on": {
           "status": "missing"
@@ -409,13 +1592,13 @@
       "language": "crystal",
       "label": "Crystal",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/crystal/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         }
       }
     },
@@ -425,16 +1608,187 @@
       "language": "csharp",
       "label": "C#",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/csharp/csharp.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
-          "status": "partial"
-        },
         "discriminates_on": {
           "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.driver.cassandra",
+      "category": "orm",
+      "language": "csharp",
+      "label": "CassandraCSharpDriver",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.driver.dynamodb",
+      "category": "orm",
+      "language": "csharp",
+      "label": "AWSSDK.DynamoDBv2",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.driver.elastic",
+      "category": "orm",
+      "language": "csharp",
+      "label": "NEST (Elasticsearch .NET)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.driver.mongodb",
+      "category": "orm",
+      "language": "csharp",
+      "label": "MongoDB.Driver (C#)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.driver.mysql",
+      "category": "orm",
+      "language": "csharp",
+      "label": "MySQL.Data / MySqlConnector",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.driver.neo4j",
+      "category": "orm",
+      "language": "csharp",
+      "label": "Neo4j.Driver (C#)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.driver.npgsql",
+      "category": "orm",
+      "language": "csharp",
+      "label": "Npgsql (PostgreSQL)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.driver.redis",
+      "category": "orm",
+      "language": "csharp",
+      "label": "StackExchange.Redis",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.driver.sqlite",
+      "category": "orm",
+      "language": "csharp",
+      "label": "Microsoft.Data.Sqlite",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -444,9 +1798,12 @@
       "language": "csharp",
       "label": "ASP.NET Core",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/aspnet_core_routes.go"],
+          "cites": ["internal/engine/aspnet_core_routes.go","internal/engine/rules/csharp/frameworks/asp_net_core.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
@@ -454,8 +1811,10 @@
           "cites": ["internal/engine/aspnet_core_routes.go"],
           "verified_at": "2026-05-28"
         },
-        "auth_coverage": {
-          "status": "missing"
+        "middleware_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/aspnet_core_routes.go"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -463,17 +1822,23 @@
       "id": "lang.csharp.framework.aspnet-mvc",
       "category": "http_framework",
       "language": "csharp",
-      "label": "ASP.NET MVC (attribute-route subset)",
+      "label": "ASP.NET MVC (legacy)",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
-          "status": "partial",
-          "cites": ["internal/engine/aspnet_core_routes.go"],
+          "status": "full",
+          "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/aspnet_core_routes.go"],
+          "status": "full",
+          "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -489,21 +1854,361 @@
       }
     },
     {
+      "id": "lang.csharp.framework.blazor-server",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "Blazor Server",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/frameworks/blazor_server.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.blazor-wasm",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "Blazor WebAssembly",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.carter",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "Carter",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.fastendpoints",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "FastEndpoints",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.grpc-net",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "grpc-dotnet",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/grpc_edges.go","internal/engine/rules/csharp/frameworks/grpc_net.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/frameworks/grpc_net.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.nancyfx",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "NancyFX",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.net-maui",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": ".NET MAUI",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/frameworks/net_maui.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.servicestack",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "ServiceStack",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.uno",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "Uno Platform",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/frameworks/uno_platform.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.winforms",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "Windows Forms",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/frameworks/winforms.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.wpf",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "WPF",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/frameworks/wpf.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.framework.xamarin",
+      "category": "http_framework",
+      "language": "csharp",
+      "label": "Xamarin",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/frameworks/xamarin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.orm.dapper",
+      "category": "orm",
+      "language": "csharp",
+      "label": "Dapper",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
       "id": "lang.csharp.orm.efcore",
       "category": "orm",
       "language": "csharp",
       "label": "Entity Framework Core",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/_engine/column_schema_extractor.yaml"],
+          "status": "full",
+          "cites": ["internal/engine/rules/csharp/frameworks/entity_framework_core.yaml","internal/engine/rules/csharp/orms/entity_framework_core.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
-          "status": "missing"
-        },
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.orm.linq-to-sql",
+      "category": "orm",
+      "language": "csharp",
+      "label": "LINQ to SQL",
+      "capabilities": {
         "migration_parsing": {
           "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.orm.linqtodb",
+      "category": "orm",
+      "language": "csharp",
+      "label": "LinqToDB",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "missing"
+        },
+        "query_attribution": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.csharp.orm.nhibernate",
+      "category": "orm",
+      "language": "csharp",
+      "label": "NHibernate",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -513,13 +2218,13 @@
       "language": "dart",
       "label": "Dart",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/dart/dart.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         },
         "discriminates_on": {
           "status": "missing"
@@ -532,16 +2237,300 @@
       "language": "elixir",
       "label": "Elixir",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/elixir/elixir.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
-          "status": "partial"
-        },
         "discriminates_on": {
           "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.driver.dynamodb",
+      "category": "orm",
+      "language": "elixir",
+      "label": "ExAws DynamoDB",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.driver.elastic",
+      "category": "orm",
+      "language": "elixir",
+      "label": "elasticsearch-elixir",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.driver.mongodb",
+      "category": "orm",
+      "language": "elixir",
+      "label": "mongodb (Elixir driver)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.driver.myxql",
+      "category": "orm",
+      "language": "elixir",
+      "label": "MyXQL",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/myxql.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.driver.neo4j",
+      "category": "orm",
+      "language": "elixir",
+      "label": "bolt_sips (Neo4j)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.driver.postgrex",
+      "category": "orm",
+      "language": "elixir",
+      "label": "Postgrex",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/postgrex.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.driver.redix",
+      "category": "orm",
+      "language": "elixir",
+      "label": "Redix",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/redix.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.driver.xandra",
+      "category": "orm",
+      "language": "elixir",
+      "label": "Xandra (Cassandra)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/xandra.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.absinthe",
+      "category": "http_framework",
+      "language": "elixir",
+      "label": "Absinthe (GraphQL)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml","internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.ash",
+      "category": "http_framework",
+      "language": "elixir",
+      "label": "Ash Framework",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.bandit",
+      "category": "http_framework",
+      "language": "elixir",
+      "label": "Bandit",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.cowboy",
+      "category": "http_framework",
+      "language": "elixir",
+      "label": "Cowboy",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.nerves",
+      "category": "http_framework",
+      "language": "elixir",
+      "label": "Nerves (embedded)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/nerves.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.oban",
+      "category": "http_framework",
+      "language": "elixir",
+      "label": "Oban (job queue)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/oban.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -551,9 +2540,12 @@
       "language": "elixir",
       "label": "Phoenix",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/phoenix_routes.go"],
+          "cites": ["internal/engine/phoenix_routes.go","internal/engine/rules/elixir/frameworks/phoenix.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
@@ -561,7 +2553,7 @@
           "cites": ["internal/engine/phoenix_routes.go"],
           "verified_at": "2026-05-28"
         },
-        "auth_coverage": {
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -570,17 +2562,43 @@
       "id": "lang.elixir.framework.phoenix-liveview",
       "category": "http_framework",
       "language": "elixir",
-      "label": "Phoenix LiveView (pages indexed; lifecycle hooks not surfaced)",
+      "label": "Phoenix LiveView",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
-          "status": "partial",
-          "cites": ["internal/engine/phoenix_routes.go"],
+          "status": "full",
+          "cites": ["internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/phoenix_routes.go"],
+          "status": "full",
+          "cites": ["internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.plug",
+      "category": "http_framework",
+      "language": "elixir",
+      "label": "Plug",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -590,16 +2608,39 @@
       "language": "elixir",
       "label": "Ecto",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
-          "status": "missing"
-        },
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.orm.ecto-sqlite3",
+      "category": "orm",
+      "language": "elixir",
+      "label": "ecto_sqlite3",
+      "capabilities": {
         "migration_parsing": {
           "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -609,13 +2650,13 @@
       "language": "erlang",
       "label": "Erlang",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/erlang/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         }
       }
     },
@@ -625,13 +2666,13 @@
       "language": "fsharp",
       "label": "F#",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/fsharp/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         }
       }
     },
@@ -641,12 +2682,12 @@
       "language": "go",
       "label": "Go",
       "capabilities": {
-        "core_extraction": {
+        "call_line_precision": {
           "status": "full",
           "cites": ["internal/extractors/golang/extractor.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
+        "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/golang/extractor.go"],
           "verified_at": "2026-05-28"
@@ -660,12 +2701,201 @@
       }
     },
     {
+      "id": "lang.go.driver.cassandra",
+      "category": "orm",
+      "language": "go",
+      "label": "gocql (Cassandra)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/cassandra_go.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.driver.dynamodb",
+      "category": "orm",
+      "language": "go",
+      "label": "AWS SDK DynamoDB (Go)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/dynamodb_go.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.driver.elastic",
+      "category": "orm",
+      "language": "go",
+      "label": "go-elasticsearch",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/elasticsearch_go.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.driver.mongodb",
+      "category": "orm",
+      "language": "go",
+      "label": "mongo-go-driver",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/mongo_driver.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.driver.mysql",
+      "category": "orm",
+      "language": "go",
+      "label": "go-sql-driver/mysql",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/mysql_go.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.driver.neo4j",
+      "category": "orm",
+      "language": "go",
+      "label": "neo4j-go-driver",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.driver.redis",
+      "category": "orm",
+      "language": "go",
+      "label": "go-redis",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/go_redis.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.driver.sqlite",
+      "category": "orm",
+      "language": "go",
+      "label": "mattn/go-sqlite3",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/sqlite_go.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
       "id": "lang.go.framework.beego",
       "category": "http_framework",
       "language": "go",
       "label": "Beego",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.buffalo",
+      "category": "http_framework",
+      "language": "go",
+      "label": "Buffalo",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -674,17 +2904,23 @@
       "id": "lang.go.framework.chi",
       "category": "http_framework",
       "language": "go",
-      "label": "go-chi/chi",
+      "label": "chi",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/chi.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -692,17 +2928,47 @@
       "id": "lang.go.framework.echo",
       "category": "http_framework",
       "language": "go",
-      "label": "labstack/echo",
+      "label": "Echo",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/echo.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.fasthttp",
+      "category": "http_framework",
+      "language": "go",
+      "label": "fasthttp",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -710,17 +2976,45 @@
       "id": "lang.go.framework.fiber",
       "category": "http_framework",
       "language": "go",
-      "label": "gofiber/fiber",
+      "label": "Fiber",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/fiber.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.fyne",
+      "category": "http_framework",
+      "language": "go",
+      "label": "Fyne (desktop GUI)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/fyne.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -728,17 +3022,69 @@
       "id": "lang.go.framework.gin",
       "category": "http_framework",
       "language": "go",
-      "label": "gin-gonic/gin",
+      "label": "Gin",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gin.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.go-zero",
+      "category": "http_framework",
+      "language": "go",
+      "label": "go-zero",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.gomobile",
+      "category": "http_framework",
+      "language": "go",
+      "label": "gomobile (mobile bindings)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/gomobile.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -746,17 +3092,47 @@
       "id": "lang.go.framework.gorilla-mux",
       "category": "http_framework",
       "language": "go",
-      "label": "gorilla/mux",
+      "label": "Gorilla Mux",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_go_trio.go"],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gorilla_mux.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.hertz",
+      "category": "http_framework",
+      "language": "go",
+      "label": "Hertz (CloudWeGo)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -766,6 +3142,9 @@
       "language": "go",
       "label": "Huma",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
           "cites": ["internal/engine/http_endpoint_go_trio.go"],
@@ -775,6 +3154,57 @@
           "status": "full",
           "cites": ["internal/engine/http_endpoint_go_trio.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.iris",
+      "category": "http_framework",
+      "language": "go",
+      "label": "Iris",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.kratos",
+      "category": "http_framework",
+      "language": "go",
+      "label": "Kratos (Bilibili)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -782,16 +3212,67 @@
       "id": "lang.go.framework.net-http",
       "category": "http_framework",
       "language": "go",
-      "label": "Go net/http stdlib",
+      "label": "net/http (stdlib)",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_go_trio.go"],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/net_http_stdlib.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/go_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.framework.revel",
+      "category": "http_framework",
+      "language": "go",
+      "label": "Revel",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.go.orm.bun",
+      "category": "orm",
+      "language": "go",
+      "label": "Bun (uptrace)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -800,8 +3281,32 @@
       "id": "lang.go.orm.ent",
       "category": "orm",
       "language": "go",
-      "label": "ent",
+      "label": "ent (Facebook)",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/go/orms/ent.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.orm.gen",
+      "category": "orm",
+      "language": "go",
+      "label": "gen (gentleman / GORM gen)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
           "status": "missing"
         },
@@ -816,17 +3321,116 @@
       "language": "go",
       "label": "GORM",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/go/frameworks/gorm.yaml","internal/engine/rules/go/orms/gorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": ["internal/engine/orm_queries.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.orm.migrate",
+      "category": "orm",
+      "language": "go",
+      "label": "golang-migrate",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/golang_migrate.yaml"],
           "verified_at": "2026-05-28"
         },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.go.orm.pgx",
+      "category": "orm",
+      "language": "go",
+      "label": "pgx (PostgreSQL driver)",
+      "capabilities": {
         "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/pgx.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.orm.sqlc",
+      "category": "orm",
+      "language": "go",
+      "label": "sqlc (codegen)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.orm.sqlx",
+      "category": "orm",
+      "language": "go",
+      "label": "sqlx",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.go.orm.xo",
+      "category": "orm",
+      "language": "go",
+      "label": "xo (codegen)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "missing"
+        },
+        "query_attribution": {
           "status": "missing"
         }
       }
@@ -837,13 +3441,13 @@
       "language": "groovy",
       "label": "Groovy",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/groovy/groovy.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         }
       }
     },
@@ -853,13 +3457,13 @@
       "language": "haskell",
       "label": "Haskell",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/haskell/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         }
       }
     },
@@ -869,12 +3473,12 @@
       "language": "java",
       "label": "Java",
       "capabilities": {
-        "core_extraction": {
+        "call_line_precision": {
           "status": "full",
           "cites": ["internal/extractors/java/java.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
+        "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/java/java.go"],
           "verified_at": "2026-05-28"
@@ -885,20 +3489,178 @@
       }
     },
     {
+      "id": "lang.java.framework.akka-http",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Akka HTTP (Java DSL)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.android-jetpack",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/android_jetpack_compose.yaml","internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.android-sdk",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Android SDK (Activity/Fragment routing)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/android_sdk.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
       "id": "lang.java.framework.dropwizard",
       "category": "http_framework",
       "language": "java",
-      "label": "Dropwizard (JAX-RS subset)",
+      "label": "Dropwizard",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/dropwizard.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/java_annotation_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.gwt",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Google Web Toolkit (GWT)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/java_annotation_routes.go"],
+          "cites": ["internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/java_annotation_routes.go"],
+          "cites": ["internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.helidon",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Helidon",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.jakarta-ee",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Jakarta EE (Servlet / EE Platform)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.javalin",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Javalin",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -906,11 +3668,16 @@
       "id": "lang.java.framework.jaxrs",
       "category": "http_framework",
       "language": "java",
-      "label": "JAX-RS / Jakarta EE",
+      "label": "JAX-RS / Jakarta REST",
       "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go", "internal/engine/java_annotation_routes.go"],
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
@@ -918,10 +3685,30 @@
           "cites": ["internal/engine/java_annotation_routes.go"],
           "verified_at": "2026-05-28"
         },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.langchain4j",
+      "category": "http_framework",
+      "language": "java",
+      "label": "LangChain4J (LLM agent framework)",
+      "capabilities": {
         "auth_coverage": {
-          "status": "full",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/langchain4j.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -931,7 +3718,70 @@
       "language": "java",
       "label": "Micronaut",
       "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/micronaut.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/java_annotation_routes.go"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.microprofile",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Eclipse MicroProfile",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.play",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Play Framework",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/play_framework.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/play_framework.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -940,11 +3790,16 @@
       "id": "lang.java.framework.quarkus",
       "category": "http_framework",
       "language": "java",
-      "label": "Quarkus (JAX-RS-backed)",
+      "label": "Quarkus",
       "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go"],
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/quarkus.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
@@ -952,10 +3807,8 @@
           "cites": ["internal/engine/java_annotation_routes.go"],
           "verified_at": "2026-05-28"
         },
-        "auth_coverage": {
-          "status": "full",
-          "cites": ["internal/engine/java_auth_policy.go"],
-          "verified_at": "2026-05-28"
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -965,19 +3818,24 @@
       "language": "java",
       "label": "Spring Boot / Spring MVC",
       "capabilities": {
+        "auth_coverage": {
+          "status": "full",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go", "internal/engine/spring_routes.go"],
+          "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/java/frameworks/spring_boot.yaml","internal/engine/rules/java/frameworks/spring_mvc.yaml","internal/engine/spring_routes.go"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/spring_routes.go"],
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/spring_routes.go"],
           "verified_at": "2026-05-28"
         },
-        "auth_coverage": {
-          "status": "full",
-          "cites": ["internal/engine/java_auth_policy.go"],
+        "middleware_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/java_annotation_params.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -986,11 +3844,16 @@
       "id": "lang.java.framework.spring-webflux",
       "category": "http_framework",
       "language": "java",
-      "label": "Spring WebFlux",
+      "label": "Spring WebFlux (reactive)",
       "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/spring_routes.go"],
+          "cites": ["internal/engine/rules/java/frameworks/spring_webflux.yaml","internal/engine/spring_routes.go"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
@@ -998,10 +3861,135 @@
           "cites": ["internal/engine/spring_routes.go"],
           "verified_at": "2026-05-28"
         },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.struts",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Apache Struts",
+      "capabilities": {
         "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.vaadin",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Vaadin (UI-as-server)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/vaadin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/vaadin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.framework.vertx",
+      "category": "http_framework",
+      "language": "java",
+      "label": "Vert.x",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.dynamodb",
+      "category": "orm",
+      "language": "java",
+      "label": "AWS SDK DynamoDB (Java)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.ebean",
+      "category": "orm",
+      "language": "java",
+      "label": "Ebean ORM",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "missing"
+        },
+        "query_attribution": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.eclipselink",
+      "category": "orm",
+      "language": "java",
+      "label": "EclipseLink",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "missing"
+        },
+        "query_attribution": {
+          "status": "missing"
         }
       }
     },
@@ -1009,16 +3997,145 @@
       "id": "lang.java.orm.hibernate",
       "category": "orm",
       "language": "java",
-      "label": "Hibernate / JPA",
+      "label": "Hibernate ORM",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/hibernate_core.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.jooq",
+      "category": "orm",
+      "language": "java",
+      "label": "jOOQ",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.jpa",
+      "category": "orm",
+      "language": "java",
+      "label": "JPA / Jakarta Persistence API",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/orm_queries.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.mybatis",
+      "category": "orm",
+      "language": "java",
+      "label": "MyBatis",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.neo4j",
+      "category": "orm",
+      "language": "java",
+      "label": "Neo4j (Java driver)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.spring-data-cassandra",
+      "category": "orm",
+      "language": "java",
+      "label": "Spring Data Cassandra",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.spring-data-elastic",
+      "category": "orm",
+      "language": "java",
+      "label": "Spring Data Elasticsearch",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1029,14 +4146,59 @@
       "language": "java",
       "label": "Spring Data JPA",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/spring_data_jpa.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.spring-data-mongo",
+      "category": "orm",
+      "language": "java",
+      "label": "Spring Data MongoDB",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.java.orm.spring-data-redis",
+      "category": "orm",
+      "language": "java",
+      "label": "Spring Data Redis",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1047,12 +4209,12 @@
       "language": "javascript",
       "label": "JavaScript",
       "capabilities": {
-        "core_extraction": {
+        "call_line_precision": {
           "status": "full",
           "cites": ["internal/extractors/javascript/extractor.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
+        "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/javascript/extractor.go"],
           "verified_at": "2026-05-28"
@@ -1070,13 +4232,234 @@
       }
     },
     {
+      "id": "lang.javascript.driver.cassandra",
+      "category": "orm",
+      "language": "javascript",
+      "label": "cassandra-driver (JS)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.driver.dynamodb",
+      "category": "orm",
+      "language": "javascript",
+      "label": "AWS SDK DynamoDB (JS)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.driver.elastic",
+      "category": "orm",
+      "language": "javascript",
+      "label": "@elastic/elasticsearch",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.driver.mongodb",
+      "category": "orm",
+      "language": "javascript",
+      "label": "MongoDB Node.js driver",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.driver.mysql",
+      "category": "orm",
+      "language": "javascript",
+      "label": "mysql / mysql2",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.driver.neo4j",
+      "category": "orm",
+      "language": "javascript",
+      "label": "neo4j-driver (JS)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.driver.postgres",
+      "category": "orm",
+      "language": "javascript",
+      "label": "node-postgres / pg",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.driver.redis",
+      "category": "orm",
+      "language": "javascript",
+      "label": "ioredis / node-redis",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/redis_js.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.driver.sqlite",
+      "category": "orm",
+      "language": "javascript",
+      "label": "better-sqlite3 / sqlite3",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.driver.supabase",
+      "category": "orm",
+      "language": "javascript",
+      "label": "supabase-js",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.adonisjs",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "AdonisJS",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
       "id": "lang.javascript.framework.angular",
       "category": "http_framework",
       "language": "javascript",
       "label": "Angular",
       "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
         "endpoint_synthesis": {
-          "status": "missing"
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/angular.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1086,8 +4469,65 @@
       "language": "javascript",
       "label": "Astro",
       "capabilities": {
-        "endpoint_synthesis": {
+        "auth_coverage": {
           "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.electron",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Electron",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/electron.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.expo",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Expo",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1095,15 +4535,25 @@
       "id": "lang.javascript.framework.express",
       "category": "http_framework",
       "language": "javascript",
-      "label": "Express.js",
+      "label": "Express",
       "capabilities": {
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
-          "verified_at": "2026-05-27"
-        },
         "auth_coverage": {
           "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -1113,15 +4563,65 @@
       "language": "javascript",
       "label": "Fastify",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_jsts_extra.go"],
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_jsts_extra.go"],
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.feathers",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Feathers",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.gatsby",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Gatsby",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -1129,17 +4629,43 @@
       "id": "lang.javascript.framework.graphql-resolvers",
       "category": "http_framework",
       "language": "javascript",
-      "label": "GraphQL resolvers (Apollo / Yoga)",
+      "label": "GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.hapi",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Hapi",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -1149,8 +4675,43 @@
       "language": "javascript",
       "label": "Hono",
       "capabilities": {
-        "endpoint_synthesis": {
+        "auth_coverage": {
           "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/extractors/javascript/framework_dsl.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/extractors/javascript/framework_dsl.go"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.ionic",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Ionic",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/ionic.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1160,8 +4721,85 @@
       "language": "javascript",
       "label": "Koa",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/extractors/javascript/framework_dsl.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/extractors/javascript/framework_dsl.go"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.langchain",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "LangChain.js",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.marblejs",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Marble.js",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.nativescript",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "NativeScript",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nativescript.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1171,20 +4809,24 @@
       "language": "javascript",
       "label": "NestJS",
       "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+          "verified_at": "2026-05-28"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
-          "verified_at": "2026-05-27"
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+          "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
           "verified_at": "2026-05-28"
         },
-        "auth_coverage": {
+        "middleware_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/1942",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1193,17 +4835,23 @@
       "id": "lang.javascript.framework.next-api",
       "category": "http_framework",
       "language": "javascript",
-      "label": "Next.js API routes",
+      "label": "Next.js API Routes / App Router",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_jsts_extra.go"],
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_jsts_extra.go"],
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -1213,8 +4861,85 @@
       "language": "javascript",
       "label": "Nuxt",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.polka",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Polka",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.react",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "React",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.react-native",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "React Native",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1224,8 +4949,83 @@
       "language": "javascript",
       "label": "Remix",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.restify",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Restify",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.sails",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Sails",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.svelte",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Svelte",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/svelte.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1233,9 +5033,22 @@
       "id": "lang.javascript.framework.sveltekit",
       "category": "http_framework",
       "language": "javascript",
-      "label": "Svelte / SvelteKit",
+      "label": "SvelteKit",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1246,15 +5059,43 @@
       "language": "javascript",
       "label": "tRPC",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_trpc.go"],
+          "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/http_endpoint_trpc.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.framework.vue",
+      "category": "http_framework",
+      "language": "javascript",
+      "label": "Vue",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/vue.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1262,13 +5103,60 @@
       "id": "lang.javascript.orm.drizzle",
       "category": "orm",
       "language": "javascript",
-      "label": "Drizzle ORM",
+      "label": "Drizzle",
       "capabilities": {
-        "model_extraction": {
+        "migration_parsing": {
           "status": "missing"
         },
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/drizzle.yaml"],
+          "verified_at": "2026-05-28"
+        },
         "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.orm.knex",
+      "category": "orm",
+      "language": "javascript",
+      "label": "Knex (query builder)",
+      "capabilities": {
+        "migration_parsing": {
           "status": "missing"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/knex.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.orm.mikro-orm",
+      "category": "orm",
+      "language": "javascript",
+      "label": "MikroORM",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -1278,15 +5166,35 @@
       "language": "javascript",
       "label": "Mongoose",
       "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
         "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mongoose.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
           "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.javascript.orm.objection",
+      "category": "orm",
+      "language": "javascript",
+      "label": "Objection.js",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "missing"
+        },
+        "query_attribution": {
+          "status": "missing"
         }
       }
     },
@@ -1296,18 +5204,20 @@
       "language": "javascript",
       "label": "Prisma",
       "capabilities": {
+        "migration_parsing": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/prisma/_manifest.yaml"],
+          "verified_at": "2026-05-28"
+        },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/prisma.yaml","internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml","internal/engine/rules/prisma/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
           "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
-        },
-        "migration_parsing": {
-          "status": "missing"
         }
       }
     },
@@ -1317,9 +5227,12 @@
       "language": "javascript",
       "label": "Sequelize",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/sequelize.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
@@ -1335,18 +5248,18 @@
       "language": "javascript",
       "label": "TypeORM",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/typeorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
           "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
-        },
-        "migration_parsing": {
-          "status": "missing"
         }
       }
     },
@@ -1356,16 +5269,126 @@
       "language": "kotlin",
       "label": "Kotlin",
       "capabilities": {
+        "call_line_precision": {
+          "status": "full"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/kotlin/imports.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
-          "status": "full"
-        },
         "discriminates_on": {
           "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.arrow",
+      "category": "http_framework",
+      "language": "kotlin",
+      "label": "Arrow (functional Kotlin)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.compose",
+      "category": "http_framework",
+      "language": "kotlin",
+      "label": "Jetpack Compose (Android UI)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.compose-desktop",
+      "category": "http_framework",
+      "language": "kotlin",
+      "label": "Compose Desktop",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/compose_desktop.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.compose-multiplatform",
+      "category": "http_framework",
+      "language": "kotlin",
+      "label": "Compose Multiplatform",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/compose_multiplatform.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.coroutines",
+      "category": "http_framework",
+      "language": "kotlin",
+      "label": "kotlinx.coroutines (structured concurrency)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1375,8 +5398,63 @@
       "language": "kotlin",
       "label": "http4k",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.javalin",
+      "category": "http_framework",
+      "language": "kotlin",
+      "label": "Javalin (Kotlin)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.kmp",
+      "category": "http_framework",
+      "language": "kotlin",
+      "label": "Kotlin Multiplatform (KMP / KMM)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/kmp.yaml","internal/engine/rules/kotlin/frameworks/kotlin_multiplatform_kmp_kmm.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1386,7 +5464,68 @@
       "language": "kotlin",
       "label": "Ktor",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.micronaut",
+      "category": "http_framework",
+      "language": "kotlin",
+      "label": "Micronaut (Kotlin)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.quarkus",
+      "category": "http_framework",
+      "language": "kotlin",
+      "label": "Quarkus (Kotlin)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1397,9 +5536,14 @@
       "language": "kotlin",
       "label": "Spring Boot (Kotlin)",
       "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/spring_routes_kotlin.go"],
+          "cites": ["internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml","internal/engine/spring_routes_kotlin.go"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
@@ -1407,9 +5551,154 @@
           "cites": ["internal/engine/spring_routes_kotlin.go"],
           "verified_at": "2026-05-28"
         },
-        "auth_coverage": {
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.orm.exposed",
+      "category": "orm",
+      "language": "kotlin",
+      "label": "Exposed (JetBrains)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.orm.hibernate",
+      "category": "orm",
+      "language": "kotlin",
+      "label": "Hibernate (Kotlin)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.orm.ktorm",
+      "category": "orm",
+      "language": "kotlin",
+      "label": "Ktorm",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.orm.mongodb",
+      "category": "orm",
+      "language": "kotlin",
+      "label": "MongoDB (Kotlin driver)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.orm.room",
+      "category": "orm",
+      "language": "kotlin",
+      "label": "Room (Android)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.orm.spring-data",
+      "category": "orm",
+      "language": "kotlin",
+      "label": "Spring Data (Kotlin)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.orm.sqldelight",
+      "category": "orm",
+      "language": "kotlin",
+      "label": "SQLDelight",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1442,13 +5731,13 @@
       "language": "nim",
       "label": "Nim",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/nim/nim.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         }
       }
     },
@@ -1458,13 +5747,13 @@
       "language": "ocaml",
       "label": "OCaml",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/ocaml/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         }
       }
     },
@@ -1474,15 +5763,282 @@
       "language": "php",
       "label": "PHP",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/php/php.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
-          "status": "partial"
-        },
         "discriminates_on": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.driver.cassandra",
+      "category": "orm",
+      "language": "php",
+      "label": "datastax/php-driver (Cassandra)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/cassandra_php.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.driver.dynamodb",
+      "category": "orm",
+      "language": "php",
+      "label": "AWS SDK DynamoDB (PHP)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/dynamodb_php.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.driver.elastic",
+      "category": "orm",
+      "language": "php",
+      "label": "elasticsearch-php",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/elasticsearch_php.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.driver.mongodb",
+      "category": "orm",
+      "language": "php",
+      "label": "mongodb (PHP driver)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/mongodb_php.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.driver.mysql",
+      "category": "orm",
+      "language": "php",
+      "label": "PDO MySQL / mysqli",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/mysql_php.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.driver.neo4j",
+      "category": "orm",
+      "language": "php",
+      "label": "neo4j-php-client",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.driver.postgres",
+      "category": "orm",
+      "language": "php",
+      "label": "PDO PostgreSQL",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/postgresql_php.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.driver.redis",
+      "category": "orm",
+      "language": "php",
+      "label": "phpredis / Predis",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/redis_php.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.driver.sqlite",
+      "category": "orm",
+      "language": "php",
+      "label": "PDO SQLite",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/sqlite_php.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.cakephp",
+      "category": "http_framework",
+      "language": "php",
+      "label": "CakePHP",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.codeigniter",
+      "category": "http_framework",
+      "language": "php",
+      "label": "CodeIgniter",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.drupal",
+      "category": "http_framework",
+      "language": "php",
+      "label": "Drupal",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.laminas",
+      "category": "http_framework",
+      "language": "php",
+      "label": "Laminas (formerly Zend)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1493,9 +6049,12 @@
       "language": "php",
       "label": "Laravel",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_php_producer.go"],
+          "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/laravel.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
@@ -1503,7 +6062,71 @@
           "cites": ["internal/engine/http_endpoint_php_producer.go"],
           "verified_at": "2026-05-28"
         },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.lumen",
+      "category": "http_framework",
+      "language": "php",
+      "label": "Lumen",
+      "capabilities": {
         "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.magento",
+      "category": "http_framework",
+      "language": "php",
+      "label": "Magento",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.phalcon",
+      "category": "http_framework",
+      "language": "php",
+      "label": "Phalcon",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1514,7 +6137,20 @@
       "language": "php",
       "label": "Slim",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1525,9 +6161,86 @@
       "language": "php",
       "label": "Symfony",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2717"
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/symfony.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_php_producer.go"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.wordpress",
+      "category": "http_framework",
+      "language": "php",
+      "label": "WordPress",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.framework.yii",
+      "category": "http_framework",
+      "language": "php",
+      "label": "Yii",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.php.orm.cycleorm",
+      "category": "orm",
+      "language": "php",
+      "label": "CycleORM",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "missing"
+        },
+        "query_attribution": {
+          "status": "missing"
         }
       }
     },
@@ -1535,13 +6248,20 @@
       "id": "lang.php.orm.doctrine",
       "category": "orm",
       "language": "php",
-      "label": "Doctrine",
+      "label": "Doctrine ORM",
       "capabilities": {
-        "model_extraction": {
+        "migration_parsing": {
           "status": "missing"
         },
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/php/orms/doctrine_orm.yaml"],
+          "verified_at": "2026-05-28"
+        },
         "query_attribution": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -1549,15 +6269,62 @@
       "id": "lang.php.orm.eloquent",
       "category": "orm",
       "language": "php",
-      "label": "Eloquent (Laravel ActiveRecord)",
+      "label": "Eloquent (Laravel)",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/extractors/php/eloquent.go"],
+          "status": "full",
+          "cites": ["internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/orm_queries_other.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.orm.propel",
+      "category": "orm",
+      "language": "php",
+      "label": "Propel",
+      "capabilities": {
+        "migration_parsing": {
           "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.php.orm.redbeanphp",
+      "category": "orm",
+      "language": "php",
+      "label": "RedBeanPHP",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -1567,12 +6334,12 @@
       "language": "python",
       "label": "Python",
       "capabilities": {
-        "core_extraction": {
+        "call_line_precision": {
           "status": "full",
           "cites": ["internal/extractors/python/extractor.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
+        "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/python/extractor.go"],
           "verified_at": "2026-05-28"
@@ -1588,12 +6355,177 @@
       }
     },
     {
+      "id": "lang.python.driver.cassandra",
+      "category": "orm",
+      "language": "python",
+      "label": "cassandra-driver",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/cassandra_py.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.driver.dynamodb",
+      "category": "orm",
+      "language": "python",
+      "label": "boto3 DynamoDB",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/dynamodb_py.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.driver.elastic",
+      "category": "orm",
+      "language": "python",
+      "label": "elasticsearch-py",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/elasticsearch_py.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.driver.mysql",
+      "category": "orm",
+      "language": "python",
+      "label": "MySQL (PyMySQL / mysqlclient)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.driver.neo4j",
+      "category": "orm",
+      "language": "python",
+      "label": "neo4j (Python driver)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.driver.postgres",
+      "category": "orm",
+      "language": "python",
+      "label": "psycopg / asyncpg (PostgreSQL drivers)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.driver.redis",
+      "category": "orm",
+      "language": "python",
+      "label": "redis-py",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/redis_py.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.driver.sqlite",
+      "category": "orm",
+      "language": "python",
+      "label": "sqlite3 (stdlib)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
       "id": "lang.python.framework.aiohttp",
       "category": "http_framework",
       "language": "python",
       "label": "aiohttp",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1604,7 +6536,62 @@
       "language": "python",
       "label": "Bottle",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.celery",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Celery (task queue)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/celery.yaml","internal/extractors/python/celery.go"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.cherrypy",
+      "category": "http_framework",
+      "language": "python",
+      "label": "CherryPy",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1613,21 +6600,26 @@
       "id": "lang.python.framework.django",
       "category": "http_framework",
       "language": "python",
-      "label": "Django (URLconf)",
+      "label": "Django",
       "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/django_drf_actions.go"],
+          "verified_at": "2026-05-28"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/django_routes.go", "internal/engine/django_urlconf_nested.go", "internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/django_routes.go","internal/engine/django_urlconf_nested.go","internal/engine/rules/python/frameworks/django.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/django_drf_actions.go"],
+          "cites": ["internal/engine/django_admin_routes.go","internal/engine/django_routes.go"],
           "verified_at": "2026-05-28"
         },
-        "auth_coverage": {
+        "middleware_coverage": {
           "status": "partial",
-          "issue": "https://github.com/cajasmota/archigraph/issues/1942",
+          "cites": ["internal/engine/django_imports_rewrite.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1638,21 +6630,65 @@
       "language": "python",
       "label": "Django REST Framework",
       "capabilities": {
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/engine/django_drf_actions.go", "internal/engine/http_endpoint_synthesis.go"],
-          "verified_at": "2026-05-27"
-        },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/django_drf_actions.go"],
-          "verified_at": "2026-05-27"
-        },
         "auth_coverage": {
           "status": "partial",
           "cites": ["internal/engine/django_drf_actions.go"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/1942",
-          "verified_at": "2026-05-27"
+          "verified_at": "2026-05-28"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/django_drf_actions.go"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/drf_serializer_fields.go"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.dramatiq",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Dramatiq (task queue)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/frameworks/dramatiq.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.falcon",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Falcon",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -1662,12 +6698,22 @@
       "language": "python",
       "label": "FastAPI",
       "capabilities": {
+        "auth_coverage": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
+          "verified_at": "2026-05-28"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
-          "verified_at": "2026-05-27"
+          "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/fastapi.yaml"],
+          "verified_at": "2026-05-28"
         },
-        "auth_coverage": {
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1678,13 +6724,63 @@
       "language": "python",
       "label": "Flask",
       "capabilities": {
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
-          "verified_at": "2026-05-27"
-        },
         "auth_coverage": {
           "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/flask.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/flask.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.hug",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Hug",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.langchain",
+      "category": "http_framework",
+      "language": "python",
+      "label": "LangChain (LLM agent framework)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/frameworks/langchain.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1694,7 +6790,20 @@
       "language": "python",
       "label": "Litestar",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1705,15 +6814,41 @@
       "language": "python",
       "label": "Pyramid",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.quart",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Quart",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -1723,7 +6858,20 @@
       "language": "python",
       "label": "Robyn",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1734,7 +6882,20 @@
       "language": "python",
       "label": "Sanic",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1745,15 +6906,45 @@
       "language": "python",
       "label": "Starlette",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.strawberry-graphql",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Strawberry GraphQL",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/graphql/frameworks/strawberry_python.yaml","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -1763,14 +6954,60 @@
       "language": "python",
       "label": "Tornado",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
+          "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.python.orm.alembic",
+      "category": "orm",
+      "language": "python",
+      "label": "Alembic (migration tool)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.python.orm.beanie",
+      "category": "orm",
+      "language": "python",
+      "label": "Beanie (async MongoDB ODM)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1781,14 +7018,14 @@
       "language": "python",
       "label": "Django ORM",
       "capabilities": {
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/extractors/python/django_relational.go", "internal/extractors/python/extractor.go"],
-          "verified_at": "2026-05-28"
-        },
         "migration_parsing": {
           "status": "full",
           "cites": ["internal/extractors/python/django_migration.go"],
+          "verified_at": "2026-05-28"
+        },
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/orms/django_orm.yaml","internal/extractors/python/django_relational.go"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
@@ -1804,11 +7041,18 @@
       "language": "python",
       "label": "MongoEngine",
       "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
         "model_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
+          "verified_at": "2026-05-28"
         },
         "query_attribution": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -1818,12 +7062,38 @@
       "language": "python",
       "label": "Peewee",
       "capabilities": {
-        "model_extraction": {
+        "migration_parsing": {
           "status": "missing"
         },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
+          "verified_at": "2026-05-28"
+        },
         "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.python.orm.pony",
+      "category": "orm",
+      "language": "python",
+      "label": "Pony ORM",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1834,19 +7104,20 @@
       "language": "python",
       "label": "SQLAlchemy",
       "capabilities": {
+        "migration_parsing": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
+          "verified_at": "2026-05-28"
+        },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/python/orms/sqlalchemy.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
           "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
-        },
-        "migration_parsing": {
-          "status": "partial",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2720"
         }
       }
     },
@@ -1856,11 +7127,16 @@
       "language": "python",
       "label": "SQLModel",
       "capabilities": {
-        "model_extraction": {
+        "migration_parsing": {
           "status": "missing"
         },
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/orms/sqlmodel.yaml"],
+          "verified_at": "2026-05-28"
+        },
         "query_attribution": {
-          "status": "partial",
+          "status": "full",
           "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
@@ -1872,11 +7148,16 @@
       "language": "python",
       "label": "Tortoise ORM",
       "capabilities": {
-        "model_extraction": {
+        "migration_parsing": {
           "status": "missing"
         },
-        "query_attribution": {
+        "model_extraction": {
           "status": "full",
+          "cites": ["internal/engine/rules/python/orms/tortoise_orm.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
           "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
@@ -1888,16 +7169,210 @@
       "language": "ruby",
       "label": "Ruby",
       "capabilities": {
+        "call_line_precision": {
+          "status": "full"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/ruby/ruby.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
-          "status": "full"
-        },
         "discriminates_on": {
           "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.driver.cassandra",
+      "category": "orm",
+      "language": "ruby",
+      "label": "cassandra-driver (Ruby)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/cassandra_ruby.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.driver.dynamodb",
+      "category": "orm",
+      "language": "ruby",
+      "label": "AWS SDK DynamoDB (Ruby)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.driver.elastic",
+      "category": "orm",
+      "language": "ruby",
+      "label": "elasticsearch-ruby",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.driver.mysql",
+      "category": "orm",
+      "language": "ruby",
+      "label": "mysql2 (Ruby driver)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/mysql_ruby.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.driver.neo4j",
+      "category": "orm",
+      "language": "ruby",
+      "label": "neo4j-ruby-driver",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.driver.postgres",
+      "category": "orm",
+      "language": "ruby",
+      "label": "pg (Ruby driver)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/pg_ruby.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.driver.redis",
+      "category": "orm",
+      "language": "ruby",
+      "label": "redis-rb",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/redis_rb.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.driver.sqlite",
+      "category": "orm",
+      "language": "ruby",
+      "label": "sqlite3 (Ruby driver)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/sqlite_ruby.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.framework.cuba",
+      "category": "http_framework",
+      "language": "ruby",
+      "label": "Cuba",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.framework.dry-rb",
+      "category": "http_framework",
+      "language": "ruby",
+      "label": "dry-rb (ecosystem)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/frameworks/dry_rb.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
         }
       }
     },
@@ -1907,7 +7382,20 @@
       "language": "ruby",
       "label": "Grape",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1918,7 +7406,44 @@
       "language": "ruby",
       "label": "Hanami",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.framework.padrino",
+      "category": "http_framework",
+      "language": "ruby",
+      "label": "Padrino",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1929,9 +7454,12 @@
       "language": "ruby",
       "label": "Ruby on Rails",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
@@ -1939,7 +7467,31 @@
           "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
           "verified_at": "2026-05-28"
         },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.framework.roda",
+      "category": "http_framework",
+      "language": "ruby",
+      "label": "Roda",
+      "capabilities": {
         "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -1950,15 +7502,21 @@
       "language": "ruby",
       "label": "Sinatra",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/sinatra.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -1968,14 +7526,101 @@
       "language": "ruby",
       "label": "ActiveRecord",
       "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/cross/ormlink/extractor.go"],
+          "cites": ["internal/engine/rules/ruby/orms/activerecord.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": ["internal/engine/orm_queries.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.orm.datamapper",
+      "category": "orm",
+      "language": "ruby",
+      "label": "DataMapper / Hanami Model (legacy)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.orm.mongoid",
+      "category": "orm",
+      "language": "ruby",
+      "label": "Mongoid",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.orm.rom-rb",
+      "category": "orm",
+      "language": "ruby",
+      "label": "ROM (Ruby Object Mapper)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml","internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.ruby.orm.sequel",
+      "category": "orm",
+      "language": "ruby",
+      "label": "Sequel",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1986,13 +7631,13 @@
       "language": "rust",
       "label": "Rust",
       "capabilities": {
+        "call_line_precision": {
+          "status": "full"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/rust/rust.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "full"
         },
         "discriminates_on": {
           "status": "missing"
@@ -2000,12 +7645,196 @@
       }
     },
     {
+      "id": "lang.rust.driver.cassandra",
+      "category": "orm",
+      "language": "rust",
+      "label": "cdrs / scylla-rust-driver",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/cassandra_rust.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.driver.dynamodb",
+      "category": "orm",
+      "language": "rust",
+      "label": "aws-sdk-dynamodb (Rust)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/dynamodb_rust.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.driver.elastic",
+      "category": "orm",
+      "language": "rust",
+      "label": "elasticsearch-rs",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/elasticsearch_rs.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.driver.mongodb",
+      "category": "orm",
+      "language": "rust",
+      "label": "mongodb (Rust driver)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/mongodb_mongodb.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.driver.mysql",
+      "category": "orm",
+      "language": "rust",
+      "label": "mysql / mysql_async",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/mysql_rust.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.driver.neo4j",
+      "category": "orm",
+      "language": "rust",
+      "label": "neo4rs",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/neo4j.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.driver.postgres",
+      "category": "orm",
+      "language": "rust",
+      "label": "tokio-postgres / postgres",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/postgresql_rust.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.driver.redis",
+      "category": "orm",
+      "language": "rust",
+      "label": "redis-rs",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/redis_redis_rs.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.driver.sqlite",
+      "category": "orm",
+      "language": "rust",
+      "label": "sqlite (Rust)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/sqlite_rust.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
       "id": "lang.rust.framework.actix",
       "category": "http_framework",
       "language": "rust",
-      "label": "Actix",
+      "label": "Actix Web",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -2016,15 +7845,45 @@
       "language": "rust",
       "label": "Axum",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_axum.go"],
+          "cites": ["internal/engine/http_endpoint_axum.go","internal/engine/rules/rust/frameworks/axum.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/http_endpoint_axum.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.framework.gotham",
+      "category": "http_framework",
+      "language": "rust",
+      "label": "Gotham",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -2032,9 +7891,46 @@
       "id": "lang.rust.framework.hyper",
       "category": "http_framework",
       "language": "rust",
-      "label": "Hyper",
+      "label": "hyper",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.framework.poem",
+      "category": "http_framework",
+      "language": "rust",
+      "label": "Poem",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
           "status": "missing"
         }
       }
@@ -2045,15 +7941,107 @@
       "language": "rust",
       "label": "Rocket",
       "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rocket_routes.go"],
+          "cites": ["internal/engine/rocket_routes.go","internal/engine/rules/rust/frameworks/rocket.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
           "cites": ["internal/engine/rocket_routes.go"],
           "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.framework.salvo",
+      "category": "http_framework",
+      "language": "rust",
+      "label": "Salvo",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.framework.tauri",
+      "category": "http_framework",
+      "language": "rust",
+      "label": "Tauri (desktop)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/frameworks/tauri.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.framework.tide",
+      "category": "http_framework",
+      "language": "rust",
+      "label": "Tide",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.framework.tower",
+      "category": "http_framework",
+      "language": "rust",
+      "label": "Tower (service abstraction)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
         }
       }
     },
@@ -2063,8 +8051,120 @@
       "language": "rust",
       "label": "Warp",
       "capabilities": {
-        "endpoint_synthesis": {
+        "auth_coverage": {
           "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.orm.diesel",
+      "category": "orm",
+      "language": "rust",
+      "label": "Diesel",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.orm.rbatis",
+      "category": "orm",
+      "language": "rust",
+      "label": "Rbatis",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "missing"
+        },
+        "query_attribution": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.orm.rusqlite",
+      "category": "orm",
+      "language": "rust",
+      "label": "rusqlite",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "not_applicable"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/rusqlite.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.orm.seaorm",
+      "category": "orm",
+      "language": "rust",
+      "label": "SeaORM",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.rust.orm.sqlx",
+      "category": "orm",
+      "language": "rust",
+      "label": "sqlx (Rust)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -2074,16 +8174,352 @@
       "language": "scala",
       "label": "Scala",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/scala/scala.go"],
           "verified_at": "2026-05-28"
         },
-        "call_line_precision": {
-          "status": "partial"
-        },
         "discriminates_on": {
           "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.akka-http",
+      "category": "http_framework",
+      "language": "scala",
+      "label": "Akka HTTP / Pekko HTTP",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.cask",
+      "category": "http_framework",
+      "language": "scala",
+      "label": "Cask",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "missing"
+        },
+        "handler_attribution": {
+          "status": "missing"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.cats-effect",
+      "category": "http_framework",
+      "language": "scala",
+      "label": "Cats Effect (concurrency runtime)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "not_applicable"
+        },
+        "endpoint_synthesis": {
+          "status": "not_applicable"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/cats_effect.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.finatra",
+      "category": "http_framework",
+      "language": "scala",
+      "label": "Finatra (Twitter Finagle)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.http4s",
+      "category": "http_framework",
+      "language": "scala",
+      "label": "http4s",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.lagom",
+      "category": "http_framework",
+      "language": "scala",
+      "label": "Lagom",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.play",
+      "category": "http_framework",
+      "language": "scala",
+      "label": "Play Framework (Scala)",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/play_framework.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/play_framework.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.scalatra",
+      "category": "http_framework",
+      "language": "scala",
+      "label": "Scalatra",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.zio-http",
+      "category": "http_framework",
+      "language": "scala",
+      "label": "ZIO HTTP / ZIO",
+      "capabilities": {
+        "auth_coverage": {
+          "status": "missing"
+        },
+        "endpoint_synthesis": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "handler_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "middleware_coverage": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.orm.doobie",
+      "category": "orm",
+      "language": "scala",
+      "label": "Doobie",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.orm.elastic4s",
+      "category": "orm",
+      "language": "scala",
+      "label": "Elastic4s",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.orm.quill",
+      "category": "orm",
+      "language": "scala",
+      "label": "Quill",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.orm.scalikejdbc",
+      "category": "orm",
+      "language": "scala",
+      "label": "ScalikeJDBC",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.orm.scanamo",
+      "category": "orm",
+      "language": "scala",
+      "label": "Scanamo (DynamoDB)",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "not_applicable"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.scala.orm.slick",
+      "category": "orm",
+      "language": "scala",
+      "label": "Slick",
+      "capabilities": {
+        "migration_parsing": {
+          "status": "missing"
+        },
+        "model_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "query_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -2093,13 +8529,13 @@
       "language": "solidity",
       "label": "Solidity",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/solidity/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         }
       }
     },
@@ -2109,13 +8545,13 @@
       "language": "swift",
       "label": "Swift",
       "capabilities": {
+        "call_line_precision": {
+          "status": "partial"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/swift/swift.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "partial"
         },
         "discriminates_on": {
           "status": "missing"
@@ -2139,13 +8575,13 @@
       "language": "typescript",
       "label": "TypeScript (shares the JavaScript extractor)",
       "capabilities": {
+        "call_line_precision": {
+          "status": "full"
+        },
         "core_extraction": {
           "status": "full",
           "cites": ["internal/extractors/javascript/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "call_line_precision": {
-          "status": "full"
         },
         "discriminates_on": {
           "status": "full",
@@ -2165,11 +8601,51 @@
       "language": "zig",
       "label": "Zig",
       "capabilities": {
-        "core_extraction": {
-          "status": "partial"
-        },
         "call_line_precision": {
           "status": "partial"
+        },
+        "core_extraction": {
+          "status": "partial"
+        }
+      }
+    },
+    {
+      "id": "msg.broker.amqp",
+      "category": "message_broker",
+      "language": "multi",
+      "label": "AMQP (generic)",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "producer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "topic_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "msg.broker.azure-service-bus",
+      "category": "message_broker",
+      "language": "multi",
+      "label": "Azure Service Bus",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "missing"
+        },
+        "producer_extraction": {
+          "status": "missing"
+        },
+        "topic_attribution": {
+          "status": "missing"
         }
       }
     },
@@ -2179,19 +8655,19 @@
       "language": "multi",
       "label": "CloudEvents",
       "capabilities": {
-        "producer_extraction": {
-          "status": "full",
+        "consumer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
-          "status": "full",
+        "producer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
-          "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "status": "partial",
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2200,20 +8676,20 @@
       "id": "msg.broker.debezium",
       "category": "message_broker",
       "language": "multi",
-      "label": "Debezium / Kafka Connect CDC",
+      "label": "Debezium (CDC)",
       "capabilities": {
-        "producer_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/debezium_cdc_edges.go"],
-          "verified_at": "2026-05-28"
-        },
         "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         },
+        "producer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
+          "verified_at": "2026-05-28"
+        },
         "topic_attribution": {
-          "status": "partial",
+          "status": "full",
           "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         }
@@ -2225,19 +8701,19 @@
       "language": "multi",
       "label": "AWS EventBridge",
       "capabilities": {
-        "producer_extraction": {
-          "status": "full",
+        "consumer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
-          "status": "full",
+        "producer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
-          "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "status": "partial",
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2248,19 +8724,19 @@
       "language": "multi",
       "label": "Azure Event Grid",
       "capabilities": {
-        "producer_extraction": {
-          "status": "full",
+        "consumer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
-          "status": "full",
+        "producer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
-          "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "status": "partial",
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2271,19 +8747,19 @@
       "language": "multi",
       "label": "GCP Pub/Sub",
       "capabilities": {
-        "producer_extraction": {
-          "status": "full",
+        "consumer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
-          "status": "full",
+        "producer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
-          "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "status": "partial",
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2294,19 +8770,19 @@
       "language": "multi",
       "label": "Apache Kafka",
       "capabilities": {
-        "producer_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/kafka_edges.go", "internal/engine/kafka_wrapper_edges.go"],
-          "verified_at": "2026-05-28"
-        },
         "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/kafka_edges.go"],
           "verified_at": "2026-05-28"
         },
+        "producer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/kafka_edges.go","internal/engine/kafka_wrapper_edges.go"],
+          "verified_at": "2026-05-28"
+        },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": ["internal/engine/kafka_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2317,11 +8793,20 @@
       "language": "multi",
       "label": "MQTT",
       "capabilities": {
-        "producer_extraction": {
-          "status": "missing"
-        },
         "consumer_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/engine/event_bus_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "producer_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/event_bus_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "topic_attribution": {
+          "status": "partial",
+          "cites": ["internal/engine/event_bus_edges.go"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -2331,19 +8816,19 @@
       "language": "multi",
       "label": "NATS",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2354,19 +8839,19 @@
       "language": "multi",
       "label": "Apache Pulsar",
       "capabilities": {
-        "producer_extraction": {
-          "status": "full",
+        "consumer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
-          "status": "full",
+        "producer_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
-          "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "status": "partial",
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2377,19 +8862,19 @@
       "language": "multi",
       "label": "RabbitMQ",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2398,21 +8883,21 @@
       "id": "msg.broker.redis",
       "category": "message_broker",
       "language": "multi",
-      "label": "Redis pub/sub + Streams",
+      "label": "Redis pub/sub \u0026 streams",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2421,21 +8906,21 @@
       "id": "msg.broker.sns",
       "category": "message_broker",
       "language": "multi",
-      "label": "AWS SNS (IaC-declared)",
+      "label": "AWS SNS",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2446,19 +8931,19 @@
       "language": "multi",
       "label": "AWS SQS",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2469,12 +8954,12 @@
       "language": "javascript",
       "label": "BullMQ / bull (Node task queue)",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
@@ -2492,14 +8977,14 @@
       "language": "python",
       "label": "Celery (Python task queue)",
       "capabilities": {
-        "producer_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go", "internal/extractors/python/celery.go"],
-          "verified_at": "2026-05-28"
-        },
         "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/scheduled_jobs_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "producer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/extractors/python/celery.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
@@ -2515,12 +9000,12 @@
       "language": "python",
       "label": "Django signals (intra-repo pub/sub)",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
@@ -2538,10 +9023,10 @@
       "language": "python",
       "label": "Dramatiq (Python task queue)",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "missing"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "missing"
         }
       }
@@ -2552,12 +9037,12 @@
       "language": "multi",
       "label": "GraphQL subscriptions",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
@@ -2575,10 +9060,10 @@
       "language": "multi",
       "label": "Kafka Streams / Faust",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "missing"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "missing"
         }
       }
@@ -2589,10 +9074,10 @@
       "language": "ruby",
       "label": "Sidekiq (Ruby task queue)",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "missing"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "missing"
         }
       }
@@ -2603,15 +9088,18 @@
       "language": "multi",
       "label": "Server-Sent Events",
       "capabilities": {
+        "consumer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/sse_edges.go"],
+          "verified_at": "2026-05-28"
+        },
         "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/sse_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/sse_edges.go"],
-          "verified_at": "2026-05-28"
+        "topic_attribution": {
+          "status": "not_applicable"
         }
       }
     },
@@ -2619,15 +9107,20 @@
       "id": "msg.webhook",
       "category": "message_broker",
       "language": "multi",
-      "label": "Webhook inbound (Stripe, GitHub, Twilio, Slack, SendGrid, Mailgun, ...)",
+      "label": "Webhooks",
       "capabilities": {
+        "consumer_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/webhooks_edges.go"],
+          "verified_at": "2026-05-28"
+        },
         "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
-          "status": "full",
+        "topic_attribution": {
+          "status": "partial",
           "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         }
@@ -2637,14 +9130,14 @@
       "id": "msg.websocket",
       "category": "message_broker",
       "language": "multi",
-      "label": "WebSocket channels",
+      "label": "WebSocket",
       "capabilities": {
-        "producer_extraction": {
+        "consumer_extraction": {
           "status": "full",
           "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "consumer_extraction": {
+        "producer_extraction": {
           "status": "full",
           "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
@@ -2662,13 +9155,13 @@
       "language": "rust",
       "label": "Cargo.toml",
       "capabilities": {
+        "lockfile_parsing": {
+          "status": "missing"
+        },
         "manifest_parsing": {
           "status": "full",
           "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "lockfile_parsing": {
-          "status": "missing"
         }
       }
     },
@@ -2678,10 +9171,10 @@
       "language": "php",
       "label": "composer.json",
       "capabilities": {
-        "manifest_parsing": {
+        "lockfile_parsing": {
           "status": "missing"
         },
-        "lockfile_parsing": {
+        "manifest_parsing": {
           "status": "missing"
         }
       }
@@ -2692,10 +9185,10 @@
       "language": "csharp",
       "label": ".csproj / packages.config",
       "capabilities": {
-        "manifest_parsing": {
+        "lockfile_parsing": {
           "status": "missing"
         },
-        "lockfile_parsing": {
+        "manifest_parsing": {
           "status": "missing"
         }
       }
@@ -2706,13 +9199,13 @@
       "language": "ruby",
       "label": "Gemfile",
       "capabilities": {
+        "lockfile_parsing": {
+          "status": "missing"
+        },
         "manifest_parsing": {
           "status": "full",
           "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "lockfile_parsing": {
-          "status": "missing"
         }
       }
     },
@@ -2722,13 +9215,13 @@
       "language": "go",
       "label": "go.mod",
       "capabilities": {
+        "lockfile_parsing": {
+          "status": "partial"
+        },
         "manifest_parsing": {
           "status": "full",
           "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "lockfile_parsing": {
-          "status": "partial"
         }
       }
     },
@@ -2738,10 +9231,10 @@
       "language": "java",
       "label": "build.gradle / build.gradle.kts",
       "capabilities": {
-        "manifest_parsing": {
+        "lockfile_parsing": {
           "status": "missing"
         },
-        "lockfile_parsing": {
+        "manifest_parsing": {
           "status": "missing"
         }
       }
@@ -2763,13 +9256,13 @@
       "language": "javascript",
       "label": "package.json (npm/yarn/pnpm)",
       "capabilities": {
+        "lockfile_parsing": {
+          "status": "missing"
+        },
         "manifest_parsing": {
           "status": "full",
           "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "lockfile_parsing": {
-          "status": "missing"
         }
       }
     },
@@ -2779,10 +9272,10 @@
       "language": "python",
       "label": "Pipfile / Pipfile.lock",
       "capabilities": {
-        "manifest_parsing": {
+        "lockfile_parsing": {
           "status": "missing"
         },
-        "lockfile_parsing": {
+        "manifest_parsing": {
           "status": "missing"
         }
       }
@@ -2806,13 +9299,13 @@
       "language": "dart",
       "label": "pubspec.yaml",
       "capabilities": {
+        "lockfile_parsing": {
+          "status": "missing"
+        },
         "manifest_parsing": {
           "status": "full",
           "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "lockfile_parsing": {
-          "status": "missing"
         }
       }
     },
@@ -2822,13 +9315,13 @@
       "language": "python",
       "label": "pyproject.toml",
       "capabilities": {
+        "lockfile_parsing": {
+          "status": "missing"
+        },
         "manifest_parsing": {
           "status": "full",
           "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
-        },
-        "lockfile_parsing": {
-          "status": "missing"
         }
       }
     },
@@ -2871,11 +9364,11 @@
       "id": "protocol.graphql",
       "category": "protocol",
       "language": "multi",
-      "label": "GraphQL SDL (Query/Mutation/Subscription)",
+      "label": "GraphQL",
       "capabilities": {
-        "service_extraction": {
-          "status": "full",
-          "cites": ["internal/extractors/graphql/graphql.go"],
+        "cross_repo_linkage": {
+          "status": "partial",
+          "cites": ["internal/engine/http_endpoint_match.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
@@ -2883,8 +9376,10 @@
           "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
-        "cross_repo_linkage": {
-          "status": "partial"
+        "service_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/graphql_subscriptions.go","internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
+          "verified_at": "2026-05-28"
         }
       }
     },
@@ -2892,9 +9387,9 @@
       "id": "protocol.grpc",
       "category": "protocol",
       "language": "multi",
-      "label": "gRPC services",
+      "label": "gRPC",
       "capabilities": {
-        "service_extraction": {
+        "cross_repo_linkage": {
           "status": "full",
           "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
@@ -2904,10 +9399,27 @@
           "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
-        "cross_repo_linkage": {
+        "service_extraction": {
           "status": "full",
-          "cites": ["internal/links/grpc_pass.go"],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "protocol.jsonrpc",
+      "category": "protocol",
+      "language": "multi",
+      "label": "JSON-RPC",
+      "capabilities": {
+        "cross_repo_linkage": {
+          "status": "missing"
+        },
+        "method_attribution": {
+          "status": "missing"
+        },
+        "service_extraction": {
+          "status": "missing"
         }
       }
     },
@@ -2915,21 +9427,21 @@
       "id": "protocol.openapi",
       "category": "protocol",
       "language": "multi",
-      "label": "OpenAPI / Swagger spec",
+      "label": "OpenAPI / Swagger",
       "capabilities": {
-        "service_extraction": {
-          "status": "full",
-          "cites": ["internal/links/openapi_pass.go"],
+        "cross_repo_linkage": {
+          "status": "partial",
+          "cites": ["internal/engine/http_endpoint_match.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/links/openapi_pass.go"],
+          "cites": ["internal/engine/rules/openapi/language.yaml"],
           "verified_at": "2026-05-28"
         },
-        "cross_repo_linkage": {
+        "service_extraction": {
           "status": "full",
-          "cites": ["internal/links/openapi_pass.go"],
+          "cites": ["internal/engine/rules/openapi/language.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2938,22 +9450,39 @@
       "id": "protocol.protobuf",
       "category": "protocol",
       "language": "multi",
-      "label": "Protocol Buffers (.proto)",
+      "label": "Protocol Buffers",
       "capabilities": {
-        "service_extraction": {
-          "status": "full",
-          "cites": ["internal/extractors/proto/proto.go"],
+        "cross_repo_linkage": {
+          "status": "partial",
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/proto/proto.go"],
+          "cites": ["internal/extractors/proto"],
           "verified_at": "2026-05-28"
         },
-        "cross_repo_linkage": {
+        "service_extraction": {
           "status": "full",
-          "cites": ["internal/engine/grpc_edges.go"],
+          "cites": ["internal/engine/rules/protobuf/_manifest.yaml","internal/extractors/proto"],
           "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "protocol.soap",
+      "category": "protocol",
+      "language": "multi",
+      "label": "SOAP / WSDL",
+      "capabilities": {
+        "cross_repo_linkage": {
+          "status": "missing"
+        },
+        "method_attribution": {
+          "status": "missing"
+        },
+        "service_extraction": {
+          "status": "missing"
         }
       }
     },
@@ -2979,6 +9508,118 @@
         "auth_policy": {
           "status": "missing",
           "issue": "https://github.com/cajasmota/archigraph/issues/1942"
+        }
+      }
+    },
+    {
+      "id": "security.auth.basic",
+      "category": "security",
+      "language": "multi",
+      "label": "HTTP Basic Auth",
+      "capabilities": {
+        "auth_policy": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
+        "secret_detection": {
+          "status": "missing"
+        },
+        "sql_injection": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "security.auth.jwt",
+      "category": "security",
+      "language": "multi",
+      "label": "JWT",
+      "capabilities": {
+        "auth_policy": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
+        "secret_detection": {
+          "status": "missing"
+        },
+        "sql_injection": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "security.auth.oauth2",
+      "category": "security",
+      "language": "multi",
+      "label": "OAuth2",
+      "capabilities": {
+        "auth_policy": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
+        "secret_detection": {
+          "status": "missing"
+        },
+        "sql_injection": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "security.auth.oidc",
+      "category": "security",
+      "language": "multi",
+      "label": "OIDC (OpenID Connect)",
+      "capabilities": {
+        "auth_policy": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
+        "secret_detection": {
+          "status": "missing"
+        },
+        "sql_injection": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "security.auth.saml",
+      "category": "security",
+      "language": "multi",
+      "label": "SAML",
+      "capabilities": {
+        "auth_policy": {
+          "status": "missing"
+        },
+        "secret_detection": {
+          "status": "missing"
+        },
+        "sql_injection": {
+          "status": "not_applicable"
+        }
+      }
+    },
+    {
+      "id": "security.auth.session",
+      "category": "security",
+      "language": "multi",
+      "label": "Session cookies",
+      "capabilities": {
+        "auth_policy": {
+          "status": "partial",
+          "cites": ["internal/engine/java_auth_policy.go"],
+          "verified_at": "2026-05-28"
+        },
+        "secret_detection": {
+          "status": "missing"
+        },
+        "sql_injection": {
+          "status": "not_applicable"
         }
       }
     },
@@ -3017,6 +9658,650 @@
         "sql_injection": {
           "status": "full",
           "cites": ["internal/engine/rules/_engine/sql_injection_detector.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.assertj",
+      "category": "build_system",
+      "language": "java",
+      "label": "AssertJ",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.ava",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "AVA",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.behat",
+      "category": "build_system",
+      "language": "php",
+      "label": "Behat",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.cargo-test",
+      "category": "build_system",
+      "language": "rust",
+      "label": "cargo test (stdlib)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/rust/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.codeception",
+      "category": "build_system",
+      "language": "php",
+      "label": "Codeception",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.criterion",
+      "category": "build_system",
+      "language": "rust",
+      "label": "criterion (benchmark)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.cucumber",
+      "category": "build_system",
+      "language": "ruby",
+      "label": "Cucumber",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.cypress",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Cypress",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.doctest",
+      "category": "build_system",
+      "language": "python",
+      "label": "doctest (stdlib)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.exunit",
+      "category": "build_system",
+      "language": "elixir",
+      "label": "ExUnit",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/elixir/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.fluentassertions",
+      "category": "build_system",
+      "language": "csharp",
+      "label": "FluentAssertions",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.ginkgo",
+      "category": "build_system",
+      "language": "go",
+      "label": "Ginkgo",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.go-testing",
+      "category": "build_system",
+      "language": "go",
+      "label": "go testing (stdlib)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/go/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.gomega",
+      "category": "build_system",
+      "language": "go",
+      "label": "Gomega",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.hypothesis",
+      "category": "build_system",
+      "language": "python",
+      "label": "Hypothesis (property tests)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.jasmine",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Jasmine",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.jest",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Jest",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/jest.yaml","internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.junit4",
+      "category": "build_system",
+      "language": "java",
+      "label": "JUnit 4",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.junit5",
+      "category": "build_system",
+      "language": "java",
+      "label": "JUnit 5",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/java/frameworks/junit5.yaml","internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.minitest",
+      "category": "build_system",
+      "language": "ruby",
+      "label": "Minitest",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/ruby/test_patterns.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.mocha",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Mocha",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.mockall",
+      "category": "build_system",
+      "language": "rust",
+      "label": "mockall",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.mockito",
+      "category": "build_system",
+      "language": "java",
+      "label": "Mockito",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.mstest",
+      "category": "build_system",
+      "language": "csharp",
+      "label": "MSTest",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.nose2",
+      "category": "build_system",
+      "language": "python",
+      "label": "nose2",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.nunit",
+      "category": "build_system",
+      "language": "csharp",
+      "label": "NUnit",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.pest",
+      "category": "build_system",
+      "language": "php",
+      "label": "Pest",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.phpunit",
+      "category": "build_system",
+      "language": "php",
+      "label": "PHPUnit",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/php/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.playwright",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Playwright",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.proptest",
+      "category": "build_system",
+      "language": "rust",
+      "label": "proptest",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.pytest",
+      "category": "build_system",
+      "language": "python",
+      "label": "pytest",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/python/frameworks/pytest.yaml","internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.restassured",
+      "category": "build_system",
+      "language": "java",
+      "label": "REST-assured",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.rspec",
+      "category": "build_system",
+      "language": "ruby",
+      "label": "RSpec",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "full",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "full",
+          "cites": ["internal/engine/rules/ruby/frameworks/rspec.yaml","internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.spock",
+      "category": "build_system",
+      "language": "groovy",
+      "label": "Spock",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.streamdata",
+      "category": "build_system",
+      "language": "elixir",
+      "label": "StreamData (property tests)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.tap",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "tap / node:test",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "missing"
+        }
+      }
+    },
+    {
+      "id": "test.testify",
+      "category": "build_system",
+      "language": "go",
+      "label": "testify",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/go/test_patterns.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.testng",
+      "category": "build_system",
+      "language": "java",
+      "label": "TestNG",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "missing"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.unittest",
+      "category": "build_system",
+      "language": "python",
+      "label": "unittest (stdlib)",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/python/test_patterns.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.vitest",
+      "category": "build_system",
+      "language": "javascript",
+      "label": "Vitest",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "test.xunit",
+      "category": "build_system",
+      "language": "csharp",
+      "label": "xUnit",
+      "capabilities": {
+        "dependency_graph": {
+          "status": "partial",
+          "cites": ["internal/engine/tests_edges.go"],
+          "verified_at": "2026-05-28"
+        },
+        "target_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 27 · **Frameworks**: 62 · **ORMs**: 20 · **Tools**: 19 · **Other**: 79
+**Languages**: 27 · **Frameworks**: 165 · **ORMs**: 143 · **Tools**: 94 · **Other**: 124
 
 ## Coverage by language
 
@@ -10,29 +10,29 @@
 | [clojure](by-language/clojure.md) | 0 | 0 | 0 | 1 |
 | [cpp](by-language/cpp.md) | 0 | 0 | 0 | 1 |
 | [crystal](by-language/crystal.md) | 0 | 0 | 0 | 1 |
-| [csharp](by-language/csharp.md) | 3 | 1 | 1 | 1 |
+| [csharp](by-language/csharp.md) | 15 | 7 | 14 | 1 |
 | [dart](by-language/dart.md) | 0 | 1 | 0 | 1 |
-| [elixir](by-language/elixir.md) | 2 | 1 | 1 | 1 |
+| [elixir](by-language/elixir.md) | 9 | 5 | 10 | 1 |
 | [erlang](by-language/erlang.md) | 0 | 0 | 0 | 1 |
 | [fsharp](by-language/fsharp.md) | 0 | 0 | 0 | 1 |
-| [go](by-language/go.md) | 8 | 1 | 2 | 1 |
-| [groovy](by-language/groovy.md) | 0 | 0 | 0 | 1 |
+| [go](by-language/go.md) | 17 | 8 | 17 | 1 |
+| [groovy](by-language/groovy.md) | 0 | 1 | 0 | 1 |
 | [haskell](by-language/haskell.md) | 0 | 0 | 0 | 1 |
-| [java](by-language/java.md) | 6 | 2 | 2 | 3 |
-| [javascript](by-language/javascript.md) | 13 | 1 | 5 | 3 |
-| [kotlin](by-language/kotlin.md) | 3 | 0 | 0 | 1 |
+| [java](by-language/java.md) | 19 | 10 | 13 | 3 |
+| [javascript](by-language/javascript.md) | 30 | 21 | 18 | 3 |
+| [kotlin](by-language/kotlin.md) | 12 | 0 | 7 | 1 |
 | [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
 | [nim](by-language/nim.md) | 0 | 0 | 0 | 1 |
 | [ocaml](by-language/ocaml.md) | 0 | 0 | 0 | 1 |
-| [php](by-language/php.md) | 3 | 1 | 2 | 1 |
-| [python](by-language/python.md) | 12 | 3 | 6 | 4 |
-| [ruby](by-language/ruby.md) | 4 | 1 | 1 | 2 |
-| [rust](by-language/rust.md) | 5 | 1 | 0 | 1 |
-| [scala](by-language/scala.md) | 0 | 1 | 0 | 1 |
+| [php](by-language/php.md) | 12 | 6 | 14 | 1 |
+| [python](by-language/python.md) | 20 | 15 | 17 | 4 |
+| [ruby](by-language/ruby.md) | 8 | 6 | 13 | 2 |
+| [rust](by-language/rust.md) | 11 | 6 | 14 | 1 |
+| [scala](by-language/scala.md) | 9 | 3 | 6 | 1 |
 | [solidity](by-language/solidity.md) | 0 | 0 | 0 | 1 |
 | [swift](by-language/swift.md) | 1 | 1 | 0 | 1 |
 | [typescript](by-language/typescript.md) | 0 | 0 | 0 | 1 |
 | [zig](by-language/zig.md) | 0 | 0 | 0 | 1 |
-| Uncategorized | 0 | 4 | 0 | 46 |
+| Uncategorized | 0 | 4 | 0 | 91 |
 
-Total: 62 frameworks · 19 tools · 20 ORMs · 79 other
+Total: 165 frameworks · 94 tools · 143 ORMs · 124 other


### PR DESCRIPTION
## Summary
- Closes #2726. Expands `docs/coverage/registry.json` from 180 to **526** records via a deep audit of every language ecosystem in `internal/extractors/` and `internal/engine/rules/`.
- Every `full` / `partial` record cites the actual implementing rule pack or engine pass (cite paths validated on disk).
- `missing` records flag major frameworks/ORMs/tools we don't yet support — they form the backlog index.
- `not_applicable` is used honestly (e.g. `endpoint_synthesis` on a UI framework or build tool).

## Coverage (post-PR)
| Language | Frameworks | ORMs | Build/Test |
|---|---:|---:|---:|
| Java | 19 | 13 | 8 |
| Kotlin | 12 | 7 | — |
| Scala | 9 | 6 | 2 |
| Python | 20 | 17 | 12 |
| JS/TS | 30 | 18 | 20 |
| Go | 17 | 17 | 7 |
| Ruby | 8 | 13 | 5 |
| PHP | 12 | 14 | 5 |
| C# | 15 | 14 | 6 |
| Rust | 11 | 14 | 5 |
| Elixir | 9 | 10 | 4 |
| multi (language-neutral) | — | — | 95 records (observability, message brokers, protocols, auth, IaC, containers, CI, databases) |

Total: **526 records** · 331 full · 415 partial · 530 missing · 274 not_applicable.

All acceptance criteria from #2726 met (Java ≥8 frameworks/≥4 ORMs/≥3 build tools, Python ≥10/≥5, JS/TS ≥12/≥6, Go ≥8/≥4, every supported language has frameworks + ORMs + build tools, language-neutral covers OpenTelemetry/Kafka/RabbitMQ/Redis pub-sub/GraphQL/gRPC/OpenAPI/Docker/k8s and more).

## Test plan
- [x] `go run ./tools/coverage validate` → `ok: 526 record(s), 944 warning(s)` (warnings = `missing`/`partial` cells without tracking issue, expected)
- [x] `go run ./tools/coverage gen` is byte-stable across re-runs (md5 verified)
- [x] `go test ./tools/coverage/...` passes
- [x] `make coverage` exits 0
- [x] Every cite path exists on disk (validate enforces)

## Notable findings
- archigraph already supports ~15 Go frameworks (not just the 8 shown previously) — Hertz, Kratos, go-zero, Fyne, gomobile, Buffalo, Iris, Revel, fasthttp all have rule packs.
- Comprehensive driver-level coverage exists for **every** major DB (Postgres/MySQL/SQLite/MongoDB/Redis/Elasticsearch/Cassandra/DynamoDB/Neo4j) across **every** mainstream language — the rule packs were there, just unindexed in the registry.
- Kotlin ecosystem is much broader than the registry showed: Exposed, Ktorm, Room, SQLDelight, Hibernate-Kotlin, Spring Data Kotlin, plus Compose / Compose Desktop / Compose Multiplatform / KMP / coroutines / Arrow.
- C# / .NET has full Blazor (Server + WASM) plus MAUI/Uno/WinForms/WPF/Xamarin rule packs not previously surfaced.
- Gaps worth filing tracking issues for: Hapi, Restify, AdonisJS, Sails, Feathers, Marblejs (JS); Quart, Falcon, CherryPy, Hug (Python); Javalin, Helidon, Akka HTTP (Java); NancyFX, ServiceStack, Carter, FastEndpoints (C#); Salvo, Tower, Rbatis (Rust); Cuba (Ruby); Lumen, Phalcon (PHP); ClickHouse, Snowflake, Cassandra schema, Neo4j schema, Bicep, Kustomize, Drone CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)