### PR TITLE
feat(tools/coverage): summary includes all extractor-supported languages (#2742)

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -1,19 +1,19 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # build_system
 
-**Total**: 79 records · **csharp**: 6 · **elixir**: 4 · **go**: 7 · **groovy**: 1 · **java**: 8 · **JS/TS**: 20 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 5 · **scala**: 2
+**Total**: 79 records · **C#**: 6 · **elixir**: 4 · **go**: 7 · **groovy**: 1 · **java**: 8 · **JS/TS**: 20 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 5 · **scala**: 2
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
 
 | Language | Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|---|
-| [csharp](../by-language/csharp.md) | [FluentAssertions](../detail/test.fluentassertions.md) | ❌ | — | — | ❌ | |
-| [csharp](../by-language/csharp.md) | [MSTest](../detail/test.mstest.md) | ⚠️ | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [NUnit](../detail/test.nunit.md) | ⚠️ | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [NuGet](../detail/build.nuget.md) | ⚠️ | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | — | — | ✅ | |
-| [csharp](../by-language/csharp.md) | [xUnit](../detail/test.xunit.md) | ⚠️ | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [FluentAssertions](../detail/test.fluentassertions.md) | ❌ | — | — | ❌ | |
+| [C#](../by-language/csharp.md) | [MSTest](../detail/test.mstest.md) | ⚠️ | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [NUnit](../detail/test.nunit.md) | ⚠️ | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [NuGet](../detail/build.nuget.md) | ⚠️ | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [dotnet CLI / MSBuild](../detail/build.dotnet.md) | ✅ | — | — | ✅ | |
+| [C#](../by-language/csharp.md) | [xUnit](../detail/test.xunit.md) | ⚠️ | — | — | ⚠️ | |
 | [elixir](../by-language/elixir.md) | [ExUnit](../detail/test.exunit.md) | ✅ | — | — | ✅ | |
 | [elixir](../by-language/elixir.md) | [Hex](../detail/build.hex.md) | ⚠️ | — | — | ⚠️ | |
 | [elixir](../by-language/elixir.md) | [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | ✅ | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 165 records · **csharp**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 12 · **lua**: 2 · **php**: 12 · **python**: 20 · **ruby**: 8 · **rust**: 11 · **scala**: 9 · **swift**: 1
+**Total**: 165 records · **C#**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 12 · **lua**: 2 · **php**: 12 · **python**: 20 · **ruby**: 8 · **rust**: 11 · **scala**: 9 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -83,21 +83,21 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|---|
-| [csharp](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | — | — | ⚠️ | — | |
-| [csharp](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ | ✅ | ✅ | ❌ | |
-| [csharp](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | — | — | ⚠️ | — | |
-| [csharp](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | — | ❌ | — | — | |
-| [csharp](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | — | — | ⚠️ | — | |
-| [csharp](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ | ❌ | ❌ | ❌ | |
-| [csharp](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ | ❌ | ❌ | ❌ | |
-| [csharp](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ | ❌ | ❌ | ❌ | |
-| [csharp](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ | ❌ | ❌ | ❌ | |
-| [csharp](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | — | — | ⚠️ | — | |
-| [csharp](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | — | — | ⚠️ | — | |
-| [csharp](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | — | — | ⚠️ | — | |
-| [csharp](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | — | — | ⚠️ | — | |
-| [csharp](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | — | — | ⚠️ | — | |
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | ⚠️ | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ | ✅ | ✅ | ❌ | |
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | — | — | ⚠️ | — | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | — | ❌ | — | — | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | — | — | ⚠️ | — | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ | ❌ | ❌ | ❌ | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ | ❌ | ❌ | ❌ | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ | ❌ | ❌ | ❌ | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ | ❌ | ❌ | ❌ | |
+| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | — | — | ⚠️ | — | |
+| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | — | — | ⚠️ | — | |
+| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | — | — | ⚠️ | — | |
+| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | — | — | ⚠️ | — | |
+| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 | [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 | [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
 | [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ | ❌ | ❌ | ❌ | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,27 +1,27 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 143 records · **csharp**: 14 · **elixir**: 10 · **go**: 17 · **java**: 13 · **JS/TS**: 18 · **kotlin**: 7 · **php**: 14 · **python**: 17 · **ruby**: 13 · **rust**: 14 · **scala**: 6
+**Total**: 143 records · **C#**: 14 · **elixir**: 10 · **go**: 17 · **java**: 13 · **JS/TS**: 18 · **kotlin**: 7 · **php**: 14 · **python**: 17 · **ruby**: 13 · **rust**: 14 · **scala**: 6
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
 
 | Language | Name | Migration Parsing | Model Extraction | Query Attribution | Notes |
 |---|---|---|---|---|---|
-| [csharp](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ | ⚠️ | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ | ✅ | ✅ | |
-| [csharp](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ | ⚠️ | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ | ❌ | ❌ | |
-| [csharp](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ | ⚠️ | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | — | — | ⚠️ | |
-| [csharp](../by-language/csharp.md) | [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ | ⚠️ | ⚠️ | |
+| [C#](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ | ✅ | ✅ | |
+| [C#](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ | ⚠️ | ⚠️ | |
+| [C#](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ | ❌ | ❌ | |
+| [C#](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ | ⚠️ | ⚠️ | |
+| [C#](../by-language/csharp.md) | [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | — | — | ⚠️ | |
+| [C#](../by-language/csharp.md) | [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | — | — | ⚠️ | |
 | [elixir](../by-language/elixir.md) | [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ | ✅ | ✅ | |
 | [elixir](../by-language/elixir.md) | [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | — | — | ⚠️ | |
 | [elixir](../by-language/elixir.md) | [MyXQL](../detail/lang.elixir.driver.myxql.md) | — | — | ⚠️ | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,14 +1,14 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 15 records · **csharp**: 1 · **dart**: 1 · **elixir**: 1 · **go**: 1 · **java**: 2 · **JS/TS**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
+**Total**: 15 records · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **go**: 1 · **java**: 2 · **JS/TS**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
 
 | Language | Name | Dependency Graph | Lockfile Parsing | Manifest Parsing | Target Extraction | Notes |
 |---|---|---|---|---|---|---|
-| [csharp](../by-language/csharp.md) | [.csproj / packages.config](../detail/pkg.csproj.md) | — | ❌ | ❌ | — | |
+| [C#](../by-language/csharp.md) | [.csproj / packages.config](../detail/pkg.csproj.md) | — | ❌ | ❌ | — | |
 | [dart](../by-language/dart.md) | [pubspec.yaml](../detail/pkg.pubspec.md) | — | ❌ | ✅ | — | |
 | [elixir](../by-language/elixir.md) | [mix.exs](../detail/pkg.mix.md) | — | — | ❌ | — | |
 | [go](../by-language/go.md) | [go.mod](../detail/pkg.go-mod.md) | — | ⚠️ | ✅ | — | |

--- a/docs/coverage/by-language/astro.md
+++ b/docs/coverage/by-language/astro.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Astro
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/astro/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.astro.framework.<name>`).

--- a/docs/coverage/by-language/clojure.md
+++ b/docs/coverage/by-language/clojure.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Clojure
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/clojure/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.clojure.framework.<name>`).

--- a/docs/coverage/by-language/cpp.md
+++ b/docs/coverage/by-language/cpp.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# C++
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/cpp/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.cpp.framework.<name>`).

--- a/docs/coverage/by-language/crystal.md
+++ b/docs/coverage/by-language/crystal.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Crystal
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/crystal/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.crystal.framework.<name>`).

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# csharp
+# C#
 
 **Frameworks**: 15 · **Tools**: 7 · **ORMs**: 14 · **Other**: 0
 

--- a/docs/coverage/by-language/elm.md
+++ b/docs/coverage/by-language/elm.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Elm
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/elm/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.elm.framework.<name>`).

--- a/docs/coverage/by-language/erlang.md
+++ b/docs/coverage/by-language/erlang.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Erlang
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/erlang/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.erlang.framework.<name>`).

--- a/docs/coverage/by-language/fsharp.md
+++ b/docs/coverage/by-language/fsharp.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# F#
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/fsharp/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.fsharp.framework.<name>`).

--- a/docs/coverage/by-language/haskell.md
+++ b/docs/coverage/by-language/haskell.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Haskell
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/haskell/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.haskell.framework.<name>`).

--- a/docs/coverage/by-language/idris.md
+++ b/docs/coverage/by-language/idris.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Idris
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/idris/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.idris.framework.<name>`).

--- a/docs/coverage/by-language/lisp.md
+++ b/docs/coverage/by-language/lisp.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Lisp
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/lisp/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.lisp.framework.<name>`).

--- a/docs/coverage/by-language/nim.md
+++ b/docs/coverage/by-language/nim.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Nim
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/nim/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.nim.framework.<name>`).

--- a/docs/coverage/by-language/ocaml.md
+++ b/docs/coverage/by-language/ocaml.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# OCaml
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/ocaml/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.ocaml.framework.<name>`).

--- a/docs/coverage/by-language/pony.md
+++ b/docs/coverage/by-language/pony.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Pony
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/pony/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.pony.framework.<name>`).

--- a/docs/coverage/by-language/reasonml.md
+++ b/docs/coverage/by-language/reasonml.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# ReasonML
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/reasonml/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.reasonml.framework.<name>`).

--- a/docs/coverage/by-language/rescript.md
+++ b/docs/coverage/by-language/rescript.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# ReScript
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/rescript/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.rescript.framework.<name>`).

--- a/docs/coverage/by-language/sml.md
+++ b/docs/coverage/by-language/sml.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Standard ML
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/sml/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.sml.framework.<name>`).

--- a/docs/coverage/by-language/solidity.md
+++ b/docs/coverage/by-language/solidity.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Solidity
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/solidity/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.solidity.framework.<name>`).

--- a/docs/coverage/by-language/svelte.md
+++ b/docs/coverage/by-language/svelte.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Svelte
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/svelte/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.svelte.framework.<name>`).

--- a/docs/coverage/by-language/verilog.md
+++ b/docs/coverage/by-language/verilog.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Verilog
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/verilog/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.verilog.framework.<name>`).

--- a/docs/coverage/by-language/vhdl.md
+++ b/docs/coverage/by-language/vhdl.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# VHDL
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/vhdl/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.vhdl.framework.<name>`).

--- a/docs/coverage/by-language/vue.md
+++ b/docs/coverage/by-language/vue.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Vue
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/vue/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.vue.framework.<name>`).

--- a/docs/coverage/by-language/zig.md
+++ b/docs/coverage/by-language/zig.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Zig
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/zig/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.zig.framework.<name>`).

--- a/docs/coverage/detail/build.dotnet.md
+++ b/docs/coverage/detail/build.dotnet.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/build.nuget.md
+++ b/docs/coverage/detail/build.nuget.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/lang.csharp.driver.cassandra.md
+++ b/docs/coverage/detail/lang.csharp.driver.cassandra.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.dynamodb.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.driver.elastic.md
+++ b/docs/coverage/detail/lang.csharp.driver.elastic.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.driver.mongodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.mongodb.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.driver.mysql.md
+++ b/docs/coverage/detail/lang.csharp.driver.mysql.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.driver.neo4j.md
+++ b/docs/coverage/detail/lang.csharp.driver.neo4j.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.driver.npgsql.md
+++ b/docs/coverage/detail/lang.csharp.driver.npgsql.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.driver.redis.md
+++ b/docs/coverage/detail/lang.csharp.driver.redis.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.driver.sqlite.md
+++ b/docs/coverage/detail/lang.csharp.driver.sqlite.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 1
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.net-maui.md
+++ b/docs/coverage/detail/lang.csharp.framework.net-maui.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.uno.md
+++ b/docs/coverage/detail/lang.csharp.framework.uno.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.winforms.md
+++ b/docs/coverage/detail/lang.csharp.framework.winforms.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.wpf.md
+++ b/docs/coverage/detail/lang.csharp.framework.wpf.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.framework.xamarin.md
+++ b/docs/coverage/detail/lang.csharp.framework.xamarin.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 4
 

--- a/docs/coverage/detail/lang.csharp.orm.dapper.md
+++ b/docs/coverage/detail/lang.csharp.orm.dapper.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.orm.efcore.md
+++ b/docs/coverage/detail/lang.csharp.orm.efcore.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
+++ b/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.orm.linqtodb.md
+++ b/docs/coverage/detail/lang.csharp.orm.linqtodb.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/lang.csharp.orm.nhibernate.md
+++ b/docs/coverage/detail/lang.csharp.orm.nhibernate.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Capability cells:** 3
 

--- a/docs/coverage/detail/pkg.csproj.md
+++ b/docs/coverage/detail/pkg.csproj.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [package_manager](../by-category/package_manager.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/test.fluentassertions.md
+++ b/docs/coverage/detail/test.fluentassertions.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/test.mstest.md
+++ b/docs/coverage/detail/test.mstest.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/test.nunit.md
+++ b/docs/coverage/detail/test.nunit.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/test.xunit.md
+++ b/docs/coverage/detail/test.xunit.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [csharp](../by-language/csharp.md)
+- **Language:** [C#](../by-language/csharp.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,27 +1,51 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 16 · **Frameworks**: 165 · **ORMs**: 143 · **Tools**: 94 · **Other**: 99
+**Languages**: 38 · **Frameworks**: 165 · **ORMs**: 143 · **Tools**: 94 · **Other**: 99
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
-| [csharp](by-language/csharp.md) | 15 | 7 | 14 | 0 |
-| [dart](by-language/dart.md) | 0 | 1 | 0 | 0 |
-| [elixir](by-language/elixir.md) | 9 | 5 | 10 | 0 |
-| [go](by-language/go.md) | 17 | 8 | 17 | 0 |
-| [groovy](by-language/groovy.md) | 0 | 1 | 0 | 0 |
-| [java](by-language/java.md) | 19 | 10 | 13 | 2 |
 | [JS/TS](by-language/jsts.md) | 30 | 21 | 18 | 2 |
-| [kotlin](by-language/kotlin.md) | 12 | 0 | 7 | 0 |
-| [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
-| [php](by-language/php.md) | 12 | 6 | 14 | 0 |
 | [python](by-language/python.md) | 20 | 15 | 17 | 3 |
-| [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
+| [java](by-language/java.md) | 19 | 10 | 13 | 2 |
+| [go](by-language/go.md) | 17 | 8 | 17 | 0 |
+| [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
+| [kotlin](by-language/kotlin.md) | 12 | 0 | 7 | 0 |
+| [php](by-language/php.md) | 12 | 6 | 14 | 0 |
 | [rust](by-language/rust.md) | 11 | 6 | 14 | 0 |
+| [elixir](by-language/elixir.md) | 9 | 5 | 10 | 0 |
 | [scala](by-language/scala.md) | 9 | 3 | 6 | 0 |
+| [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
+| [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
 | [swift](by-language/swift.md) | 1 | 1 | 0 | 0 |
+| [Astro](by-language/astro.md) † | 0 | 0 | 0 | 0 |
+| [Clojure](by-language/clojure.md) † | 0 | 0 | 0 | 0 |
+| [C++](by-language/cpp.md) † | 0 | 0 | 0 | 0 |
+| [Crystal](by-language/crystal.md) † | 0 | 0 | 0 | 0 |
+| [dart](by-language/dart.md) | 0 | 1 | 0 | 0 |
+| [Elm](by-language/elm.md) † | 0 | 0 | 0 | 0 |
+| [Erlang](by-language/erlang.md) † | 0 | 0 | 0 | 0 |
+| [F#](by-language/fsharp.md) † | 0 | 0 | 0 | 0 |
+| [groovy](by-language/groovy.md) | 0 | 1 | 0 | 0 |
+| [Haskell](by-language/haskell.md) † | 0 | 0 | 0 | 0 |
+| [Idris](by-language/idris.md) † | 0 | 0 | 0 | 0 |
+| [Lisp](by-language/lisp.md) † | 0 | 0 | 0 | 0 |
+| [Nim](by-language/nim.md) † | 0 | 0 | 0 | 0 |
+| [OCaml](by-language/ocaml.md) † | 0 | 0 | 0 | 0 |
+| [Pony](by-language/pony.md) † | 0 | 0 | 0 | 0 |
+| [ReasonML](by-language/reasonml.md) † | 0 | 0 | 0 | 0 |
+| [ReScript](by-language/rescript.md) † | 0 | 0 | 0 | 0 |
+| [Standard ML](by-language/sml.md) † | 0 | 0 | 0 | 0 |
+| [Solidity](by-language/solidity.md) † | 0 | 0 | 0 | 0 |
+| [Svelte](by-language/svelte.md) † | 0 | 0 | 0 | 0 |
+| [Verilog](by-language/verilog.md) † | 0 | 0 | 0 | 0 |
+| [VHDL](by-language/vhdl.md) † | 0 | 0 | 0 | 0 |
+| [Vue](by-language/vue.md) † | 0 | 0 | 0 | 0 |
+| [Zig](by-language/zig.md) † | 0 | 0 | 0 | 0 |
 | Uncategorized | 0 | 4 | 0 | 91 |
+
+† Extractor supported but no ecosystem records tracked yet: Astro, C++, Clojure, Crystal, Elm, Erlang, F#, Haskell, Idris, Lisp, Nim, OCaml, Pony, ReScript, ReasonML, Solidity, Standard ML, Svelte, VHDL, Verilog, Vue, Zig.
 
 Total: 165 frameworks · 94 tools · 143 ORMs · 99 other

--- a/tools/coverage/gen_test.go
+++ b/tools/coverage/gen_test.go
@@ -183,6 +183,59 @@ func TestGenGoldenFixture(t *testing.T) {
 	}
 }
 
+// TestGenSummaryIncludesExtractorSupportedLanguages confirms that when a
+// synthetic internal/extractors/ tree contains languages with no records
+// in the loaded registry, those languages still appear in the summary
+// pivot (zero counts) and a footnote enumerates them. Also asserts that
+// placeholder by-language pages are emitted for each untracked language.
+func TestGenSummaryIncludesExtractorSupportedLanguages(t *testing.T) {
+	reg, err := loadRegistry(fixturePath(t))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	root := t.TempDir()
+	// Synthetic extractor tree: zig (untracked) + python (tracked by fixture).
+	for _, d := range []string{"zig", "python", "complexity", "yaml"} {
+		if err := os.MkdirAll(filepath.Join(root, "internal", "extractors", d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := generate(reg, root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	summary, err := os.ReadFile(filepath.Join(root, "docs", "coverage", "summary.md"))
+	if err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	if !bytes.Contains(summary, []byte("by-language/zig.md")) {
+		t.Errorf("expected summary to link zig.md, got:\n%s", summary)
+	}
+	if !bytes.Contains(summary, []byte("Extractor supported but no ecosystem records tracked yet")) {
+		t.Errorf("expected untracked footnote, got:\n%s", summary)
+	}
+	if !bytes.Contains(summary, []byte("Zig")) {
+		t.Errorf("expected Zig in footnote list, got:\n%s", summary)
+	}
+	// Placeholder page must exist and cite the extractor dir.
+	pl, err := os.ReadFile(filepath.Join(root, "docs", "coverage", "by-language", "zig.md"))
+	if err != nil {
+		t.Fatalf("read placeholder: %v", err)
+	}
+	if !bytes.Contains(pl, []byte("No ecosystem records tracked yet")) {
+		t.Errorf("placeholder missing notice")
+	}
+	if !bytes.Contains(pl, []byte("internal/extractors/zig/")) {
+		t.Errorf("placeholder missing extractor dir cite")
+	}
+	// Utility + non-language dirs must NOT produce placeholder pages.
+	if _, err := os.Stat(filepath.Join(root, "docs", "coverage", "by-language", "complexity.md")); !os.IsNotExist(err) {
+		t.Errorf("complexity.md should not exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", "coverage", "by-language", "yaml.md")); !os.IsNotExist(err) {
+		t.Errorf("yaml.md should not exist: %v", err)
+	}
+}
+
 func TestGenSubcommandWiring(t *testing.T) {
 	reg, err := loadRegistry(fixturePath(t))
 	if err != nil {

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -101,6 +101,7 @@ type pivotRow struct {
 	ORMs          int
 	Other         int
 	Uncategorized bool // true for the language-neutral "Uncategorized" row
+	Untracked     bool // true for supported-but-zero-record languages
 }
 
 // bucketSection is one rendered section on a by-language page. When a
@@ -129,13 +130,14 @@ type subSection struct {
 
 // summaryData feeds summary.md.tmpl.
 type summaryData struct {
-	Marker          string
-	TotalLanguages  int
-	TotalFrameworks int
-	TotalTools      int
-	TotalORMs       int
-	TotalOther      int
-	Rows            []pivotRow // sorted by language; Uncategorized last
+	Marker           string
+	TotalLanguages   int
+	TotalFrameworks  int
+	TotalTools       int
+	TotalORMs        int
+	TotalOther       int
+	Rows             []pivotRow // sorted by language; Uncategorized last
+	UntrackedLangs   []string   // display labels for footnote, sorted
 }
 
 // languagePageData feeds by-language/<lang>.md.tmpl.
@@ -147,6 +149,17 @@ type languagePageData struct {
 	ORMs       int
 	Other      int
 	Sections   []bucketSection // bucketOrder, empty sections omitted
+}
+
+// placeholderPageData feeds by-language-placeholder.md.tmpl. Rendered
+// for each extractor-supported language that has zero ecosystem records;
+// the page explains how to contribute records and cites the on-disk
+// extractor directory.
+type placeholderPageData struct {
+	Marker       string
+	Slug         string
+	Language     string
+	ExtractorDir string
 }
 
 // categoryLanguageCount is one element of the by-category banner.
@@ -312,13 +325,14 @@ func groupDigest(caps map[string]Capability) string {
 	return fmt.Sprintf("%s %d/%d", statusGlyph(worst), full, len(caps))
 }
 
-// languageDisplay maps a language slug to its human-facing label. Slugs
-// without an entry render verbatim. "jsts" expands to "JS/TS" because
-// the registry collapses JavaScript and TypeScript under one tag.
+// languageDisplay maps a language slug to its human-facing label. The
+// underlying table is shared with the placeholder by-language pages —
+// see languageDisplayName. Slugs that exist as records but lack an
+// override render verbatim (preserves existing per-record labelling for
+// languages like "python", "ruby", "go").
 func languageDisplay(slug string) string {
-	switch slug {
-	case "jsts":
-		return "JS/TS"
+	if v, ok := languageDisplayOverrides[slug]; ok {
+		return v
 	}
 	return slug
 }
@@ -442,23 +456,68 @@ func generate(reg *Registry, outRoot string) error {
 		}
 		rows = append(rows, row)
 	}
+
+	// Union with extractor-supported languages so the summary reflects
+	// every language archigraph CAN extract, not just languages with at
+	// least one ecosystem record. Languages discovered on disk that have
+	// no record set get a zero-count row + an Untracked marker so the
+	// footnote can enumerate them.
+	supported := SupportedLanguages(outRoot)
+	untrackedDisplay := make([]string, 0, len(supported))
+	for _, s := range supported {
+		if _, present := langSet[s]; present {
+			continue
+		}
+		display := languageDisplayName(s)
+		rows = append(rows, pivotRow{
+			Name:      s,
+			Display:   display,
+			Untracked: true,
+		})
+		untrackedDisplay = append(untrackedDisplay, display)
+	}
+	sort.Strings(untrackedDisplay)
+
 	sort.SliceStable(rows, func(i, j int) bool {
 		if rows[i].Uncategorized != rows[j].Uncategorized {
 			return !rows[i].Uncategorized
+		}
+		if rows[i].Frameworks != rows[j].Frameworks {
+			return rows[i].Frameworks > rows[j].Frameworks
 		}
 		return rows[i].Name < rows[j].Name
 	})
 
 	if err := renderToFile(tmpls, "summary.md.tmpl", filepath.Join(root, "summary.md"), summaryData{
 		Marker:          doNotEditMarker,
-		TotalLanguages:  len(langNames),
+		TotalLanguages:  len(langNames) + len(untrackedDisplay),
 		TotalFrameworks: totals.Frameworks,
 		TotalTools:      totals.Tools,
 		TotalORMs:       totals.ORMs,
 		TotalOther:      totals.Other,
 		Rows:            rows,
+		UntrackedLangs:  untrackedDisplay,
 	}); err != nil {
 		return err
+	}
+
+	// Emit placeholder by-language pages for each supported-but-untracked
+	// language so the summary links resolve and contributors land on a
+	// page that explains how to add records.
+	for _, s := range supported {
+		if _, present := langSet[s]; present {
+			continue
+		}
+		if err := renderToFile(tmpls, "by-language-placeholder.md.tmpl",
+			filepath.Join(root, "by-language", s+".md"),
+			placeholderPageData{
+				Marker:       doNotEditMarker,
+				Slug:         s,
+				Language:     languageDisplayName(s),
+				ExtractorDir: extractorDirForSlug(s),
+			}); err != nil {
+			return err
+		}
 	}
 
 	for _, n := range langNames {

--- a/tools/coverage/languages.go
+++ b/tools/coverage/languages.go
@@ -1,0 +1,157 @@
+// languages.go surfaces the canonical list of languages archigraph has
+// extractor support for, derived from internal/extractors/<lang>/ directories.
+// This list is the source of truth for the coverage summary's pivot rows —
+// languages with zero ecosystem records still appear so the matrix reflects
+// extractor coverage, not just registry-record coverage.
+//
+// Standalone scope: stdlib only. No imports from internal/ packages — we
+// only inspect directory names and the well-known utility/format excludes.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// extractorUtilityDirs are subdirectories of internal/extractors/ that
+// implement shared utilities (not per-language extractors) and must be
+// excluded from the supported-languages list.
+var extractorUtilityDirs = map[string]bool{
+	"complexity": true,
+	"config":     true,
+	"cross":      true,
+	"references": true,
+	"sresolver":  true,
+}
+
+// extractorNonLanguageFormats are subdirectories of internal/extractors/
+// that extract non-language formats (build files, config, markup) and are
+// represented in the coverage matrix's "multi" bucket rather than as
+// standalone language rows.
+var extractorNonLanguageFormats = map[string]bool{
+	"bazel":      true,
+	"css":        true,
+	"dockerfile": true,
+	"fish":       true,
+	"graphql":    true,
+	"hcl":        true,
+	"html":       true,
+	"just":       true,
+	"markdown":   true,
+	"proto":      true,
+	"razor":      true,
+	"shell":      true,
+	"sql":        true,
+	"yaml":       true,
+}
+
+// extractorDirAliases maps extractor directory names to the canonical
+// language slug used by the registry. JavaScript and TypeScript collapse
+// to "jsts" because the registry tags both under a single slug; "golang"
+// is the extractor dirname but the registry uses "go".
+var extractorDirAliases = map[string]string{
+	"javascript": "jsts",
+	"typescript": "jsts",
+	"golang":     "go",
+}
+
+// languageDisplayOverrides maps a canonical language slug to its human
+// label when the default (title-cased slug) is unsuitable. Slugs not
+// listed here render via titleCase(slug).
+var languageDisplayOverrides = map[string]string{
+	"jsts":     "JS/TS",
+	"csharp":   "C#",
+	"cpp":      "C++",
+	"fsharp":   "F#",
+	"reasonml": "ReasonML",
+	"rescript": "ReScript",
+	"sml":      "Standard ML",
+	"ocaml":    "OCaml",
+	"vhdl":     "VHDL",
+}
+
+// SupportedLanguages returns the canonical, sorted, deduplicated list of
+// language slugs archigraph has extractor support for. The source of
+// truth is internal/extractors/<lang>/ directories under repoRoot;
+// utility-only directories and non-language format extractors are
+// excluded, and aliases are applied so the slugs align with the
+// registry's tagging conventions.
+//
+// Returns an empty slice (never nil) when repoRoot does not contain an
+// internal/extractors/ directory — keeps callers free of nil checks.
+func SupportedLanguages(repoRoot string) []string {
+	root := filepath.Join(repoRoot, "internal", "extractors")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return []string{}
+	}
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if extractorUtilityDirs[name] {
+			continue
+		}
+		if extractorNonLanguageFormats[name] {
+			continue
+		}
+		slug := name
+		if a, ok := extractorDirAliases[name]; ok {
+			slug = a
+		}
+		seen[slug] = true
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// languageDisplayName returns the human-facing label for a language
+// slug. The display table is small and stable; slugs without an entry
+// fall back to title-casing the slug. Used by both the summary pivot
+// table and the placeholder by-language pages.
+func languageDisplayName(slug string) string {
+	if v, ok := languageDisplayOverrides[slug]; ok {
+		return v
+	}
+	if slug == "" {
+		return ""
+	}
+	return titleCase(slug)
+}
+
+// extractorDirForSlug returns the primary internal/extractors/<dir>/
+// directory that backs a canonical language slug. Used by the placeholder
+// page template to cite a concrete on-disk location. When multiple
+// extractor directories alias to the same slug (e.g. javascript + typescript
+// both map to "jsts"), this returns the canonical primary; for slugs with
+// no alias the slug itself names the directory.
+func extractorDirForSlug(slug string) string {
+	switch slug {
+	case "jsts":
+		return "javascript"
+	case "go":
+		return "golang"
+	}
+	return slug
+}
+
+// titleCase upper-cases the first rune of slug and leaves the rest as-is.
+// Slugs are already lowercase ASCII tokens by convention, so this is a
+// purely cosmetic transform — not a Unicode-aware title-case operation.
+func titleCase(slug string) string {
+	if slug == "" {
+		return ""
+	}
+	first := slug[0]
+	if first >= 'a' && first <= 'z' {
+		return string(first-('a'-'A')) + slug[1:]
+	}
+	return slug
+}

--- a/tools/coverage/languages_test.go
+++ b/tools/coverage/languages_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestSupportedLanguagesEmptyRepo confirms that pointing the helper at a
+// directory with no internal/extractors/ tree returns an empty slice
+// (never nil) so callers can iterate unconditionally.
+func TestSupportedLanguagesEmptyRepo(t *testing.T) {
+	got := SupportedLanguages(t.TempDir())
+	if got == nil {
+		t.Fatalf("expected non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+// TestSupportedLanguagesAliasingAndExcludes builds a synthetic
+// internal/extractors/ tree containing language dirs, utility dirs,
+// non-language formats, and aliased dirs (javascript+typescript collapse
+// to jsts, golang→go). Verifies the returned list is sorted, unique,
+// excludes utility/non-language formats, and applies aliases.
+func TestSupportedLanguagesAliasingAndExcludes(t *testing.T) {
+	root := t.TempDir()
+	extractorsRoot := filepath.Join(root, "internal", "extractors")
+	dirs := []string{
+		"python",
+		"ruby",
+		"javascript",
+		"typescript",
+		"golang",
+		"haskell",
+		"cpp",
+		"complexity",
+		"config",
+		"cross",
+		"references",
+		"sresolver",
+		"yaml",
+		"bazel",
+		"dockerfile",
+		"hcl",
+		"shell",
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(extractorsRoot, d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	// A regular file inside extractors/ must be ignored.
+	if err := os.WriteFile(filepath.Join(extractorsRoot, "registry.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	got := SupportedLanguages(root)
+	want := []string{"cpp", "go", "haskell", "jsts", "python", "ruby"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SupportedLanguages mismatch:\nwant %v\n got %v", want, got)
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("result not sorted: %v", got)
+	}
+}
+
+// TestLanguageDisplayName covers the override table and the title-case
+// fallback used by placeholder pages.
+func TestLanguageDisplayName(t *testing.T) {
+	cases := []struct {
+		slug string
+		want string
+	}{
+		{"jsts", "JS/TS"},
+		{"csharp", "C#"},
+		{"cpp", "C++"},
+		{"fsharp", "F#"},
+		{"reasonml", "ReasonML"},
+		{"rescript", "ReScript"},
+		{"sml", "Standard ML"},
+		{"ocaml", "OCaml"},
+		{"vhdl", "VHDL"},
+		{"haskell", "Haskell"},
+		{"zig", "Zig"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := languageDisplayName(c.slug); got != c.want {
+			t.Errorf("languageDisplayName(%q) = %q; want %q", c.slug, got, c.want)
+		}
+	}
+}
+
+// TestExtractorDirForSlug pins the inverse alias map used to cite a
+// concrete on-disk extractor directory on placeholder pages.
+func TestExtractorDirForSlug(t *testing.T) {
+	cases := map[string]string{
+		"jsts":    "javascript",
+		"go":      "golang",
+		"haskell": "haskell",
+		"zig":     "zig",
+	}
+	for slug, want := range cases {
+		if got := extractorDirForSlug(slug); got != want {
+			t.Errorf("extractorDirForSlug(%q) = %q; want %q", slug, got, want)
+		}
+	}
+}

--- a/tools/coverage/templates/by-language-placeholder.md.tmpl
+++ b/tools/coverage/templates/by-language-placeholder.md.tmpl
@@ -1,0 +1,12 @@
+{{.Marker}}
+# {{.Language}}
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/{{.ExtractorDir}}/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.{{.Slug}}.framework.<name>`).

--- a/tools/coverage/templates/summary.md.tmpl
+++ b/tools/coverage/templates/summary.md.tmpl
@@ -10,9 +10,13 @@
 {{- range .Rows}}
 {{- if .Uncategorized}}
 | {{.Display}} | {{.Frameworks}} | {{.Tools}} | {{.ORMs}} | {{.Other}} |
+{{- else if .Untracked}}
+| [{{.Display}}](by-language/{{.Name}}.md) † | 0 | 0 | 0 | 0 |
 {{- else}}
 | [{{.Display}}](by-language/{{.Name}}.md) | {{.Frameworks}} | {{.Tools}} | {{.ORMs}} | {{.Other}} |
 {{- end}}
 {{- end}}
-
+{{if .UntrackedLangs}}
+† Extractor supported but no ecosystem records tracked yet: {{range $i, $l := .UntrackedLangs}}{{if $i}}, {{end}}{{$l}}{{end}}.
+{{end}}
 Total: {{.TotalFrameworks}} frameworks · {{.TotalTools}} tools · {{.TotalORMs}} ORMs · {{.TotalOther}} other

--- a/tools/coverage/testdata/fixture-out/summary.md
+++ b/tools/coverage/testdata/fixture-out/summary.md
@@ -7,7 +7,7 @@
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
-| [JS/TS](by-language/jsts.md) | 2 | 0 | 0 | 0 |
 | [python](by-language/python.md) | 3 | 0 | 0 | 0 |
+| [JS/TS](by-language/jsts.md) | 2 | 0 | 0 | 0 |
 
 Total: 5 frameworks · 0 tools · 0 ORMs · 0 other


### PR DESCRIPTION
## Summary

- Adds `SupportedLanguages(repoRoot)` in `tools/coverage/languages.go` — derives the canonical language list from `internal/extractors/<lang>/` directories, with utility/non-language excludes and the standard aliases (javascript+typescript → jsts, golang → go).
- `generate()` unions per-record languages with extractor-supported languages, emits zero-row pivot entries plus a footnote enumerating untracked languages, and renders a placeholder by-language page for each one. Display-name overrides (C#, C++, F#, JS/TS, OCaml, VHDL, ReasonML, ReScript, Standard ML) propagate to detail / by-category pages.
- Pivot now sorts by descending Frameworks count then name, so high-coverage languages surface first and zero-row languages land naturally at the bottom.

Closes #2742.

## Files touched

- `tools/coverage/languages.go` (new) — SupportedLanguages, display-name overrides, alias maps
- `tools/coverage/languages_test.go` (new) — alias + exclude + display coverage
- `tools/coverage/generate.go` — pivot union, sort change, placeholder emit, language-display consolidation
- `tools/coverage/gen_test.go` — new TestGenSummaryIncludesExtractorSupportedLanguages
- `tools/coverage/templates/summary.md.tmpl` — Untracked row variant + footnote
- `tools/coverage/templates/by-language-placeholder.md.tmpl` (new)
- `tools/coverage/testdata/fixture-out/summary.md` — golden update for new sort order
- `docs/coverage/**` — regenerated (22 new placeholder pages, summary, csharp display-name propagation)

## Numbers

- Summary rows before: 14 language rows + Uncategorized
- Summary rows after: 38 language rows + Uncategorized (+22 extractor-supported languages with zero records: astro, clojure, cpp, crystal, elm, erlang, fsharp, haskell, idris, lisp, nim, ocaml, pony, reasonml, rescript, sml, solidity, svelte, verilog, vhdl, vue, zig)

## Test plan

- [x] `go test ./tools/coverage/` — passes (incl. new tests, golden fixture updated)
- [x] `go run ./tools/coverage validate` — exits 0
- [x] `go run ./tools/coverage gen` — produces summary with 22+ extractor-supported languages
- [x] Determinism: two consecutive gen runs produce byte-identical output (sha256 confirmed)
- [x] Placeholder pages render notice + correct extractor-dir cite
- [x] Standalone tool: stdlib only, no internal/* imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)