### PR TITLE
feat(tools/coverage/discover): add walkers for build/ci/infra/db categories (#2736)

### DIFF
--- a/tools/coverage/discover.go
+++ b/tools/coverage/discover.go
@@ -113,8 +113,25 @@ const (
 // slug. The rule tree uses combined slugs like "javascript_typescript";
 // the registry splits them or shortens them.
 var languageDirAlias = map[string]string{
-	"javascript_typescript": "javascript",
+	"javascript_typescript": "jsts",
 	"objective_c":           "objc",
+}
+
+// frameworkSlugAliases canonicalises yaml-file-derived framework slugs to
+// the registry's shortened convention (e.g. "actix-web" → "actix",
+// "ruby-on-rails" → "rails"). Applied per (langSlug, categorySegment).
+// The key is "<langSlug>.<seg>.<file-derived-slug>", the value is the
+// registry's expected slug for that ID.
+var frameworkSlugAliases = map[string]string{
+	"rust.framework.actix-web":              "actix",
+	"ruby.framework.ruby-on-rails":          "rails",
+	"ruby.orm.rom-rb-ruby-object-mapper":    "rom-rb",
+	"python.orm.django-orm":                 "django",
+	"python.orm.pony-orm":                   "pony",
+	"python.orm.tortoise-orm":               "tortoise",
+	"ruby.orm.datamapper-hanami-model-legacy": "datamapper",
+	"php.orm.doctrine-orm":                  "doctrine",
+	"php.orm.eloquent-laravel":              "eloquent",
 }
 
 // engineNamePrefixes are the file-prefix tokens we treat as framework
@@ -164,6 +181,20 @@ func walkAll(repoRoot string) map[string]*Candidate {
 	extractorDirLister(repoRoot, cands)
 	fixtureLister(repoRoot, cands)
 	enginePatternMatcher(repoRoot, cands)
+	buildWalker(repoRoot, cands)
+	ciWalker(repoRoot, cands)
+	observabilityWalker(repoRoot, cands)
+	brokerWalker(repoRoot, cands)
+	containerWalker(repoRoot, cands)
+	iacWalker(repoRoot, cands)
+	databaseWalker(repoRoot, cands)
+	configWalker(repoRoot, cands)
+	messagingWalker(repoRoot, cands)
+	packageManifestWalker(repoRoot, cands)
+	infraResourceWalker(repoRoot, cands)
+	protocolWalker(repoRoot, cands)
+	securityWalker(repoRoot, cands)
+	testFrameworkWalker(repoRoot, cands)
 	return cands
 }
 
@@ -302,6 +333,9 @@ func yamlWalker(repoRoot string, cands map[string]*Candidate) {
 				}
 				base := strings.TrimSuffix(f.Name(), ".yaml")
 				slug := slugifyFramework(base)
+				if alias, ok := frameworkSlugAliases[langSlug+"."+seg+"."+slug]; ok {
+					slug = alias
+				}
 				id := fmt.Sprintf("lang.%s.%s.%s", langSlug, seg, slug)
 				label := labelize(slug)
 				fc := ensureCandidate(cands, id, cat, langSlug, label)
@@ -512,6 +546,1153 @@ func enginePatternMatcher(repoRoot string, cands map[string]*Candidate) {
 			}
 		}
 	}
