### PR TITLE
feat(tools/coverage): nested capability groups + group-digest rendering (#2737)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -9,68 +9,75 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 ## Backend HTTP
 
-| Language | Name | Auth Coverage | DTO Extraction | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Request Validation | Route Extraction | Tests Linkage | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ❌ | — | ✅ | ✅ | ⚠️ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ⚠️ | — | ✅ | ✅ | ⚠️ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| Language | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+
 
 ## UI Frontend
 
-| Language | Name | Component Extraction | Data Fetching | Hook Recognition | JSX Template | Prop Extraction | Router Pattern | State Management | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ | ❌ | — | — | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ | |
-| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ | ❌ | — | — | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ | ❌ | ❌ | — | ❌ | ❌ | ❌ | |
+| Language | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 0/3 | ⚠️ 0/3 | ✅ 1/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
+
 
 ## Meta Framework
 
-| Language | Name | Component Extraction | Data Loaders | Hook Recognition | Hydration Boundaries | Route Extraction | Router Pattern | Server Components | Static Generation | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ | ❌ | ❌ | ❌ | ⚠️ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
+| Language | Name | Structure | Data Flow | Server | Routing | Build | Notes |
+|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | |
+| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+
 
 ## Mobile
 
-| Language | Name | Deep Link Extraction | Native Module Imports | Navigation Extraction | Platform Branching | Screen Detection | State Management | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ❌ | ❌ | ✅ | ⚠️ | ✅ | ⚠️ | |
-| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ❌ | ❌ | ✅ | ⚠️ | ✅ | ⚠️ | |
+| Language | Name | Navigation | Platform | Native Bridge | Data Flow | Lifecycle | Notes |
+|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 0/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 0/1 | — | |
+
 
 ## Desktop
 
-| Language | Name | IPC Extraction | Main Renderer Split | Native Module Imports | Notes |
+| Language | Name | Process | Native | Updates | Notes |
 |---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | ❌ | ⚠️ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | ❌ 0/2 | ❌ 0/1 | — | |
+
 
 ## RPC Framework
 
-| Language | Name | Client Codegen | Procedure Extraction | Schema Extraction | Notes |
+| Language | Name | Schema | Codegen | Transport | Notes |
 |---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ❌ | ✅ | ⚠️ | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | |
+
 
 ## AI Integration
 
-| Language | Name | Chain Composition | Prompt Template Extraction | Tool Use Detection | Notes |
+| Language | Name | Prompts | Composition | Tracking | Notes |
 |---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ⚠️ | ⚠️ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ⚠️ 0/1 | ❌ 0/2 | — | |
+
 
 ## Other
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -10,68 +10,75 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Auth Coverage | DTO Extraction | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Request Validation | Route Extraction | Tests Linkage | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [Express](../detail/lang.jsts.framework.express.md) | ❌ | — | ✅ | ✅ | ⚠️ | — | — | — | |
-| [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
-| [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [Hono](../detail/lang.jsts.framework.hono.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
-| [Koa](../detail/lang.jsts.framework.koa.md) | ❌ | — | ✅ | ✅ | ❌ | — | — | — | |
-| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ⚠️ | — | ✅ | ✅ | ⚠️ | — | — | — | |
-| [Polka](../detail/lang.jsts.framework.polka.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [Restify](../detail/lang.jsts.framework.restify.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
-| [Sails](../detail/lang.jsts.framework.sails.md) | ❌ | — | ❌ | ❌ | ❌ | — | — | — | |
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | |
+| [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | |
+| [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+
 
 ### UI Frontend
 
-| Name | Component Extraction | Data Fetching | Hook Recognition | JSX Template | Prop Extraction | Router Pattern | State Management | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [Angular](../detail/lang.jsts.framework.angular.md) | ❌ | ❌ | — | — | ❌ | ❌ | ❌ | |
-| [React](../detail/lang.jsts.framework.react.md) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ | |
-| [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ | ❌ | — | — | ❌ | ❌ | ❌ | |
-| [Vue](../detail/lang.jsts.framework.vue.md) | ❌ | ❌ | ❌ | — | ❌ | ❌ | ❌ | |
+| Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|
+| [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
+| [React](../detail/lang.jsts.framework.react.md) | ⚠️ 0/3 | ⚠️ 0/3 | ✅ 1/1 | — | — | — | |
+| [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
+| [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
+
 
 ### Meta Framework
 
-| Name | Component Extraction | Data Loaders | Hook Recognition | Hydration Boundaries | Route Extraction | Router Pattern | Server Components | Static Generation | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
-| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ | ❌ | ❌ | ❌ | ⚠️ | ❌ | ❌ | ❌ | |
-| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
-| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ | ❌ | — | ❌ | ✅ | ❌ | ❌ | ❌ | |
+| Name | Structure | Data Flow | Server | Routing | Build | Notes |
+|---|---|---|---|---|---|---|
+| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | |
+| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+
 
 ### Mobile
 
-| Name | Deep Link Extraction | Native Module Imports | Navigation Extraction | Platform Branching | Screen Detection | State Management | Notes |
-|---|---|---|---|---|---|---|---|
-| [Expo](../detail/lang.jsts.framework.expo.md) | ❌ | ❌ | ✅ | ⚠️ | ✅ | ⚠️ | |
-| [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | |
-| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | |
-| [React Native](../detail/lang.jsts.framework.react-native.md) | ❌ | ❌ | ✅ | ⚠️ | ✅ | ⚠️ | |
+| Name | Navigation | Platform | Native Bridge | Data Flow | Lifecycle | Notes |
+|---|---|---|---|---|---|---|
+| [Expo](../detail/lang.jsts.framework.expo.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 0/1 | — | |
+| [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/1 | — | |
+| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/1 | — | |
+| [React Native](../detail/lang.jsts.framework.react-native.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 0/1 | — | |
+
 
 ### Desktop
 
-| Name | IPC Extraction | Main Renderer Split | Native Module Imports | Notes |
+| Name | Process | Native | Updates | Notes |
 |---|---|---|---|---|
-| [Electron](../detail/lang.jsts.framework.electron.md) | ❌ | ⚠️ | ❌ | |
+| [Electron](../detail/lang.jsts.framework.electron.md) | ❌ 0/2 | ❌ 0/1 | — | |
+
 
 ### RPC Framework
 
-| Name | Client Codegen | Procedure Extraction | Schema Extraction | Notes |
+| Name | Schema | Codegen | Transport | Notes |
 |---|---|---|---|---|
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ | ✅ | ✅ | |
-| [tRPC](../detail/lang.jsts.framework.trpc.md) | ❌ | ✅ | ⚠️ | |
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | |
+| [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | |
+
 
 ### AI Integration
 
-| Name | Chain Composition | Prompt Template Extraction | Tool Use Detection | Notes |
+| Name | Prompts | Composition | Tracking | Notes |
 |---|---|---|---|---|
-| [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ⚠️ | ⚠️ | ❌ | |
+| [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ⚠️ 0/1 | ❌ 0/2 | — | |
+
 
 ## Tools
 

--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.angular.md
+++ b/docs/coverage/detail/lang.jsts.framework.angular.md
@@ -10,15 +10,43 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — |
-| `data_fetching` | ❌ `missing` | — | — | — | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — |
 | `jsx_template` | — `not_applicable` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_fetching` | ❌ `missing` | — | — | — | — |
 | `prop_extraction` | ❌ `missing` | — | — | — | — |
-| `router_pattern` | ❌ `missing` | — | — | — | — |
 | `state_management` | ❌ `missing` | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.astro.md
+++ b/docs/coverage/detail/lang.jsts.framework.astro.md
@@ -10,15 +10,38 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — |
-| `data_loaders` | ❌ `missing` | — | — | — | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+
+### Server
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` |
 | `router_pattern` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Build
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.jsts.framework.electron.md
+++ b/docs/coverage/detail/lang.jsts.framework.electron.md
@@ -10,11 +10,24 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Process
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `ipc_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
 | `main_renderer_split` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/electron.yaml` |
+
+### Native
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `native_module_imports` | ❌ `missing` | — | — | — | — |
+
+### Updates
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.expo.md
+++ b/docs/coverage/detail/lang.jsts.framework.expo.md
@@ -10,14 +10,37 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Navigation
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `deep_link_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
 | `navigation_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
-| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
 | `screen_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml` |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml` |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml` |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.feathers.md
+++ b/docs/coverage/detail/lang.jsts.framework.feathers.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.gatsby.md
+++ b/docs/coverage/detail/lang.jsts.framework.gatsby.md
@@ -10,15 +10,38 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — |
-| `data_loaders` | ❌ `missing` | — | — | — | — |
 | `hook_recognition` | ❌ `missing` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+
+### Server
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `route_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml` |
 | `router_pattern` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Build
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -10,11 +10,24 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Schema
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml` |
+| `schema_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml` |
+
+### Codegen
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `client_codegen` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml` |
-| `schema_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml` |
+
+### Transport
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.hapi.md
+++ b/docs/coverage/detail/lang.jsts.framework.hapi.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.hono.md
+++ b/docs/coverage/detail/lang.jsts.framework.hono.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.ionic.md
+++ b/docs/coverage/detail/lang.jsts.framework.ionic.md
@@ -10,14 +10,37 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Navigation
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `deep_link_extraction` | ❌ `missing` | — | — | — | — |
-| `native_module_imports` | ❌ `missing` | — | — | — | — |
 | `navigation_extraction` | ❌ `missing` | — | — | — | — |
-| `platform_branching` | ❌ `missing` | — | — | — | — |
 | `screen_detection` | ❌ `missing` | — | — | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `state_management` | ❌ `missing` | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.koa.md
+++ b/docs/coverage/detail/lang.jsts.framework.koa.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.langchain.md
+++ b/docs/coverage/detail/lang.jsts.framework.langchain.md
@@ -10,11 +10,24 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Prompts
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `prompt_template_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` |
+
+### Composition
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `chain_composition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` |
-| `prompt_template_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` |
 | `tool_use_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+
+### Tracking
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.marblejs.md
+++ b/docs/coverage/detail/lang.jsts.framework.marblejs.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nativescript.md
+++ b/docs/coverage/detail/lang.jsts.framework.nativescript.md
@@ -10,14 +10,37 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Navigation
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `deep_link_extraction` | ❌ `missing` | — | — | — | — |
-| `native_module_imports` | ❌ `missing` | — | — | — | — |
 | `navigation_extraction` | ❌ `missing` | — | — | — | — |
-| `platform_branching` | ❌ `missing` | — | — | — | — |
 | `screen_detection` | ❌ `missing` | — | — | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `state_management` | ❌ `missing` | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -10,15 +10,38 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `data_loaders` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
 | `hook_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+
+### Server
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `hydration_boundaries` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| `server_components` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
 | `router_pattern` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
-| `server_components` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+
+### Build
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `static_generation` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -10,15 +10,38 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — |
-| `data_loaders` | ❌ `missing` | — | — | — | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+
+### Server
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` |
 | `router_pattern` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Build
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.jsts.framework.polka.md
+++ b/docs/coverage/detail/lang.jsts.framework.polka.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.react-native.md
+++ b/docs/coverage/detail/lang.jsts.framework.react-native.md
@@ -10,14 +10,37 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Navigation
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `deep_link_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
 | `navigation_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
-| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
 | `screen_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -10,15 +10,43 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
-| `data_fetching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2554) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
 | `hook_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
 | `jsx_template` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_fetching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2554) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
 | `prop_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2665) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
-| `router_pattern` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
 | `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `router_pattern` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.remix.md
+++ b/docs/coverage/detail/lang.jsts.framework.remix.md
@@ -10,15 +10,38 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — |
-| `data_loaders` | ❌ `missing` | — | — | — | — |
 | `hook_recognition` | ❌ `missing` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+
+### Server
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` |
 | `router_pattern` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Build
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.jsts.framework.restify.md
+++ b/docs/coverage/detail/lang.jsts.framework.restify.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -10,12 +10,45 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Security
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.svelte.md
+++ b/docs/coverage/detail/lang.jsts.framework.svelte.md
@@ -10,15 +10,43 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — |
-| `data_fetching` | ❌ `missing` | — | — | — | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — |
 | `jsx_template` | — `not_applicable` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_fetching` | ❌ `missing` | — | — | — | — |
 | `prop_extraction` | ❌ `missing` | — | — | — | — |
-| `router_pattern` | ❌ `missing` | — | — | — | — |
 | `state_management` | ❌ `missing` | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -10,15 +10,38 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — |
-| `data_loaders` | ❌ `missing` | — | — | — | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — |
+
+### Server
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `hydration_boundaries` | ❌ `missing` | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` |
 | `router_pattern` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+
+### Build
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 | `static_generation` | ❌ `missing` | — | — | — | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -10,11 +10,24 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Schema
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` |
+| `schema_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/http_endpoint_trpc.go` |
+
+### Codegen
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `client_codegen` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` |
-| `schema_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/http_endpoint_trpc.go` |
+
+### Transport
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.vue.md
+++ b/docs/coverage/detail/lang.jsts.framework.vue.md
@@ -10,15 +10,43 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — |
-| `data_fetching` | ❌ `missing` | — | — | — | — |
 | `hook_recognition` | ❌ `missing` | — | — | — | — |
 | `jsx_template` | — `not_applicable` | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `data_fetching` | ❌ `missing` | — | — | — | — |
 | `prop_extraction` | ❌ `missing` | — | — | — | — |
-| `router_pattern` | ❌ `missing` | — | — | — | — |
 | `state_management` | ❌ `missing` | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -4180,17 +4180,23 @@
       "language": "jsts",
       "label": "AdonisJS",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing"
+          },
+          "handler_attribution": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "missing"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "missing"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4201,26 +4207,32 @@
       "language": "jsts",
       "label": "Angular",
       "capabilities": {
-        "component_extraction": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "not_applicable"
+          },
+          "jsx_template": {
+            "status": "not_applicable"
+          }
         },
-        "data_fetching": {
-          "status": "missing"
+        "Data Flow": {
+          "data_fetching": {
+            "status": "missing"
+          },
+          "prop_extraction": {
+            "status": "missing"
+          },
+          "state_management": {
+            "status": "missing"
+          }
         },
-        "hook_recognition": {
-          "status": "not_applicable"
-        },
-        "jsx_template": {
-          "status": "not_applicable"
-        },
-        "prop_extraction": {
-          "status": "missing"
-        },
-        "router_pattern": {
-          "status": "missing"
-        },
-        "state_management": {
-          "status": "missing"
+        "Navigation": {
+          "router_pattern": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4231,31 +4243,41 @@
       "language": "jsts",
       "label": "Astro",
       "capabilities": {
-        "component_extraction": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "not_applicable"
+          }
         },
-        "data_loaders": {
-          "status": "missing"
+        "Data Flow": {
+          "data_loaders": {
+            "status": "missing"
+          }
         },
-        "hook_recognition": {
-          "status": "not_applicable"
+        "Server": {
+          "hydration_boundaries": {
+            "status": "missing"
+          },
+          "server_components": {
+            "status": "missing"
+          }
         },
-        "hydration_boundaries": {
-          "status": "missing"
+        "Routing": {
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "router_pattern": {
+            "status": "missing"
+          }
         },
-        "route_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "router_pattern": {
-          "status": "missing"
-        },
-        "server_components": {
-          "status": "missing"
-        },
-        "static_generation": {
-          "status": "missing"
+        "Build": {
+          "static_generation": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4266,18 +4288,22 @@
       "language": "jsts",
       "label": "Electron",
       "capabilities": {
-        "ipc_extraction": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Process": {
+          "ipc_extraction": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          },
+          "main_renderer_split": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/electron.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "verified_at": "2026-05-28"
+          }
         },
-        "main_renderer_split": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/electron.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-          "verified_at": "2026-05-28"
-        },
-        "native_module_imports": {
-          "status": "missing"
+        "Native": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4288,35 +4314,43 @@
       "language": "jsts",
       "label": "Expo",
       "capabilities": {
-        "deep_link_extraction": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Navigation": {
+          "deep_link_extraction": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          },
+          "navigation_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "screen_detection": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "native_module_imports": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Platform": {
+          "platform_branching": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2666",
+            "verified_at": "2026-05-28"
+          }
         },
-        "navigation_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
-          "verified_at": "2026-05-28"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
         },
-        "platform_branching": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2666",
-          "verified_at": "2026-05-28"
-        },
-        "screen_detection": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "state_management": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2632",
-          "verified_at": "2026-05-28"
+        "Data Flow": {
+          "state_management": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -4327,23 +4361,29 @@
       "language": "jsts",
       "label": "Express",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
+            "verified_at": "2026-05-28"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
-          "verified_at": "2026-05-28"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
-          "verified_at": "2026-05-28"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -4354,21 +4394,27 @@
       "language": "jsts",
       "label": "Fastify",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
-          "verified_at": "2026-05-28"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4379,17 +4425,23 @@
       "language": "jsts",
       "label": "Feathers",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing"
+          },
+          "handler_attribution": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "missing"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "missing"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4400,32 +4452,42 @@
       "language": "jsts",
       "label": "Gatsby",
       "capabilities": {
-        "component_extraction": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          }
         },
-        "data_loaders": {
-          "status": "missing"
+        "Data Flow": {
+          "data_loaders": {
+            "status": "missing"
+          }
         },
-        "hook_recognition": {
-          "status": "missing"
+        "Server": {
+          "hydration_boundaries": {
+            "status": "missing"
+          },
+          "server_components": {
+            "status": "missing"
+          }
         },
-        "hydration_boundaries": {
-          "status": "missing"
+        "Routing": {
+          "route_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "verified_at": "2026-05-28"
+          },
+          "router_pattern": {
+            "status": "missing"
+          }
         },
-        "route_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-          "verified_at": "2026-05-28"
-        },
-        "router_pattern": {
-          "status": "missing"
-        },
-        "server_components": {
-          "status": "missing"
-        },
-        "static_generation": {
-          "status": "missing"
+        "Build": {
+          "static_generation": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4436,19 +4498,23 @@
       "language": "jsts",
       "label": "GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)",
       "capabilities": {
-        "client_codegen": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Schema": {
+          "procedure_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "procedure_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "schema_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
-          "verified_at": "2026-05-28"
+        "Codegen": {
+          "client_codegen": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
         }
       }
     },
@@ -4459,17 +4525,23 @@
       "language": "jsts",
       "label": "Hapi",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing"
+          },
+          "handler_attribution": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "missing"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "missing"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4480,21 +4552,27 @@
       "language": "jsts",
       "label": "Hono",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "verified_at": "2026-05-28"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/extractors/javascript/framework_dsl.go"],
-          "verified_at": "2026-05-28"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/extractors/javascript/framework_dsl.go"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4505,23 +4583,31 @@
       "language": "jsts",
       "label": "Ionic",
       "capabilities": {
-        "deep_link_extraction": {
-          "status": "missing"
+        "Navigation": {
+          "deep_link_extraction": {
+            "status": "missing"
+          },
+          "navigation_extraction": {
+            "status": "missing"
+          },
+          "screen_detection": {
+            "status": "missing"
+          }
         },
-        "native_module_imports": {
-          "status": "missing"
+        "Platform": {
+          "platform_branching": {
+            "status": "missing"
+          }
         },
-        "navigation_extraction": {
-          "status": "missing"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         },
-        "platform_branching": {
-          "status": "missing"
-        },
-        "screen_detection": {
-          "status": "missing"
-        },
-        "state_management": {
-          "status": "missing"
+        "Data Flow": {
+          "state_management": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4532,21 +4618,27 @@
       "language": "jsts",
       "label": "Koa",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "verified_at": "2026-05-28"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/extractors/javascript/framework_dsl.go"],
-          "verified_at": "2026-05-28"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/extractors/javascript/framework_dsl.go"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4557,21 +4649,25 @@
       "language": "jsts",
       "label": "LangChain.js",
       "capabilities": {
-        "chain_composition": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-          "verified_at": "2026-05-28"
+        "Prompts": {
+          "prompt_template_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "verified_at": "2026-05-28"
+          }
         },
-        "prompt_template_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-          "verified_at": "2026-05-28"
-        },
-        "tool_use_detection": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Composition": {
+          "chain_composition": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "verified_at": "2026-05-28"
+          },
+          "tool_use_detection": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
         }
       }
     },
@@ -4582,17 +4678,23 @@
       "language": "jsts",
       "label": "Marble.js",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing"
+          },
+          "handler_attribution": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "missing"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "missing"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4603,23 +4705,31 @@
       "language": "jsts",
       "label": "NativeScript",
       "capabilities": {
-        "deep_link_extraction": {
-          "status": "missing"
+        "Navigation": {
+          "deep_link_extraction": {
+            "status": "missing"
+          },
+          "navigation_extraction": {
+            "status": "missing"
+          },
+          "screen_detection": {
+            "status": "missing"
+          }
         },
-        "native_module_imports": {
-          "status": "missing"
+        "Platform": {
+          "platform_branching": {
+            "status": "missing"
+          }
         },
-        "navigation_extraction": {
-          "status": "missing"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         },
-        "platform_branching": {
-          "status": "missing"
-        },
-        "screen_detection": {
-          "status": "missing"
-        },
-        "state_management": {
-          "status": "missing"
+        "Data Flow": {
+          "state_management": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4630,25 +4740,31 @@
       "language": "jsts",
       "label": "NestJS",
       "capabilities": {
-        "auth_coverage": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
-          "verified_at": "2026-05-28"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
-          "verified_at": "2026-05-28"
+        "Security": {
+          "auth_coverage": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
-          "verified_at": "2026-05-28"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -4659,39 +4775,49 @@
       "language": "jsts",
       "label": "Next.js API Routes / App Router",
       "capabilities": {
-        "component_extraction": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          },
+          "hook_recognition": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
         },
-        "data_loaders": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Data Flow": {
+          "data_loaders": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
         },
-        "hook_recognition": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Server": {
+          "hydration_boundaries": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          },
+          "server_components": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
         },
-        "hydration_boundaries": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Routing": {
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "router_pattern": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "route_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "router_pattern": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "server_components": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
-        },
-        "static_generation": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Build": {
+          "static_generation": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
         }
       }
     },
@@ -4702,31 +4828,41 @@
       "language": "jsts",
       "label": "Nuxt",
       "capabilities": {
-        "component_extraction": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "not_applicable"
+          }
         },
-        "data_loaders": {
-          "status": "missing"
+        "Data Flow": {
+          "data_loaders": {
+            "status": "missing"
+          }
         },
-        "hook_recognition": {
-          "status": "not_applicable"
+        "Server": {
+          "hydration_boundaries": {
+            "status": "missing"
+          },
+          "server_components": {
+            "status": "missing"
+          }
         },
-        "hydration_boundaries": {
-          "status": "missing"
+        "Routing": {
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "router_pattern": {
+            "status": "missing"
+          }
         },
-        "route_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "router_pattern": {
-          "status": "missing"
-        },
-        "server_components": {
-          "status": "missing"
-        },
-        "static_generation": {
-          "status": "missing"
+        "Build": {
+          "static_generation": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4737,17 +4873,23 @@
       "language": "jsts",
       "label": "Polka",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing"
+          },
+          "handler_attribution": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "missing"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "missing"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4758,46 +4900,52 @@
       "language": "jsts",
       "label": "React",
       "capabilities": {
-        "component_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-          "verified_at": "2026-05-28"
+        "Structure": {
+          "component_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "verified_at": "2026-05-28"
+          },
+          "hook_recognition": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "verified_at": "2026-05-28"
+          },
+          "jsx_template": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "verified_at": "2026-05-28"
+          }
         },
-        "data_fetching": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2554",
-          "verified_at": "2026-05-28"
+        "Data Flow": {
+          "data_fetching": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2554",
+            "verified_at": "2026-05-28"
+          },
+          "prop_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2665",
+            "verified_at": "2026-05-28"
+          },
+          "state_management": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+            "verified_at": "2026-05-28"
+          }
         },
-        "hook_recognition": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-          "verified_at": "2026-05-28"
-        },
-        "jsx_template": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-          "verified_at": "2026-05-28"
-        },
-        "prop_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2665",
-          "verified_at": "2026-05-28"
-        },
-        "router_pattern": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "state_management": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2632",
-          "verified_at": "2026-05-28"
+        "Navigation": {
+          "router_pattern": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react.yaml"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -4808,35 +4956,43 @@
       "language": "jsts",
       "label": "React Native",
       "capabilities": {
-        "deep_link_extraction": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Navigation": {
+          "deep_link_extraction": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          },
+          "navigation_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "screen_detection": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "verified_at": "2026-05-28"
+          }
         },
-        "native_module_imports": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Platform": {
+          "platform_branching": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2666",
+            "verified_at": "2026-05-28"
+          }
         },
-        "navigation_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
-          "verified_at": "2026-05-28"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
         },
-        "platform_branching": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2666",
-          "verified_at": "2026-05-28"
-        },
-        "screen_detection": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "state_management": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2632",
-          "verified_at": "2026-05-28"
+        "Data Flow": {
+          "state_management": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -4847,31 +5003,41 @@
       "language": "jsts",
       "label": "Remix",
       "capabilities": {
-        "component_extraction": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          }
         },
-        "data_loaders": {
-          "status": "missing"
+        "Data Flow": {
+          "data_loaders": {
+            "status": "missing"
+          }
         },
-        "hook_recognition": {
-          "status": "missing"
+        "Server": {
+          "hydration_boundaries": {
+            "status": "missing"
+          },
+          "server_components": {
+            "status": "missing"
+          }
         },
-        "hydration_boundaries": {
-          "status": "missing"
+        "Routing": {
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "router_pattern": {
+            "status": "missing"
+          }
         },
-        "route_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "router_pattern": {
-          "status": "missing"
-        },
-        "server_components": {
-          "status": "missing"
-        },
-        "static_generation": {
-          "status": "missing"
+        "Build": {
+          "static_generation": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4882,17 +5048,23 @@
       "language": "jsts",
       "label": "Restify",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing"
+          },
+          "handler_attribution": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "missing"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "missing"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4903,17 +5075,23 @@
       "language": "jsts",
       "label": "Sails",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing"
+          },
+          "handler_attribution": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "missing"
+        "Security": {
+          "auth_coverage": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "missing"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4924,26 +5102,32 @@
       "language": "jsts",
       "label": "Svelte",
       "capabilities": {
-        "component_extraction": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "not_applicable"
+          },
+          "jsx_template": {
+            "status": "not_applicable"
+          }
         },
-        "data_fetching": {
-          "status": "missing"
+        "Data Flow": {
+          "data_fetching": {
+            "status": "missing"
+          },
+          "prop_extraction": {
+            "status": "missing"
+          },
+          "state_management": {
+            "status": "missing"
+          }
         },
-        "hook_recognition": {
-          "status": "not_applicable"
-        },
-        "jsx_template": {
-          "status": "not_applicable"
-        },
-        "prop_extraction": {
-          "status": "missing"
-        },
-        "router_pattern": {
-          "status": "missing"
-        },
-        "state_management": {
-          "status": "missing"
+        "Navigation": {
+          "router_pattern": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4954,31 +5138,41 @@
       "language": "jsts",
       "label": "SvelteKit",
       "capabilities": {
-        "component_extraction": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "not_applicable"
+          }
         },
-        "data_loaders": {
-          "status": "missing"
+        "Data Flow": {
+          "data_loaders": {
+            "status": "missing"
+          }
         },
-        "hook_recognition": {
-          "status": "not_applicable"
+        "Server": {
+          "hydration_boundaries": {
+            "status": "missing"
+          },
+          "server_components": {
+            "status": "missing"
+          }
         },
-        "hydration_boundaries": {
-          "status": "missing"
+        "Routing": {
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "router_pattern": {
+            "status": "missing"
+          }
         },
-        "route_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "router_pattern": {
-          "status": "missing"
-        },
-        "server_components": {
-          "status": "missing"
-        },
-        "static_generation": {
-          "status": "missing"
+        "Build": {
+          "static_generation": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -4989,20 +5183,24 @@
       "language": "jsts",
       "label": "tRPC",
       "capabilities": {
-        "client_codegen": {
-          "status": "missing",
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+        "Schema": {
+          "procedure_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_trpc.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "verified_at": "2026-05-28"
+          }
         },
-        "procedure_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "schema_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/http_endpoint_trpc.go"],
-          "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-          "verified_at": "2026-05-28"
+        "Codegen": {
+          "client_codegen": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
         }
       }
     },
@@ -5013,26 +5211,32 @@
       "language": "jsts",
       "label": "Vue",
       "capabilities": {
-        "component_extraction": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          },
+          "jsx_template": {
+            "status": "not_applicable"
+          }
         },
-        "data_fetching": {
-          "status": "missing"
+        "Data Flow": {
+          "data_fetching": {
+            "status": "missing"
+          },
+          "prop_extraction": {
+            "status": "missing"
+          },
+          "state_management": {
+            "status": "missing"
+          }
         },
-        "hook_recognition": {
-          "status": "missing"
-        },
-        "jsx_template": {
-          "status": "not_applicable"
-        },
-        "prop_extraction": {
-          "status": "missing"
-        },
-        "router_pattern": {
-          "status": "missing"
-        },
-        "state_management": {
-          "status": "missing"
+        "Navigation": {
+          "router_pattern": {
+            "status": "missing"
+          }
         }
       }
     },

--- a/tools/coverage/discover.go
+++ b/tools/coverage/discover.go
@@ -1828,7 +1828,7 @@ func MergeWithRegistry(discovered map[string]*Candidate, reg *Registry, repoRoot
 				// Record has no discovered code evidence. Classification depends on status.
 				// Only records with status full/partial are orphans; status=missing is intentional.
 				isOrphan := false
-				for _, cap := range rec.Capabilities {
+				for _, cap := range rec.AllCapabilities() {
 					if cap.Status == StatusFull || cap.Status == StatusPartial {
 						isOrphan = true
 						break
@@ -1843,13 +1843,14 @@ func MergeWithRegistry(discovered map[string]*Candidate, reg *Registry, repoRoot
 			// Record has discovered code evidence. Check if it should be a status_upgrade_candidate.
 			isStatusUpgradeCandidate := true
 			suggestedStatus := "partial"
-			for _, cap := range rec.Capabilities {
+			recCaps := rec.AllCapabilities()
+			for _, cap := range recCaps {
 				if cap.Status != StatusMissing {
 					isStatusUpgradeCandidate = false
 					break
 				}
 			}
-			if isStatusUpgradeCandidate && len(rec.Capabilities) > 0 {
+			if isStatusUpgradeCandidate && len(recCaps) > 0 {
 				// All non-empty capabilities have status=missing, and we found evidence.
 				// Suggest partial (conservative) unless evidence suggests full.
 				if len(c.Evidence) > 3 {
@@ -1877,7 +1878,7 @@ func MergeWithRegistry(discovered map[string]*Candidate, reg *Registry, repoRoot
 			// exist on disk (resolved relative to repoRoot).
 			stale := []string{}
 			seen := map[string]bool{}
-			for _, cap := range rec.Capabilities {
+			for _, cap := range recCaps {
 				for _, cite := range cap.Cites {
 					if seen[cite] {
 						continue

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -57,23 +57,36 @@ type capEntry struct {
 	Cap Capability
 }
 
-// recordView wraps a Record with a pre-sorted CapList for templates.
+// groupView is one capability group rendered on a detail page or as a
+// digest cell on a pivot table.
+type groupView struct {
+	Name    string     // canonical group name (or "Uncategorized")
+	CapList []capEntry // sorted capability cells in this group
+	Digest  string     // "<glyph> <full>/<total>" or "—" when empty
+}
+
+// recordView wraps a Record with template-ready capability listings.
+//
+//   - CapList / CapByKey are the flat per-key listing used by pivot
+//     tables and the legacy non-grouped detail rendering.
+//   - GroupViews is populated only for grouped records and drives the
+//     per-group sub-tables on the detail page plus the group-digest
+//     cells on the per-language and per-category pivot tables.
+//   - GroupDigestByName maps canonical group name → its digest for
+//     templates that want O(1) cell lookup by column header.
 type recordView struct {
-	ID          string
-	Category    string
-	Subcategory string
-	Language    string
-	Label       string
-	Bucket      string
-	CapList     []capEntry
-	// CapByKey lets templates look up a capability cell by key without
-	// re-ranging CapList. Empty (missing) keys return the zero Capability;
-	// templates pair this with the Glyph helper to render "—".
-	CapByKey map[string]Capability
-	// Digest is the worst-status across this record's capabilities.
-	// Populated for every record; templates use it for the Other bucket's
-	// single Status column.
-	Digest string
+	ID                string
+	Category          string
+	Subcategory       string
+	Language          string
+	Label             string
+	Bucket            string
+	CapList           []capEntry
+	CapByKey          map[string]Capability
+	GroupViews        []groupView
+	GroupDigestByName map[string]string
+	Digest            string
+	Grouped           bool
 }
 
 // pivotRow is one row of the summary pivot table (rows = language,
@@ -93,22 +106,24 @@ type pivotRow struct {
 // bucketSection is one rendered section on a by-language page. When a
 // bucket contains records with subcategories the section is split into
 // Subsections (one per subcategory, ordered by subcategoryOrder) and a
-// final Records list holds the un-subcategorized tail. Records without
-// any subcategorised siblings fall through to the legacy single-table
-// rendering where Subsections is empty and CapabilityKeys carries the
-// bucket-wide union.
+// final Records list holds the un-subcategorized tail.
 type bucketSection struct {
-	Name           string   // bucket display name (Frameworks/Tools/ORMs/Other)
-	CapabilityKeys []string // capability columns; empty for Other
+	Name           string
+	CapabilityKeys []string
 	Records        []recordView
 	Subsections    []subSection
 }
 
 // subSection is one subcategory-scoped table inside a bucketSection.
+// When the subcategory has a declared group taxonomy (subcategoryGroups)
+// the table renders one column per group (group-digest cells) and
+// CapabilityKeys is unused. Otherwise the legacy per-capability column
+// set is used.
 type subSection struct {
 	Subcategory    string       // raw slug, used in IDs
 	Heading        string       // display heading (e.g. "UI Frontend")
-	CapabilityKeys []string     // columns specific to this subcategory
+	CapabilityKeys []string     // legacy columns (when no group taxonomy)
+	GroupNames     []string     // group-digest column headers
 	Records        []recordView // pre-sorted (label, ID)
 }
 
@@ -143,74 +158,163 @@ type categoryLanguageCount struct {
 // categoryRow is one row in the by-category table (Language column +
 // capability glyphs + Notes).
 type categoryRow struct {
-	Language    string
-	Label       string
-	ID          string
-	Subcategory string
-	CapList     []capEntry
-	CapByKey    map[string]Capability
-	Digest      string
+	Language          string
+	Label             string
+	ID                string
+	Subcategory       string
+	CapList           []capEntry
+	CapByKey          map[string]Capability
+	GroupViews        []groupView
+	GroupDigestByName map[string]string
+	Digest            string
+	Grouped           bool
 }
 
-// categoryPageData feeds by-category/<cat>.md.tmpl. Subsections holds
-// per-subcategory tables when the category exposes them; the legacy
-// single-table render uses Records + CapabilityKeys with Subsections
-// empty.
+// categoryPageData feeds by-category/<cat>.md.tmpl.
 type categoryPageData struct {
 	Marker         string
 	Category       string
 	Bucket         string
 	Total          int
 	ByLanguage     []categoryLanguageCount
-	CapabilityKeys []string // capability columns for this category's bucket
+	CapabilityKeys []string
 	Records        []categoryRow
 	Subsections    []categorySubSection
 }
 
 // categorySubSection is one subcategory-scoped table on a by-category
-// page (mirrors subSection for by-language, but uses categoryRow rows
-// because by-category tables include a Language column).
+// page. Mirrors subSection.
 type categorySubSection struct {
 	Subcategory    string
 	Heading        string
 	CapabilityKeys []string
+	GroupNames     []string
 	Records        []categoryRow
 }
 
-// detailPageData feeds detail/<id>.md.tmpl.
+// detailPageData feeds detail/<id>.md.tmpl. When Grouped is true the
+// template renders one sub-table per group (GroupViews); otherwise the
+// legacy single capability table (CapList) is used.
 type detailPageData struct {
-	Marker  string
-	Record  Record
-	CapList []capEntry
+	Marker     string
+	Record     Record
+	CapList    []capEntry
+	GroupViews []groupView
+	Grouped    bool
 }
 
 // recordToView materialises a Record with sorted capability entries so
 // templates iterate deterministically.
 func recordToView(rec Record) recordView {
-	keys := sortedCapKeys(rec.Capabilities)
+	flat := rec.AllCapabilities()
+	keys := sortedCapKeys(flat)
 	list := make([]capEntry, 0, len(keys))
 	byKey := make(map[string]Capability, len(keys))
 	for _, k := range keys {
-		list = append(list, capEntry{Key: k, Cap: rec.Capabilities[k]})
-		byKey[k] = rec.Capabilities[k]
+		list = append(list, capEntry{Key: k, Cap: flat[k]})
+		byKey[k] = flat[k]
 	}
-	return recordView{
-		ID:          rec.ID,
-		Category:    rec.Category,
-		Subcategory: rec.Subcategory,
-		Language:    rec.Language,
-		Label:       rec.Label,
-		Bucket:      bucketOf(rec.Category),
-		CapList:     list,
-		CapByKey:    byKey,
-		Digest:      digestStatus(rec.Capabilities),
+	view := recordView{
+		ID:                rec.ID,
+		Category:          rec.Category,
+		Subcategory:       rec.Subcategory,
+		Language:          rec.Language,
+		Label:             rec.Label,
+		Bucket:            bucketOf(rec.Category),
+		CapList:           list,
+		CapByKey:          byKey,
+		Digest:            digestStatus(flat),
+		Grouped:           rec.IsGrouped(),
+		GroupDigestByName: map[string]string{},
 	}
+	if rec.IsGrouped() {
+		view.GroupViews = buildGroupViews(rec)
+		for _, g := range view.GroupViews {
+			view.GroupDigestByName[g.Name] = g.Digest
+		}
+	}
+	return view
+}
+
+// buildGroupViews materialises one groupView per declared group in the
+// subcategory's taxonomy, in canonical order. Empty groups (records that
+// have not yet populated every group) still render with a "—" digest so
+// the pivot table column layout is stable across records.
+func buildGroupViews(rec Record) []groupView {
+	canon := knownGroupNames(rec.Subcategory)
+	seen := map[string]bool{}
+	views := make([]groupView, 0, len(canon)+len(rec.Groups))
+	for _, name := range canon {
+		caps := rec.Groups[name]
+		views = append(views, makeGroupView(name, caps))
+		seen[name] = true
+	}
+	// Any extras (Uncategorized or unknown group names that survived
+	// validation only because of legacy data) get appended alphabetically.
+	extras := make([]string, 0)
+	for name := range rec.Groups {
+		if !seen[name] {
+			extras = append(extras, name)
+		}
+	}
+	sort.Strings(extras)
+	for _, name := range extras {
+		views = append(views, makeGroupView(name, rec.Groups[name]))
+	}
+	return views
+}
+
+// makeGroupView constructs a groupView from a group name + its cell
+// map. The CapList is sorted alphabetically by key; the digest follows
+// the "<glyph> <full-count>/<total>" convention from #2737.
+func makeGroupView(name string, caps map[string]Capability) groupView {
+	keys := sortedCapKeys(caps)
+	list := make([]capEntry, 0, len(keys))
+	for _, k := range keys {
+		list = append(list, capEntry{Key: k, Cap: caps[k]})
+	}
+	return groupView{
+		Name:    name,
+		CapList: list,
+		Digest:  groupDigest(caps),
+	}
+}
+
+// groupDigest returns the worst-glyph + full-count/total summary for a
+// group's capability cells. Empty groups (no cells declared) render as
+// "—" so pivot rows for sparsely-populated records still align under
+// every group column. The full-count counts StatusFull only — partials
+// are folded into the glyph severity but not the numerator (the cell
+// already differentiates ✅/⚠️/❌).
+func groupDigest(caps map[string]Capability) string {
+	if len(caps) == 0 {
+		return "—"
+	}
+	full := 0
+	worst := ""
+	worstRank := -1
+	rank := map[string]int{
+		StatusMissing:       4,
+		StatusPartial:       3,
+		StatusFull:          2,
+		StatusNotApplicable: 1,
+		"":                  0,
+	}
+	for _, c := range caps {
+		if c.Status == StatusFull {
+			full++
+		}
+		if r := rank[c.Status]; r > worstRank {
+			worstRank = r
+			worst = c.Status
+		}
+	}
+	return fmt.Sprintf("%s %d/%d", statusGlyph(worst), full, len(caps))
 }
 
 // languageDisplay maps a language slug to its human-facing label. Slugs
 // without an entry render verbatim. "jsts" expands to "JS/TS" because
-// the registry collapses JavaScript and TypeScript under one tag (see
-// the Record.Language docstring).
+// the registry collapses JavaScript and TypeScript under one tag.
 func languageDisplay(slug string) string {
 	switch slug {
 	case "jsts":
@@ -219,13 +323,27 @@ func languageDisplay(slug string) string {
 	return slug
 }
 
-// templateFuncs are the helpers exposed to templates. Kept minimal so
-// most rendering logic lives in Go where it can be tested.
+// templateFuncs are the helpers exposed to templates.
 var templateFuncs = template.FuncMap{
-	"glyph":       statusGlyph,
-	"langDsp":     languageDisplay,
-	"prettyKey":   prettyKey,
-	"subHeading":  subcategoryHeading,
+	"glyph":      statusGlyph,
+	"langDsp":    languageDisplay,
+	"prettyKey":  prettyKey,
+	"subHeading": subcategoryHeading,
+	"groupCell":  groupCell,
+}
+
+// groupCell returns the digest string for groupName on a recordView or
+// categoryRow-like value. It accepts a map[string]string lookup so the
+// template can keep its expressions terse. Missing entries render as
+// "—" so columns never leave blank cells.
+func groupCell(byName map[string]string, groupName string) string {
+	if byName == nil {
+		return "—"
+	}
+	if v, ok := byName[groupName]; ok {
+		return v
+	}
+	return "—"
 }
 
 // generate writes the full markdown tree under outRoot/docs/coverage.
@@ -238,8 +356,6 @@ func generate(reg *Registry, outRoot string) error {
 		return err
 	}
 
-	// Sorted record views (registry already sorts records, but be defensive
-	// so generate works on any *Registry, not just one fresh from saveRegistry).
 	sortedRecs := make([]Record, len(reg.Records))
 	copy(sortedRecs, reg.Records)
 	sort.Slice(sortedRecs, func(i, j int) bool { return sortedRecs[i].ID < sortedRecs[j].ID })
@@ -248,7 +364,6 @@ func generate(reg *Registry, outRoot string) error {
 		allViews[i] = recordToView(r)
 	}
 
-	// Group views per language, per category, and per (language, bucket).
 	byLang := map[string][]recordView{}
 	byCat := map[string][]recordView{}
 	byLangBucket := map[string]map[string][]recordView{}
@@ -263,23 +378,18 @@ func generate(reg *Registry, outRoot string) error {
 		langSet[v.Language] = struct{}{}
 	}
 
-	// Sort language names for deterministic iteration. The pivot table
-	// lists each language alphabetically; templates do not re-sort.
 	langNames := make([]string, 0, len(langSet))
 	for n := range langSet {
 		langNames = append(langNames, n)
 	}
 	sort.Strings(langNames)
 
-	// Sort category names.
 	catNames := make([]string, 0, len(byCat))
 	for n := range byCat {
 		catNames = append(catNames, n)
 	}
 	sort.Strings(catNames)
 
-	// Records within each slice are sorted by label (then ID for stability)
-	// per #2725 rendering rules.
 	sortByLabel := func(rs []recordView) {
 		sort.SliceStable(rs, func(i, j int) bool {
 			if rs[i].Label != rs[j].Label {
@@ -309,7 +419,6 @@ func generate(reg *Registry, outRoot string) error {
 		return err
 	}
 
-	// Build summary pivot rows.
 	totals := pivotRow{}
 	rows := make([]pivotRow, 0, len(langNames)+1)
 	for _, n := range langNames {
@@ -326,9 +435,6 @@ func generate(reg *Registry, outRoot string) error {
 		totals.Tools += row.Tools
 		totals.ORMs += row.ORMs
 		totals.Other += row.Other
-		// Language-neutral pseudo-language. Surface it as an explicit
-		// "Uncategorized" row at the bottom rather than blending into the
-		// alphabetical list (per #2725 spec).
 		if n == "multi" || n == "" {
 			row.Name = "Uncategorized"
 			row.Display = "Uncategorized"
@@ -336,7 +442,6 @@ func generate(reg *Registry, outRoot string) error {
 		}
 		rows = append(rows, row)
 	}
-	// Move any Uncategorized rows to the end.
 	sort.SliceStable(rows, func(i, j int) bool {
 		if rows[i].Uncategorized != rows[j].Uncategorized {
 			return !rows[i].Uncategorized
@@ -356,7 +461,6 @@ func generate(reg *Registry, outRoot string) error {
 		return err
 	}
 
-	// Per-language pages.
 	for _, n := range langNames {
 		buckets := byLangBucket[n]
 		sections := make([]bucketSection, 0, len(bucketOrder))
@@ -386,11 +490,9 @@ func generate(reg *Registry, outRoot string) error {
 		}
 	}
 
-	// Per-category pages.
 	for _, n := range catNames {
 		recs := byCat[n]
 		bucket := bucketOf(n)
-		// Per-language banner counts for this category.
 		perLang := map[string]int{}
 		for _, r := range recs {
 			perLang[r.Language]++
@@ -404,11 +506,6 @@ func generate(reg *Registry, outRoot string) error {
 		for _, l := range langs {
 			banner = append(banner, categoryLanguageCount{Language: l, Count: perLang[l]})
 		}
-		// Capability keys: prefer the bucket-wide union for framework/orm/tool
-		// pages so the column set is consistent across categories in the
-		// same bucket. For Other categories, use the category's own keys
-		// (the bucket-wide nil signals "digest only", but per-category
-		// pages still benefit from showing the real columns).
 		var keys []string
 		if bucket == BucketOther {
 			keys = make([]string, len(categoryCapabilities[n]))
@@ -417,18 +514,19 @@ func generate(reg *Registry, outRoot string) error {
 		} else {
 			keys = bucketCapabilityKeys(bucket)
 		}
-		// Rows sorted by language then label (already label-sorted; do a
-		// stable resort by language).
 		rows := make([]categoryRow, 0, len(recs))
 		for _, r := range recs {
 			rows = append(rows, categoryRow{
-				Language:    r.Language,
-				Label:       r.Label,
-				ID:          r.ID,
-				Subcategory: r.Subcategory,
-				CapList:     r.CapList,
-				CapByKey:    r.CapByKey,
-				Digest:      r.Digest,
+				Language:          r.Language,
+				Label:             r.Label,
+				ID:                r.ID,
+				Subcategory:       r.Subcategory,
+				CapList:           r.CapList,
+				CapByKey:          r.CapByKey,
+				GroupViews:        r.GroupViews,
+				GroupDigestByName: r.GroupDigestByName,
+				Digest:            r.Digest,
+				Grouped:           r.Grouped,
 			})
 		}
 		sort.SliceStable(rows, func(i, j int) bool {
@@ -437,9 +535,6 @@ func generate(reg *Registry, outRoot string) error {
 			}
 			return rows[i].Label < rows[j].Label
 		})
-		// Group by subcategory when the category supports them and at
-		// least one record opts in. Records without a subcategory fall
-		// through to the legacy flat table at the bottom of the page.
 		subSecs, flatRows := splitCategoryRowsBySubcategory(n, rows)
 		if err := renderToFile(tmpls, "by-category.md.tmpl",
 			filepath.Join(root, "by-category", n+".md"),
@@ -457,15 +552,16 @@ func generate(reg *Registry, outRoot string) error {
 		}
 	}
 
-	// Per-record detail pages.
 	for _, rec := range sortedRecs {
 		view := recordToView(rec)
 		if err := renderToFile(tmpls, "detail.md.tmpl",
 			filepath.Join(root, "detail", rec.ID+".md"),
 			detailPageData{
-				Marker:  doNotEditMarker,
-				Record:  rec,
-				CapList: view.CapList,
+				Marker:     doNotEditMarker,
+				Record:     rec,
+				CapList:    view.CapList,
+				GroupViews: view.GroupViews,
+				Grouped:    view.Grouped,
 			}); err != nil {
 			return err
 		}
@@ -477,27 +573,17 @@ func generate(reg *Registry, outRoot string) error {
 // When any record in recs declares a subcategory, the section is split
 // into one subSection per subcategory (ordered by subcategoryOrder)
 // plus a final flat Records list for legacy un-subcategorised entries.
-// Buckets whose records all live at the category level keep the
-// original single-table render with CapabilityKeys = bucket union.
+// Subsections whose subcategory has a declared group taxonomy switch
+// from per-capability columns to per-group digest columns.
 func buildBucketSection(bucket string, recs []recordView) bucketSection {
 	bySub := map[string][]recordView{}
 	var flat []recordView
-	subCat := ""
 	for _, r := range recs {
 		if r.Subcategory == "" {
 			flat = append(flat, r)
 			continue
 		}
-		// All records in a bucket share the same category? Not strictly:
-		// the bucket maps multiple categories. But subcategoryCapabilities
-		// is category-scoped, so we route subcategory rendering by the
-		// record's own category. Track the dominant category for ordering
-		// — when multiple categories appear in one bucket we union their
-		// subcategoryOrder lists.
 		bySub[r.Subcategory] = append(bySub[r.Subcategory], r)
-		if subCat == "" {
-			subCat = r.Category
-		}
 	}
 	if len(bySub) == 0 {
 		return bucketSection{
@@ -506,9 +592,6 @@ func buildBucketSection(bucket string, recs []recordView) bucketSection {
 			Records:        recs,
 		}
 	}
-	// Collect ordered subcategory slugs across all categories represented
-	// in this bucket. categoriesInBucket is small (1–5) so the nested
-	// loop is fine and keeps ordering deterministic.
 	cats := map[string]bool{}
 	for _, r := range recs {
 		if r.Subcategory != "" {
@@ -520,11 +603,11 @@ func buildBucketSection(bucket string, recs []recordView) bucketSection {
 		catList = append(catList, c)
 	}
 	sort.Strings(catList)
-	seen := map[string]bool{}
 	merged := map[string]bool{}
 	for s := range bySub {
 		merged[s] = true
 	}
+	seen := map[string]bool{}
 	ordered := make([]string, 0, len(merged))
 	for _, c := range catList {
 		for _, s := range subcategoryOrder[c] {
@@ -534,8 +617,6 @@ func buildBucketSection(bucket string, recs []recordView) bucketSection {
 			}
 		}
 	}
-	// Any leftover subcategories (declared on records but not in
-	// subcategoryOrder for their category) sort alphabetically.
 	extras := make([]string, 0)
 	for s := range merged {
 		if !seen[s] {
@@ -548,17 +629,19 @@ func buildBucketSection(bucket string, recs []recordView) bucketSection {
 	subs := make([]subSection, 0, len(ordered))
 	for _, s := range ordered {
 		recsForSub := bySub[s]
-		// Pick a representative category to source the capability key
-		// union. When multiple categories share a subcategory slug we
-		// pick the first record's category (deterministic because recs
-		// is pre-sorted by label/ID).
 		cat := recsForSub[0].Category
-		subs = append(subs, subSection{
-			Subcategory:    s,
-			Heading:        subcategoryHeading(s),
-			CapabilityKeys: subcategoryRenderKeys(cat, s),
-			Records:        recsForSub,
-		})
+		groupNames := knownGroupNames(s)
+		sec := subSection{
+			Subcategory: s,
+			Heading:     subcategoryHeading(s),
+			Records:     recsForSub,
+		}
+		if len(groupNames) > 0 {
+			sec.GroupNames = groupNames
+		} else {
+			sec.CapabilityKeys = subcategoryRenderKeys(cat, s)
+		}
+		subs = append(subs, sec)
 	}
 	return bucketSection{
 		Name:           bucket,
@@ -570,9 +653,8 @@ func buildBucketSection(bucket string, recs []recordView) bucketSection {
 
 // splitCategoryRowsBySubcategory partitions by-category rows into
 // per-subcategory subsections plus a tail of un-subcategorised rows.
-// When no row carries a subcategory, the subsection slice is nil and
-// all rows are returned verbatim so the legacy single-table template
-// path takes over.
+// Subcategories with a declared group taxonomy switch from per-capability
+// columns to per-group digest columns (parallel to buildBucketSection).
 func splitCategoryRowsBySubcategory(category string, rows []categoryRow) ([]categorySubSection, []categoryRow) {
 	bySub := map[string][]categoryRow{}
 	var flat []categoryRow
@@ -593,12 +675,18 @@ func splitCategoryRowsBySubcategory(category string, rows []categoryRow) ([]cate
 	ordered := orderedSubcategories(category, present)
 	subs := make([]categorySubSection, 0, len(ordered))
 	for _, s := range ordered {
-		subs = append(subs, categorySubSection{
-			Subcategory:    s,
-			Heading:        subcategoryHeading(s),
-			CapabilityKeys: subcategoryRenderKeys(category, s),
-			Records:        bySub[s],
-		})
+		groupNames := knownGroupNames(s)
+		sec := categorySubSection{
+			Subcategory: s,
+			Heading:     subcategoryHeading(s),
+			Records:     bySub[s],
+		}
+		if len(groupNames) > 0 {
+			sec.GroupNames = groupNames
+		} else {
+			sec.CapabilityKeys = subcategoryRenderKeys(category, s)
+		}
+		subs = append(subs, sec)
 	}
 	return subs, flat
 }
@@ -610,9 +698,6 @@ func renderToFile(tmpls *template.Template, name, path string, data any) error {
 	if err := tmpls.ExecuteTemplate(&buf, name, data); err != nil {
 		return fmt.Errorf("execute %s: %w", name, err)
 	}
-	// Ensure file ends with exactly one trailing newline. Templates may
-	// or may not include one; normalising here keeps output stable across
-	// template edits.
 	out := bytes.TrimRight(buf.Bytes(), "\n")
 	out = append(out, '\n')
 

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -212,29 +212,29 @@ func cmdUpdate(args []string, out io.Writer) error {
 	} else if !validCapabilityKey(rec.Category, *cap) {
 		return fmt.Errorf("update: capability %q not valid for category %q", *cap, rec.Category)
 	}
-	if rec.Capabilities == nil {
-		rec.Capabilities = map[string]Capability{}
-	}
-	cell := rec.Capabilities[*cap]
-	cell.Status = *status
-	if *cites != "" {
-		parts := strings.Split(*cites, ",")
-		clean := make([]string, 0, len(parts))
-		for _, p := range parts {
-			p = strings.TrimSpace(p)
-			if p != "" {
-				clean = append(clean, p)
-			}
+	// Route the write to the right shape. Grouped records auto-place
+	// the cell into its canonical group (per subcategoryGroups); keys
+	// outside the taxonomy fall into the synthetic Uncategorized
+	// group so we never lose data.
+	if rec.IsGrouped() {
+		group := groupForCapability(rec.Subcategory, *cap)
+		if group == "" {
+			group = uncategorizedGroup
 		}
-		cell.Cites = clean
+		if rec.Groups[group] == nil {
+			rec.Groups[group] = map[string]Capability{}
+		}
+		cell := rec.Groups[group][*cap]
+		applyUpdateFlags(&cell, *status, *cites, *issue, *verifiedNow)
+		rec.Groups[group][*cap] = cell
+	} else {
+		if rec.Capabilities == nil {
+			rec.Capabilities = map[string]Capability{}
+		}
+		cell := rec.Capabilities[*cap]
+		applyUpdateFlags(&cell, *status, *cites, *issue, *verifiedNow)
+		rec.Capabilities[*cap] = cell
 	}
-	if *issue != "" {
-		cell.Issue = *issue
-	}
-	if *verifiedNow {
-		cell.VerifiedAt = time.Now().UTC().Format("2006-01-02")
-	}
-	rec.Capabilities[*cap] = cell
 	if err := saveRegistry(*path, reg); err != nil {
 		return err
 	}
@@ -352,6 +352,30 @@ func cmdValidate(args []string, out, errw io.Writer) error {
 	}
 	fmt.Fprintf(out, "ok: %d record(s), %d warning(s)\n", len(reg.Records), len(res.Warnings))
 	return nil
+}
+
+// applyUpdateFlags mutates cell with the non-empty CLI flags from
+// cmdUpdate. Shared between the flat and grouped write paths so cell
+// semantics stay identical regardless of capability shape.
+func applyUpdateFlags(cell *Capability, status, cites, issue string, verifiedNow bool) {
+	cell.Status = status
+	if cites != "" {
+		parts := strings.Split(cites, ",")
+		clean := make([]string, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				clean = append(clean, p)
+			}
+		}
+		cell.Cites = clean
+	}
+	if issue != "" {
+		cell.Issue = issue
+	}
+	if verifiedNow {
+		cell.VerifiedAt = time.Now().UTC().Format("2006-01-02")
+	}
 }
 
 // sortStrings is a tiny local helper to avoid pulling sort into main.go

--- a/tools/coverage/schema.go
+++ b/tools/coverage/schema.go
@@ -1,12 +1,15 @@
 // Package main implements the coverage registry CLI.
 //
 // The schema mirrors docs/coverage/registry.json. Keep this file in sync
-// with the documented schema in issues #2720 (foundation) and #2735
-// (subcategory + per-subcategory capabilities). Pure value types: zero
-// imports from internal/ packages.
+// with the documented schema in issues #2720 (foundation), #2735
+// (subcategory + per-subcategory capabilities), and #2737 (capability
+// groups + group-digest rendering). Pure value types: zero imports from
+// internal/ packages.
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -26,6 +29,13 @@ var acronyms = map[string]string{
 	"api":  "API",
 	"orm":  "ORM",
 	"sdk":  "SDK",
+	"isr":  "ISR",
+	"ios":  "iOS",
+	"jni":  "JNI",
+	"ui":   "UI",
+	"ai":   "AI",
+	"rpc":  "RPC",
+	"ci":   "CI",
 }
 
 // prettyKey converts a snake_case capability or subcategory slug into
@@ -54,6 +64,12 @@ func prettyKey(s string) string {
 // SchemaVersion is the current registry schema version. Bump when the
 // on-disk JSON shape changes incompatibly.
 const SchemaVersion = 1
+
+// uncategorizedGroup is the synthetic group bucket for capability keys
+// that do not fit any canonical group declared in subcategoryGroups for
+// a record's subcategory. Migration emits a warning when it places a
+// key here so the taxonomy can be extended deliberately.
+const uncategorizedGroup = "Uncategorized"
 
 // Status enum values for a capability cell.
 const (
@@ -94,18 +110,28 @@ type Registry struct {
 // Subcategory is an OPTIONAL refinement of Category. It carves a broad
 // category (e.g. http_framework) into honest narrower lanes (ui_frontend,
 // mobile, meta_framework, ...). When set it MUST be one of the slugs
-// declared for Record.Category in subcategoryCapabilities, and the
-// record's capability keys are then validated against the union of
-// (subcategory keys + category keys) rather than the category-wide list.
-// Records without Subcategory keep the legacy category-only validation
-// and render in their bucket's default column set.
+// declared for Record.Category in subcategoryCapabilities.
+//
+// Capabilities and Groups are mutually exclusive carriers of the per-
+// record capability cells:
+//
+//   - Capabilities is the legacy flat map used by records without a
+//     subcategory. Loaded when the on-disk "capabilities" object's
+//     values are Capability cells (have a "status" field).
+//   - Groups is the nested shape (group → key → cell) introduced by
+//     #2737. Loaded when the on-disk values are sub-objects whose own
+//     values are Capability cells. Group names are validated against
+//     subcategoryGroups for the record's (category, subcategory).
+//
+// Use Record.AllCapabilities to iterate every cell regardless of shape.
 type Record struct {
-	ID           string                `json:"id"`
-	Category     string                `json:"category"`
-	Subcategory  string                `json:"subcategory,omitempty"`
-	Language     string                `json:"language"`
-	Label        string                `json:"label"`
-	Capabilities map[string]Capability `json:"capabilities"`
+	ID           string
+	Category     string
+	Subcategory  string
+	Language     string
+	Label        string
+	Capabilities map[string]Capability
+	Groups       map[string]map[string]Capability
 }
 
 // Capability is a single capability cell on a record.
@@ -115,6 +141,168 @@ type Capability struct {
 	VerifiedAt  string   `json:"verified_at,omitempty"`
 	VerifiedSHA string   `json:"verified_sha,omitempty"`
 	Issue       string   `json:"issue,omitempty"`
+}
+
+// IsGrouped reports whether the record carries grouped capabilities.
+func (r *Record) IsGrouped() bool { return len(r.Groups) > 0 }
+
+// AllCapabilities returns every capability cell on the record as a flat
+// map keyed by capability slug. For grouped records keys are flattened
+// across all groups (each key appears exactly once per validation).
+func (r *Record) AllCapabilities() map[string]Capability {
+	if !r.IsGrouped() {
+		out := make(map[string]Capability, len(r.Capabilities))
+		for k, v := range r.Capabilities {
+			out[k] = v
+		}
+		return out
+	}
+	out := map[string]Capability{}
+	for _, g := range r.Groups {
+		for k, v := range g {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// MarshalJSON emits the record in either the flat or the grouped shape
+// based on whether Groups is populated. Capabilities maps are serialised
+// with sorted keys via an intermediate ordered structure so the result
+// is deterministic — callers that need byte-stable output should still
+// prefer marshalRegistry, which controls indentation as well.
+func (r Record) MarshalJSON() ([]byte, error) {
+	type capWire struct {
+		Status      string   `json:"status"`
+		Cites       []string `json:"cites,omitempty"`
+		VerifiedAt  string   `json:"verified_at,omitempty"`
+		VerifiedSHA string   `json:"verified_sha,omitempty"`
+		Issue       string   `json:"issue,omitempty"`
+	}
+	toWire := func(c Capability) capWire {
+		return capWire{
+			Status: c.Status, Cites: c.Cites, VerifiedAt: c.VerifiedAt,
+			VerifiedSHA: c.VerifiedSHA, Issue: c.Issue,
+		}
+	}
+	out := struct {
+		ID           string         `json:"id"`
+		Category     string         `json:"category"`
+		Subcategory  string         `json:"subcategory,omitempty"`
+		Language     string         `json:"language"`
+		Label        string         `json:"label"`
+		Capabilities map[string]any `json:"capabilities"`
+	}{
+		ID: r.ID, Category: r.Category, Subcategory: r.Subcategory,
+		Language: r.Language, Label: r.Label,
+		Capabilities: map[string]any{},
+	}
+	if r.IsGrouped() {
+		for g, caps := range r.Groups {
+			inner := map[string]capWire{}
+			for k, c := range caps {
+				inner[k] = toWire(c)
+			}
+			out.Capabilities[g] = inner
+		}
+	} else {
+		for k, c := range r.Capabilities {
+			out.Capabilities[k] = toWire(c)
+		}
+	}
+	return json.Marshal(out)
+}
+
+// recordJSON is the on-wire shape used by Record's marshal helpers. The
+// Capabilities field is deferred to json.RawMessage so UnmarshalJSON can
+// inspect the inner structure and route to the flat or grouped target.
+type recordJSON struct {
+	ID           string          `json:"id"`
+	Category     string          `json:"category"`
+	Subcategory  string          `json:"subcategory,omitempty"`
+	Language     string          `json:"language"`
+	Label        string          `json:"label"`
+	Capabilities json.RawMessage `json:"capabilities"`
+}
+
+// UnmarshalJSON decodes a record, distinguishing the flat capability
+// shape ({"key": {"status": ...}}) from the grouped shape
+// ({"Group": {"key": {"status": ...}}}) by inspecting whether each
+// top-level value carries a "status" field.
+func (r *Record) UnmarshalJSON(data []byte) error {
+	var raw recordJSON
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&raw); err != nil {
+		return err
+	}
+	r.ID = raw.ID
+	r.Category = raw.Category
+	r.Subcategory = raw.Subcategory
+	r.Language = raw.Language
+	r.Label = raw.Label
+	r.Capabilities = nil
+	r.Groups = nil
+	if len(raw.Capabilities) == 0 || bytes.Equal(bytes.TrimSpace(raw.Capabilities), []byte("null")) {
+		return nil
+	}
+	grouped, err := capabilitiesAreGrouped(raw.Capabilities)
+	if err != nil {
+		return fmt.Errorf("record %s: capabilities: %w", raw.ID, err)
+	}
+	if grouped {
+		var g map[string]map[string]Capability
+		gdec := json.NewDecoder(bytes.NewReader(raw.Capabilities))
+		gdec.DisallowUnknownFields()
+		if err := gdec.Decode(&g); err != nil {
+			return fmt.Errorf("record %s: decode grouped capabilities: %w", raw.ID, err)
+		}
+		r.Groups = g
+		return nil
+	}
+	var flat map[string]Capability
+	fdec := json.NewDecoder(bytes.NewReader(raw.Capabilities))
+	fdec.DisallowUnknownFields()
+	if err := fdec.Decode(&flat); err != nil {
+		return fmt.Errorf("record %s: decode flat capabilities: %w", raw.ID, err)
+	}
+	r.Capabilities = flat
+	return nil
+}
+
+// capabilitiesAreGrouped peeks at the first non-empty inner object value
+// in the capabilities map: if it carries a "status" field the outer map
+// is flat (key → Capability); otherwise it is grouped (group → key →
+// Capability). Empty objects mean the record has no cells declared yet,
+// in which case the caller treats it as flat (no-op).
+func capabilitiesAreGrouped(raw json.RawMessage) (bool, error) {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return false, err
+	}
+	if len(probe) == 0 {
+		return false, nil
+	}
+	// Inspect in a deterministic key order so identical inputs always
+	// resolve the same way (matters only for malformed mixed shapes).
+	keys := make([]string, 0, len(probe))
+	for k := range probe {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		var inner map[string]json.RawMessage
+		if err := json.Unmarshal(probe[k], &inner); err != nil {
+			return false, fmt.Errorf("capability %q: not an object", k)
+		}
+		if _, hasStatus := inner["status"]; hasStatus {
+			return false, nil
+		}
+		// No status: this value is itself a map of capabilities, so the
+		// outer shape is grouped.
+		return true, nil
+	}
+	return false, nil
 }
 
 // categoryCapabilities maps each registry category to the set of
@@ -287,6 +475,133 @@ var subcategoryDisplay = map[string]string{
 	"rpc_framework":  "RPC Framework",
 	"static_site":    "Static Site",
 	"ai_integration": "AI Integration",
+}
+
+// subcategoryGroups declares the canonical capability-group taxonomy
+// per subcategory: subcategory → group name → ordered capability keys.
+// Group names are exact strings (case + spacing preserved); they appear
+// verbatim as section headings on detail pages and as column headers on
+// pivot tables. Capability keys must also be declared in
+// subcategoryCapabilities for their (category, subcategory) so the
+// allow-list and the taxonomy stay in sync.
+//
+// Groups are listed in display order — render order on the detail page
+// and column order in the pivot table both follow this slice.
+var subcategoryGroups = map[string][]capabilityGroup{
+	"ui_frontend": {
+		{Name: "Structure", Keys: []string{"component_extraction", "hook_recognition", "jsx_template"}},
+		{Name: "Data Flow", Keys: []string{"prop_extraction", "state_management", "data_fetching"}},
+		{Name: "Navigation", Keys: []string{"router_pattern"}},
+		{Name: "Type System", Keys: []string{}},
+		{Name: "Lifecycle", Keys: []string{}},
+		{Name: "Testing", Keys: []string{}},
+	},
+	"mobile": {
+		{Name: "Navigation", Keys: []string{"navigation_extraction", "deep_link_extraction", "screen_detection"}},
+		{Name: "Platform", Keys: []string{"platform_branching"}},
+		{Name: "Native Bridge", Keys: []string{"native_module_imports"}},
+		{Name: "Data Flow", Keys: []string{"state_management"}},
+		{Name: "Lifecycle", Keys: []string{}},
+	},
+	"http_backend": {
+		{Name: "Routing", Keys: []string{"endpoint_synthesis", "handler_attribution", "route_extraction"}},
+		{Name: "Security", Keys: []string{"auth_coverage"}},
+		{Name: "Validation", Keys: []string{"request_validation", "dto_extraction"}},
+		{Name: "Middleware", Keys: []string{"middleware_coverage"}},
+		{Name: "Testing", Keys: []string{"tests_linkage"}},
+		{Name: "Observability", Keys: []string{}},
+		{Name: "Data", Keys: []string{}},
+	},
+	"meta_framework": {
+		{Name: "Structure", Keys: []string{"component_extraction", "hook_recognition"}},
+		{Name: "Data Flow", Keys: []string{"data_loaders"}},
+		{Name: "Server", Keys: []string{"server_components", "hydration_boundaries"}},
+		{Name: "Routing", Keys: []string{"route_extraction", "router_pattern"}},
+		{Name: "Build", Keys: []string{"static_generation"}},
+	},
+	"desktop": {
+		{Name: "Process", Keys: []string{"ipc_extraction", "main_renderer_split"}},
+		{Name: "Native", Keys: []string{"native_module_imports"}},
+		{Name: "Updates", Keys: []string{}},
+	},
+	"rpc_framework": {
+		{Name: "Schema", Keys: []string{"schema_extraction", "procedure_extraction"}},
+		{Name: "Codegen", Keys: []string{"client_codegen"}},
+		{Name: "Transport", Keys: []string{}},
+	},
+	"ai_integration": {
+		{Name: "Prompts", Keys: []string{"prompt_template_extraction"}},
+		{Name: "Composition", Keys: []string{"chain_composition", "tool_use_detection"}},
+		{Name: "Tracking", Keys: []string{}},
+	},
+}
+
+// capabilityGroup pairs a group name with its ordered capability keys.
+// Render order follows the slice; templates do not re-sort.
+type capabilityGroup struct {
+	Name string
+	Keys []string
+}
+
+// groupsForSubcategory returns the canonical group taxonomy for sub or
+// nil when the subcategory has no declared taxonomy (e.g. static_site).
+func groupsForSubcategory(sub string) []capabilityGroup {
+	return subcategoryGroups[sub]
+}
+
+// groupForCapability returns the canonical group name that owns key in
+// sub's taxonomy, or "" when the key is not declared in any group. Used
+// by migration and validation to enforce capability-belongs-to-group.
+func groupForCapability(sub, key string) string {
+	for _, g := range subcategoryGroups[sub] {
+		for _, k := range g.Keys {
+			if k == key {
+				return g.Name
+			}
+		}
+	}
+	return ""
+}
+
+// groupAllowedKeys returns the declared keys for (sub, group) or nil
+// when group is not part of sub's taxonomy. Validation uses this to
+// reject keys placed under the wrong group within a record.
+func groupAllowedKeys(sub, group string) []string {
+	for _, g := range subcategoryGroups[sub] {
+		if g.Name == group {
+			return g.Keys
+		}
+	}
+	return nil
+}
+
+// knownGroupNames returns the declared group names for sub in canonical
+// render order, or nil when sub has no group taxonomy.
+func knownGroupNames(sub string) []string {
+	groups := subcategoryGroups[sub]
+	if len(groups) == 0 {
+		return nil
+	}
+	out := make([]string, len(groups))
+	for i, g := range groups {
+		out[i] = g.Name
+	}
+	return out
+}
+
+// validGroupName reports whether group is part of sub's taxonomy. The
+// synthetic uncategorizedGroup is always accepted so migration can park
+// keys that fall outside the canonical taxonomy without losing data.
+func validGroupName(sub, group string) bool {
+	if group == uncategorizedGroup {
+		return true
+	}
+	for _, g := range subcategoryGroups[sub] {
+		if g.Name == group {
+			return true
+		}
+	}
+	return false
 }
 
 // knownSubcategories returns the sorted subcategory slugs declared for

--- a/tools/coverage/store.go
+++ b/tools/coverage/store.go
@@ -68,7 +68,8 @@ func saveRegistry(path string, reg *Registry) error {
 
 // sortRegistry sorts records by ID and also sorts each record's cites
 // slice deterministically. Capability map ordering is handled at
-// marshal time.
+// marshal time. Both flat and grouped capability shapes have their
+// cite slices normalised.
 func sortRegistry(reg *Registry) {
 	sort.Slice(reg.Records, func(i, j int) bool {
 		return reg.Records[i].ID < reg.Records[j].ID
@@ -77,6 +78,13 @@ func sortRegistry(reg *Registry) {
 		for k, cap := range reg.Records[i].Capabilities {
 			sort.Strings(cap.Cites)
 			reg.Records[i].Capabilities[k] = cap
+		}
+		for g, inner := range reg.Records[i].Groups {
+			for k, cap := range inner {
+				sort.Strings(cap.Cites)
+				inner[k] = cap
+			}
+			reg.Records[i].Groups[g] = inner
 		}
 	}
 }
@@ -132,24 +140,105 @@ func writeRecord(buf *bytes.Buffer, rec Record, indent string) error {
 		return err
 	}
 	buf.WriteString(inner + "\"capabilities\": {")
-	keys := sortedCapKeys(rec.Capabilities)
-	if len(keys) > 0 {
-		buf.WriteString("\n")
-	}
-	for i, k := range keys {
-		cap := rec.Capabilities[k]
-		if err := writeCapability(buf, inner+"  ", k, cap); err != nil {
+	if rec.IsGrouped() {
+		if err := writeGroupedCapabilities(buf, inner+"  ", rec); err != nil {
 			return err
 		}
-		if i < len(keys)-1 {
-			buf.WriteString(",\n")
-		} else {
-			buf.WriteString("\n" + inner)
+	} else {
+		keys := sortedCapKeys(rec.Capabilities)
+		if len(keys) > 0 {
+			buf.WriteString("\n")
+		}
+		for i, k := range keys {
+			cap := rec.Capabilities[k]
+			if err := writeCapability(buf, inner+"  ", k, cap); err != nil {
+				return err
+			}
+			if i < len(keys)-1 {
+				buf.WriteString(",\n")
+			} else {
+				buf.WriteString("\n" + inner)
+			}
 		}
 	}
 	buf.WriteString("}\n")
 	buf.WriteString(indent + "}")
 	return nil
+}
+
+// writeGroupedCapabilities serialises the nested capability shape as
+// "capabilities": { "Group": { "key": {cell}, ... }, ... }. Group names
+// are emitted in their canonical taxonomy order (subcategoryGroups),
+// then any extras (including the synthetic "Uncategorized" group) in
+// alphabetical order. Within each group, capability keys sort
+// alphabetically so output is byte-for-byte stable.
+func writeGroupedCapabilities(buf *bytes.Buffer, indent string, rec Record) error {
+	groups := orderedGroupNames(rec.Subcategory, rec.Groups)
+	if len(groups) == 0 {
+		return nil
+	}
+	buf.WriteString("\n")
+	for gi, gname := range groups {
+		encG, err := json.Marshal(gname)
+		if err != nil {
+			return err
+		}
+		buf.WriteString(indent)
+		buf.Write(encG)
+		buf.WriteString(": {")
+		inner := indent + "  "
+		caps := rec.Groups[gname]
+		keys := sortedCapKeys(caps)
+		if len(keys) > 0 {
+			buf.WriteString("\n")
+		}
+		for i, k := range keys {
+			if err := writeCapability(buf, inner, k, caps[k]); err != nil {
+				return err
+			}
+			if i < len(keys)-1 {
+				buf.WriteString(",\n")
+			} else {
+				buf.WriteString("\n" + indent)
+			}
+		}
+		buf.WriteString("}")
+		if gi < len(groups)-1 {
+			buf.WriteString(",\n")
+		} else {
+			buf.WriteString("\n")
+			// Trim indent back to the "capabilities": { level.
+			buf.WriteString(indent[:len(indent)-2])
+		}
+	}
+	return nil
+}
+
+// orderedGroupNames returns the group names present in groups, sorted
+// by canonical order from subcategoryGroups first then alphabetically
+// for any extras (e.g. the synthetic "Uncategorized" bucket).
+func orderedGroupNames(sub string, groups map[string]map[string]Capability) []string {
+	known := knownGroupNames(sub)
+	present := map[string]bool{}
+	for g := range groups {
+		present[g] = true
+	}
+	out := make([]string, 0, len(present))
+	seen := map[string]bool{}
+	for _, g := range known {
+		if present[g] {
+			out = append(out, g)
+			seen[g] = true
+		}
+	}
+	extras := make([]string, 0)
+	for g := range present {
+		if !seen[g] {
+			extras = append(extras, g)
+		}
+	}
+	sort.Strings(extras)
+	return append(out, extras...)
 }
 
 // writeJSONField writes a "key": value pair using encoding/json for

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -189,9 +189,107 @@ func TestBuildBucketSectionGroupsBySubcategory(t *testing.T) {
 	if len(sec.Records) != 1 || sec.Records[0].ID != "lang.jsts.framework.legacy" {
 		t.Errorf("legacy record should fall through to flat Records, got %+v", sec.Records)
 	}
-	// Render keys must be subcategory-scoped, not the bucket union.
-	if got := sec.Subsections[1].CapabilityKeys; len(got) == 0 || got[0] == "auth_coverage" {
-		t.Errorf("ui_frontend columns should not include auth_coverage, got %v", got)
+	// ui_frontend has a declared group taxonomy (#2737), so the
+	// subsection now renders group-digest columns rather than per-
+	// capability columns. CapabilityKeys is unset; GroupNames carries
+	// the canonical group render order.
+	uiSec := sec.Subsections[1]
+	if len(uiSec.CapabilityKeys) != 0 {
+		t.Errorf("ui_frontend should use group columns, got CapabilityKeys=%v", uiSec.CapabilityKeys)
+	}
+	wantGroups := []string{"Structure", "Data Flow", "Navigation", "Type System", "Lifecycle", "Testing"}
+	if !reflect.DeepEqual(uiSec.GroupNames, wantGroups) {
+		t.Errorf("ui_frontend GroupNames = %v, want %v", uiSec.GroupNames, wantGroups)
+	}
+}
+
+// TestGroupForCapability checks the canonical taxonomy lookups.
+func TestGroupForCapability(t *testing.T) {
+	if g := groupForCapability("ui_frontend", "router_pattern"); g != "Navigation" {
+		t.Errorf("router_pattern should resolve to Navigation, got %q", g)
+	}
+	if g := groupForCapability("ui_frontend", "component_extraction"); g != "Structure" {
+		t.Errorf("component_extraction should resolve to Structure, got %q", g)
+	}
+	if g := groupForCapability("ui_frontend", "nonexistent_key"); g != "" {
+		t.Errorf("nonexistent_key should return empty, got %q", g)
+	}
+}
+
+// TestGroupDigest checks the worst-glyph + full-count/total digest.
+func TestGroupDigest(t *testing.T) {
+	caps := map[string]Capability{
+		"a": {Status: StatusFull},
+		"b": {Status: StatusPartial},
+		"c": {Status: StatusMissing},
+	}
+	if got := groupDigest(caps); got != "❌ 1/3" {
+		t.Errorf("groupDigest = %q, want ❌ 1/3", got)
+	}
+	if got := groupDigest(map[string]Capability{}); got != "—" {
+		t.Errorf("empty groupDigest = %q, want —", got)
+	}
+}
+
+// TestValidateGroupedRecord exercises the new #2737 validation rules:
+// canonical group names, capability-belongs-to-group, and
+// uniqueness-within-record.
+func TestValidateGroupedRecord(t *testing.T) {
+	reg := &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{
+			{
+				ID: "lang.jsts.framework.react", Category: "http_framework",
+				Subcategory: "ui_frontend", Language: "jsts", Label: "React",
+				Groups: map[string]map[string]Capability{
+					"Structure":  {"component_extraction": {Status: StatusPartial, Issue: "x"}},
+					"Navigation": {"router_pattern": {Status: StatusFull}},
+				},
+			},
+			{
+				ID: "lang.jsts.framework.bad-group", Category: "http_framework",
+				Subcategory: "ui_frontend", Language: "jsts", Label: "BadGroup",
+				Groups: map[string]map[string]Capability{
+					"Strcture": {"component_extraction": {Status: StatusFull}},
+				},
+			},
+			{
+				ID: "lang.jsts.framework.bad-place", Category: "http_framework",
+				Subcategory: "ui_frontend", Language: "jsts", Label: "BadPlace",
+				Groups: map[string]map[string]Capability{
+					"Structure": {"router_pattern": {Status: StatusFull}},
+				},
+			},
+			{
+				ID: "lang.jsts.framework.dup-key", Category: "http_framework",
+				Subcategory: "ui_frontend", Language: "jsts", Label: "DupKey",
+				Groups: map[string]map[string]Capability{
+					"Structure":  {"component_extraction": {Status: StatusFull}},
+					"Navigation": {"component_extraction": {Status: StatusFull}},
+				},
+			},
+		},
+	}
+	res := validateRegistry(reg, ".")
+	hasError := func(needle string) bool {
+		for _, e := range res.Errors {
+			if containsStr(e, needle) {
+				return true
+			}
+		}
+		return false
+	}
+	if hasError("lang.jsts.framework.react") {
+		t.Errorf("react should validate; got: %v", res.Errors)
+	}
+	if !hasError(`unknown group "Strcture"`) {
+		t.Errorf("expected unknown group error; got: %v", res.Errors)
+	}
+	if !hasError("does not belong to group") {
+		t.Errorf("expected capability-belongs-to-group error; got: %v", res.Errors)
+	}
+	if !hasError("already declared under group") {
+		t.Errorf("expected duplicate-key error; got: %v", res.Errors)
 	}
 }
 

--- a/tools/coverage/templates/by-category.md.tmpl
+++ b/tools/coverage/templates/by-category.md.tmpl
@@ -18,7 +18,15 @@ Back to [summary](../summary.md). Bucket: **{{.Bucket}}**.
 {{- range .Subsections}}
 
 ## {{.Heading}}
-
+{{if .GroupNames}}
+| Language | Name |{{range .GroupNames}} {{.}} |{{end}} Notes |
+|---|---|{{range .GroupNames}}---|{{end}}---|
+{{- $groups := .GroupNames}}
+{{- range .Records}}
+{{- $rec := .}}
+| [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $groups}} {{groupCell $rec.GroupDigestByName .}} |{{end}} |
+{{- end}}
+{{else}}
 | Language | Name |{{range .CapabilityKeys}} {{prettyKey .}} |{{end}} Notes |
 |---|---|{{range .CapabilityKeys}}---|{{end}}---|
 {{- $caps := .CapabilityKeys}}
@@ -26,6 +34,7 @@ Back to [summary](../summary.md). Bucket: **{{.Bucket}}**.
 {{- $rec := .}}
 | [{{langDsp .Language}}](../by-language/{{.Language}}.md) | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} |
 {{- end}}
+{{end}}
 {{- end}}
 {{- if .Records}}
 

--- a/tools/coverage/templates/by-language.md.tmpl
+++ b/tools/coverage/templates/by-language.md.tmpl
@@ -17,7 +17,15 @@ Back to [summary](../summary.md).
 {{- range .Subsections}}
 
 ### {{.Heading}}
-
+{{if .GroupNames}}
+| Name |{{range .GroupNames}} {{.}} |{{end}} Notes |
+|---|{{range .GroupNames}}---|{{end}}---|
+{{- $groups := .GroupNames}}
+{{- range .Records}}
+{{- $rec := .}}
+| [{{.Label}}](../detail/{{.ID}}.md) |{{range $groups}} {{groupCell $rec.GroupDigestByName .}} |{{end}} |
+{{- end}}
+{{else}}
 | Name |{{range .CapabilityKeys}} {{prettyKey .}} |{{end}} Notes |
 |---|{{range .CapabilityKeys}}---|{{end}}---|
 {{- $caps := .CapabilityKeys}}
@@ -25,6 +33,7 @@ Back to [summary](../summary.md).
 {{- $rec := .}}
 | [{{.Label}}](../detail/{{.ID}}.md) |{{range $caps}} {{glyph (index $rec.CapByKey .).Status}} |{{end}} |
 {{- end}}
+{{end}}
 {{- end}}
 {{- if .Records}}
 

--- a/tools/coverage/templates/detail.md.tmpl
+++ b/tools/coverage/templates/detail.md.tmpl
@@ -9,13 +9,23 @@ Auto-generated. Back to [summary](../summary.md).
 - **Capability cells:** {{len .CapList}}
 
 ## Capabilities
+{{if .Grouped}}{{range .GroupViews}}
+
+### {{.Name}}
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites |
 |------------|--------|-------------|--------------|-------|-------|
 {{- range .CapList}}
 | `{{.Key}}` | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} |
 {{- end}}
-
+{{- end}}
+{{else}}
+| Capability | Status | Verified at | Verified SHA | Issue | Cites |
+|------------|--------|-------------|--------------|-------|-------|
+{{- range .CapList}}
+| `{{.Key}}` | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} |
+{{- end}}
+{{end}}
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/tools/coverage/validate.go
+++ b/tools/coverage/validate.go
@@ -59,52 +59,140 @@ func validateRegistry(reg *Registry, repoRoot string) *ValidationResult {
 			res.Errors = append(res.Errors, prefix+": label is empty")
 		}
 
-		// Capabilities: sort keys for deterministic error ordering.
-		keys := sortedCapKeys(rec.Capabilities)
-		for _, k := range keys {
-			cap := rec.Capabilities[k]
-			capPrefix := fmt.Sprintf("%s.capabilities[%s]", prefix, k)
-			// When a record opts in to a subcategory, accept either the
-			// subcategory's keys or the category-wide keys (subcategories
-			// extend, they do not replace). Without a subcategory, fall
-			// back to the legacy category-only allow-list.
-			validKey := false
-			if rec.Subcategory != "" && validSubcategory(rec.Category, rec.Subcategory) {
-				validKey = validCapabilityKeyForSubcategory(rec.Category, rec.Subcategory, k)
-			} else {
-				validKey = validCapabilityKey(rec.Category, k)
-			}
-			if !validKey {
-				if rec.Subcategory != "" {
-					res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid capability key for category %q subcategory %q", capPrefix, rec.Category, rec.Subcategory))
-				} else {
-					res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid capability key for category %q", capPrefix, rec.Category))
-				}
-			}
-			if _, ok := validStatuses[cap.Status]; !ok {
-				res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid status %q", capPrefix, cap.Status))
-			}
-			for _, cite := range cap.Cites {
-				full := filepath.Join(repoRoot, cite)
-				if _, err := os.Stat(full); err != nil {
-					res.Errors = append(res.Errors, fmt.Sprintf("%s: cite %q not found on disk", capPrefix, cite))
-				}
-			}
-			if cap.VerifiedAt != "" {
-				t, err := time.Parse("2006-01-02", cap.VerifiedAt)
-				if err != nil {
-					res.Errors = append(res.Errors, fmt.Sprintf("%s: verified_at %q not a valid ISO date", capPrefix, cap.VerifiedAt))
-				} else if time.Since(t) > staleDays*24*time.Hour {
-					res.Warnings = append(res.Warnings, fmt.Sprintf("%s: verified_at %s is older than %d days", capPrefix, cap.VerifiedAt, staleDays))
-				}
-			}
-			if (cap.Status == StatusMissing || cap.Status == StatusPartial) && cap.Issue == "" {
-				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %s capability has no tracking issue", capPrefix, cap.Status))
-			}
+		// A record must not carry both shapes — the on-disk loader
+		// guarantees one or the other but defensive validation guards
+		// against in-memory mutation paths populating both.
+		if rec.IsGrouped() && len(rec.Capabilities) > 0 {
+			res.Errors = append(res.Errors, prefix+": record carries both flat and grouped capabilities")
+		}
+
+		if rec.IsGrouped() {
+			validateGroupedRecord(res, prefix, rec, repoRoot)
+		} else {
+			validateFlatRecord(res, prefix, rec, repoRoot)
 		}
 	}
 
 	sort.Strings(res.Errors)
 	sort.Strings(res.Warnings)
 	return res
+}
+
+// validateFlatRecord runs the legacy capability-key + status + cite +
+// freshness checks against a record using the flat capability shape.
+func validateFlatRecord(res *ValidationResult, prefix string, rec Record, repoRoot string) {
+	keys := sortedCapKeys(rec.Capabilities)
+	for _, k := range keys {
+		cap := rec.Capabilities[k]
+		capPrefix := fmt.Sprintf("%s.capabilities[%s]", prefix, k)
+		validKey := false
+		if rec.Subcategory != "" && validSubcategory(rec.Category, rec.Subcategory) {
+			validKey = validCapabilityKeyForSubcategory(rec.Category, rec.Subcategory, k)
+		} else {
+			validKey = validCapabilityKey(rec.Category, k)
+		}
+		if !validKey {
+			if rec.Subcategory != "" {
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid capability key for category %q subcategory %q", capPrefix, rec.Category, rec.Subcategory))
+			} else {
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid capability key for category %q", capPrefix, rec.Category))
+			}
+		}
+		validateCapabilityCell(res, capPrefix, cap, repoRoot)
+	}
+}
+
+// validateGroupedRecord enforces the #2737 rules for the nested shape:
+// group names must be canonical for the record's subcategory; each
+// capability key appears in exactly one group within the record; each
+// capability key must be a member of its declared group's allow-list.
+func validateGroupedRecord(res *ValidationResult, prefix string, rec Record, repoRoot string) {
+	if rec.Subcategory == "" {
+		res.Errors = append(res.Errors, prefix+": grouped capabilities require a subcategory")
+		return
+	}
+	if !validSubcategory(rec.Category, rec.Subcategory) {
+		// Already reported above; skip group-level checks to avoid a
+		// cascade of duplicates.
+		return
+	}
+	known := knownGroupNames(rec.Subcategory)
+	if len(known) == 0 {
+		res.Errors = append(res.Errors, fmt.Sprintf("%s: subcategory %q has no declared group taxonomy", prefix, rec.Subcategory))
+		return
+	}
+	// Track each key's first occurrence so duplicates across groups are
+	// reported with both locations.
+	keyOwner := map[string]string{}
+	groupNames := make([]string, 0, len(rec.Groups))
+	for g := range rec.Groups {
+		groupNames = append(groupNames, g)
+	}
+	sort.Strings(groupNames)
+	for _, gname := range groupNames {
+		gPrefix := fmt.Sprintf("%s.capabilities[%s]", prefix, gname)
+		if !validGroupName(rec.Subcategory, gname) {
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: unknown group %q for subcategory %q (known: %v)", gPrefix, gname, rec.Subcategory, known))
+			continue
+		}
+		caps := rec.Groups[gname]
+		keys := sortedCapKeys(caps)
+		for _, k := range keys {
+			capPrefix := fmt.Sprintf("%s.%s", gPrefix, k)
+			if prev, dup := keyOwner[k]; dup {
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: capability key %q already declared under group %q", capPrefix, k, prev))
+				continue
+			}
+			keyOwner[k] = gname
+			if !validCapabilityKeyForSubcategory(rec.Category, rec.Subcategory, k) {
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid capability key for category %q subcategory %q", capPrefix, rec.Category, rec.Subcategory))
+			}
+			// Capability must belong to this group's allow-list. The
+			// synthetic Uncategorized group accepts anything (it exists
+			// precisely to park keys outside the canonical taxonomy).
+			if gname != uncategorizedGroup {
+				allowed := groupAllowedKeys(rec.Subcategory, gname)
+				if !inStringSlice(k, allowed) {
+					res.Errors = append(res.Errors, fmt.Sprintf("%s: capability %q does not belong to group %q (allowed: %v)", capPrefix, k, gname, allowed))
+				}
+			}
+			validateCapabilityCell(res, capPrefix, caps[k], repoRoot)
+		}
+	}
+}
+
+// validateCapabilityCell runs the per-cell checks (status enum, cite
+// paths, ISO date, freshness, tracking issue). Shared between the flat
+// and grouped paths.
+func validateCapabilityCell(res *ValidationResult, capPrefix string, cap Capability, repoRoot string) {
+	if _, ok := validStatuses[cap.Status]; !ok {
+		res.Errors = append(res.Errors, fmt.Sprintf("%s: invalid status %q", capPrefix, cap.Status))
+	}
+	for _, cite := range cap.Cites {
+		full := filepath.Join(repoRoot, cite)
+		if _, err := os.Stat(full); err != nil {
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: cite %q not found on disk", capPrefix, cite))
+		}
+	}
+	if cap.VerifiedAt != "" {
+		t, err := time.Parse("2006-01-02", cap.VerifiedAt)
+		if err != nil {
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: verified_at %q not a valid ISO date", capPrefix, cap.VerifiedAt))
+		} else if time.Since(t) > staleDays*24*time.Hour {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("%s: verified_at %s is older than %d days", capPrefix, cap.VerifiedAt, staleDays))
+		}
+	}
+	if (cap.Status == StatusMissing || cap.Status == StatusPartial) && cap.Issue == "" {
+		res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %s capability has no tracking issue", capPrefix, cap.Status))
+	}
+}
+
+// inStringSlice reports whether needle is present in haystack.
+func inStringSlice(needle string, haystack []string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/tools/coverage/views.go
+++ b/tools/coverage/views.go
@@ -30,9 +30,10 @@ func listRecords(reg *Registry, f ListFilter) []Record {
 		if f.Category != "" && rec.Category != f.Category {
 			continue
 		}
+		caps := rec.AllCapabilities()
 		if f.Status != "" {
 			match := false
-			for _, cap := range rec.Capabilities {
+			for _, cap := range caps {
 				if cap.Status == f.Status {
 					match = true
 					break
@@ -44,7 +45,7 @@ func listRecords(reg *Registry, f ListFilter) []Record {
 		}
 		if f.StaleDays > 0 {
 			stale := false
-			for _, cap := range rec.Capabilities {
+			for _, cap := range caps {
 				if cap.VerifiedAt == "" {
 					continue
 				}
@@ -104,7 +105,7 @@ func computeStats(reg *Registry) Stats {
 		s.ByCategory[rec.Category]++
 		ls := s.ByLanguage[rec.Language]
 		ls.Records++
-		for _, cap := range rec.Capabilities {
+		for _, cap := range rec.AllCapabilities() {
 			s.Capabilities++
 			s.ByStatus[cap.Status]++
 			switch cap.Status {
@@ -135,7 +136,7 @@ func gapsRecords(reg *Registry, language, category string) []Record {
 			continue
 		}
 		hit := false
-		for _, cap := range rec.Capabilities {
+		for _, cap := range rec.AllCapabilities() {
 			if cap.Status == StatusMissing || cap.Status == StatusPartial {
 				hit = true
 				break
@@ -149,14 +150,16 @@ func gapsRecords(reg *Registry, language, category string) []Record {
 	return out
 }
 
-// printRecordsText writes a human-readable table to w.
+// printRecordsText writes a human-readable table to w. Grouped records
+// flatten capabilities for display; the per-group structure is shown
+// on the markdown detail pages and via JSON output.
 func printRecordsText(w io.Writer, recs []Record) {
 	for _, rec := range recs {
 		fmt.Fprintf(w, "%-50s  %-18s  %-12s  %s\n", rec.ID, rec.Category, rec.Language, rec.Label)
-		keys := sortedCapKeys(rec.Capabilities)
+		caps := rec.AllCapabilities()
+		keys := sortedCapKeys(caps)
 		for _, k := range keys {
-			cap := rec.Capabilities[k]
-			fmt.Fprintf(w, "    %-30s  %s\n", k, cap.Status)
+			fmt.Fprintf(w, "    %-30s  %s\n", k, caps[k].Status)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds the #2737 nested capability-group shape on top of #2735's subcategory schema. Detail pages now render one sub-table per group (Structure, Data Flow, Navigation, ...); by-language and by-category pivot tables show a "worst-glyph full/total" group-digest per column instead of per-capability glyphs.
- Per-subcategory taxonomies are declared in `subcategoryGroups` (ui_frontend / mobile / http_backend / meta_framework / desktop / rpc_framework / ai_integration); validation rejects unknown groups, mis-placed capability keys, and duplicate keys across groups within a record. Records without a subcategory keep the legacy flat shape.
- Migrated the live registry: 30 subcategorised records reorganised into the nested shape; 0 cells fell into the synthetic "Uncategorized" group; 471 flat records untouched. Docs regenerated via `go run ./tools/coverage gen`.

Closes #2737.

## Test plan

- [x] `go test ./tools/coverage/` (47 tests, including new `TestGroupForCapability`, `TestGroupDigest`, `TestValidateGroupedRecord` and the updated `TestBuildBucketSectionGroupsBySubcategory`).
- [x] `go run ./tools/coverage validate --repo-root .` exits 0 (501 records, 945 stale/no-issue warnings).
- [x] `go run ./tools/coverage gen` is byte-for-byte deterministic across consecutive runs.
- [x] `go run ./tools/coverage gen --out .` produces the committed docs/coverage tree exactly (`git status` clean after re-running).
- [x] React detail page shows Structure / Data Flow / Navigation / Type System / Lifecycle / Testing sub-tables.
- [x] jsts by-language UI Frontend section shows group-digest cells (e.g. React: `⚠️ 0/3 | ⚠️ 0/3 | ✅ 1/1 | — | — | —`).
- [x] `coverage update` against a grouped record (React, `router_pattern`, partial) routes the cell into its canonical group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)