### PR TITLE
feat(tools/coverage): subcategory schema + per-subcat capabilities + dynamic rendering (#2735)

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -5,7 +5,8 @@
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
-| Language | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+
+| Language | Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|---|
 | [csharp](../by-language/csharp.md) | [FluentAssertions](../detail/test.fluentassertions.md) | ❌ | — | — | ❌ | |
 | [csharp](../by-language/csharp.md) | [MSTest](../detail/test.mstest.md) | ⚠️ | — | — | ⚠️ | |

--- a/docs/coverage/by-category/configuration.md
+++ b/docs/coverage/by-category/configuration.md
@@ -5,7 +5,7 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | env_resolution | file_parsing | Status | Notes |
+| Language | Name | Env Resolution | File Parsing | Status | Notes |
 |---|---|---|---|---|---|
 | [java](../by-language/java.md) | [.properties (application.properties)](../detail/config.properties.md) | — | ✅ | ✅ | |
 | [JS/TS](../by-language/jsts.md) | [tsconfig.json](../detail/config.tsconfig.md) | — | ⚠️ | ⚠️ | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -5,7 +5,76 @@
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
-| Language | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+
+
+## Backend HTTP
+
+| Language | Name | Auth Coverage | DTO Extraction | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Request Validation | Route Extraction | Tests Linkage | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ❌ | — | ✅ | ✅ | ⚠️ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ⚠️ | — | ✅ | ✅ | ⚠️ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+
+## UI Frontend
+
+| Language | Name | Component Extraction | Data Fetching | Hook Recognition | JSX Template | Prop Extraction | Router Pattern | State Management | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ | ❌ | — | — | ❌ | ❌ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ | |
+| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ | ❌ | — | — | ❌ | ❌ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ | ❌ | ❌ | — | ❌ | ❌ | ❌ | |
+
+## Meta Framework
+
+| Language | Name | Component Extraction | Data Loaders | Hook Recognition | Hydration Boundaries | Route Extraction | Router Pattern | Server Components | Static Generation | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ | ❌ | ❌ | ❌ | ⚠️ | ❌ | ❌ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
+
+## Mobile
+
+| Language | Name | Deep Link Extraction | Native Module Imports | Navigation Extraction | Platform Branching | Screen Detection | State Management | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ❌ | ❌ | ✅ | ⚠️ | ✅ | ⚠️ | |
+| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ❌ | ❌ | ✅ | ⚠️ | ✅ | ⚠️ | |
+
+## Desktop
+
+| Language | Name | IPC Extraction | Main Renderer Split | Native Module Imports | Notes |
+|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | ❌ | ⚠️ | ❌ | |
+
+## RPC Framework
+
+| Language | Name | Client Codegen | Procedure Extraction | Schema Extraction | Notes |
+|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ❌ | ✅ | ⚠️ | |
+
+## AI Integration
+
+| Language | Name | Chain Composition | Prompt Template Extraction | Tool Use Detection | Notes |
+|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ⚠️ | ⚠️ | ❌ | |
+
+## Other
+
+| Language | Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|---|
 | [csharp](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | — | — | ⚠️ | — | |
 | [csharp](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | ⚠️ | |
@@ -67,36 +136,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ⚠️ | ✅ | ✅ | ❌ | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | — | — | ✅ | — | |
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ | ✅ | ✅ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | — | — | ⚠️ | — | |
-| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | — | — | ⚠️ | — | |
-| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ❌ | ✅ | ✅ | ⚠️ | |
-| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ | ✅ | ✅ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ | ✅ | ✅ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ❌ | ✅ | ✅ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | — | — | ⚠️ | — | |
-| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ❌ | ✅ | ✅ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | — | — | ⚠️ | — | |
-| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | — | — | ⚠️ | — | |
-| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
-| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ | ✅ | ✅ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ | ✅ | ✅ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | — | — | ⚠️ | — | |
-| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | — | — | ⚠️ | — | |
-| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ | ✅ | ✅ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | — | — | ⚠️ | — | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ | ✅ | ✅ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | — | — | ⚠️ | — | |
-| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ❌ | ✅ | ✅ | ❌ | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | — | — | ⚠️ | — | |
 | [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | — | — | ⚠️ | — | |
 | [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | — | — | ⚠️ | — | |

--- a/docs/coverage/by-category/infrastructure.md
+++ b/docs/coverage/by-category/infrastructure.md
@@ -5,7 +5,7 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | dependency_attribution | resource_extraction | Status | Notes |
+| Language | Name | Dependency Attribution | Resource Extraction | Status | Notes |
 |---|---|---|---|---|---|
 | [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | ⚠️ | ⚠️ | ⚠️ | |
 | [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | ✅ | ✅ | |

--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -5,7 +5,7 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | consumer_extraction | producer_extraction | topic_attribution | Status | Notes |
+| Language | Name | Consumer Extraction | Producer Extraction | Topic Attribution | Status | Notes |
 |---|---|---|---|---|---|---|
 | [JS/TS](../by-language/jsts.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
 | [multi](../by-language/multi.md) | [AMQP (generic)](../detail/msg.broker.amqp.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | |

--- a/docs/coverage/by-category/observability.md
+++ b/docs/coverage/by-category/observability.md
@@ -5,7 +5,7 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | log_extraction | metric_extraction | trace_extraction | Status | Notes |
+| Language | Name | Log Extraction | Metric Extraction | Trace Extraction | Status | Notes |
 |---|---|---|---|---|---|---|
 | [multi](../by-language/multi.md) | [Datadog](../detail/infra.observability.datadog.md) | ❌ | ❌ | ❌ | ❌ | |
 | [multi](../by-language/multi.md) | [Elastic APM](../detail/infra.observability.elastic-apm.md) | ❌ | ❌ | ❌ | ❌ | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -5,7 +5,8 @@
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
-| Language | Name | migration_parsing | model_extraction | query_attribution | Notes |
+
+| Language | Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|---|
 | [csharp](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | — | — | ⚠️ | |
 | [csharp](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | — | — | ⚠️ | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -5,7 +5,8 @@
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
-| Language | Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+
+| Language | Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|---|
 | [csharp](../by-language/csharp.md) | [.csproj / packages.config](../detail/pkg.csproj.md) | — | ❌ | ❌ | — | |
 | [dart](../by-language/dart.md) | [pubspec.yaml](../detail/pkg.pubspec.md) | — | ❌ | ✅ | — | |

--- a/docs/coverage/by-category/protocol.md
+++ b/docs/coverage/by-category/protocol.md
@@ -5,7 +5,7 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | cross_repo_linkage | method_attribution | service_extraction | Status | Notes |
+| Language | Name | Cross Repo Linkage | Method Attribution | Service Extraction | Status | Notes |
 |---|---|---|---|---|---|---|
 | [multi](../by-language/multi.md) | [GraphQL](../detail/protocol.graphql.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
 | [multi](../by-language/multi.md) | [JSON-RPC](../detail/protocol.jsonrpc.md) | ❌ | ❌ | ❌ | ❌ | |

--- a/docs/coverage/by-category/security.md
+++ b/docs/coverage/by-category/security.md
@@ -5,7 +5,7 @@
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | auth_policy | secret_detection | sql_injection | Status | Notes |
+| Language | Name | Auth Policy | Secret Detection | Sql Injection | Status | Notes |
 |---|---|---|---|---|---|---|
 | [java](../by-language/java.md) | [Auth policy resolver (Java/Kotlin — Phase 1 of #1942)](../detail/security.auth-java.md) | ✅ | — | — | ✅ | |
 | [multi](../by-language/multi.md) | [Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)](../detail/security.auth-other.md) | ❌ | — | — | ❌ | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | — | — | ⚠️ | — | |
 | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | ⚠️ | |
@@ -27,7 +27,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [.csproj / packages.config](../detail/pkg.csproj.md) | — | ❌ | ❌ | — | |
 | [FluentAssertions](../detail/test.fluentassertions.md) | ❌ | — | — | ❌ | |
@@ -39,7 +39,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | — | — | ⚠️ | |
 | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | — | — | ⚠️ | |

--- a/docs/coverage/by-language/dart.md
+++ b/docs/coverage/by-language/dart.md
@@ -7,6 +7,6 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [pubspec.yaml](../detail/pkg.pubspec.md) | — | ❌ | ✅ | — | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
@@ -21,7 +21,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [ExUnit](../detail/test.exunit.md) | ✅ | — | — | ✅ | |
 | [Hex](../detail/build.hex.md) | ⚠️ | — | — | ⚠️ | |
@@ -31,7 +31,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ | ✅ | ✅ | |
 | [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | — | — | ⚠️ | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Beego](../detail/lang.go.framework.beego.md) | ❌ | ✅ | ✅ | ❌ | |
 | [Buffalo](../detail/lang.go.framework.buffalo.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
@@ -29,7 +29,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [Ginkgo](../detail/test.ginkgo.md) | ❌ | — | — | ❌ | |
 | [Gomega](../detail/test.gomega.md) | ❌ | — | — | ❌ | |
@@ -42,7 +42,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | — | — | ⚠️ | |
 | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ | ⚠️ | ⚠️ | |

--- a/docs/coverage/by-language/groovy.md
+++ b/docs/coverage/by-language/groovy.md
@@ -7,6 +7,6 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [Spock](../detail/test.spock.md) | ❌ | — | — | ❌ | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ | ❌ | ❌ | ❌ | |
 | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | — | — | ⚠️ | — | |
@@ -31,7 +31,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [AssertJ](../detail/test.assertj.md) | ❌ | — | — | ❌ | |
 | [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | — | — | ✅ | |
@@ -46,7 +46,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | — | ⚠️ | ⚠️ | |
 | [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ | ❌ | ❌ | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -7,42 +7,75 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
-|---|---|---|---|---|---|
-| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Angular](../detail/lang.jsts.framework.angular.md) | — | — | ✅ | — | |
-| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Electron](../detail/lang.jsts.framework.electron.md) | — | — | ⚠️ | — | |
-| [Expo](../detail/lang.jsts.framework.expo.md) | — | — | ⚠️ | — | |
-| [Express](../detail/lang.jsts.framework.express.md) | ❌ | ✅ | ✅ | ⚠️ | |
-| [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Hono](../detail/lang.jsts.framework.hono.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Ionic](../detail/lang.jsts.framework.ionic.md) | — | — | ⚠️ | — | |
-| [Koa](../detail/lang.jsts.framework.koa.md) | ❌ | ✅ | ✅ | ❌ | |
-| [LangChain.js](../detail/lang.jsts.framework.langchain.md) | — | — | ⚠️ | — | |
-| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ | ❌ | ❌ | ❌ | |
-| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | — | — | ⚠️ | — | |
-| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
-| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Polka](../detail/lang.jsts.framework.polka.md) | ❌ | ❌ | ❌ | ❌ | |
-| [React](../detail/lang.jsts.framework.react.md) | — | — | ⚠️ | — | |
-| [React Native](../detail/lang.jsts.framework.react-native.md) | — | — | ⚠️ | — | |
-| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Restify](../detail/lang.jsts.framework.restify.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Sails](../detail/lang.jsts.framework.sails.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Svelte](../detail/lang.jsts.framework.svelte.md) | — | — | ⚠️ | — | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Vue](../detail/lang.jsts.framework.vue.md) | — | — | ⚠️ | — | |
-| [tRPC](../detail/lang.jsts.framework.trpc.md) | ❌ | ✅ | ✅ | ❌ | |
+
+### Backend HTTP
+
+| Name | Auth Coverage | DTO Extraction | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Request Validation | Route Extraction | Tests Linkage | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [Express](../detail/lang.jsts.framework.express.md) | ❌ | — | ✅ | ✅ | ⚠️ | — | — | — | |
+| [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
+| [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [Hono](../detail/lang.jsts.framework.hono.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
+| [Koa](../detail/lang.jsts.framework.koa.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
+| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ⚠️ | — | ✅ | ✅ | ⚠️ | — | — | — | |
+| [Polka](../detail/lang.jsts.framework.polka.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [Restify](../detail/lang.jsts.framework.restify.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| [Sails](../detail/lang.jsts.framework.sails.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+
+### UI Frontend
+
+| Name | Component Extraction | Data Fetching | Hook Recognition | JSX Template | Prop Extraction | Router Pattern | State Management | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Angular](../detail/lang.jsts.framework.angular.md) | ❌ | ❌ | — | — | ❌ | ❌ | ❌ | |
+| [React](../detail/lang.jsts.framework.react.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ | |
+| [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ | ❌ | — | — | ❌ | ❌ | ❌ | |
+| [Vue](../detail/lang.jsts.framework.vue.md) | ❌ | ❌ | ❌ | — | ❌ | ❌ | ❌ | |
+
+### Meta Framework
+
+| Name | Component Extraction | Data Loaders | Hook Recognition | Hydration Boundaries | Route Extraction | Router Pattern | Server Components | Static Generation | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
+| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ | ❌ | ❌ | ❌ | ⚠️ | ❌ | ❌ | ❌ | |
+| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
+| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
+
+### Mobile
+
+| Name | Deep Link Extraction | Native Module Imports | Navigation Extraction | Platform Branching | Screen Detection | State Management | Notes |
+|---|---|---|---|---|---|---|---|
+| [Expo](../detail/lang.jsts.framework.expo.md) | ❌ | ❌ | ✅ | ⚠️ | ✅ | ⚠️ | |
+| [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | |
+| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | |
+| [React Native](../detail/lang.jsts.framework.react-native.md) | ❌ | ❌ | ✅ | ⚠️ | ✅ | ⚠️ | |
+
+### Desktop
+
+| Name | IPC Extraction | Main Renderer Split | Native Module Imports | Notes |
+|---|---|---|---|---|
+| [Electron](../detail/lang.jsts.framework.electron.md) | ❌ | ⚠️ | ❌ | |
+
+### RPC Framework
+
+| Name | Client Codegen | Procedure Extraction | Schema Extraction | Notes |
+|---|---|---|---|---|
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ | ✅ | ✅ | |
+| [tRPC](../detail/lang.jsts.framework.trpc.md) | ❌ | ✅ | ⚠️ | |
+
+### AI Integration
+
+| Name | Chain Composition | Prompt Template Extraction | Tool Use Detection | Notes |
+|---|---|---|---|---|
+| [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ⚠️ | ⚠️ | ❌ | |
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [AVA](../detail/test.ava.md) | ❌ | — | — | ❌ | |
 | [Bun (runtime + manager)](../detail/build.bun.md) | ⚠️ | — | — | ⚠️ | |
@@ -68,7 +101,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | — | — | ⚠️ | |
 | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | — | — | ⚠️ | |

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | — | — | ⚠️ | — | |
 | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | — | — | ⚠️ | — | |
@@ -24,7 +24,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | ❌ | ✅ | ✅ | |
 | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ | ⚠️ | ⚠️ | |

--- a/docs/coverage/by-language/lua.md
+++ b/docs/coverage/by-language/lua.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Lapis](../detail/lang.lua.framework.lapis.md) | — | ❌ | — | — | |
 | [OpenResty](../detail/lang.lua.framework.openresty.md) | — | ❌ | — | — | |

--- a/docs/coverage/by-language/multi.md
+++ b/docs/coverage/by-language/multi.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [Bazel / BUCK / WORKSPACE](../detail/build.bazel.md) | ✅ | — | — | ✅ | |
 | [Dockerfile](../detail/build.dockerfile.md) | ✅ | — | — | ✅ | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [CakePHP](../detail/lang.php.framework.cakephp.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
@@ -24,7 +24,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [Behat](../detail/test.behat.md) | ❌ | — | — | ❌ | |
 | [Codeception](../detail/test.codeception.md) | ❌ | — | — | ❌ | |
@@ -35,7 +35,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | — | — | ⚠️ | |
 | [CycleORM](../detail/lang.php.orm.cycleorm.md) | ❌ | ❌ | ❌ | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ | ✅ | ✅ | ❌ | |
 | [Celery (task queue)](../detail/lang.python.framework.celery.md) | — | — | ✅ | — | |
@@ -32,7 +32,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [Flit](../detail/build.flit.md) | ❌ | — | — | ❌ | |
 | [Hatch](../detail/build.hatch.md) | ❌ | — | — | ❌ | |
@@ -52,7 +52,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ⚠️ | — | — | |
 | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | — | ⚠️ | ⚠️ | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ | ❌ | ❌ | ❌ | |
 | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ | ✅ | ✅ | ❌ | |
@@ -20,7 +20,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [Bundler (Gemfile)](../detail/build.bundler.md) | ✅ | — | — | ✅ | |
 | [Cucumber](../detail/test.cucumber.md) | ❌ | — | — | ❌ | |
@@ -31,7 +31,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | — | — | ⚠️ | |
 | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ❌ | ✅ | ✅ | |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Actix Web](../detail/lang.rust.framework.actix.md) | ❌ | ✅ | ✅ | ❌ | |
 | [Axum](../detail/lang.rust.framework.axum.md) | ❌ | ✅ | ✅ | ❌ | |
@@ -23,7 +23,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | — | — | ✅ | |
 | [Cargo.toml](../detail/pkg.cargo.md) | — | ❌ | ✅ | — | |
@@ -34,7 +34,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [Diesel](../detail/lang.rust.orm.diesel.md) | ❌ | ✅ | ✅ | |
 | [Rbatis](../detail/lang.rust.orm.rbatis.md) | ❌ | ❌ | ❌ | |

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 | [Cask](../detail/lang.scala.framework.cask.md) | ❌ | ❌ | ❌ | ❌ | |
@@ -21,7 +21,7 @@ Back to [summary](../summary.md).
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [Mill](../detail/build.mill.md) | ❌ | — | — | ❌ | |
 | [SBT](../detail/build.sbt.md) | ✅ | — | — | ✅ | |
@@ -29,7 +29,7 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | migration_parsing | model_extraction | query_attribution | Notes |
+| Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|
 | [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ | ⚠️ | ⚠️ | |
 | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | — | ⚠️ | ⚠️ | |

--- a/docs/coverage/by-language/swift.md
+++ b/docs/coverage/by-language/swift.md
@@ -7,12 +7,12 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Vapor](../detail/lang.swift.framework.vapor.md) | — | ❌ | — | — | |
 
 ## Tools
 
-| Name | dependency_graph | lockfile_parsing | manifest_parsing | target_extraction | Notes |
+| Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|
 | [Package.swift / Podfile](../detail/pkg.swift-package.md) | — | — | ❌ | — | |

--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.angular.md
+++ b/docs/coverage/detail/lang.jsts.framework.angular.md
@@ -5,16 +5,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** UI Frontend
+- **Capability cells:** 7
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/angular.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — |
+| `jsx_template` | — `not_applicable` | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.astro.md
+++ b/docs/coverage/detail/lang.jsts.framework.astro.md
@@ -5,16 +5,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Meta Framework
+- **Capability cells:** 8
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — |
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — |
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` |
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+| `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.electron.md
+++ b/docs/coverage/detail/lang.jsts.framework.electron.md
@@ -5,16 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Desktop
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/electron.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `ipc_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `main_renderer_split` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/electron.yaml` |
+| `native_module_imports` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.expo.md
+++ b/docs/coverage/detail/lang.jsts.framework.expo.md
@@ -5,16 +5,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 6
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `deep_link_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `navigation_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+| `screen_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.feathers.md
+++ b/docs/coverage/detail/lang.jsts.framework.feathers.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.gatsby.md
+++ b/docs/coverage/detail/lang.jsts.framework.gatsby.md
@@ -5,16 +5,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Meta Framework
+- **Capability cells:** 8
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — |
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — |
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `route_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml` |
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+| `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -5,16 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** RPC Framework
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| `client_codegen` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml` |
+| `schema_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.hapi.md
+++ b/docs/coverage/detail/lang.jsts.framework.hapi.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.hono.md
+++ b/docs/coverage/detail/lang.jsts.framework.hono.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.ionic.md
+++ b/docs/coverage/detail/lang.jsts.framework.ionic.md
@@ -5,16 +5,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 6
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/ionic.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — |
+| `native_module_imports` | ❌ `missing` | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — |
+| `platform_branching` | ❌ `missing` | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.koa.md
+++ b/docs/coverage/detail/lang.jsts.framework.koa.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.langchain.md
+++ b/docs/coverage/detail/lang.jsts.framework.langchain.md
@@ -5,16 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** AI Integration
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `chain_composition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` |
+| `prompt_template_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` |
+| `tool_use_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.marblejs.md
+++ b/docs/coverage/detail/lang.jsts.framework.marblejs.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.nativescript.md
+++ b/docs/coverage/detail/lang.jsts.framework.nativescript.md
@@ -5,16 +5,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 6
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nativescript.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — |
+| `native_module_imports` | ❌ `missing` | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — |
+| `platform_branching` | ❌ `missing` | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -5,16 +5,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Meta Framework
+- **Capability cells:** 8
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `data_loaders` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `hook_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `hydration_boundaries` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
+| `router_pattern` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
+| `server_components` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `static_generation` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -5,16 +5,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Meta Framework
+- **Capability cells:** 8
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — |
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — |
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` |
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+| `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.polka.md
+++ b/docs/coverage/detail/lang.jsts.framework.polka.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.react-native.md
+++ b/docs/coverage/detail/lang.jsts.framework.react-native.md
@@ -5,16 +5,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 6
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `deep_link_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `navigation_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+| `screen_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -5,16 +5,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** UI Frontend
+- **Capability cells:** 7
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `component_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| `data_fetching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2554) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| `hook_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| `jsx_template` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| `prop_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2665) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| `router_pattern` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.remix.md
+++ b/docs/coverage/detail/lang.jsts.framework.remix.md
@@ -5,16 +5,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Meta Framework
+- **Capability cells:** 8
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — |
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — |
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` |
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+| `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.restify.md
+++ b/docs/coverage/detail/lang.jsts.framework.restify.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.jsts.framework.svelte.md
+++ b/docs/coverage/detail/lang.jsts.framework.svelte.md
@@ -5,16 +5,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** UI Frontend
+- **Capability cells:** 7
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/svelte.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — |
+| `jsx_template` | — `not_applicable` | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -5,16 +5,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Meta Framework
+- **Capability cells:** 8
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — |
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — |
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` |
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+| `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -5,16 +5,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** RPC Framework
+- **Capability cells:** 3
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| `client_codegen` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` |
+| `schema_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/http_endpoint_trpc.go` |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.vue.md
+++ b/docs/coverage/detail/lang.jsts.framework.vue.md
@@ -5,16 +5,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** UI Frontend
+- **Capability cells:** 7
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/vue.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — |
+| `jsx_template` | — `not_applicable` | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -4176,6 +4176,7 @@
     {
       "id": "lang.jsts.framework.adonisjs",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "AdonisJS",
       "capabilities": {
@@ -4196,45 +4197,64 @@
     {
       "id": "lang.jsts.framework.angular",
       "category": "http_framework",
+      "subcategory": "ui_frontend",
       "language": "jsts",
       "label": "Angular",
       "capabilities": {
-        "auth_coverage": {
+        "component_extraction": {
+          "status": "missing"
+        },
+        "data_fetching": {
+          "status": "missing"
+        },
+        "hook_recognition": {
           "status": "not_applicable"
         },
-        "endpoint_synthesis": {
+        "jsx_template": {
           "status": "not_applicable"
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/angular.yaml"],
-          "verified_at": "2026-05-28"
+        "prop_extraction": {
+          "status": "missing"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "router_pattern": {
+          "status": "missing"
+        },
+        "state_management": {
+          "status": "missing"
         }
       }
     },
     {
       "id": "lang.jsts.framework.astro",
       "category": "http_framework",
+      "subcategory": "meta_framework",
       "language": "jsts",
       "label": "Astro",
       "capabilities": {
-        "auth_coverage": {
+        "component_extraction": {
           "status": "missing"
         },
-        "endpoint_synthesis": {
+        "data_loaders": {
+          "status": "missing"
+        },
+        "hook_recognition": {
+          "status": "not_applicable"
+        },
+        "hydration_boundaries": {
+          "status": "missing"
+        },
+        "route_extraction": {
           "status": "full",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
           "verified_at": "2026-05-28"
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
-          "verified_at": "2026-05-28"
+        "router_pattern": {
+          "status": "missing"
         },
-        "middleware_coverage": {
+        "server_components": {
+          "status": "missing"
+        },
+        "static_generation": {
           "status": "missing"
         }
       }
@@ -4242,50 +4262,68 @@
     {
       "id": "lang.jsts.framework.electron",
       "category": "http_framework",
+      "subcategory": "desktop",
       "language": "jsts",
       "label": "Electron",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "ipc_extraction": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
+        "main_renderer_split": {
           "status": "partial",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/electron.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
           "verified_at": "2026-05-28"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "native_module_imports": {
+          "status": "missing"
         }
       }
     },
     {
       "id": "lang.jsts.framework.expo",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "jsts",
       "label": "Expo",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "deep_link_extraction": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "native_module_imports": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         },
-        "handler_attribution": {
-          "status": "partial",
+        "navigation_extraction": {
+          "status": "full",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
           "verified_at": "2026-05-28"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "platform_branching": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2666",
+          "verified_at": "2026-05-28"
+        },
+        "screen_detection": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "state_management": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+          "verified_at": "2026-05-28"
         }
       }
     },
     {
       "id": "lang.jsts.framework.express",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Express",
       "capabilities": {
@@ -4312,6 +4350,7 @@
     {
       "id": "lang.jsts.framework.fastify",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Fastify",
       "capabilities": {
@@ -4336,6 +4375,7 @@
     {
       "id": "lang.jsts.framework.feathers",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Feathers",
       "capabilities": {
@@ -4356,23 +4396,35 @@
     {
       "id": "lang.jsts.framework.gatsby",
       "category": "http_framework",
+      "subcategory": "meta_framework",
       "language": "jsts",
       "label": "Gatsby",
       "capabilities": {
-        "auth_coverage": {
+        "component_extraction": {
           "status": "missing"
         },
-        "endpoint_synthesis": {
+        "data_loaders": {
+          "status": "missing"
+        },
+        "hook_recognition": {
+          "status": "missing"
+        },
+        "hydration_boundaries": {
+          "status": "missing"
+        },
+        "route_extraction": {
           "status": "partial",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
           "verified_at": "2026-05-28"
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
-          "verified_at": "2026-05-28"
+        "router_pattern": {
+          "status": "missing"
         },
-        "middleware_coverage": {
+        "server_components": {
+          "status": "missing"
+        },
+        "static_generation": {
           "status": "missing"
         }
       }
@@ -4380,30 +4432,30 @@
     {
       "id": "lang.jsts.framework.graphql-resolvers",
       "category": "http_framework",
+      "subcategory": "rpc_framework",
       "language": "jsts",
       "label": "GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "client_codegen": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         },
-        "endpoint_synthesis": {
+        "procedure_extraction": {
           "status": "full",
           "cites": ["internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"],
           "verified_at": "2026-05-28"
         },
-        "handler_attribution": {
+        "schema_extraction": {
           "status": "full",
           "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
           "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "missing"
         }
       }
     },
     {
       "id": "lang.jsts.framework.hapi",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Hapi",
       "capabilities": {
@@ -4424,6 +4476,7 @@
     {
       "id": "lang.jsts.framework.hono",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Hono",
       "capabilities": {
@@ -4448,28 +4501,34 @@
     {
       "id": "lang.jsts.framework.ionic",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "jsts",
       "label": "Ionic",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "deep_link_extraction": {
+          "status": "missing"
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "native_module_imports": {
+          "status": "missing"
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/ionic.yaml"],
-          "verified_at": "2026-05-28"
+        "navigation_extraction": {
+          "status": "missing"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "platform_branching": {
+          "status": "missing"
+        },
+        "screen_detection": {
+          "status": "missing"
+        },
+        "state_management": {
+          "status": "missing"
         }
       }
     },
     {
       "id": "lang.jsts.framework.koa",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Koa",
       "capabilities": {
@@ -4494,28 +4553,32 @@
     {
       "id": "lang.jsts.framework.langchain",
       "category": "http_framework",
+      "subcategory": "ai_integration",
       "language": "jsts",
       "label": "LangChain.js",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
-        },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
+        "chain_composition": {
           "status": "partial",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
           "verified_at": "2026-05-28"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "prompt_template_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+          "verified_at": "2026-05-28"
+        },
+        "tool_use_detection": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         }
       }
     },
     {
       "id": "lang.jsts.framework.marblejs",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Marble.js",
       "capabilities": {
@@ -4536,28 +4599,34 @@
     {
       "id": "lang.jsts.framework.nativescript",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "jsts",
       "label": "NativeScript",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "deep_link_extraction": {
+          "status": "missing"
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "native_module_imports": {
+          "status": "missing"
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nativescript.yaml"],
-          "verified_at": "2026-05-28"
+        "navigation_extraction": {
+          "status": "missing"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "platform_branching": {
+          "status": "missing"
+        },
+        "screen_detection": {
+          "status": "missing"
+        },
+        "state_management": {
+          "status": "missing"
         }
       }
     },
     {
       "id": "lang.jsts.framework.nestjs",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "NestJS",
       "capabilities": {
@@ -4586,47 +4655,77 @@
     {
       "id": "lang.jsts.framework.next-api",
       "category": "http_framework",
+      "subcategory": "meta_framework",
       "language": "jsts",
       "label": "Next.js API Routes / App Router",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "component_extraction": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         },
-        "endpoint_synthesis": {
+        "data_loaders": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        },
+        "hook_recognition": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        },
+        "hydration_boundaries": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        },
+        "route_extraction": {
           "status": "full",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
           "verified_at": "2026-05-28"
         },
-        "handler_attribution": {
+        "router_pattern": {
           "status": "full",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
           "verified_at": "2026-05-28"
         },
-        "middleware_coverage": {
-          "status": "missing"
+        "server_components": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        },
+        "static_generation": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         }
       }
     },
     {
       "id": "lang.jsts.framework.nuxt",
       "category": "http_framework",
+      "subcategory": "meta_framework",
       "language": "jsts",
       "label": "Nuxt",
       "capabilities": {
-        "auth_coverage": {
+        "component_extraction": {
           "status": "missing"
         },
-        "endpoint_synthesis": {
+        "data_loaders": {
+          "status": "missing"
+        },
+        "hook_recognition": {
+          "status": "not_applicable"
+        },
+        "hydration_boundaries": {
+          "status": "missing"
+        },
+        "route_extraction": {
           "status": "full",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
           "verified_at": "2026-05-28"
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
-          "verified_at": "2026-05-28"
+        "router_pattern": {
+          "status": "missing"
         },
-        "middleware_coverage": {
+        "server_components": {
+          "status": "missing"
+        },
+        "static_generation": {
           "status": "missing"
         }
       }
@@ -4634,6 +4733,7 @@
     {
       "id": "lang.jsts.framework.polka",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Polka",
       "capabilities": {
@@ -4654,67 +4754,123 @@
     {
       "id": "lang.jsts.framework.react",
       "category": "http_framework",
+      "subcategory": "ui_frontend",
       "language": "jsts",
       "label": "React",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
-        },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
+        "component_extraction": {
           "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+          "verified_at": "2026-05-28"
+        },
+        "data_fetching": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2554",
+          "verified_at": "2026-05-28"
+        },
+        "hook_recognition": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+          "verified_at": "2026-05-28"
+        },
+        "jsx_template": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+          "verified_at": "2026-05-28"
+        },
+        "prop_extraction": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2665",
+          "verified_at": "2026-05-28"
+        },
+        "router_pattern": {
+          "status": "full",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
           "verified_at": "2026-05-28"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "state_management": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+          "verified_at": "2026-05-28"
         }
       }
     },
     {
       "id": "lang.jsts.framework.react-native",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "jsts",
       "label": "React Native",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "deep_link_extraction": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "native_module_imports": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         },
-        "handler_attribution": {
-          "status": "partial",
+        "navigation_extraction": {
+          "status": "full",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
           "verified_at": "2026-05-28"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "platform_branching": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2666",
+          "verified_at": "2026-05-28"
+        },
+        "screen_detection": {
+          "status": "full",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+          "verified_at": "2026-05-28"
+        },
+        "state_management": {
+          "status": "partial",
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+          "verified_at": "2026-05-28"
         }
       }
     },
     {
       "id": "lang.jsts.framework.remix",
       "category": "http_framework",
+      "subcategory": "meta_framework",
       "language": "jsts",
       "label": "Remix",
       "capabilities": {
-        "auth_coverage": {
+        "component_extraction": {
           "status": "missing"
         },
-        "endpoint_synthesis": {
+        "data_loaders": {
+          "status": "missing"
+        },
+        "hook_recognition": {
+          "status": "missing"
+        },
+        "hydration_boundaries": {
+          "status": "missing"
+        },
+        "route_extraction": {
           "status": "full",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
           "verified_at": "2026-05-28"
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
-          "verified_at": "2026-05-28"
+        "router_pattern": {
+          "status": "missing"
         },
-        "middleware_coverage": {
+        "server_components": {
+          "status": "missing"
+        },
+        "static_generation": {
           "status": "missing"
         }
       }
@@ -4722,6 +4878,7 @@
     {
       "id": "lang.jsts.framework.restify",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Restify",
       "capabilities": {
@@ -4742,6 +4899,7 @@
     {
       "id": "lang.jsts.framework.sails",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "Sails",
       "capabilities": {
@@ -4762,45 +4920,64 @@
     {
       "id": "lang.jsts.framework.svelte",
       "category": "http_framework",
+      "subcategory": "ui_frontend",
       "language": "jsts",
       "label": "Svelte",
       "capabilities": {
-        "auth_coverage": {
+        "component_extraction": {
+          "status": "missing"
+        },
+        "data_fetching": {
+          "status": "missing"
+        },
+        "hook_recognition": {
           "status": "not_applicable"
         },
-        "endpoint_synthesis": {
+        "jsx_template": {
           "status": "not_applicable"
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/svelte.yaml"],
-          "verified_at": "2026-05-28"
+        "prop_extraction": {
+          "status": "missing"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "router_pattern": {
+          "status": "missing"
+        },
+        "state_management": {
+          "status": "missing"
         }
       }
     },
     {
       "id": "lang.jsts.framework.sveltekit",
       "category": "http_framework",
+      "subcategory": "meta_framework",
       "language": "jsts",
       "label": "SvelteKit",
       "capabilities": {
-        "auth_coverage": {
+        "component_extraction": {
           "status": "missing"
         },
-        "endpoint_synthesis": {
+        "data_loaders": {
+          "status": "missing"
+        },
+        "hook_recognition": {
+          "status": "not_applicable"
+        },
+        "hydration_boundaries": {
+          "status": "missing"
+        },
+        "route_extraction": {
           "status": "full",
           "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
           "verified_at": "2026-05-28"
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
-          "verified_at": "2026-05-28"
+        "router_pattern": {
+          "status": "missing"
         },
-        "middleware_coverage": {
+        "server_components": {
+          "status": "missing"
+        },
+        "static_generation": {
           "status": "missing"
         }
       }
@@ -4808,46 +4985,54 @@
     {
       "id": "lang.jsts.framework.trpc",
       "category": "http_framework",
+      "subcategory": "rpc_framework",
       "language": "jsts",
       "label": "tRPC",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "client_codegen": {
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
         },
-        "endpoint_synthesis": {
+        "procedure_extraction": {
           "status": "full",
           "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
           "verified_at": "2026-05-28"
         },
-        "handler_attribution": {
-          "status": "full",
+        "schema_extraction": {
+          "status": "partial",
           "cites": ["internal/engine/http_endpoint_trpc.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
           "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "missing"
         }
       }
     },
     {
       "id": "lang.jsts.framework.vue",
       "category": "http_framework",
+      "subcategory": "ui_frontend",
       "language": "jsts",
       "label": "Vue",
       "capabilities": {
-        "auth_coverage": {
+        "component_extraction": {
+          "status": "missing"
+        },
+        "data_fetching": {
+          "status": "missing"
+        },
+        "hook_recognition": {
+          "status": "missing"
+        },
+        "jsx_template": {
           "status": "not_applicable"
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "prop_extraction": {
+          "status": "missing"
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/vue.yaml"],
-          "verified_at": "2026-05-28"
+        "router_pattern": {
+          "status": "missing"
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "state_management": {
+          "status": "missing"
         }
       }
     },

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -59,12 +59,13 @@ type capEntry struct {
 
 // recordView wraps a Record with a pre-sorted CapList for templates.
 type recordView struct {
-	ID       string
-	Category string
-	Language string
-	Label    string
-	Bucket   string
-	CapList  []capEntry
+	ID          string
+	Category    string
+	Subcategory string
+	Language    string
+	Label       string
+	Bucket      string
+	CapList     []capEntry
 	// CapByKey lets templates look up a capability cell by key without
 	// re-ranging CapList. Empty (missing) keys return the zero Capability;
 	// templates pair this with the Glyph helper to render "—".
@@ -89,11 +90,26 @@ type pivotRow struct {
 	Uncategorized bool // true for the language-neutral "Uncategorized" row
 }
 
-// bucketSection is one rendered section on a by-language page.
+// bucketSection is one rendered section on a by-language page. When a
+// bucket contains records with subcategories the section is split into
+// Subsections (one per subcategory, ordered by subcategoryOrder) and a
+// final Records list holds the un-subcategorized tail. Records without
+// any subcategorised siblings fall through to the legacy single-table
+// rendering where Subsections is empty and CapabilityKeys carries the
+// bucket-wide union.
 type bucketSection struct {
 	Name           string   // bucket display name (Frameworks/Tools/ORMs/Other)
 	CapabilityKeys []string // capability columns; empty for Other
 	Records        []recordView
+	Subsections    []subSection
+}
+
+// subSection is one subcategory-scoped table inside a bucketSection.
+type subSection struct {
+	Subcategory    string       // raw slug, used in IDs
+	Heading        string       // display heading (e.g. "UI Frontend")
+	CapabilityKeys []string     // columns specific to this subcategory
+	Records        []recordView // pre-sorted (label, ID)
 }
 
 // summaryData feeds summary.md.tmpl.
@@ -127,15 +143,19 @@ type categoryLanguageCount struct {
 // categoryRow is one row in the by-category table (Language column +
 // capability glyphs + Notes).
 type categoryRow struct {
-	Language string
-	Label    string
-	ID       string
-	CapList  []capEntry
-	CapByKey map[string]Capability
-	Digest   string
+	Language    string
+	Label       string
+	ID          string
+	Subcategory string
+	CapList     []capEntry
+	CapByKey    map[string]Capability
+	Digest      string
 }
 
-// categoryPageData feeds by-category/<cat>.md.tmpl.
+// categoryPageData feeds by-category/<cat>.md.tmpl. Subsections holds
+// per-subcategory tables when the category exposes them; the legacy
+// single-table render uses Records + CapabilityKeys with Subsections
+// empty.
 type categoryPageData struct {
 	Marker         string
 	Category       string
@@ -143,6 +163,17 @@ type categoryPageData struct {
 	Total          int
 	ByLanguage     []categoryLanguageCount
 	CapabilityKeys []string // capability columns for this category's bucket
+	Records        []categoryRow
+	Subsections    []categorySubSection
+}
+
+// categorySubSection is one subcategory-scoped table on a by-category
+// page (mirrors subSection for by-language, but uses categoryRow rows
+// because by-category tables include a Language column).
+type categorySubSection struct {
+	Subcategory    string
+	Heading        string
+	CapabilityKeys []string
 	Records        []categoryRow
 }
 
@@ -164,14 +195,15 @@ func recordToView(rec Record) recordView {
 		byKey[k] = rec.Capabilities[k]
 	}
 	return recordView{
-		ID:       rec.ID,
-		Category: rec.Category,
-		Language: rec.Language,
-		Label:    rec.Label,
-		Bucket:   bucketOf(rec.Category),
-		CapList:  list,
-		CapByKey: byKey,
-		Digest:   digestStatus(rec.Capabilities),
+		ID:          rec.ID,
+		Category:    rec.Category,
+		Subcategory: rec.Subcategory,
+		Language:    rec.Language,
+		Label:       rec.Label,
+		Bucket:      bucketOf(rec.Category),
+		CapList:     list,
+		CapByKey:    byKey,
+		Digest:      digestStatus(rec.Capabilities),
 	}
 }
 
@@ -190,8 +222,10 @@ func languageDisplay(slug string) string {
 // templateFuncs are the helpers exposed to templates. Kept minimal so
 // most rendering logic lives in Go where it can be tested.
 var templateFuncs = template.FuncMap{
-	"glyph":   statusGlyph,
-	"langDsp": languageDisplay,
+	"glyph":       statusGlyph,
+	"langDsp":     languageDisplay,
+	"prettyKey":   prettyKey,
+	"subHeading":  subcategoryHeading,
 }
 
 // generate writes the full markdown tree under outRoot/docs/coverage.
@@ -331,11 +365,7 @@ func generate(reg *Registry, outRoot string) error {
 			if len(recs) == 0 {
 				continue
 			}
-			sections = append(sections, bucketSection{
-				Name:           b,
-				CapabilityKeys: bucketCapabilityKeys(b),
-				Records:        recs,
-			})
+			sections = append(sections, buildBucketSection(b, recs))
 		}
 		displayLang := languageDisplay(n)
 		if n == "multi" || n == "" {
@@ -392,12 +422,13 @@ func generate(reg *Registry, outRoot string) error {
 		rows := make([]categoryRow, 0, len(recs))
 		for _, r := range recs {
 			rows = append(rows, categoryRow{
-				Language: r.Language,
-				Label:    r.Label,
-				ID:       r.ID,
-				CapList:  r.CapList,
-				CapByKey: r.CapByKey,
-				Digest:   r.Digest,
+				Language:    r.Language,
+				Label:       r.Label,
+				ID:          r.ID,
+				Subcategory: r.Subcategory,
+				CapList:     r.CapList,
+				CapByKey:    r.CapByKey,
+				Digest:      r.Digest,
 			})
 		}
 		sort.SliceStable(rows, func(i, j int) bool {
@@ -406,6 +437,10 @@ func generate(reg *Registry, outRoot string) error {
 			}
 			return rows[i].Label < rows[j].Label
 		})
+		// Group by subcategory when the category supports them and at
+		// least one record opts in. Records without a subcategory fall
+		// through to the legacy flat table at the bottom of the page.
+		subSecs, flatRows := splitCategoryRowsBySubcategory(n, rows)
 		if err := renderToFile(tmpls, "by-category.md.tmpl",
 			filepath.Join(root, "by-category", n+".md"),
 			categoryPageData{
@@ -415,7 +450,8 @@ func generate(reg *Registry, outRoot string) error {
 				Total:          len(recs),
 				ByLanguage:     banner,
 				CapabilityKeys: keys,
-				Records:        rows,
+				Records:        flatRows,
+				Subsections:    subSecs,
 			}); err != nil {
 			return err
 		}
@@ -435,6 +471,136 @@ func generate(reg *Registry, outRoot string) error {
 		}
 	}
 	return nil
+}
+
+// buildBucketSection produces a bucketSection for a per-language page.
+// When any record in recs declares a subcategory, the section is split
+// into one subSection per subcategory (ordered by subcategoryOrder)
+// plus a final flat Records list for legacy un-subcategorised entries.
+// Buckets whose records all live at the category level keep the
+// original single-table render with CapabilityKeys = bucket union.
+func buildBucketSection(bucket string, recs []recordView) bucketSection {
+	bySub := map[string][]recordView{}
+	var flat []recordView
+	subCat := ""
+	for _, r := range recs {
+		if r.Subcategory == "" {
+			flat = append(flat, r)
+			continue
+		}
+		// All records in a bucket share the same category? Not strictly:
+		// the bucket maps multiple categories. But subcategoryCapabilities
+		// is category-scoped, so we route subcategory rendering by the
+		// record's own category. Track the dominant category for ordering
+		// — when multiple categories appear in one bucket we union their
+		// subcategoryOrder lists.
+		bySub[r.Subcategory] = append(bySub[r.Subcategory], r)
+		if subCat == "" {
+			subCat = r.Category
+		}
+	}
+	if len(bySub) == 0 {
+		return bucketSection{
+			Name:           bucket,
+			CapabilityKeys: bucketCapabilityKeys(bucket),
+			Records:        recs,
+		}
+	}
+	// Collect ordered subcategory slugs across all categories represented
+	// in this bucket. categoriesInBucket is small (1–5) so the nested
+	// loop is fine and keeps ordering deterministic.
+	cats := map[string]bool{}
+	for _, r := range recs {
+		if r.Subcategory != "" {
+			cats[r.Category] = true
+		}
+	}
+	catList := make([]string, 0, len(cats))
+	for c := range cats {
+		catList = append(catList, c)
+	}
+	sort.Strings(catList)
+	seen := map[string]bool{}
+	merged := map[string]bool{}
+	for s := range bySub {
+		merged[s] = true
+	}
+	ordered := make([]string, 0, len(merged))
+	for _, c := range catList {
+		for _, s := range subcategoryOrder[c] {
+			if merged[s] && !seen[s] {
+				ordered = append(ordered, s)
+				seen[s] = true
+			}
+		}
+	}
+	// Any leftover subcategories (declared on records but not in
+	// subcategoryOrder for their category) sort alphabetically.
+	extras := make([]string, 0)
+	for s := range merged {
+		if !seen[s] {
+			extras = append(extras, s)
+		}
+	}
+	sort.Strings(extras)
+	ordered = append(ordered, extras...)
+
+	subs := make([]subSection, 0, len(ordered))
+	for _, s := range ordered {
+		recsForSub := bySub[s]
+		// Pick a representative category to source the capability key
+		// union. When multiple categories share a subcategory slug we
+		// pick the first record's category (deterministic because recs
+		// is pre-sorted by label/ID).
+		cat := recsForSub[0].Category
+		subs = append(subs, subSection{
+			Subcategory:    s,
+			Heading:        subcategoryHeading(s),
+			CapabilityKeys: subcategoryRenderKeys(cat, s),
+			Records:        recsForSub,
+		})
+	}
+	return bucketSection{
+		Name:           bucket,
+		CapabilityKeys: bucketCapabilityKeys(bucket),
+		Records:        flat,
+		Subsections:    subs,
+	}
+}
+
+// splitCategoryRowsBySubcategory partitions by-category rows into
+// per-subcategory subsections plus a tail of un-subcategorised rows.
+// When no row carries a subcategory, the subsection slice is nil and
+// all rows are returned verbatim so the legacy single-table template
+// path takes over.
+func splitCategoryRowsBySubcategory(category string, rows []categoryRow) ([]categorySubSection, []categoryRow) {
+	bySub := map[string][]categoryRow{}
+	var flat []categoryRow
+	for _, r := range rows {
+		if r.Subcategory == "" {
+			flat = append(flat, r)
+			continue
+		}
+		bySub[r.Subcategory] = append(bySub[r.Subcategory], r)
+	}
+	if len(bySub) == 0 {
+		return nil, rows
+	}
+	present := map[string]bool{}
+	for s := range bySub {
+		present[s] = true
+	}
+	ordered := orderedSubcategories(category, present)
+	subs := make([]categorySubSection, 0, len(ordered))
+	for _, s := range ordered {
+		subs = append(subs, categorySubSection{
+			Subcategory:    s,
+			Heading:        subcategoryHeading(s),
+			CapabilityKeys: subcategoryRenderKeys(category, s),
+			Records:        bySub[s],
+		})
+	}
+	return subs, flat
 }
 
 // renderToFile executes the named template into a buffer and writes it

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -66,7 +66,7 @@ func printUsage(w io.Writer) {
 subcommands:
   list      list records (filters: --status, --by-language, --by-category, --stale-days, --json)
   get       show one record by id (--json)
-  add       insert a new record (--id, --category, --language, --label)
+  add       insert a new record (--id, --category, [--subcategory], --language, --label)
   update    update one capability cell (id positional, --capability, --status, --cites, --verified-now, --issue)
   remove    delete a record by id
   gaps      list missing/partial records (--language, --category, --json)
@@ -136,6 +136,7 @@ func cmdAdd(args []string, out io.Writer) error {
 	path := registryFlag(fs)
 	id := fs.String("id", "", "record ID (required)")
 	cat := fs.String("category", "", "category (required)")
+	sub := fs.String("subcategory", "", "subcategory (optional; must be declared for --category)")
 	lang := fs.String("language", "", "language (required)")
 	label := fs.String("label", "", "human-readable label (required)")
 	if err := fs.Parse(args); err != nil {
@@ -150,6 +151,9 @@ func cmdAdd(args []string, out io.Writer) error {
 	if _, ok := categoryCapabilities[*cat]; !ok {
 		return fmt.Errorf("add: unknown category %q (known: %v)", *cat, knownCategories())
 	}
+	if *sub != "" && !validSubcategory(*cat, *sub) {
+		return fmt.Errorf("add: unknown subcategory %q for category %q (known: %v)", *sub, *cat, knownSubcategories(*cat))
+	}
 	reg, err := loadRegistry(*path)
 	if err != nil {
 		return err
@@ -160,6 +164,7 @@ func cmdAdd(args []string, out io.Writer) error {
 	reg.Records = append(reg.Records, Record{
 		ID:           *id,
 		Category:     *cat,
+		Subcategory:  *sub,
 		Language:     *lang,
 		Label:        *label,
 		Capabilities: map[string]Capability{},
@@ -200,7 +205,11 @@ func cmdUpdate(args []string, out io.Writer) error {
 	if rec == nil {
 		return fmt.Errorf("update: id %q not found", id)
 	}
-	if !validCapabilityKey(rec.Category, *cap) {
+	if rec.Subcategory != "" && validSubcategory(rec.Category, rec.Subcategory) {
+		if !validCapabilityKeyForSubcategory(rec.Category, rec.Subcategory, *cap) {
+			return fmt.Errorf("update: capability %q not valid for category %q subcategory %q", *cap, rec.Category, rec.Subcategory)
+		}
+	} else if !validCapabilityKey(rec.Category, *cap) {
 		return fmt.Errorf("update: capability %q not valid for category %q", *cap, rec.Category)
 	}
 	if rec.Capabilities == nil {

--- a/tools/coverage/schema.go
+++ b/tools/coverage/schema.go
@@ -1,7 +1,8 @@
 // Package main implements the coverage registry CLI.
 //
 // The schema mirrors docs/coverage/registry.json. Keep this file in sync
-// with the documented schema in issue #2720. Pure value types: zero
+// with the documented schema in issues #2720 (foundation) and #2735
+// (subcategory + per-subcategory capabilities). Pure value types: zero
 // imports from internal/ packages.
 package main
 
@@ -9,7 +10,46 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strings"
 )
+
+// acronyms is the exception map used by prettyKey to keep canonical
+// uppercase spellings in column headers ("DTO Extraction" rather than
+// "Dto Extraction"). Add a slug here when a new acronym surfaces in
+// capability keys; matching is case-insensitive against the original
+// snake_case segment.
+var acronyms = map[string]string{
+	"dto":  "DTO",
+	"jsx":  "JSX",
+	"ipc":  "IPC",
+	"http": "HTTP",
+	"api":  "API",
+	"orm":  "ORM",
+	"sdk":  "SDK",
+}
+
+// prettyKey converts a snake_case capability or subcategory slug into
+// a human-readable label: split on underscores, Title-case each segment,
+// substitute known acronyms, and re-join with spaces. Empty input
+// returns "". prettyKey is exposed to templates as the `prettyKey`
+// helper (see templateFuncs in generate.go).
+func prettyKey(s string) string {
+	if s == "" {
+		return ""
+	}
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		if a, ok := acronyms[strings.ToLower(p)]; ok {
+			parts[i] = a
+			continue
+		}
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}
 
 // SchemaVersion is the current registry schema version. Bump when the
 // on-disk JSON shape changes incompatibly.
@@ -50,9 +90,19 @@ type Registry struct {
 // sources, so a single tag covers them all. Records that span multiple
 // language ecosystems (build systems, observability vendors, infra
 // resources) use "multi" and render under the "Uncategorized" pivot row.
+//
+// Subcategory is an OPTIONAL refinement of Category. It carves a broad
+// category (e.g. http_framework) into honest narrower lanes (ui_frontend,
+// mobile, meta_framework, ...). When set it MUST be one of the slugs
+// declared for Record.Category in subcategoryCapabilities, and the
+// record's capability keys are then validated against the union of
+// (subcategory keys + category keys) rather than the category-wide list.
+// Records without Subcategory keep the legacy category-only validation
+// and render in their bucket's default column set.
 type Record struct {
 	ID           string                `json:"id"`
 	Category     string                `json:"category"`
+	Subcategory  string                `json:"subcategory,omitempty"`
 	Language     string                `json:"language"`
 	Label        string                `json:"label"`
 	Capabilities map[string]Capability `json:"capabilities"`
@@ -138,6 +188,233 @@ func validCapabilityKey(category, key string) bool {
 		}
 	}
 	return false
+}
+
+// subcategoryCapabilities maps (category → subcategory → capability keys).
+// Records that opt in to a subcategory validate against the union of
+// that subcategory's keys and the category-wide keys, allowing fine-
+// grained capability vocabulary (e.g. React's component_extraction) to
+// coexist with the broad category lane (http_framework).
+//
+// Adding a new subcategory: drop a line here, list its capability keys,
+// re-run validate. The slugs are surfaced verbatim as section headers
+// in the by-language and by-category pages via prettyKey.
+var subcategoryCapabilities = map[string]map[string][]string{
+	"http_framework": {
+		"http_backend": {
+			"endpoint_synthesis",
+			"handler_attribution",
+			"auth_coverage",
+			"middleware_coverage",
+			"route_extraction",
+			"request_validation",
+			"tests_linkage",
+			"dto_extraction",
+		},
+		"ui_frontend": {
+			"component_extraction",
+			"prop_extraction",
+			"hook_recognition",
+			"state_management",
+			"data_fetching",
+			"router_pattern",
+			"jsx_template",
+		},
+		"meta_framework": {
+			"server_components",
+			"data_loaders",
+			"route_extraction",
+			"hydration_boundaries",
+			"static_generation",
+			"component_extraction",
+			"hook_recognition",
+			"router_pattern",
+		},
+		"mobile": {
+			"navigation_extraction",
+			"native_module_imports",
+			"platform_branching",
+			"screen_detection",
+			"deep_link_extraction",
+			"state_management",
+		},
+		"desktop": {
+			"ipc_extraction",
+			"main_renderer_split",
+			"native_module_imports",
+		},
+		"rpc_framework": {
+			"procedure_extraction",
+			"schema_extraction",
+			"client_codegen",
+		},
+		"static_site": {
+			"build_extraction",
+			"template_extraction",
+		},
+		"ai_integration": {
+			"prompt_template_extraction",
+			"chain_composition",
+			"tool_use_detection",
+		},
+	},
+}
+
+// subcategoryOrder is the canonical render order for subcategory
+// sub-sections under a bucket. Entries not listed here render
+// alphabetically after the canonical ones (see orderedSubcategories).
+var subcategoryOrder = map[string][]string{
+	"http_framework": {
+		"http_backend",
+		"ui_frontend",
+		"meta_framework",
+		"mobile",
+		"desktop",
+		"rpc_framework",
+		"static_site",
+		"ai_integration",
+	},
+}
+
+// subcategoryDisplay maps a subcategory slug to its human-facing section
+// heading. Slugs without an entry fall back to prettyKey of the slug.
+var subcategoryDisplay = map[string]string{
+	"http_backend":   "Backend HTTP",
+	"ui_frontend":    "UI Frontend",
+	"meta_framework": "Meta Framework",
+	"mobile":         "Mobile",
+	"desktop":        "Desktop",
+	"rpc_framework":  "RPC Framework",
+	"static_site":    "Static Site",
+	"ai_integration": "AI Integration",
+}
+
+// knownSubcategories returns the sorted subcategory slugs declared for
+// category. Empty slice if category has no subcategory map.
+func knownSubcategories(category string) []string {
+	m, ok := subcategoryCapabilities[category]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// validSubcategory reports whether sub is declared for category.
+func validSubcategory(category, sub string) bool {
+	m, ok := subcategoryCapabilities[category]
+	if !ok {
+		return false
+	}
+	_, ok = m[sub]
+	return ok
+}
+
+// validCapabilityKeyForSubcategory reports whether key is in the union
+// of (category keys + subcategory keys) for (category, sub). Callers
+// SHOULD verify (category, sub) is a valid pair via validSubcategory
+// before relying on a positive result.
+func validCapabilityKeyForSubcategory(category, sub, key string) bool {
+	if validCapabilityKey(category, key) {
+		return true
+	}
+	m, ok := subcategoryCapabilities[category]
+	if !ok {
+		return false
+	}
+	keys, ok := m[sub]
+	if !ok {
+		return false
+	}
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// subcategoryRenderKeys returns the sorted capability keys to render
+// as columns for a subcategory-scoped table. Only the subcategory's
+// own keys appear — category-wide keys (e.g. auth_coverage on a UI
+// Frontend record) are deliberately excluded from the column set so
+// each lane shows the vocabulary appropriate to it. Records may still
+// carry category-level cells; those are surfaced on the per-record
+// detail page but suppressed in the per-language summary table.
+func subcategoryRenderKeys(category, sub string) []string {
+	m, ok := subcategoryCapabilities[category]
+	if !ok {
+		return nil
+	}
+	keys, ok := m[sub]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(keys))
+	copy(out, keys)
+	sort.Strings(out)
+	return out
+}
+
+// subcategoryCapabilityKeys returns the merged sorted capability key
+// set for (category, sub) — union of subcategory keys and category-wide
+// keys, de-duplicated. Used by validation (not rendering) so cells
+// declared at either level pass the allow-list check.
+func subcategoryCapabilityKeys(category, sub string) []string {
+	seen := map[string]struct{}{}
+	for _, k := range categoryCapabilities[category] {
+		seen[k] = struct{}{}
+	}
+	if m, ok := subcategoryCapabilities[category]; ok {
+		for _, k := range m[sub] {
+			seen[k] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// orderedSubcategories returns the subcategory slugs that have records
+// in subs, ordered by subcategoryOrder[category] first then alphabetical
+// for any extras. Slugs in order but absent from subs are dropped.
+func orderedSubcategories(category string, subs map[string]bool) []string {
+	canon := subcategoryOrder[category]
+	out := make([]string, 0, len(subs))
+	for _, s := range canon {
+		if subs[s] {
+			out = append(out, s)
+		}
+	}
+	extras := make([]string, 0)
+	known := map[string]bool{}
+	for _, s := range canon {
+		known[s] = true
+	}
+	for s := range subs {
+		if !known[s] {
+			extras = append(extras, s)
+		}
+	}
+	sort.Strings(extras)
+	return append(out, extras...)
+}
+
+// subcategoryHeading returns the human-facing heading for sub. Falls
+// back to prettyKey when no display string is registered so brand-new
+// subcategories render reasonably without code changes.
+func subcategoryHeading(sub string) string {
+	if d, ok := subcategoryDisplay[sub]; ok {
+		return d
+	}
+	return prettyKey(sub)
 }
 
 // knownCategories returns sorted category names. Used by views and

--- a/tools/coverage/store.go
+++ b/tools/coverage/store.go
@@ -116,6 +116,15 @@ func writeRecord(buf *bytes.Buffer, rec Record, indent string) error {
 	if err := writeJSONField(buf, inner, "category", rec.Category, false); err != nil {
 		return err
 	}
+	// Subcategory is optional (omitempty in the struct tag); preserve
+	// the same on-disk behaviour by only emitting when set. Placement
+	// between category and language keeps the field grouping intuitive
+	// and matches the schema doc comment.
+	if rec.Subcategory != "" {
+		if err := writeJSONField(buf, inner, "subcategory", rec.Subcategory, false); err != nil {
+			return err
+		}
+	}
 	if err := writeJSONField(buf, inner, "language", rec.Language, false); err != nil {
 		return err
 	}

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPrettyKey(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"auth_coverage", "Auth Coverage"},
+		{"endpoint_synthesis", "Endpoint Synthesis"},
+		{"jsx_template", "JSX Template"},
+		{"dto_extraction", "DTO Extraction"},
+		{"ipc_extraction", "IPC Extraction"},
+		{"http_backend", "HTTP Backend"},
+		{"sdk", "SDK"},
+		{"single", "Single"},
+	}
+	for _, c := range cases {
+		if got := prettyKey(c.in); got != c.want {
+			t.Errorf("prettyKey(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestValidSubcategory(t *testing.T) {
+	if !validSubcategory("http_framework", "ui_frontend") {
+		t.Errorf("ui_frontend should be valid for http_framework")
+	}
+	if validSubcategory("http_framework", "bogus") {
+		t.Errorf("bogus should not be valid")
+	}
+	if validSubcategory("orm", "ui_frontend") {
+		t.Errorf("orm has no subcategories — ui_frontend should not validate")
+	}
+}
+
+func TestValidCapabilityKeyForSubcategory(t *testing.T) {
+	// Subcategory-specific key.
+	if !validCapabilityKeyForSubcategory("http_framework", "ui_frontend", "component_extraction") {
+		t.Errorf("component_extraction should be valid under ui_frontend")
+	}
+	// Category-wide key still acceptable under any subcategory.
+	if !validCapabilityKeyForSubcategory("http_framework", "ui_frontend", "auth_coverage") {
+		t.Errorf("auth_coverage (category key) should remain valid under ui_frontend")
+	}
+	// Unknown key.
+	if validCapabilityKeyForSubcategory("http_framework", "ui_frontend", "bogus_key") {
+		t.Errorf("bogus_key should not validate")
+	}
+	// Cross-subcategory key should NOT leak.
+	if validCapabilityKeyForSubcategory("http_framework", "ui_frontend", "ipc_extraction") {
+		t.Errorf("ipc_extraction (desktop key) must not validate under ui_frontend")
+	}
+}
+
+func TestSubcategoryRenderKeysExcludesCategoryUnion(t *testing.T) {
+	// Render columns should be only the subcategory's keys — no auth_coverage
+	// or middleware_coverage leaking into the UI Frontend table.
+	got := subcategoryRenderKeys("http_framework", "ui_frontend")
+	want := []string{
+		"component_extraction",
+		"data_fetching",
+		"hook_recognition",
+		"jsx_template",
+		"prop_extraction",
+		"router_pattern",
+		"state_management",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("render keys = %v, want %v", got, want)
+	}
+}
+
+func TestSubcategoryCapabilityKeysSorted(t *testing.T) {
+	keys := subcategoryCapabilityKeys("http_framework", "ui_frontend")
+	// Must include all ui_frontend keys + category-wide keys, sorted, deduped.
+	want := []string{
+		"auth_coverage",
+		"component_extraction",
+		"data_fetching",
+		"endpoint_synthesis",
+		"handler_attribution",
+		"hook_recognition",
+		"jsx_template",
+		"middleware_coverage",
+		"prop_extraction",
+		"router_pattern",
+		"state_management",
+	}
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("subcategoryCapabilityKeys ui_frontend = %v, want %v", keys, want)
+	}
+}
+
+func TestOrderedSubcategoriesCanonicalFirst(t *testing.T) {
+	subs := map[string]bool{
+		"ui_frontend":  true,
+		"http_backend": true,
+		"mobile":       true,
+	}
+	got := orderedSubcategories("http_framework", subs)
+	want := []string{"http_backend", "ui_frontend", "mobile"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ordered = %v, want %v", got, want)
+	}
+}
+
+func TestValidateRegistrySubcategory(t *testing.T) {
+	reg := &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{
+			{
+				ID:          "lang.jsts.framework.react",
+				Category:    "http_framework",
+				Subcategory: "ui_frontend",
+				Language:    "jsts",
+				Label:       "React",
+				Capabilities: map[string]Capability{
+					"router_pattern":       {Status: StatusFull},
+					"component_extraction": {Status: StatusPartial, Issue: "x"},
+				},
+			},
+			{
+				ID:          "bad.subcat",
+				Category:    "http_framework",
+				Subcategory: "no_such_subcategory",
+				Language:    "jsts",
+				Label:       "Bad",
+				Capabilities: map[string]Capability{
+					"auth_coverage": {Status: StatusMissing, Issue: "x"},
+				},
+			},
+			{
+				ID:          "bad.key",
+				Category:    "http_framework",
+				Subcategory: "ui_frontend",
+				Language:    "jsts",
+				Label:       "BadKey",
+				Capabilities: map[string]Capability{
+					"ipc_extraction": {Status: StatusMissing, Issue: "x"},
+				},
+			},
+		},
+	}
+	res := validateRegistry(reg, ".")
+	// React record should be clean (no errors involving it).
+	hasError := func(needle string) bool {
+		for _, e := range res.Errors {
+			if containsStr(e, needle) {
+				return true
+			}
+		}
+		return false
+	}
+	if hasError("lang.jsts.framework.react") {
+		t.Errorf("react record should validate; got errors: %v", res.Errors)
+	}
+	if !hasError("no_such_subcategory") {
+		t.Errorf("expected unknown-subcategory error; got: %v", res.Errors)
+	}
+	if !hasError("ipc_extraction") {
+		t.Errorf("expected cross-subcategory key rejection; got: %v", res.Errors)
+	}
+}
+
+func TestBuildBucketSectionGroupsBySubcategory(t *testing.T) {
+	recs := []recordView{
+		{ID: "lang.jsts.framework.express", Category: "http_framework", Subcategory: "http_backend", Label: "Express",
+			CapByKey: map[string]Capability{"endpoint_synthesis": {Status: StatusFull}}},
+		{ID: "lang.jsts.framework.react", Category: "http_framework", Subcategory: "ui_frontend", Label: "React",
+			CapByKey: map[string]Capability{"router_pattern": {Status: StatusFull}}},
+		{ID: "lang.jsts.framework.legacy", Category: "http_framework", Label: "Legacy",
+			CapByKey: map[string]Capability{}},
+	}
+	sec := buildBucketSection(BucketFrameworks, recs)
+	if len(sec.Subsections) != 2 {
+		t.Fatalf("want 2 subsections, got %d", len(sec.Subsections))
+	}
+	if sec.Subsections[0].Subcategory != "http_backend" {
+		t.Errorf("first sub should be http_backend, got %s", sec.Subsections[0].Subcategory)
+	}
+	if sec.Subsections[1].Subcategory != "ui_frontend" {
+		t.Errorf("second sub should be ui_frontend, got %s", sec.Subsections[1].Subcategory)
+	}
+	if len(sec.Records) != 1 || sec.Records[0].ID != "lang.jsts.framework.legacy" {
+		t.Errorf("legacy record should fall through to flat Records, got %+v", sec.Records)
+	}
+	// Render keys must be subcategory-scoped, not the bucket union.
+	if got := sec.Subsections[1].CapabilityKeys; len(got) == 0 || got[0] == "auth_coverage" {
+		t.Errorf("ui_frontend columns should not include auth_coverage, got %v", got)
+	}
+}
+
+func TestBuildBucketSectionNoSubcategoriesUsesLegacy(t *testing.T) {
+	recs := []recordView{
+		{ID: "x", Category: "http_framework", Label: "X",
+			CapByKey: map[string]Capability{}},
+	}
+	sec := buildBucketSection(BucketFrameworks, recs)
+	if len(sec.Subsections) != 0 {
+		t.Errorf("want no subsections, got %d", len(sec.Subsections))
+	}
+	if len(sec.Records) != 1 {
+		t.Errorf("want 1 flat record, got %d", len(sec.Records))
+	}
+}
+
+// containsStr is a tiny wrapper to avoid importing strings just for this.
+func containsStr(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/coverage/templates/by-category.md.tmpl
+++ b/tools/coverage/templates/by-category.md.tmpl
@@ -6,7 +6,7 @@
 Back to [summary](../summary.md). Bucket: **{{.Bucket}}**.
 
 {{if eq .Bucket "Other" -}}
-| Language | Name |{{range .CapabilityKeys}} {{.}} |{{end}} Status | Notes |
+| Language | Name |{{range .CapabilityKeys}} {{prettyKey .}} |{{end}} Status | Notes |
 |---|---|{{range .CapabilityKeys}}---|{{end}}---|---|
 {{- $caps := .CapabilityKeys}}
 {{- range .Records}}
@@ -14,11 +14,38 @@ Back to [summary](../summary.md). Bucket: **{{.Bucket}}**.
 | [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} {{glyph $rec.Digest}} | |
 {{- end}}
 {{- else -}}
-| Language | Name |{{range .CapabilityKeys}} {{.}} |{{end}} Notes |
+{{- if .Subsections}}
+{{- range .Subsections}}
+
+## {{.Heading}}
+
+| Language | Name |{{range .CapabilityKeys}} {{prettyKey .}} |{{end}} Notes |
 |---|---|{{range .CapabilityKeys}}---|{{end}}---|
 {{- $caps := .CapabilityKeys}}
 {{- range .Records}}
 {{- $rec := .}}
 | [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} |
+{{- end}}
+{{- end}}
+{{- if .Records}}
+
+## Other
+
+| Language | Name |{{range .CapabilityKeys}} {{prettyKey .}} |{{end}} Notes |
+|---|---|{{range .CapabilityKeys}}---|{{end}}---|
+{{- $caps := .CapabilityKeys}}
+{{- range .Records}}
+{{- $rec := .}}
+| [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} |
+{{- end}}
+{{- end}}
+{{- else}}
+| Language | Name |{{range .CapabilityKeys}} {{prettyKey .}} |{{end}} Notes |
+|---|---|{{range .CapabilityKeys}}---|{{end}}---|
+{{- $caps := .CapabilityKeys}}
+{{- range .Records}}
+{{- $rec := .}}
+| [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} |
+{{- end}}
 {{- end}}
 {{- end}}

--- a/tools/coverage/templates/by-language.md.tmpl
+++ b/tools/coverage/templates/by-language.md.tmpl
@@ -13,12 +13,39 @@ Back to [summary](../summary.md).
 | [{{.Label}}](../detail/{{.ID}}.md) | [{{.Category}}](../by-category/{{.Category}}.md) | {{glyph .Digest}} | |
 {{- end}}
 {{else}}
-| Name |{{range .CapabilityKeys}} {{.}} |{{end}} Notes |
+{{- if .Subsections}}
+{{- range .Subsections}}
+
+### {{.Heading}}
+
+| Name |{{range .CapabilityKeys}} {{prettyKey .}} |{{end}} Notes |
 |---|{{range .CapabilityKeys}}---|{{end}}---|
 {{- $caps := .CapabilityKeys}}
 {{- range .Records}}
 {{- $rec := .}}
 | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} |
+{{- end}}
+{{- end}}
+{{- if .Records}}
+
+### Other
+
+| Name |{{range .CapabilityKeys}} {{prettyKey .}} |{{end}} Notes |
+|---|{{range .CapabilityKeys}}---|{{end}}---|
+{{- $caps := .CapabilityKeys}}
+{{- range .Records}}
+{{- $rec := .}}
+| [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} |
+{{- end}}
+{{- end}}
+{{- else}}
+| Name |{{range .CapabilityKeys}} {{prettyKey .}} |{{end}} Notes |
+|---|{{range .CapabilityKeys}}---|{{end}}---|
+{{- $caps := .CapabilityKeys}}
+{{- range .Records}}
+{{- $rec := .}}
+| [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} |
+{{- end}}
 {{- end}}
 {{end}}
 {{- end}}

--- a/tools/coverage/templates/detail.md.tmpl
+++ b/tools/coverage/templates/detail.md.tmpl
@@ -4,7 +4,8 @@
 Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [{{langDsp .Record.Language}}](../by-language/{{.Record.Language}}.md)
-- **Category:** [{{.Record.Category}}](../by-category/{{.Record.Category}}.md)
+- **Category:** [{{.Record.Category}}](../by-category/{{.Record.Category}}.md){{if .Record.Subcategory}}
+- **Subcategory:** {{subHeading .Record.Subcategory}}{{end}}
 - **Capability cells:** {{len .CapList}}
 
 ## Capabilities

--- a/tools/coverage/testdata/fixture-out/by-category/http_framework.md
+++ b/tools/coverage/testdata/fixture-out/by-category/http_framework.md
@@ -5,7 +5,8 @@
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
-| Language | Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+
+| Language | Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|---|
 | [JS/TS](../by-language/jsts.md) | [Express.js](../detail/lang.jsts.framework.express.md) | — | ✅ | — | — | |
 | [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | — | ✅ | — | — | |

--- a/tools/coverage/testdata/fixture-out/by-language/jsts.md
+++ b/tools/coverage/testdata/fixture-out/by-language/jsts.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Express.js](../detail/lang.jsts.framework.express.md) | — | ✅ | — | — | |
 | [NestJS](../detail/lang.jsts.framework.nestjs.md) | — | ✅ | — | — | |

--- a/tools/coverage/testdata/fixture-out/by-language/python.md
+++ b/tools/coverage/testdata/fixture-out/by-language/python.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | auth_coverage | endpoint_synthesis | handler_attribution | middleware_coverage | Notes |
+| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | — | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | — | ✅ | — | — | |

--- a/tools/coverage/validate.go
+++ b/tools/coverage/validate.go
@@ -46,6 +46,12 @@ func validateRegistry(reg *Registry, repoRoot string) *ValidationResult {
 		} else if _, ok := categoryCapabilities[rec.Category]; !ok {
 			res.Errors = append(res.Errors, fmt.Sprintf("%s: unknown category %q (known: %v)", prefix, rec.Category, knownCategories()))
 		}
+		if rec.Subcategory != "" {
+			if !validSubcategory(rec.Category, rec.Subcategory) {
+				known := knownSubcategories(rec.Category)
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: unknown subcategory %q for category %q (known: %v)", prefix, rec.Subcategory, rec.Category, known))
+			}
+		}
 		if rec.Language == "" {
 			res.Errors = append(res.Errors, prefix+": language is empty")
 		}
@@ -58,8 +64,22 @@ func validateRegistry(reg *Registry, repoRoot string) *ValidationResult {
 		for _, k := range keys {
 			cap := rec.Capabilities[k]
 			capPrefix := fmt.Sprintf("%s.capabilities[%s]", prefix, k)
-			if !validCapabilityKey(rec.Category, k) {
-				res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid capability key for category %q", capPrefix, rec.Category))
+			// When a record opts in to a subcategory, accept either the
+			// subcategory's keys or the category-wide keys (subcategories
+			// extend, they do not replace). Without a subcategory, fall
+			// back to the legacy category-only allow-list.
+			validKey := false
+			if rec.Subcategory != "" && validSubcategory(rec.Category, rec.Subcategory) {
+				validKey = validCapabilityKeyForSubcategory(rec.Category, rec.Subcategory, k)
+			} else {
+				validKey = validCapabilityKey(rec.Category, k)
+			}
+			if !validKey {
+				if rec.Subcategory != "" {
+					res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid capability key for category %q subcategory %q", capPrefix, rec.Category, rec.Subcategory))
+				} else {
+					res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid capability key for category %q", capPrefix, rec.Category))
+				}
 			}
 			if _, ok := validStatuses[cap.Status]; !ok {
 				res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid status %q", capPrefix, cap.Status))


### PR DESCRIPTION
Closes #2735.

## Summary

- Adds an optional `subcategory` field on Record plus a category→subcategory→capability-keys table. Records without a subcategory keep the existing bucket-only rendering (fully backward-compatible).
- Validation widens to accept any key from the union of the record's category and subcategory; cross-subcategory keys (e.g. `ipc_extraction` on a UI Frontend record) are rejected.
- Templates now render column headers via a `prettyKey` helper (`auth_coverage` → "Auth Coverage", `jsx_template` → "JSX Template", `ipc_extraction` → "IPC Extraction") and group records by subcategory inside each bucket section.
- Re-curates 30 JS/TS framework records with honest subcategory + capability values across http_backend / ui_frontend / meta_framework / mobile / desktop / rpc_framework / ai_integration.

### React / React Native before-after (full / partial / missing / not_applicable)

| Record | Before | After |
|---|---|---|
| `lang.jsts.framework.react` | 0 / 1 / 0 / 3 (4 cells) | 1 / 6 / 0 / 0 (7 cells) |
| `lang.jsts.framework.react-native` | 0 / 1 / 0 / 3 (4 cells) | 2 / 2 / 2 / 0 (6 cells) |

### Files touched

- `tools/coverage/schema.go` — new `Subcategory` field, `subcategoryCapabilities` map, `prettyKey` + acronym table, `subcategoryRenderKeys` (rendering) vs `subcategoryCapabilityKeys` (validation), `orderedSubcategories`, `subcategoryHeading`.
- `tools/coverage/validate.go` — accept (category ∪ subcategory) keys; reject unknown subcategories.
- `tools/coverage/store.go` — serialise `subcategory` between `category` and `language`, omit-empty.
- `tools/coverage/generate.go` — `buildBucketSection` / `splitCategoryRowsBySubcategory` helpers; new `subSection` / `categorySubSection` view types; `prettyKey` + `subHeading` template funcs.
- `tools/coverage/templates/by-language.md.tmpl` + `by-category.md.tmpl` — sub-section sub-headings + per-subcategory column sets, with a fall-through "Other" sub-table for legacy records that share a bucket.
- `tools/coverage/templates/detail.md.tmpl` — surface subcategory on detail pages.
- `tools/coverage/main.go` — `--subcategory` flag on `add`, subcategory-aware capability key validation on `update`.
- `tools/coverage/subcategory_test.go` — new test file covering prettyKey, validation, render-key column scope, bucket section grouping, and the legacy fall-through.
- `docs/coverage/registry.json` — 30 JS/TS records re-curated with subcategory + honest cells.
- `docs/coverage/**` — regenerated.
- `tools/coverage/testdata/fixture-out/**` — golden regenerated (only header-pretty-naming diff vs `main`).

### Surprises from the taxonomy

- The bucket→category→subcategory model fits cleanly for `http_framework`, but the union semantics matter: cells set at the category level (e.g. `auth_coverage`) are still valid on a `ui_frontend` record (silently ignored from the rendered column set, surfaced on the detail page). The split between `subcategoryRenderKeys` (columns only) and `subcategoryCapabilityKeys` (validation union) keeps both honest.
- prettyKey on raw subcategory slugs ("ui_frontend" → "Ui Frontend") wasn't enough — added an explicit `subcategoryDisplay` map so each lane carries a curated heading ("UI Frontend", "Backend HTTP", "RPC Framework"). Brand-new subcategories without a display entry still render via prettyKey, just with the title-case fallback.
- `Other` falls out of subcategory rendering: Other-bucket records keep the legacy Status digest column and never get split.

## Test plan

- [x] `go test ./tools/coverage/` passes (existing + new TestPrettyKey, TestValidSubcategory, TestValidCapabilityKeyForSubcategory, TestSubcategoryRenderKeysExcludesCategoryUnion, TestSubcategoryCapabilityKeysSorted, TestOrderedSubcategoriesCanonicalFirst, TestValidateRegistrySubcategory, TestBuildBucketSectionGroupsBySubcategory, TestBuildBucketSectionNoSubcategoriesUsesLegacy)
- [x] `go vet ./tools/coverage/` clean
- [x] `go run ./tools/coverage validate --repo-root .` → `ok: 501 record(s), 945 warning(s)` (0 errors)
- [x] `go run ./tools/coverage gen` → produces docs that match committed state byte-for-byte (idempotent: ran twice, sha matched)
- [x] `make coverage` exits 0
- [x] `docs/coverage/by-language/jsts.md` Frameworks section renders sub-headers (Backend HTTP / UI Frontend / Mobile / Meta Framework / Desktop / RPC Framework / AI Integration) with per-subcategory column sets
- [x] `docs/coverage/detail/lang.jsts.framework.react.md` shows the UI Frontend capabilities (component_extraction, hook_recognition, state_management, data_fetching, router_pattern, jsx_template, prop_extraction) with honest statuses + tracking issues

Generated with [Claude Code](https://claude.com/claude-code).