+}
+
+// buildBuilderSlugs is the closed set of build/package-manager names the
+// buildWalker recognises in extractor code or build_tools.yaml rule files.
+// Each entry is normalised to its registry-side slug (so "Go modules" → "go-modules").
+// Sorted by registry slug; keep alphabetic for review.
+var buildBuilderSlugs = []struct {
+	slug    string   // registry id segment: build.<slug>
+	needles []string // case-insensitive match tokens
+}{
+	{"bazel", []string{"bazel", "WORKSPACE", "BUILD.bazel"}},
+	{"bun", []string{"bun.lockb", "bunfig.toml"}},
+	{"bundler", []string{"Gemfile", "bundler"}},
+	{"cargo", []string{"Cargo.toml", "cargo"}},
+	{"composer", []string{"composer.json", "composer.lock", "composer"}},
+	{"dockerfile", []string{"Dockerfile", "dockerfile"}},
+	{"dotnet", []string{"dotnet", ".csproj", "nuget"}},
+	{"esbuild", []string{"esbuild"}},
+	{"flit", []string{"flit"}},
+	{"go-modules", []string{"go.mod", "go.sum", "go_mod", "gomod"}},
+	{"gradle", []string{"build.gradle", "gradle"}},
+	{"hatch", []string{"hatchling", "[tool.hatch"}},
+	{"hex", []string{"hex.pm", "mix.exs"}},
+	{"justfile", []string{"justfile", "Justfile"}},
+	{"lerna", []string{"lerna.json", "lerna"}},
+	{"mage", []string{"magefile"}},
+	{"makefile", []string{"Makefile", "makefile"}},
+	{"maven", []string{"pom.xml", "maven"}},
+	{"mill", []string{"build.sc", "mill"}},
+	{"mix", []string{"mix.exs", "mix.lock"}},
+	{"npm", []string{"package.json", "package-lock.json", "npm"}},
+	{"nuget", []string{"nuget", "packages.config"}},
+	{"nx", []string{"nx.json"}},
+	{"parcel", []string{"parcel"}},
+	{"pip", []string{"requirements.txt", "pip"}},
+	{"pipenv", []string{"Pipfile", "Pipfile.lock"}},
+	{"pnpm", []string{"pnpm-lock.yaml", "pnpm-workspace", "pnpm"}},
+	{"poetry", []string{"poetry.lock", "[tool.poetry"}},
+	{"rake", []string{"Rakefile", "rake"}},
+	{"rollup", []string{"rollup.config", "rollup"}},
+	{"sbt", []string{"build.sbt", "sbt"}},
+	{"setuptools", []string{"setup.py", "setup.cfg"}},
+	{"swift-pm", []string{"Package.swift"}},
+	{"task", []string{"Taskfile.yml"}},
+	{"turborepo", []string{"turbo.json"}},
+	{"uv", []string{"uv.lock"}},
+	{"vite", []string{"vite.config", "vitejs"}},
+	{"webpack", []string{"webpack.config", "webpack"}},
+	{"yarn", []string{"yarn.lock", "yarn"}},
+}
+
+// buildWalker walks per-language build_tools.yaml rule files plus the
+// build-related extractors and records evidence for the canonical build.*
+// candidate IDs from buildBuilderSlugs.
+func buildWalker(repoRoot string, cands map[string]*Candidate) {
+	// 1. Per-language build_tools.yaml rule files (and build_tools/ dirs).
+	rulesRoot := filepath.Join(repoRoot, "internal", "engine", "rules")
+	langs, _ := os.ReadDir(rulesRoot)
+	langNames := make([]string, 0, len(langs))
+	for _, l := range langs {
+		if l.IsDir() && !strings.HasPrefix(l.Name(), "_") {
+			langNames = append(langNames, l.Name())
+		}
+	}
+	sort.Strings(langNames)
+	for _, lang := range langNames {
+		// Flat file: rules/<lang>/build_tools.yaml
+		flat := filepath.Join(rulesRoot, lang, "build_tools.yaml")
+		if data, err := readFileCapped(flat, 256*1024); err == nil {
+			rel := filepath.Join("internal", "engine", "rules", lang, "build_tools.yaml")
+			scanBuildTools(data, rel, cands)
+		}
+		// Directory form: rules/<lang>/build_tools/*.yaml
+		dir := filepath.Join(rulesRoot, lang, "build_tools")
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		names := make([]string, 0, len(files))
+		for _, f := range files {
+			if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") {
+				names = append(names, f.Name())
+			}
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			rel := filepath.Join("internal", "engine", "rules", lang, "build_tools", n)
+			full := filepath.Join(dir, n)
+			data, err := readFileCapped(full, 256*1024)
+			if err != nil {
+				continue
+			}
+			scanBuildTools(data, rel, cands)
+		}
+	}
+	// 2. Dedicated build-system extractor directories.
+	buildExtractors := []struct {
+		dirName string
+		slug    string
+	}{
+		{"bazel", "bazel"},
+		{"dockerfile", "dockerfile"},
+		{"just", "justfile"},
+	}
+	for _, be := range buildExtractors {
+		dir := filepath.Join(repoRoot, "internal", "extractors", be.dirName)
+		if _, err := os.Stat(dir); err != nil {
+			continue
+		}
+		id := "build." + be.slug
+		c := ensureCandidate(cands, id, "build_system", "multi", labelize(be.slug))
+		rel := filepath.Join("internal", "extractors", be.dirName)
+		addEvidence(c, "extractor_dir", rel, "")
+	}
+	// 3. Sweep config/manifest extractor source files for build-tool tokens.
+	scanFilesForBuildTokens(repoRoot, cands)
+}
+
+// scanBuildTools reads one build_tools.yaml payload and emits candidates
+// for each canonical build slug whose detection tokens appear in the file.
+func scanBuildTools(data []byte, rel string, cands map[string]*Candidate) {
+	text := strings.ToLower(string(data))
+	for _, b := range buildBuilderSlugs {
+		hit := false
+		for _, n := range b.needles {
+			if strings.Contains(text, strings.ToLower(n)) {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			continue
+		}
+		id := "build." + b.slug
+		c := ensureCandidate(cands, id, "build_system", "multi", labelize(b.slug))
+		addEvidence(c, "yaml_rule", rel, "")
+	}
+}
+
+// scanFilesForBuildTokens walks a small set of extractor source files
+// looking for build-tool name tokens. Used to attach evidence to build.*
+// candidates that have no yaml rule but DO have extractor code.
+func scanFilesForBuildTokens(repoRoot string, cands map[string]*Candidate) {
+	targets := []string{
+		filepath.Join("internal", "extractors", "cross", "manifest", "extractor.go"),
+		filepath.Join("internal", "extractors", "config", "discover.go"),
+		filepath.Join("internal", "extractors", "golang", "gomod.go"),
+	}
+	for _, rel := range targets {
+		full := filepath.Join(repoRoot, rel)
+		data, err := readFileCapped(full, 256*1024)
+		if err != nil {
+			continue
+		}
+		text := string(data)
+		lower := strings.ToLower(text)
+		for _, b := range buildBuilderSlugs {
+			hit := false
+			for _, n := range b.needles {
+				if strings.Contains(lower, strings.ToLower(n)) {
+					hit = true
+					break
+				}
+			}
+			if !hit {
+				continue
+			}
+			id := "build." + b.slug
+			c := ensureCandidate(cands, id, "build_system", "multi", labelize(b.slug))
+			addEvidence(c, "extractor_source", rel, "")
+		}
+	}
+}
+
+// readFileCapped reads up to maxBytes from path. Returns the raw bytes
+// or an error. Capping is purely defensive against pathological inputs.
+func readFileCapped(path string, maxBytes int) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	lim := io.LimitReader(f, int64(maxBytes))
+	buf := make([]byte, 0, 4096)
+	tmp := make([]byte, 4096)
+	for {
+		n, err := lim.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+	return buf, nil
+}
+
+// ciSlugs maps cicd/frameworks/<file>.yaml basenames to registry slugs.
+// The registry uses short slugs (e.g. "ci.gitlab") that don't always
+// match the yaml file basename (e.g. "gitlab_ci.yaml") — so map both ways.
+var ciSlugs = []struct {
+	yamlBase string // basename without extension under cicd/frameworks/
+	slug     string // registry id segment: ci.<slug>
+}{
+	{"azure_pipelines", "azure-pipelines"},
+	{"bitbucket_pipelines", "bitbucket"},
+	{"buildkite", "buildkite"},
+	{"circleci", "circleci"},
+	{"drone", "drone"},
+	{"github_actions", "github-actions"},
+	{"gitlab_ci", "gitlab"},
+	{"jenkins", "jenkins"},
+	{"travis_ci", "travis"},
+}
+
+// ciWalker scans the CI/CD rule directory and the YAML extractor for
+// CI-system signatures.
+func ciWalker(repoRoot string, cands map[string]*Candidate) {
+	// Build a basename -> slug index keyed by lowercase yaml-base.
+	bySlug := map[string]string{}
+	for _, c := range ciSlugs {
+		bySlug[c.yamlBase] = c.slug
+	}
+	// 1. cicd/frameworks/<name>.yaml -> ci.<slug>
+	dir := filepath.Join(repoRoot, "internal", "engine", "rules", "cicd", "frameworks")
+	if entries, err := os.ReadDir(dir); err == nil {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".yaml") {
+				names = append(names, e.Name())
+			}
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			base := strings.TrimSuffix(n, ".yaml")
+			slug, ok := bySlug[base]
+			if !ok {
+				slug = slugifyFramework(base)
+			}
+			id := "ci." + slug
+			c := ensureCandidate(cands, id, "ci_system", "multi", labelize(slug))
+			rel := filepath.Join("internal", "engine", "rules", "cicd", "frameworks", n)
+			addEvidence(c, "yaml_rule", rel, "")
+		}
+	}
+	// 2. cicd/_manifest.yaml + language.yaml may reference systems even
+	// if no per-framework yaml exists yet (e.g. Jenkins).
+	for _, rel := range []string{
+		filepath.Join("internal", "engine", "rules", "cicd", "_manifest.yaml"),
+		filepath.Join("internal", "engine", "rules", "cicd", "language.yaml"),
+	} {
+		data, err := readFileCapped(filepath.Join(repoRoot, rel), 256*1024)
+		if err != nil {
+			continue
+		}
+		lower := strings.ToLower(string(data))
+		for _, c := range ciSlugs {
+			if strings.Contains(lower, c.yamlBase) || strings.Contains(lower, c.slug) {
+				id := "ci." + c.slug
+				cand := ensureCandidate(cands, id, "ci_system", "multi", labelize(c.slug))
+				addEvidence(cand, "yaml_rule", rel, "")
+			}
+		}
+	}
+	// 3. YAML extractor source file: the file mentions each CI system by
+	// path pattern (".github/workflows", ".gitlab-ci", "Jenkinsfile", etc.)
+	yamlExtractorRel := filepath.Join("internal", "extractors", "yaml", "extractor.go")
+	if data, err := readFileCapped(filepath.Join(repoRoot, yamlExtractorRel), 256*1024); err == nil {
+		lower := strings.ToLower(string(data))
+		patterns := map[string]string{
+			"github-actions":  ".github/workflows",
+			"gitlab":          ".gitlab-ci",
+			"circleci":        ".circleci",
+			"travis":          ".travis",
+			"azure-pipelines": "azure-pipelines",
+			"bitbucket":       "bitbucket-pipelines",
+			"jenkins":         "jenkinsfile",
+			"drone":           ".drone",
+			"buildkite":       "buildkite",
+		}
+		keys := make([]string, 0, len(patterns))
+		for k := range patterns {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if strings.Contains(lower, patterns[k]) {
+				id := "ci." + k
+				c := ensureCandidate(cands, id, "ci_system", "multi", labelize(k))
+				addEvidence(c, "extractor_source", yamlExtractorRel, "")
+			}
+		}
+	}
+}
+
+// observabilitySlugs maps registry slugs to source-text needles for the
+// observabilityWalker. The walker only scans extractor + engine code, so
+// the needles are import paths and SDK function names.
+var observabilitySlugs = []struct {
+	slug    string
+	needles []string
+}{
+	{"datadog", []string{"datadog", "dd-trace", "ddtrace"}},
+	{"elastic-apm", []string{"elastic-apm", "elasticapm"}},
+	{"grafana-loki", []string{"grafana/loki", "grafana-loki", "loki-client"}},
+	{"honeycomb", []string{"honeycombio", "honeycomb-beeline", "honeycomb"}},
+	{"newrelic", []string{"newrelic", "newrelic-agent", "newrelic.agent"}},
+	{"opentelemetry", []string{"opentelemetry", "go.opentelemetry.io/otel", "@opentelemetry/"}},
+	{"prometheus", []string{"prometheus/client_golang", "prom_client", "prometheus-client", "prometheus.io"}},
+	{"sentry", []string{"sentry-sdk", "@sentry/", "getsentry/sentry-go", "sentry-go", "raven"}},
+}
+
+// observabilityWalker scans engine + extractor sources for known
+// observability SDK signatures and emits infra.observability.<slug>
+// candidates.
+func observabilityWalker(repoRoot string, cands map[string]*Candidate) {
+	files := collectSourceFiles(repoRoot, []string{
+		filepath.Join("internal", "engine"),
+		filepath.Join("internal", "extractors"),
+	})
+	for _, rel := range files {
+		full := filepath.Join(repoRoot, rel)
+		data, err := readFileCapped(full, 256*1024)
+		if err != nil {
+			continue
+		}
+		lower := strings.ToLower(string(data))
+		for _, o := range observabilitySlugs {
+			hit := false
+			for _, n := range o.needles {
+				if strings.Contains(lower, strings.ToLower(n)) {
+					hit = true
+					break
+				}
+			}
+			if !hit {
+				continue
+			}
+			id := "infra.observability." + o.slug
+			c := ensureCandidate(cands, id, "observability", "multi", labelize(o.slug))
+			addEvidence(c, "extractor_source", rel, "")
+		}
+	}
+	// Engine-rule yaml files commonly enumerate logging-config patterns.
+	loggingRel := filepath.Join("internal", "engine", "rules", "_engine", "logging_config_extractor.yaml")
+	if _, err := os.Stat(filepath.Join(repoRoot, loggingRel)); err == nil {
+		c := ensureCandidate(cands, "infra.observability.logging-config", "observability", "multi", "Logging Config")
+		addEvidence(c, "yaml_rule", loggingRel, "")
+	}
+}
+
+// brokerSlugs maps engine-file basenames to registry slugs for messaging
+// infrastructure. brokerWalker scans internal/engine/ for these names.
+var brokerSlugs = []struct {
+	slug      string
+	fileBases []string // engine file basenames (without _test.go)
+	imports   []string // additional source-text needles (lowercased)
+}{
+	{"amqp", []string{"rabbitmq_edges.go", "amqp_edges.go"}, []string{"amqp091", "amqp.dial"}},
+	{"azure-service-bus", []string{"azure_service_bus_edges.go"}, []string{"azservicebus", "servicebus-messaging"}},
+	{"cloudevents", []string{"event_bus_edges.go", "cloudevents_edges.go"}, []string{"cloudevents"}},
+	{"debezium", []string{"debezium_cdc_edges.go"}, []string{"debezium"}},
+	{"eventbridge", []string{"event_bus_edges.go", "eventbridge_edges.go"}, []string{"eventbridge"}},
+	{"eventgrid", []string{"event_bus_edges.go", "eventgrid_edges.go"}, []string{"eventgrid"}},
+	{"gcp-pubsub", []string{"pubsub_edges.go"}, []string{"cloud.google.com/go/pubsub"}},
+	{"kafka", []string{"kafka_edges.go", "kafka_wrapper_edges.go"}, []string{"sarama", "confluent-kafka", "kafkajs"}},
+	{"mqtt", []string{"event_bus_edges.go", "mqtt_edges.go"}, []string{"paho.mqtt", "mqtt-client"}},
+	{"nats", []string{"nats_edges.go"}, []string{"nats.go", "nats-io"}},
+	{"pulsar", []string{"pulsar_edges.go"}, []string{"apache/pulsar", "pulsar-client"}},
+	{"rabbitmq", []string{"rabbitmq_edges.go"}, []string{"amqplib", "amqp091"}},
+	{"redis", []string{"redis_pubsub_edges.go"}, []string{"redis.publish", "redis-pubsub"}},
+	{"sns", []string{"iac_sns_edges.go", "sns_edges.go"}, []string{"aws-sdk/sns", "awssdk.sns"}},
+	{"sqs", []string{"sqs_edges.go"}, []string{"aws-sdk/sqs", "awssdk.sqs"}},
+}
+
+// brokerWalker scans internal/engine/ for broker-specific *_edges.go files
+// (deterministic filename-based evidence) and emits infra.broker.<slug>
+// candidates that mirror the registry's msg.broker.<slug> taxonomy.
+func brokerWalker(repoRoot string, cands map[string]*Candidate) {
+	engineDir := filepath.Join(repoRoot, "internal", "engine")
+	entries, err := os.ReadDir(engineDir)
+	if err != nil {
+		return
+	}
+	existing := map[string]bool{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			existing[e.Name()] = true
+		}
+	}
+	for _, b := range brokerSlugs {
+		for _, base := range b.fileBases {
+			if !existing[base] {
+				continue
+			}
+			rel := filepath.Join("internal", "engine", base)
+			id := "msg.broker." + b.slug
+			c := ensureCandidate(cands, id, "message_broker", "multi", labelize(b.slug))
+			addEvidence(c, "engine_file", rel, "")
+		}
+	}
+	// Engine-flow scaffolding files reference observability + broker SDK
+	// names — pick those out so msg.broker.kafka can still resolve via
+	// import-name evidence even when the .go file is named generically.
+	scaffoldFiles := []string{
+		filepath.Join("internal", "engine", "event_bus_edges.go"),
+		filepath.Join("internal", "engine", "event_flow.go"),
+	}
+	for _, rel := range scaffoldFiles {
+		data, err := readFileCapped(filepath.Join(repoRoot, rel), 256*1024)
+		if err != nil {
+			continue
+		}
+		lower := strings.ToLower(string(data))
+		for _, b := range brokerSlugs {
+			for _, n := range b.imports {
+				if strings.Contains(lower, strings.ToLower(n)) {
+					id := "msg.broker." + b.slug
+					c := ensureCandidate(cands, id, "message_broker", "multi", labelize(b.slug))
+					addEvidence(c, "extractor_source", rel, "")
+					break
+				}
+			}
+		}
+	}
+}
+
+// containerSlugs maps docker / kubernetes / helm rule filenames to the
+// registry's infra.container.<slug> ids.
+var containerSlugs = []struct {
+	relPath string // repo-relative path to the yaml rule
+	slug    string // registry id segment
+}{
+	{filepath.Join("internal", "engine", "rules", "docker", "frameworks", "dockerfile.yaml"), "dockerfile"},
+	{filepath.Join("internal", "engine", "rules", "docker", "frameworks", "docker_compose.yaml"), "docker-compose"},
+	{filepath.Join("internal", "engine", "rules", "kubernetes", "frameworks", "kubernetes_manifests.yaml"), "kubernetes"},
+}
+
+// containerWalker emits infra.container.<slug> candidates for container
+// orchestration rule files and dedicated extractor directories.
+func containerWalker(repoRoot string, cands map[string]*Candidate) {
+	for _, cs := range containerSlugs {
+		full := filepath.Join(repoRoot, cs.relPath)
+		if _, err := os.Stat(full); err != nil {
+			continue
+		}
+		id := "infra.container." + cs.slug
+		c := ensureCandidate(cands, id, "container", "multi", labelize(cs.slug))
+		addEvidence(c, "yaml_rule", cs.relPath, "")
+	}
+	// Dockerfile extractor — dedicated directory.
+	if _, err := os.Stat(filepath.Join(repoRoot, "internal", "extractors", "dockerfile")); err == nil {
+		c := ensureCandidate(cands, "infra.container.dockerfile", "container", "multi", "Dockerfile")
+		addEvidence(c, "extractor_dir", filepath.Join("internal", "extractors", "dockerfile"), "")
+	}
+	// YAML extractor recognises helm chart / k8s / docker-compose files;
+	// scan the extractor source for those tokens.
+	yamlExtractorRel := filepath.Join("internal", "extractors", "yaml", "extractor.go")
+	data, err := readFileCapped(filepath.Join(repoRoot, yamlExtractorRel), 256*1024)
+	if err == nil {
+		lower := strings.ToLower(string(data))
+		tokens := map[string]string{
+			"docker-compose": "docker-compose",
+			"helm":           "helm",
+			"kubernetes":     "kubernetes",
+			"kustomize":      "kustomize",
+		}
+		keys := make([]string, 0, len(tokens))
+		for k := range tokens {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if strings.Contains(lower, tokens[k]) {
+				id := "infra.container." + k
+				c := ensureCandidate(cands, id, "container", "multi", labelize(k))
+				addEvidence(c, "extractor_source", yamlExtractorRel, "")
+			}
+		}
+	}
+}
+
+// iacSlugs maps the IaC rule-tree directories (and well-known engine
+// files) to registry slugs.
+var iacRuleDirs = []struct {
+	dir  string // immediate child of internal/engine/rules
+	slug string
+}{
+	{"ansible", "ansible"},
+	{"cdk", "cdk"},
+	{"hcl", "terraform"}, // hcl tree carries terraform/opentofu/etc.
+	{"pulumi", "pulumi"},
+}
+
+// iacWalker emits infra.iac.<slug> candidates for IaC engine rule trees
+// plus serverless / cloudformation evidence pulled from engine sources.
+func iacWalker(repoRoot string, cands map[string]*Candidate) {
+	for _, dir := range iacRuleDirs {
+		rel := filepath.Join("internal", "engine", "rules", dir.dir, "_manifest.yaml")
+		if _, err := os.Stat(filepath.Join(repoRoot, rel)); err != nil {
+			continue
+		}
+		id := "infra.iac." + dir.slug
+		c := ensureCandidate(cands, id, "iac", "multi", labelize(dir.slug))
+		addEvidence(c, "yaml_rule", rel, "")
+	}
+	// hcl extractor → terraform evidence.
+	hclExtractorRel := filepath.Join("internal", "extractors", "hcl", "extractor.go")
+	if _, err := os.Stat(filepath.Join(repoRoot, hclExtractorRel)); err == nil {
+		c := ensureCandidate(cands, "infra.iac.terraform", "iac", "multi", "Terraform")
+		addEvidence(c, "extractor_source", hclExtractorRel, "")
+	}
+	// serverless-framework + cloudformation: look in engine sources by name.
+	engineRel := func(name string) string {
+		return filepath.Join("internal", "engine", name)
+	}
+	known := []struct {
+		file string
+		slug string
+	}{
+		{"serverless_edges.go", "serverless-framework"},
+		{"cloudformation_edges.go", "cloudformation"},
+		{"bicep_edges.go", "bicep"},
+	}
+	for _, k := range known {
+		if _, err := os.Stat(filepath.Join(repoRoot, engineRel(k.file))); err != nil {
+			continue
+		}
+		id := "infra.iac." + k.slug
+		c := ensureCandidate(cands, id, "iac", "multi", labelize(k.slug))
+		addEvidence(c, "engine_file", engineRel(k.file), "")
+	}
+	// CloudFormation: scan a small set of engine sources by content.
+	cfScanFiles := []string{
+		filepath.Join("internal", "extractors", "yaml", "extractor.go"),
+		filepath.Join("internal", "engine", "iac_sns_edges.go"),
+		filepath.Join("internal", "engine", "workflow_edges.go"),
+	}
+	for _, rel := range cfScanFiles {
+		data, err := readFileCapped(filepath.Join(repoRoot, rel), 256*1024)
+		if err != nil {
+			continue
+		}
+		lower := strings.ToLower(string(data))
+		if strings.Contains(lower, "cloudformation") {
+			c := ensureCandidate(cands, "infra.iac.cloudformation", "iac", "multi", "Cloudformation")
+			addEvidence(c, "extractor_source", rel, "")
+		}
+		if strings.Contains(lower, "bicep") {
+			c := ensureCandidate(cands, "infra.iac.bicep", "iac", "multi", "Bicep")
+			addEvidence(c, "extractor_source", rel, "")
+		}
+	}
+	// HCL extractor sometimes carries CDK metadata.
+	if data, err := readFileCapped(filepath.Join(repoRoot, hclExtractorRel), 256*1024); err == nil {
+		lower := strings.ToLower(string(data))
+		if strings.Contains(lower, "aws-cdk") || strings.Contains(lower, "aws_cdk") {
+			c := ensureCandidate(cands, "infra.resource.aws-cdk", "iac", "multi", "Aws Cdk")
+			addEvidence(c, "extractor_source", hclExtractorRel, "")
+		}
+	}
+}
+
+// driverSlugByOrmFile maps an ORM yaml-file basename (without .yaml) to a
+// canonical driver slug used in lang.<lang>.driver.<slug>. Only ORM files
+// that genuinely represent a raw database driver are mapped here; full
+// ORMs (alembic, sqlalchemy, ecto, ...) stay on the orm side.
+var driverSlugByOrmFile = []struct {
+	contains string // substring of the lowercased yaml basename
+	slug     string
+}{
+	{"cassandra", "cassandra"},
+	{"xandra", "xandra"},
+	{"dynamodb", "dynamodb"},
+	{"dynamo", "dynamodb"},
+	{"elasticsearch", "elastic"},
+	{"elastic", "elastic"},
+	{"mongo", "mongodb"},
+	{"mongodb", "mongodb"},
+	{"myxql", "myxql"},
+	{"mysql", "mysql"},
+	{"neo4j", "neo4j"},
+	{"npgsql", "npgsql"},
+	{"pg_", "postgres"},
+	{"postgres", "postgres"},
+	{"postgrex", "postgrex"},
+	{"redix", "redix"},
+	{"redis", "redis"},
+	{"sqlite", "sqlite"},
+	{"supabase", "supabase"},
+}
+
+// databaseWalker emits lang.<lang>.driver.<dbname> candidates by walking
+// per-language orms/ + drivers/ + databases/ subtrees and matching file
+// basenames against driverSlugByOrmFile.
+func databaseWalker(repoRoot string, cands map[string]*Candidate) {
+	rulesRoot := filepath.Join(repoRoot, "internal", "engine", "rules")
+	langs, err := os.ReadDir(rulesRoot)
+	if err != nil {
+		return
+	}
+	langNames := make([]string, 0, len(langs))
+	for _, l := range langs {
+		if l.IsDir() && !strings.HasPrefix(l.Name(), "_") {
+			langNames = append(langNames, l.Name())
+		}
+	}
+	sort.Strings(langNames)
+	for _, lang := range langNames {
+		langSlug := normaliseLanguage(lang)
+		// Three possible per-language driver dirs.
+		for _, sub := range []string{"orms", "drivers", "databases", "frameworks"} {
+			subPath := filepath.Join(rulesRoot, lang, sub)
+			files, err := os.ReadDir(subPath)
+			if err != nil {
+				continue
+			}
+			names := make([]string, 0, len(files))
+			for _, f := range files {
+				if !f.IsDir() && strings.HasSuffix(f.Name(), ".yaml") {
+					names = append(names, f.Name())
+				}
+			}
+			sort.Strings(names)
+			for _, n := range names {
+				base := strings.ToLower(strings.TrimSuffix(n, ".yaml"))
+				for _, m := range driverSlugByOrmFile {
+					if !strings.Contains(base, m.contains) {
+						continue
+					}
+					rel := filepath.Join("internal", "engine", "rules", lang, sub, n)
+					id := fmt.Sprintf("lang.%s.driver.%s", langSlug, m.slug)
+					c := ensureCandidate(cands, id, "database_driver", langSlug, labelize(m.slug))
+					addEvidence(c, "yaml_rule", rel, "")
+					// Also emit a top-level db.<slug> candidate. Some
+					// driver slugs use language-specific names (npgsql,
+					// postgrex, redix, myxql, xandra) — fold those into
+					// the canonical db.* family.
+					top := dbTopSlug(m.slug)
+					if top != "" {
+						tid := "db." + top
+						tc := ensureCandidate(cands, tid, "database", "multi", labelize(top))
+						addEvidence(tc, "yaml_rule", rel, "")
+					}
+					break // first match wins per file
+				}
+			}
+		}
+	}
+	// Engine-side orm_queries*.go files cite multiple DB engines by name.
+	dbEngineFiles := []string{
+		filepath.Join("internal", "engine", "orm_queries.go"),
+		filepath.Join("internal", "engine", "orm_queries_other.go"),
+		filepath.Join("internal", "engine", "orm_queries_python.go"),
+		filepath.Join("internal", "engine", "orm_queries_jsts.go"),
+	}
+	dbTopNeedles := []struct {
+		needle string
+		slug   string
+	}{
+		{"cassandra", "cassandra"},
+		{"clickhouse", "clickhouse"},
+		{"dynamodb", "dynamodb"},
+		{"elasticsearch", "elasticsearch"},
+		{"mongodb", "mongodb"},
+		{"mongo", "mongodb"},
+		{"mysql", "mysql"},
+		{"neo4j", "neo4j"},
+		{"postgres", "postgres"},
+		{"redis", "redis"},
+		{"snowflake", "snowflake"},
+		{"sqlite", "sqlite"},
+	}
+	for _, rel := range dbEngineFiles {
+		data, err := readFileCapped(filepath.Join(repoRoot, rel), 256*1024)
+		if err != nil {
+			continue
+		}
+		lower := strings.ToLower(string(data))
+		for _, n := range dbTopNeedles {
+			if !strings.Contains(lower, n.needle) {
+				continue
+			}
+			id := "db." + n.slug
+			c := ensureCandidate(cands, id, "database", "multi", labelize(n.slug))
+			addEvidence(c, "engine_file", rel, "")
+		}
+	}
+	// SQL extractor → db.sqlite signal in particular.
+	sqlExtractorRel := filepath.Join("internal", "extractors", "sql")
+	if _, err := os.Stat(filepath.Join(repoRoot, sqlExtractorRel)); err == nil {
+		c := ensureCandidate(cands, "db.sqlite", "database", "multi", "Sqlite")
+		addEvidence(c, "extractor_dir", sqlExtractorRel, "")
+	}
+}
+
+// dbTopSlug maps a language-specific driver slug to the canonical
+// top-level db.<slug> id. Returns "" when no canonical mapping exists
+// (e.g. supabase is JSTS-only, no db.supabase record).
+func dbTopSlug(driverSlug string) string {
+	switch driverSlug {
+	case "cassandra", "dynamodb", "mysql", "neo4j", "redis", "sqlite", "mongodb":
+		return driverSlug
+	case "elastic":
+		return "elasticsearch"
+	case "postgres", "postgrex", "npgsql":
+		return "postgres"
+	case "redix":
+		return "redis"
+	case "myxql":
+		return "mysql"
+	case "xandra":
+		return "cassandra"
+	}
+	return ""
+}
+
+// msgEngineSignals maps engine-file basenames to non-broker messaging
+// candidate IDs (e.g. msg.bullmq, msg.celery, msg.django-signals).
+var msgEngineSignals = []struct {
+	file string // basename of internal/engine/<file>
+	id   string // registry record id
+}{
+	{"scheduled_jobs_edges.go", "msg.bullmq"},
+	{"scheduled_jobs_edges.go", "msg.celery"},
+	{"scheduled_jobs_edges.go", "msg.sidekiq"},
+	{"django_signal_pubsub_edges.go", "msg.django-signals"},
+	{"graphql_subscriptions.go", "msg.graphql-subscriptions"},
+	{"sse_edges.go", "msg.sse"},
+	{"webhooks_edges.go", "msg.webhook"},
+	{"websocket_edges.go", "msg.websocket"},
+	{"kafka_edges.go", "msg.kafka-streams"},
+	{"debezium_cdc_edges.go", "msg.kafka-streams"},
+	{"dramatiq_edges.go", "msg.dramatiq"},
+}
+
+// messagingWalker emits non-broker msg.* candidates (background-job,
+// signals, pubsub-protocol records) by checking for the existence of
+// canonical engine source files.
+func messagingWalker(repoRoot string, cands map[string]*Candidate) {
+	engineDir := filepath.Join(repoRoot, "internal", "engine")
+	for _, m := range msgEngineSignals {
+		rel := filepath.Join("internal", "engine", m.file)
+		if _, err := os.Stat(filepath.Join(engineDir, m.file)); err != nil {
+			continue
+		}
+		c := ensureCandidate(cands, m.id, "messaging", "multi", labelize(strings.TrimPrefix(m.id, "msg.")))
+		addEvidence(c, "engine_file", rel, "")
+	}
+}
+
+// pkgManifestSlugs maps a manifest-source needle to its pkg.<slug> id.
+var pkgManifestSlugs = []struct {
+	needle string
+	slug   string
+}{
+	{"cargo.toml", "cargo"},
+	{"composer.json", "composer"},
+	{".csproj", "csproj"},
+	{"gemfile", "gemfile"},
+	{"go.mod", "go-mod"},
+	{"build.gradle", "gradle"},
+	{"mix.exs", "mix"},
+	{"package.json", "npm"},
+	{"pipfile", "pipfile"},
+	{"pom.xml", "pom"},
+	{"pubspec.yaml", "pubspec"},
+	{"pyproject.toml", "pyproject"},
+	{"requirements.txt", "requirements"},
+	{"build.sbt", "sbt"},
+	{"package.swift", "swift-package"},
+}
+
+// packageManifestWalker scans the cross-language manifest extractor for
+// per-format token signatures and emits pkg.<slug> candidates.
+func packageManifestWalker(repoRoot string, cands map[string]*Candidate) {
+	rel := filepath.Join("internal", "extractors", "cross", "manifest", "extractor.go")
+	data, err := readFileCapped(filepath.Join(repoRoot, rel), 256*1024)
+	if err != nil {
+		return
+	}
+	lower := strings.ToLower(string(data))
+	for _, p := range pkgManifestSlugs {
+		if !strings.Contains(lower, p.needle) {
+			continue
+		}
+		id := "pkg." + p.slug
+		c := ensureCandidate(cands, id, "package_manifest", "multi", labelize(p.slug))
+		addEvidence(c, "extractor_source", rel, "")
+	}
+}
+
+// infraResourceWalker emits infra.resource.<slug> candidates for cloud
+// resource extractors. Mirrors infra.iac.<slug> but the resource side is
+// about per-resource extraction (not whole IaC tooling).
+func infraResourceWalker(repoRoot string, cands map[string]*Candidate) {
+	known := []struct {
+		path string // repo-relative path of the cite
+		slug string
+	}{
+		{filepath.Join("internal", "extractors", "hcl", "extractor.go"), "terraform"},
+		{filepath.Join("internal", "extractors", "hcl", "extractor.go"), "aws-cdk"},
+		{filepath.Join("internal", "engine", "rules", "kubernetes", "_manifest.yaml"), "kubernetes"},
+		{filepath.Join("internal", "engine", "rules", "pulumi", "_manifest.yaml"), "pulumi"},
+		{filepath.Join("internal", "engine", "rules", "cdk", "_manifest.yaml"), "aws-cdk"},
+	}
+	for _, k := range known {
+		if _, err := os.Stat(filepath.Join(repoRoot, k.path)); err != nil {
+			continue
+		}
+		id := "infra.resource." + k.slug
+		c := ensureCandidate(cands, id, "iac_resource", "multi", labelize(k.slug))
+		kind := "extractor_source"
+		if strings.HasSuffix(k.path, ".yaml") {
+			kind = "yaml_rule"
+		}
+		addEvidence(c, kind, k.path, "")
+	}
+	// CloudFormation: scan engine + yaml sources for CF references.
+	cfScan := []string{
+		filepath.Join("internal", "extractors", "yaml", "extractor.go"),
+		filepath.Join("internal", "engine", "iac_sns_edges.go"),
+		filepath.Join("internal", "engine", "workflow_edges.go"),
+	}
+	for _, rel := range cfScan {
+		data, err := readFileCapped(filepath.Join(repoRoot, rel), 256*1024)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(strings.ToLower(string(data)), "cloudformation") {
+			c := ensureCandidate(cands, "infra.resource.cloudformation", "iac_resource", "multi", "Cloudformation")
+			addEvidence(c, "extractor_source", rel, "")
+		}
+	}
+}
+
+// configFormatSlugs maps a needle that appears in the config extractor
+// source to a registry config.<slug> id.
+var configFormatSlugs = []struct {
+	needle string
+	slug   string
+}{
+	{"docker-compose", "docker-compose"},
+	{"docker_compose", "docker-compose"},
+	{"dockerfile", "dockerfile"},
+	{"dotenv", "dotenv"},
+	{".env", "dotenv"},
+	{"github-actions", "github-actions"},
+	{"github_actions", "github-actions"},
+	{"gitlab-ci", "gitlab-ci"},
+	{"gitlab_ci", "gitlab-ci"},
+	{"ini", "ini"},
+	{"jenkins", "jenkins"},
+	{"makefile", "makefile"},
+	{"pipfile", "pipfile"},
+	{"properties", "properties"},
+	{"toml", "toml"},
+	{"tsconfig", "tsconfig"},
+	{"yaml", "yaml"},
+}
+
+// configWalker scans the config-discovery extractor for known
+// configuration-format tokens and emits config.<slug> candidates.
+func configWalker(repoRoot string, cands map[string]*Candidate) {
+	sourceRel := filepath.Join("internal", "extractors", "config", "discover.go")
+	data, err := readFileCapped(filepath.Join(repoRoot, sourceRel), 256*1024)
+	if err == nil {
+		lower := strings.ToLower(string(data))
+		seen := map[string]bool{}
+		// Iterate in sorted slug order for determinism.
+		sortedConfigFormats := append([]struct {
+			needle string
+			slug   string
+		}(nil), configFormatSlugs...)
+		sort.SliceStable(sortedConfigFormats, func(i, j int) bool {
+			return sortedConfigFormats[i].slug < sortedConfigFormats[j].slug
+		})
+		for _, cf := range sortedConfigFormats {
+			if !strings.Contains(lower, cf.needle) {
+				continue
+			}
+			if seen[cf.slug] {
+				continue
+			}
+			seen[cf.slug] = true
+			id := "config." + cf.slug
+			c := ensureCandidate(cands, id, "config_format", "multi", labelize(cf.slug))
+			addEvidence(c, "extractor_source", sourceRel, "")
+		}
+	}
+	// YAML extractor evidence for yaml/docker-compose/gitlab-ci/k8s-manifest.
+	yamlExtractorRel := filepath.Join("internal", "extractors", "yaml", "extractor.go")
+	if data, err := readFileCapped(filepath.Join(repoRoot, yamlExtractorRel), 256*1024); err == nil {
+		lower := strings.ToLower(string(data))
+		yamlSignals := []struct {
+			needle string
+			slug   string
+		}{
+			{"yaml", "yaml"},
+			{"docker-compose", "docker-compose"},
+			{"docker_compose", "docker-compose"},
+			{"gitlab-ci", "gitlab-ci"},
+			{"github-actions", "github-actions"},
+		}
+		for _, ys := range yamlSignals {
+			if !strings.Contains(lower, ys.needle) {
+				continue
+			}
+			id := "config." + ys.slug
+			c := ensureCandidate(cands, id, "config_format", "multi", labelize(ys.slug))
+			addEvidence(c, "extractor_source", yamlExtractorRel, "")
+		}
+	}
+	// Cross-manifest extractor cites toml + json + xml manifests.
+	manifestRel := filepath.Join("internal", "extractors", "cross", "manifest", "extractor.go")
+	if data, err := readFileCapped(filepath.Join(repoRoot, manifestRel), 256*1024); err == nil {
+		lower := strings.ToLower(string(data))
+		if strings.Contains(lower, "toml") {
+			c := ensureCandidate(cands, "config.toml", "config_format", "multi", "Toml")
+			addEvidence(c, "extractor_source", manifestRel, "")
+		}
+	}
+	// scheduled-jobs engine file cites .github/workflows for cron parsing.
+	schedRel := filepath.Join("internal", "engine", "scheduled_jobs_edges.go")
+	if data, err := readFileCapped(filepath.Join(repoRoot, schedRel), 256*1024); err == nil {
+		lower := strings.ToLower(string(data))
+		if strings.Contains(lower, ".github/workflows") || strings.Contains(lower, "github-actions") {
+			c := ensureCandidate(cands, "config.github-actions", "config_format", "multi", "Github Actions")
+			addEvidence(c, "engine_file", schedRel, "")
+		}
+	}
+}
+
+// protocolSignals maps protocol.<slug> ids to engine-side evidence files.
+var protocolSignals = []struct {
+	id    string
+	files []string
+}{
+	{"protocol.graphql", []string{
+		filepath.Join("internal", "engine", "graphql_subscriptions.go"),
+		filepath.Join("internal", "engine", "http_endpoint_match.go"),
+	}},
+	{"protocol.grpc", []string{
+		filepath.Join("internal", "engine", "grpc_edges.go"),
+	}},
+	{"protocol.openapi", []string{
+		filepath.Join("internal", "engine", "rules", "openapi", "language.yaml"),
+		filepath.Join("internal", "engine", "http_endpoint_match.go"),
+	}},
+	{"protocol.protobuf", []string{
+		filepath.Join("internal", "engine", "grpc_edges.go"),
+		filepath.Join("internal", "extractors", "proto", "proto.go"),
+	}},
+	{"protocol.soap", []string{
+		filepath.Join("internal", "engine", "soap_edges.go"),
+	}},
+	{"protocol.jsonrpc", []string{
+		filepath.Join("internal", "engine", "jsonrpc_edges.go"),
+	}},
+}
+
+// protocolWalker emits protocol.<slug> candidates by checking for the
+// existence of the canonical engine/extractor cite files.
+func protocolWalker(repoRoot string, cands map[string]*Candidate) {
+	for _, p := range protocolSignals {
+		for _, rel := range p.files {
+			if _, err := os.Stat(filepath.Join(repoRoot, rel)); err != nil {
+				continue
+			}
+			slug := strings.TrimPrefix(p.id, "protocol.")
+			c := ensureCandidate(cands, p.id, "protocol", "multi", labelize(slug))
+			kind := "engine_file"
+			if strings.HasSuffix(rel, ".yaml") {
+				kind = "yaml_rule"
+			} else if strings.Contains(rel, "/extractors/") {
+				kind = "extractor_source"
+			}
+			addEvidence(c, kind, rel, "")
+		}
+	}
+}
+
+// securitySignals maps security.<slug> ids to engine-side evidence files.
+var securitySignals = []struct {
+	id    string
+	files []string
+}{
+	{"security.auth-java", []string{filepath.Join("internal", "engine", "java_auth_policy.go")}},
+	{"security.auth.basic", []string{filepath.Join("internal", "engine", "java_auth_policy.go")}},
+	{"security.auth.jwt", []string{filepath.Join("internal", "engine", "java_auth_policy.go")}},
+	{"security.auth.oauth2", []string{filepath.Join("internal", "engine", "java_auth_policy.go")}},
+	{"security.auth.oidc", []string{filepath.Join("internal", "engine", "java_auth_policy.go")}},
+	{"security.auth.session", []string{filepath.Join("internal", "engine", "java_auth_policy.go")}},
+	{"security.csrf", []string{filepath.Join("internal", "engine", "rules", "_engine", "csrf_heuristic_detector.yaml")}},
+	{"security.secrets", []string{filepath.Join("internal", "secrets", "secrets.go")}},
+	{"security.sql-injection", []string{filepath.Join("internal", "engine", "rules", "_engine", "sql_injection_detector.yaml")}},
+}
+
+// securityWalker emits security.<slug> candidates by checking for the
+// existence of the canonical cite files. Defensive: most security
+// records cite java_auth_policy.go as a placeholder.
+func securityWalker(repoRoot string, cands map[string]*Candidate) {
+	for _, s := range securitySignals {
+		for _, rel := range s.files {
+			if _, err := os.Stat(filepath.Join(repoRoot, rel)); err != nil {
+				continue
+			}
+			slug := strings.TrimPrefix(s.id, "security.")
+			c := ensureCandidate(cands, s.id, "security", "multi", labelize(slug))
+			kind := "engine_file"
+			if strings.HasSuffix(rel, ".yaml") {
+				kind = "yaml_rule"
+			} else if strings.Contains(rel, "/extractors/") || strings.Contains(rel, "/secrets/") {
+				kind = "extractor_source"
+			}
+			addEvidence(c, kind, rel, "")
+		}
+	}
+}
+
+// testFrameworkSignals maps test.<slug> ids to language + framework yaml
+// + tests_edges.go evidence. The walker only needs to confirm the
+// per-framework yaml exists OR a generic test_patterns.yaml mentions it.
+var testFrameworkSignals = []struct {
+	id           string
+	frameworkRel string // optional explicit framework yaml
+	testPattern  string // language-relative test_patterns.yaml needle
+	language     string
+}{
+	{"test.cargo-test", "", "cargo", "rust"},
+	{"test.exunit", "", "exunit", "elixir"},
+	{"test.go-testing", "", "testing", "go"},
+	{"test.jest", filepath.Join("internal", "engine", "rules", "javascript_typescript", "frameworks", "jest.yaml"), "", "jsts"},
+	{"test.junit4", "", "junit", "java"},
+	{"test.junit5", filepath.Join("internal", "engine", "rules", "java", "frameworks", "junit5.yaml"), "", "java"},
+	{"test.minitest", "", "minitest", "ruby"},
+	{"test.mocha", "", "mocha", "jsts"},
+	{"test.mstest", "", "mstest", "csharp"},
+	{"test.nunit", "", "nunit", "csharp"},
+	{"test.phpunit", "", "phpunit", "php"},
+	{"test.pytest", filepath.Join("internal", "engine", "rules", "python", "frameworks", "pytest.yaml"), "", "python"},
+	{"test.rspec", filepath.Join("internal", "engine", "rules", "ruby", "frameworks", "rspec.yaml"), "", "ruby"},
+	{"test.testify", "", "testify", "go"},
+	{"test.testng", "", "testng", "java"},
+	{"test.unittest", "", "unittest", "python"},
+	{"test.vitest", "", "vitest", "jsts"},
+	{"test.xunit", "", "xunit", "csharp"},
+}
+
+// testFrameworkWalker emits test.<slug> candidates based on per-framework
+// yaml files plus a language-level test_patterns.yaml needle scan.
+func testFrameworkWalker(repoRoot string, cands map[string]*Candidate) {
+	// Map registry language slug back to rule-tree directory.
+	langDir := map[string]string{
+		"jsts":   "javascript_typescript",
+		"objc":   "objective_c",
+		"java":   "java",
+		"python": "python",
+		"ruby":   "ruby",
+		"go":     "go",
+		"rust":   "rust",
+		"csharp": "csharp",
+		"elixir": "elixir",
+		"php":    "php",
+	}
+	testsEdgesRel := filepath.Join("internal", "engine", "tests_edges.go")
+	testsEdgesExists := false
+	if _, err := os.Stat(filepath.Join(repoRoot, testsEdgesRel)); err == nil {
+		testsEdgesExists = true
+	}
+	for _, t := range testFrameworkSignals {
+		slug := strings.TrimPrefix(t.id, "test.")
+		// 1. explicit framework yaml
+		if t.frameworkRel != "" {
+			if _, err := os.Stat(filepath.Join(repoRoot, t.frameworkRel)); err == nil {
+				c := ensureCandidate(cands, t.id, "test_framework", t.language, labelize(slug))
+				addEvidence(c, "yaml_rule", t.frameworkRel, "")
+			}
+		}
+		// 2. test_patterns.yaml needle scan for the framework name
+		if t.testPattern != "" {
+			dir := langDir[t.language]
+			if dir == "" {
+				continue
+			}
+			rel := filepath.Join("internal", "engine", "rules", dir, "test_patterns.yaml")
+			if data, err := readFileCapped(filepath.Join(repoRoot, rel), 256*1024); err == nil {
+				if strings.Contains(strings.ToLower(string(data)), t.testPattern) {
+					c := ensureCandidate(cands, t.id, "test_framework", t.language, labelize(slug))
+					addEvidence(c, "yaml_rule", rel, "")
+				}
+			}
+		}
+		// 3. tests_edges.go is cited for most test records — attach if the
+		// candidate already has any other evidence (avoids polluting all
+		// 50+ test.* ids with the same generic cite).
+		if testsEdgesExists {
+			if c, ok := cands[t.id]; ok && len(c.Evidence) > 0 {
+				addEvidence(c, "engine_file", testsEdgesRel, "")
+			}
+		}
+	}
+}
+
+// collectSourceFiles walks each rootRel (relative to repoRoot) and
+// returns a sorted slice of repo-relative .go source paths (excluding
+// *_test.go and vendored/.git/.venv noise).
+func collectSourceFiles(repoRoot string, rootRels []string) []string {
+	var out []string
+	for _, root := range rootRels {
+		full := filepath.Join(repoRoot, root)
+		// WalkDir's outer error is always nil here: the inner function
+		// returns nil on every failure mode (we treat I/O hiccups as
+		// "skip this file" rather than as a discovery failure).
+		walkErr := filepath.WalkDir(full, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				name := d.Name()
+				if name == ".git" || name == "vendor" || name == "node_modules" || name == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			n := d.Name()
+			if !strings.HasSuffix(n, ".go") {
+				return nil
+			}
+			if strings.HasSuffix(n, "_test.go") {
+				return nil
+			}
+			rel, err := filepath.Rel(repoRoot, path)
+			if err != nil {
+				return nil
+			}
+			out = append(out, rel)
+			return nil
+		})
+		if walkErr != nil {
+			// Outer WalkDir returned a non-nil error (only happens if the
+			// supplied root is unreadable). Skip this root.
+			continue
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // inferCapabilities maps the evidence on a candidate into a capability

--- a/tools/coverage/discover_test.go
+++ b/tools/coverage/discover_test.go
@@ -233,6 +233,199 @@ func TestCmdDiscoverJSONOutput(t *testing.T) {
 	}
 }
 
+func TestBuildWalker(t *testing.T) {
+	cands := map[string]*Candidate{}
+	buildWalker(fixtureRoot(t), cands)
+	// fixture python build_tools.yaml mentions pip, poetry, uv.
+	for _, want := range []string{"build.pip", "build.poetry", "build.uv"} {
+		c, ok := cands[want]
+		if !ok {
+			t.Fatalf("expected %s candidate, got: %v", want, keys(cands))
+		}
+		if !hasEvidence(c, "yaml_rule", "python/build_tools.yaml") {
+			t.Fatalf("expected yaml_rule evidence for %s: %+v", want, c.Evidence)
+		}
+	}
+	// Dockerfile extractor dir → build.dockerfile evidence.
+	if c, ok := cands["build.dockerfile"]; !ok || !hasEvidence(c, "extractor_dir", "extractors/dockerfile") {
+		t.Fatalf("expected build.dockerfile extractor_dir evidence: %+v", c)
+	}
+	// Cross/manifest extractor source mentions go.mod, package.json, cargo.toml.
+	for _, want := range []string{"build.go-modules", "build.npm", "build.cargo"} {
+		c, ok := cands[want]
+		if !ok {
+			t.Fatalf("expected %s candidate from manifest source, got: %v", want, keys(cands))
+		}
+		if !hasEvidence(c, "extractor_source", "manifest/extractor.go") {
+			t.Fatalf("expected extractor_source evidence for %s: %+v", want, c.Evidence)
+		}
+	}
+}
+
+func TestCIWalker(t *testing.T) {
+	cands := map[string]*Candidate{}
+	ciWalker(fixtureRoot(t), cands)
+	if c, ok := cands["ci.github-actions"]; !ok || !hasEvidence(c, "yaml_rule", "github_actions.yaml") {
+		t.Fatalf("expected ci.github-actions yaml_rule evidence: %+v", c)
+	}
+	if c, ok := cands["ci.circleci"]; !ok || !hasEvidence(c, "yaml_rule", "circleci.yaml") {
+		t.Fatalf("expected ci.circleci yaml_rule evidence: %+v", c)
+	}
+}
+
+func TestObservabilityWalker(t *testing.T) {
+	cands := map[string]*Candidate{}
+	observabilityWalker(fixtureRoot(t), cands)
+	for _, want := range []string{
+		"infra.observability.opentelemetry",
+		"infra.observability.sentry",
+		"infra.observability.prometheus",
+		"infra.observability.datadog",
+		"infra.observability.newrelic",
+		"infra.observability.honeycomb",
+	} {
+		c, ok := cands[want]
+		if !ok {
+			t.Fatalf("expected %s candidate, got: %v", want, keys(cands))
+		}
+		if len(c.Evidence) == 0 {
+			t.Fatalf("%s has no evidence", want)
+		}
+	}
+}
+
+func TestBrokerWalker(t *testing.T) {
+	cands := map[string]*Candidate{}
+	brokerWalker(fixtureRoot(t), cands)
+	if c, ok := cands["msg.broker.kafka"]; !ok || !hasEvidence(c, "engine_file", "kafka_edges.go") {
+		t.Fatalf("expected msg.broker.kafka engine_file evidence: %+v", c)
+	}
+	if c, ok := cands["msg.broker.nats"]; !ok || !hasEvidence(c, "engine_file", "nats_edges.go") {
+		t.Fatalf("expected msg.broker.nats engine_file evidence: %+v", c)
+	}
+}
+
+func TestContainerWalker(t *testing.T) {
+	cands := map[string]*Candidate{}
+	containerWalker(fixtureRoot(t), cands)
+	for _, want := range []string{
+		"infra.container.dockerfile",
+		"infra.container.docker-compose",
+		"infra.container.kubernetes",
+	} {
+		c, ok := cands[want]
+		if !ok {
+			t.Fatalf("expected %s candidate, got: %v", want, keys(cands))
+		}
+		if len(c.Evidence) == 0 {
+			t.Fatalf("%s has no evidence", want)
+		}
+	}
+}
+
+func TestIacWalker(t *testing.T) {
+	cands := map[string]*Candidate{}
+	iacWalker(fixtureRoot(t), cands)
+	if c, ok := cands["infra.iac.terraform"]; !ok || !hasEvidence(c, "yaml_rule", "hcl/_manifest.yaml") {
+		t.Fatalf("expected infra.iac.terraform yaml_rule evidence: %+v", c)
+	}
+	if c, ok := cands["infra.iac.cloudformation"]; !ok {
+		t.Fatalf("expected infra.iac.cloudformation candidate, got: %v", keys(cands))
+	} else if len(c.Evidence) == 0 {
+		t.Fatalf("infra.iac.cloudformation has no evidence")
+	}
+}
+
+func TestDatabaseWalker(t *testing.T) {
+	cands := map[string]*Candidate{}
+	databaseWalker(fixtureRoot(t), cands)
+	// fixture has python/orms/postgresql_py.yaml and redis_py.yaml.
+	if c, ok := cands["lang.python.driver.postgres"]; !ok {
+		t.Fatalf("expected lang.python.driver.postgres candidate, got: %v", keys(cands))
+	} else if !hasEvidence(c, "yaml_rule", "postgresql_py.yaml") {
+		t.Fatalf("expected postgresql_py.yaml evidence: %+v", c.Evidence)
+	}
+	if c, ok := cands["lang.python.driver.redis"]; !ok {
+		t.Fatalf("expected lang.python.driver.redis candidate")
+	} else if !hasEvidence(c, "yaml_rule", "redis_py.yaml") {
+		t.Fatalf("expected redis_py.yaml evidence: %+v", c.Evidence)
+	}
+	// Also a top-level db.* candidate.
+	if _, ok := cands["db.postgres"]; !ok {
+		t.Fatalf("expected db.postgres candidate, got: %v", keys(cands))
+	}
+	if _, ok := cands["db.redis"]; !ok {
+		t.Fatalf("expected db.redis candidate")
+	}
+}
+
+func TestConfigWalker(t *testing.T) {
+	cands := map[string]*Candidate{}
+	configWalker(fixtureRoot(t), cands)
+	for _, want := range []string{
+		"config.toml", "config.ini", "config.properties", "config.dotenv",
+		"config.makefile", "config.tsconfig", "config.yaml",
+	} {
+		c, ok := cands[want]
+		if !ok {
+			t.Fatalf("expected %s candidate, got: %v", want, keys(cands))
+		}
+		if !hasEvidence(c, "extractor_source", "config/discover.go") {
+			t.Fatalf("expected extractor_source evidence for %s: %+v", want, c.Evidence)
+		}
+	}
+}
+
+func TestNewWalkersDeterminism(t *testing.T) {
+	// Run all new walkers twice and assert the candidate map is
+	// byte-identical when sorted by ID.
+	run := func() string {
+		cands := map[string]*Candidate{}
+		buildWalker(fixtureRoot(t), cands)
+		ciWalker(fixtureRoot(t), cands)
+		observabilityWalker(fixtureRoot(t), cands)
+		brokerWalker(fixtureRoot(t), cands)
+		containerWalker(fixtureRoot(t), cands)
+		iacWalker(fixtureRoot(t), cands)
+		databaseWalker(fixtureRoot(t), cands)
+		configWalker(fixtureRoot(t), cands)
+		ids := make([]string, 0, len(cands))
+		for id := range cands {
+			ids = append(ids, id)
+		}
+		insertionSortStrings(ids)
+		var b bytes.Buffer
+		for _, id := range ids {
+			c := cands[id]
+			b.WriteString(id)
+			b.WriteByte('|')
+			for _, e := range c.Evidence {
+				b.WriteString(e.Kind)
+				b.WriteByte(':')
+				b.WriteString(e.Path)
+				b.WriteByte(',')
+			}
+			b.WriteByte('\n')
+		}
+		return b.String()
+	}
+	a := run()
+	c := run()
+	if a != c {
+		t.Fatalf("non-deterministic walker output:\n%s\n---\n%s", a, c)
+	}
+}
+
+// insertionSortStrings is a tiny helper that avoids importing sort in
+// the test file; used by TestNewWalkersDeterminism only.
+func insertionSortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
 // hasEvidence reports whether the candidate has an evidence entry of
 // the requested kind whose symbol or path contains needle.
 func hasEvidence(c *Candidate, kind, needle string) bool {

--- a/tools/coverage/testdata/discover-fixture/internal/engine/iac_sns_edges.go
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/iac_sns_edges.go
@@ -1,0 +1,5 @@
+// iac_sns_edges fixture: signals infra.iac.cloudformation via content.
+package engine
+
+// AWS CloudFormation templates dispatch to SNS topics.
+const CFEvidence = "cloudformation"

--- a/tools/coverage/testdata/discover-fixture/internal/engine/kafka_edges.go
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/kafka_edges.go
@@ -1,0 +1,5 @@
+// kafka_edges fixture: signals msg.broker.kafka.
+package engine
+
+// import "github.com/Shopify/sarama"
+const KafkaEvidence = "sarama"

--- a/tools/coverage/testdata/discover-fixture/internal/engine/nats_edges.go
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/nats_edges.go
@@ -1,0 +1,5 @@
+// nats_edges fixture: signals msg.broker.nats.
+package engine
+
+// import "github.com/nats-io/nats.go"
+const NatsEvidence = "nats-io"

--- a/tools/coverage/testdata/discover-fixture/internal/engine/rules/cicd/frameworks/circleci.yaml
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/rules/cicd/frameworks/circleci.yaml
@@ -1,0 +1,3 @@
+name: CircleCI
+detection:
+  files: [.circleci/config.yml]

--- a/tools/coverage/testdata/discover-fixture/internal/engine/rules/cicd/frameworks/github_actions.yaml
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/rules/cicd/frameworks/github_actions.yaml
@@ -1,0 +1,4 @@
+name: GitHub Actions
+detection:
+  files:
+  - .github/workflows/*.yml

--- a/tools/coverage/testdata/discover-fixture/internal/engine/rules/docker/frameworks/docker_compose.yaml
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/rules/docker/frameworks/docker_compose.yaml
@@ -1,0 +1,1 @@
+name: Docker Compose

--- a/tools/coverage/testdata/discover-fixture/internal/engine/rules/docker/frameworks/dockerfile.yaml
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/rules/docker/frameworks/dockerfile.yaml
@@ -1,0 +1,1 @@
+name: Dockerfile

--- a/tools/coverage/testdata/discover-fixture/internal/engine/rules/hcl/_manifest.yaml
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/rules/hcl/_manifest.yaml
@@ -1,0 +1,1 @@
+name: Terraform / HCL

--- a/tools/coverage/testdata/discover-fixture/internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml
@@ -1,0 +1,1 @@
+name: Kubernetes Manifests

--- a/tools/coverage/testdata/discover-fixture/internal/engine/rules/python/build_tools.yaml
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/rules/python/build_tools.yaml
@@ -1,0 +1,11 @@
+build_package_tools:
+- name: pip + requirements.txt
+  detection:
+    config_files: [requirements.txt]
+- name: Poetry
+  detection:
+    config_files: [pyproject.toml]
+    lock_files: [poetry.lock]
+- name: uv
+  detection:
+    lock_files: [uv.lock]

--- a/tools/coverage/testdata/discover-fixture/internal/engine/rules/python/orms/postgresql_py.yaml
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/rules/python/orms/postgresql_py.yaml
@@ -1,0 +1,1 @@
+name: psycopg2 / asyncpg

--- a/tools/coverage/testdata/discover-fixture/internal/engine/rules/python/orms/redis_py.yaml
+++ b/tools/coverage/testdata/discover-fixture/internal/engine/rules/python/orms/redis_py.yaml
@@ -1,0 +1,1 @@
+name: redis-py

--- a/tools/coverage/testdata/discover-fixture/internal/extractors/config/discover.go
+++ b/tools/coverage/testdata/discover-fixture/internal/extractors/config/discover.go
@@ -1,0 +1,6 @@
+// config extractor fixture: recognises common configuration formats.
+package config
+
+// Formats: toml, ini, properties, yaml, env / dotenv, makefile, dockerfile,
+// pipfile, tsconfig, jenkins, gitlab-ci, github-actions.
+const Formats = "toml ini properties yaml dotenv makefile dockerfile pipfile tsconfig jenkins gitlab-ci github-actions"

--- a/tools/coverage/testdata/discover-fixture/internal/extractors/cross/manifest/extractor.go
+++ b/tools/coverage/testdata/discover-fixture/internal/extractors/cross/manifest/extractor.go
@@ -1,0 +1,6 @@
+// cross-manifest extractor fixture: mentions package manifest formats.
+package manifest
+
+// Recognised manifests: package.json, go.mod, Cargo.toml, pyproject.toml,
+// pom.xml, requirements.txt, pubspec.yaml, Gemfile.
+const Formats = "package.json go.mod Cargo.toml pyproject.toml pom.xml requirements.txt pubspec.yaml Gemfile"

--- a/tools/coverage/testdata/discover-fixture/internal/extractors/dockerfile/dockerfile.go
+++ b/tools/coverage/testdata/discover-fixture/internal/extractors/dockerfile/dockerfile.go
@@ -1,0 +1,4 @@
+// dockerfile extractor fixture.
+package dockerfile
+
+const Marker = "Dockerfile parser"

--- a/tools/coverage/testdata/discover-fixture/internal/extractors/hcl/extractor.go
+++ b/tools/coverage/testdata/discover-fixture/internal/extractors/hcl/extractor.go
@@ -1,0 +1,4 @@
+// hcl extractor fixture: terraform + aws-cdk.
+package hcl
+
+const Marker = "terraform aws_cdk"

--- a/tools/coverage/testdata/discover-fixture/internal/extractors/python/imports.go
+++ b/tools/coverage/testdata/discover-fixture/internal/extractors/python/imports.go
@@ -1,0 +1,6 @@
+// python imports fixture: contains observability library names.
+package python
+
+// Detected libs: opentelemetry, sentry-sdk, prometheus_client, datadog,
+// newrelic agent, honeycomb beeline.
+const Telemetry = "opentelemetry sentry-sdk prometheus-client datadog newrelic honeycomb"

--- a/tools/coverage/testdata/discover-fixture/internal/extractors/yaml/extractor.go
+++ b/tools/coverage/testdata/discover-fixture/internal/extractors/yaml/extractor.go
@@ -1,0 +1,7 @@
+// yaml extractor fixture: mentions multiple CI / container / IaC paths.
+package yaml
+
+// Recognised paths: .github/workflows/*.yml, .gitlab-ci.yml, .circleci/config.yml,
+// .travis.yml, azure-pipelines.yml, Jenkinsfile, bitbucket-pipelines.yml,
+// docker-compose.yml, kubernetes manifest, helm chart, cloudformation template.
+const Patterns = "yaml docker-compose kubernetes helm cloudformation"


### PR DESCRIPTION
## Summary
- Add eleven new walkers to ``tools/coverage/discover.go`` so the ``discover`` subcommand catalogs build, CI, observability, message broker, container, IaC, database, config, package-manifest, infra-resource, protocol, security, and test-framework signals it was previously blind to.
- Adjust ``languageDirAlias`` so ``javascript_typescript`` maps to the registry's canonical ``jsts`` slug (the existing alias produced ``lang.javascript.*`` candidates that orphaned 40+ records).
- Introduce a tiny ``frameworkSlugAliases`` table that canonicalises a handful of yaml-file-derived framework slugs (``actix-web`` → ``actix``, ``ruby-on-rails`` → ``rails`` etc.) so yaml-walker proposals line up with the registry's shortened ids.
- Closes #2736.

**Orphan count on the live repo: 274 → 43** (target was <50).

All walkers are stdlib-only, sorted-iteration deterministic, and reuse the existing ``ensureCandidate`` / ``addEvidence`` helpers. The fixture under ``tools/coverage/testdata/discover-fixture/`` was extended with the minimum file set needed to exercise every new walker.

## Test plan
- [x] ``go test ./tools/coverage/`` — passes (all existing + 8 new walker tests + determinism round-trip).
- [x] ``go build ./...`` — clean.
- [x] ``go vet ./tools/coverage/`` — clean.
- [x] ``go run ./tools/coverage discover --json`` on the live repo: orphan count drops from 274 to 43.
- [x] Determinism: running ``discover --json`` twice in a row produces byte-identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)