### PR TITLE
feat(tools/coverage): extend ui_frontend taxonomy + populate React/mobile/meta_framework records (#2751)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -29,32 +29,32 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 0/3 | ⚠️ 0/3 | ✅ 1/1 | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
-| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 
 
 ## Meta Framework
 
-| Language | Name | Structure | Data Flow | Server | Routing | Build | Notes |
-|---|---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
-| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | |
-| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
-| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+| Language | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 
 
 ## Mobile
 
-| Language | Name | Navigation | Platform | Native Bridge | Data Flow | Lifecycle | Notes |
-|---|---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 0/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 0/1 | — | |
+| Language | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | |
 
 
 ## Desktop

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -30,32 +30,32 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Notes |
 |---|---|---|---|---|---|---|---|
-| [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
-| [React](../detail/lang.jsts.framework.react.md) | ⚠️ 0/3 | ⚠️ 0/3 | ✅ 1/1 | — | — | — | |
-| [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
-| [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/3 | ❌ 0/3 | ❌ 0/1 | — | — | — | |
+| [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | |
+| [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 
 
 ### Meta Framework
 
-| Name | Structure | Data Flow | Server | Routing | Build | Notes |
-|---|---|---|---|---|---|---|
-| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
-| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | |
-| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
-| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | |
+| Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 
 
 ### Mobile
 
-| Name | Navigation | Platform | Native Bridge | Data Flow | Lifecycle | Notes |
-|---|---|---|---|---|---|---|
-| [Expo](../detail/lang.jsts.framework.expo.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 0/1 | — | |
-| [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/1 | — | |
-| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/1 | — | |
-| [React Native](../detail/lang.jsts.framework.react-native.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 0/1 | — | |
+| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | |
+| [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | |
 
 
 ### Desktop

--- a/docs/coverage/detail/build.bazel.md
+++ b/docs/coverage/detail/build.bazel.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/bazel/extractor.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/bazel/parser.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/bazel/extractor.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/bazel/parser.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.bun.md
+++ b/docs/coverage/detail/build.bun.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.bundler.md
+++ b/docs/coverage/detail/build.bundler.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.cargo.md
+++ b/docs/coverage/detail/build.cargo.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.composer.md
+++ b/docs/coverage/detail/build.composer.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.dockerfile.md
+++ b/docs/coverage/detail/build.dockerfile.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/dockerfile/dockerfile.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/dockerfile/dockerfile.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/dockerfile/dockerfile.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/dockerfile/dockerfile.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.dotnet.md
+++ b/docs/coverage/detail/build.dotnet.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.esbuild.md
+++ b/docs/coverage/detail/build.esbuild.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.flit.md
+++ b/docs/coverage/detail/build.flit.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.go-modules.md
+++ b/docs/coverage/detail/build.go-modules.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/golang/gomod.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/build_tools.yaml`<br>`internal/extractors/golang/gomod.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/golang/gomod.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/build_tools.yaml`<br>`internal/extractors/golang/gomod.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.gradle.md
+++ b/docs/coverage/detail/build.gradle.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml`<br>`internal/engine/rules/kotlin/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml`<br>`internal/engine/rules/kotlin/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.hatch.md
+++ b/docs/coverage/detail/build.hatch.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.hex.md
+++ b/docs/coverage/detail/build.hex.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.justfile.md
+++ b/docs/coverage/detail/build.justfile.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/just/just.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/just/just.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/just/just.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/just/just.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.lerna.md
+++ b/docs/coverage/detail/build.lerna.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.mage.md
+++ b/docs/coverage/detail/build.mage.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.makefile.md
+++ b/docs/coverage/detail/build.makefile.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.maven.md
+++ b/docs/coverage/detail/build.maven.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.mill.md
+++ b/docs/coverage/detail/build.mill.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.mix.md
+++ b/docs/coverage/detail/build.mix.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.npm.md
+++ b/docs/coverage/detail/build.npm.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.nuget.md
+++ b/docs/coverage/detail/build.nuget.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.nx.md
+++ b/docs/coverage/detail/build.nx.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.parcel.md
+++ b/docs/coverage/detail/build.parcel.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.pip.md
+++ b/docs/coverage/detail/build.pip.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.pipenv.md
+++ b/docs/coverage/detail/build.pipenv.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.pnpm.md
+++ b/docs/coverage/detail/build.pnpm.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.poetry.md
+++ b/docs/coverage/detail/build.poetry.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.rake.md
+++ b/docs/coverage/detail/build.rake.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.rollup.md
+++ b/docs/coverage/detail/build.rollup.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.sbt.md
+++ b/docs/coverage/detail/build.sbt.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/scala/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/scala/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/scala/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/scala/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.setuptools.md
+++ b/docs/coverage/detail/build.setuptools.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.task.md
+++ b/docs/coverage/detail/build.task.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.turborepo.md
+++ b/docs/coverage/detail/build.turborepo.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.uv.md
+++ b/docs/coverage/detail/build.uv.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.vite.md
+++ b/docs/coverage/detail/build.vite.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.webpack.md
+++ b/docs/coverage/detail/build.webpack.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/build.yarn.md
+++ b/docs/coverage/detail/build.yarn.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/build_tools.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.azure-pipelines.md
+++ b/docs/coverage/detail/ci.azure-pipelines.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/azure_pipelines.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/azure_pipelines.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.bitbucket.md
+++ b/docs/coverage/detail/ci.bitbucket.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.buildkite.md
+++ b/docs/coverage/detail/ci.buildkite.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/buildkite.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/buildkite.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.circleci.md
+++ b/docs/coverage/detail/ci.circleci.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/circleci.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/circleci.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.drone.md
+++ b/docs/coverage/detail/ci.drone.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ❌ `missing` | — | — | — | — |
-| `file_parsing` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ❌ `missing` | — | — | — | — | — |
+| `file_parsing` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.github-actions.md
+++ b/docs/coverage/detail/ci.github-actions.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/github_actions.yaml`<br>`internal/extractors/yaml/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/github_actions.yaml`<br>`internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.gitlab.md
+++ b/docs/coverage/detail/ci.gitlab.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/gitlab_ci.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/gitlab_ci.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.jenkins.md
+++ b/docs/coverage/detail/ci.jenkins.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ❌ `missing` | — | — | — | — |
-| `file_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/cicd/_manifest.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ❌ `missing` | — | — | — | — | — |
+| `file_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/cicd/_manifest.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.travis.md
+++ b/docs/coverage/detail/ci.travis.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/travis_ci.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/cicd/frameworks/travis_ci.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.docker-compose.md
+++ b/docs/coverage/detail/config.docker-compose.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.dotenv.md
+++ b/docs/coverage/detail/config.dotenv.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `env_resolution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` |
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `env_resolution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` | — |
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.github-actions.md
+++ b/docs/coverage/detail/config.github-actions.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.gitlab-ci.md
+++ b/docs/coverage/detail/config.gitlab-ci.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `file_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.ini.md
+++ b/docs/coverage/detail/config.ini.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `file_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.jenkins.md
+++ b/docs/coverage/detail/config.jenkins.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `file_parsing` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.properties.md
+++ b/docs/coverage/detail/config.properties.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.toml.md
+++ b/docs/coverage/detail/config.toml.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go`<br>`internal/extractors/cross/manifest/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go`<br>`internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.tsconfig.md
+++ b/docs/coverage/detail/config.tsconfig.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `file_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/config/discover.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/config.yaml.md
+++ b/docs/coverage/detail/config.yaml.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go`<br>`internal/extractors/yaml/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `file_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/config/discover.go`<br>`internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.cassandra.md
+++ b/docs/coverage/detail/db.cassandra.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ❌ `missing` | — | — | — | — |
-| `resource_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.clickhouse.md
+++ b/docs/coverage/detail/db.clickhouse.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ❌ `missing` | — | — | — | — |
-| `resource_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.dynamodb.md
+++ b/docs/coverage/detail/db.dynamodb.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.elasticsearch.md
+++ b/docs/coverage/detail/db.elasticsearch.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.mongodb.md
+++ b/docs/coverage/detail/db.mongodb.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.mysql.md
+++ b/docs/coverage/detail/db.mysql.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.neo4j.md
+++ b/docs/coverage/detail/db.neo4j.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ❌ `missing` | — | — | — | — |
-| `resource_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.postgres.md
+++ b/docs/coverage/detail/db.postgres.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/database_index/language.yaml`<br>`internal/extractors/sql` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.redis.md
+++ b/docs/coverage/detail/db.redis.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.snowflake.md
+++ b/docs/coverage/detail/db.snowflake.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ❌ `missing` | — | — | — | — |
-| `resource_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/db.sqlite.md
+++ b/docs/coverage/detail/db.sqlite.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/sql` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/sql` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.container.docker-compose.md
+++ b/docs/coverage/detail/infra.container.docker-compose.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/docker/frameworks/docker_compose.yaml`<br>`internal/extractors/yaml/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/docker/frameworks/docker_compose.yaml`<br>`internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.container.dockerfile.md
+++ b/docs/coverage/detail/infra.container.dockerfile.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/dockerfile/dockerfile.go` |
-| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/docker/frameworks/dockerfile.yaml`<br>`internal/extractors/dockerfile/dockerfile.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/dockerfile/dockerfile.go` | — |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/docker/frameworks/dockerfile.yaml`<br>`internal/extractors/dockerfile/dockerfile.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.container.helm.md
+++ b/docs/coverage/detail/infra.container.helm.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.container.kubernetes.md
+++ b/docs/coverage/detail/infra.container.kubernetes.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml`<br>`internal/extractors/yaml/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml`<br>`internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.container.kustomize.md
+++ b/docs/coverage/detail/infra.container.kustomize.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ❌ `missing` | — | — | — | — |
-| `resource_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.iac.ansible.md
+++ b/docs/coverage/detail/infra.iac.ansible.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ansible/_manifest.yaml` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ansible/_manifest.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ansible/_manifest.yaml` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ansible/_manifest.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.iac.bicep.md
+++ b/docs/coverage/detail/infra.iac.bicep.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ❌ `missing` | — | — | — | — |
-| `resource_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ❌ `missing` | — | — | — | — | — |
+| `resource_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.iac.cdk.md
+++ b/docs/coverage/detail/infra.iac.cdk.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/cdk/_manifest.yaml` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/cdk/_manifest.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/cdk/_manifest.yaml` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/cdk/_manifest.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.iac.cloudformation.md
+++ b/docs/coverage/detail/infra.iac.cloudformation.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
-| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.iac.pulumi.md
+++ b/docs/coverage/detail/infra.iac.pulumi.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/pulumi/_manifest.yaml` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/pulumi/_manifest.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/pulumi/_manifest.yaml` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/pulumi/_manifest.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.iac.serverless-framework.md
+++ b/docs/coverage/detail/infra.iac.serverless-framework.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/serverless_edges.go` |
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/serverless_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/serverless_edges.go` | — |
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/serverless_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.iac.terraform.md
+++ b/docs/coverage/detail/infra.iac.terraform.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl` |
-| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl` | — |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.datadog.md
+++ b/docs/coverage/detail/infra.observability.datadog.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `log_extraction` | ❌ `missing` | — | — | — | — |
-| `metric_extraction` | ❌ `missing` | — | — | — | — |
-| `trace_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | — | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.elastic-apm.md
+++ b/docs/coverage/detail/infra.observability.elastic-apm.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `log_extraction` | ❌ `missing` | — | — | — | — |
-| `metric_extraction` | ❌ `missing` | — | — | — | — |
-| `trace_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | — | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.grafana-loki.md
+++ b/docs/coverage/detail/infra.observability.grafana-loki.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `log_extraction` | ❌ `missing` | — | — | — | — |
-| `metric_extraction` | — `not_applicable` | — | — | — | — |
-| `trace_extraction` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — | — |
+| `metric_extraction` | — `not_applicable` | — | — | — | — | — |
+| `trace_extraction` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.honeycomb.md
+++ b/docs/coverage/detail/infra.observability.honeycomb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `log_extraction` | ❌ `missing` | — | — | — | — |
-| `metric_extraction` | ❌ `missing` | — | — | — | — |
-| `trace_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | — | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.logging-config.md
+++ b/docs/coverage/detail/infra.observability.logging-config.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `log_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/_engine/logging_config_extractor.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/_engine/logging_config_extractor.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.newrelic.md
+++ b/docs/coverage/detail/infra.observability.newrelic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `log_extraction` | ❌ `missing` | — | — | — | — |
-| `metric_extraction` | ❌ `missing` | — | — | — | — |
-| `trace_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | — | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.opentelemetry.md
+++ b/docs/coverage/detail/infra.observability.opentelemetry.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `log_extraction` | ❌ `missing` | — | — | — | — |
-| `metric_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `trace_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/event_flow.go`<br>`internal/engine/process_flow.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — | — |
+| `metric_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
+| `trace_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/event_flow.go`<br>`internal/engine/process_flow.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.prometheus.md
+++ b/docs/coverage/detail/infra.observability.prometheus.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `log_extraction` | — `not_applicable` | — | — | — | — |
-| `metric_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/_engine/comment_marker_extractor.yaml` |
-| `trace_extraction` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | — `not_applicable` | — | — | — | — | — |
+| `metric_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/_engine/comment_marker_extractor.yaml` | — |
+| `trace_extraction` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.observability.sentry.md
+++ b/docs/coverage/detail/infra.observability.sentry.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `log_extraction` | ❌ `missing` | — | — | — | — |
-| `metric_extraction` | ❌ `missing` | — | — | — | — |
-| `trace_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | — | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | — | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.resource.aws-cdk.md
+++ b/docs/coverage/detail/infra.resource.aws-cdk.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.resource.cloudformation.md
+++ b/docs/coverage/detail/infra.resource.cloudformation.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/workflow_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `resource_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/workflow_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.resource.helm.md
+++ b/docs/coverage/detail/infra.resource.helm.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `resource_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `resource_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.resource.kubernetes.md
+++ b/docs/coverage/detail/infra.resource.kubernetes.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.resource.pulumi.md
+++ b/docs/coverage/detail/infra.resource.pulumi.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.resource.terraform.md
+++ b/docs/coverage/detail/infra.resource.terraform.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl/relationships.go` |
-| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl/extractor.go`<br>`internal/extractors/hcl/relationships.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl/relationships.go` | — |
+| `resource_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/hcl/extractor.go`<br>`internal/extractors/hcl/relationships.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.cassandra.md
+++ b/docs/coverage/detail/lang.csharp.driver.cassandra.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/cassandra_csharp.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/cassandra_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.dynamodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/dynamodb_csharp.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/dynamodb_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.elastic.md
+++ b/docs/coverage/detail/lang.csharp.driver.elastic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/nest_elasticsearch.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/nest_elasticsearch.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.mongodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.mongodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/mongodb_csharp.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/mongodb_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.mysql.md
+++ b/docs/coverage/detail/lang.csharp.driver.mysql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/mysql_csharp.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/mysql_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.neo4j.md
+++ b/docs/coverage/detail/lang.csharp.driver.neo4j.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/neo4j.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.npgsql.md
+++ b/docs/coverage/detail/lang.csharp.driver.npgsql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/npgsql.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/npgsql.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.redis.md
+++ b/docs/coverage/detail/lang.csharp.driver.redis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/redis_stackexchange.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/redis_stackexchange.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.sqlite.md
+++ b/docs/coverage/detail/lang.csharp.driver.sqlite.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/sqlite_csharp.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/sqlite_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go`<br>`internal/engine/rules/csharp/frameworks/asp_net_core.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` |
-| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go`<br>`internal/engine/rules/csharp/frameworks/asp_net_core.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` | — |
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/blazor_server.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/blazor_server.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go`<br>`internal/engine/rules/csharp/frameworks/grpc_net.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/grpc_net.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go`<br>`internal/engine/rules/csharp/frameworks/grpc_net.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/grpc_net.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.net-maui.md
+++ b/docs/coverage/detail/lang.csharp.framework.net-maui.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/net_maui.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/net_maui.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.uno.md
+++ b/docs/coverage/detail/lang.csharp.framework.uno.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/uno_platform.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/uno_platform.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.winforms.md
+++ b/docs/coverage/detail/lang.csharp.framework.winforms.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/winforms.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/winforms.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.wpf.md
+++ b/docs/coverage/detail/lang.csharp.framework.wpf.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/wpf.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/wpf.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.xamarin.md
+++ b/docs/coverage/detail/lang.csharp.framework.xamarin.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/xamarin.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/xamarin.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.dapper.md
+++ b/docs/coverage/detail/lang.csharp.orm.dapper.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/dapper.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/dapper.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/dapper.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/dapper.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.efcore.md
+++ b/docs/coverage/detail/lang.csharp.orm.efcore.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/entity_framework_core.yaml`<br>`internal/engine/rules/csharp/orms/entity_framework_core.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/entity_framework_core.yaml`<br>`internal/engine/rules/csharp/orms/entity_framework_core.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
+++ b/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.linqtodb.md
+++ b/docs/coverage/detail/lang.csharp.orm.linqtodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.nhibernate.md
+++ b/docs/coverage/detail/lang.csharp.orm.nhibernate.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.dynamodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.elastic.md
+++ b/docs/coverage/detail/lang.elixir.driver.elastic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.mongodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.mongodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.myxql.md
+++ b/docs/coverage/detail/lang.elixir.driver.myxql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/myxql.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/myxql.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.neo4j.md
+++ b/docs/coverage/detail/lang.elixir.driver.neo4j.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/orms/neo4j.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.postgrex.md
+++ b/docs/coverage/detail/lang.elixir.driver.postgrex.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/postgrex.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/postgrex.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.redix.md
+++ b/docs/coverage/detail/lang.elixir.driver.redix.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/redix.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/redix.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.xandra.md
+++ b/docs/coverage/detail/lang.elixir.driver.xandra.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/xandra.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/xandra.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml`<br>`internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml`<br>`internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/nerves.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/nerves.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/oban.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/oban.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go`<br>`internal/engine/rules/elixir/frameworks/phoenix.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go`<br>`internal/engine/rules/elixir/frameworks/phoenix.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.orm.ecto.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ecto_standalone.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ecto_standalone.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.cassandra.md
+++ b/docs/coverage/detail/lang.go.driver.cassandra.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/cassandra_go.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/cassandra_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.go.driver.dynamodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/dynamodb_go.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/dynamodb_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.elastic.md
+++ b/docs/coverage/detail/lang.go.driver.elastic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/elasticsearch_go.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/elasticsearch_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.mongodb.md
+++ b/docs/coverage/detail/lang.go.driver.mongodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/mongo_driver.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/mongo_driver.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.mysql.md
+++ b/docs/coverage/detail/lang.go.driver.mysql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/mysql_go.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/mysql_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.neo4j.md
+++ b/docs/coverage/detail/lang.go.driver.neo4j.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/neo4j.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.redis.md
+++ b/docs/coverage/detail/lang.go.driver.redis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/go_redis.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/go_redis.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.sqlite.md
+++ b/docs/coverage/detail/lang.go.driver.sqlite.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlite_go.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlite_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/beego.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/beego.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/beego.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/beego.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/buffalo.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/buffalo.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/buffalo.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/buffalo.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/chi.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/chi.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/echo.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/echo.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/fiber.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/fiber.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.fyne.md
+++ b/docs/coverage/detail/lang.go.framework.fyne.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fyne.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fyne.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gin.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gin.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/go_zero.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/go_zero.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/go_zero.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/go_zero.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.gomobile.md
+++ b/docs/coverage/detail/lang.go.framework.gomobile.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/gomobile.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/gomobile.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gorilla_mux.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gorilla_mux.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/hertz.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/hertz.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/hertz.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/hertz.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/iris.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/iris.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/iris.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/iris.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/kratos.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/kratos.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/kratos.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/kratos.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/net_http_stdlib.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/net_http_stdlib.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/revel.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/revel.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/revel.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/revel.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.bun.md
+++ b/docs/coverage/detail/lang.go.orm.bun.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/bun.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/bun.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/bun.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/bun.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.ent.md
+++ b/docs/coverage/detail/lang.go.orm.ent.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/ent.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/ent.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.gen.md
+++ b/docs/coverage/detail/lang.go.orm.gen.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.gorm.md
+++ b/docs/coverage/detail/lang.go.orm.gorm.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/go/frameworks/gorm.yaml`<br>`internal/engine/rules/go/orms/gorm.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/go/frameworks/gorm.yaml`<br>`internal/engine/rules/go/orms/gorm.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.migrate.md
+++ b/docs/coverage/detail/lang.go.orm.migrate.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/golang_migrate.yaml` |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/golang_migrate.yaml` | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.pgx.md
+++ b/docs/coverage/detail/lang.go.orm.pgx.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/pgx.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/pgx.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.sqlc.md
+++ b/docs/coverage/detail/lang.go.orm.sqlc.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlc.yaml` |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlc.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlc.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlc.yaml` | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlc.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlc.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.sqlx.md
+++ b/docs/coverage/detail/lang.go.orm.sqlx.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlx.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlx.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlx.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/orms/sqlx.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.xo.md
+++ b/docs/coverage/detail/lang.go.orm.xo.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.android-jetpack.md
+++ b/docs/coverage/detail/lang.java.framework.android-jetpack.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/android_jetpack_compose.yaml`<br>`internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/android_jetpack_compose.yaml`<br>`internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.android-sdk.md
+++ b/docs/coverage/detail/lang.java.framework.android-sdk.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/android_sdk.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/android_sdk.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/dropwizard.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/dropwizard.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.gwt.md
+++ b/docs/coverage/detail/lang.java.framework.gwt.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/jakarta_ee.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.langchain4j.md
+++ b/docs/coverage/detail/lang.java.framework.langchain4j.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/langchain4j.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/langchain4j.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/micronaut.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/micronaut.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.play.md
+++ b/docs/coverage/detail/lang.java.framework.play.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/play_framework.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/play_framework.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/play_framework.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/play_framework.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/quarkus.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/quarkus.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -9,22 +9,22 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/java/frameworks/spring_boot.yaml`<br>`internal/engine/rules/java/frameworks/spring_mvc.yaml`<br>`internal/engine/spring_routes.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` |
-| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_annotation_params.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/java/frameworks/spring_boot.yaml`<br>`internal/engine/rules/java/frameworks/spring_mvc.yaml`<br>`internal/engine/spring_routes.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` | — |
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_annotation_params.go` | — |
 
 ## Framework-specific
 
 ### Spring Boot Internals
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `actuator_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `autoconfiguration_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `profile_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `actuator_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `autoconfiguration_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `profile_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/spring_webflux.yaml`<br>`internal/engine/spring_routes.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/spring_webflux.yaml`<br>`internal/engine/spring_routes.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.vaadin.md
+++ b/docs/coverage/detail/lang.java.framework.vaadin.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vaadin.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vaadin.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vaadin.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vaadin.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.dynamodb.md
+++ b/docs/coverage/detail/lang.java.orm.dynamodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.ebean.md
+++ b/docs/coverage/detail/lang.java.orm.ebean.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.eclipselink.md
+++ b/docs/coverage/detail/lang.java.orm.eclipselink.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.hibernate.md
+++ b/docs/coverage/detail/lang.java.orm.hibernate.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/hibernate_core.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/hibernate_core.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.jooq.md
+++ b/docs/coverage/detail/lang.java.orm.jooq.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/jooq.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/jooq.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/jooq.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/jooq.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.jpa.md
+++ b/docs/coverage/detail/lang.java.orm.jpa.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.mybatis.md
+++ b/docs/coverage/detail/lang.java.orm.mybatis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/mybatis.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/mybatis.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/mybatis.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/mybatis.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.neo4j.md
+++ b/docs/coverage/detail/lang.java.orm.neo4j.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/neo4j.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/neo4j.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/neo4j.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/spring_data_jpa.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/spring_data_jpa.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-redis.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-redis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.cassandra.md
+++ b/docs/coverage/detail/lang.jsts.driver.cassandra.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.dynamodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.elastic.md
+++ b/docs/coverage/detail/lang.jsts.driver.elastic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.mongodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.mongodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.mysql.md
+++ b/docs/coverage/detail/lang.jsts.driver.mysql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mysql_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mysql_js.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.neo4j.md
+++ b/docs/coverage/detail/lang.jsts.driver.neo4j.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/neo4j.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.postgres.md
+++ b/docs/coverage/detail/lang.jsts.driver.postgres.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.redis.md
+++ b/docs/coverage/detail/lang.jsts.driver.redis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/redis_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/redis_js.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.sqlite.md
+++ b/docs/coverage/detail/lang.jsts.driver.sqlite.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.supabase.md
+++ b/docs/coverage/detail/lang.jsts.driver.supabase.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/supabase_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/supabase_js.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.angular.md
+++ b/docs/coverage/detail/lang.jsts.framework.angular.md
@@ -6,58 +6,66 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 7
+- **Capability cells:** 15
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — |
-| `hook_recognition` | — `not_applicable` | — | — | — | — |
-| `jsx_template` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — | — |
+| `jsx_template` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_fetching` | ❌ `missing` | — | — | — | — |
-| `prop_extraction` | ❌ `missing` | — | — | — | — |
-| `state_management` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `router_pattern` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
 
 ### Type System
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Lifecycle
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Framework-specific
 
 ### Angular Internals
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `decorator_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `dependency_injection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `ngmodule_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `rxjs_pattern_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `decorator_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `dependency_injection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `ngmodule_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `rxjs_pattern_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.astro.md
+++ b/docs/coverage/detail/lang.jsts.framework.astro.md
@@ -6,43 +6,63 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 8
+- **Capability cells:** 13
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — |
-| `hook_recognition` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_loaders` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — | — |
 
 ### Server
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — | — |
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` |
-| `router_pattern` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
 
 ### Build
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `static_generation` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `static_generation` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.electron.md
+++ b/docs/coverage/detail/lang.jsts.framework.electron.md
@@ -13,21 +13,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Process
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `ipc_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `main_renderer_split` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/electron.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `ipc_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
+| `main_renderer_split` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/electron.yaml` | — |
 
 ### Native
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `native_module_imports` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
 
 ### Updates
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.expo.md
+++ b/docs/coverage/detail/lang.jsts.framework.expo.md
@@ -6,51 +6,74 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 6
+- **Capability cells:** 14
 
 ## Capabilities
 
 
+### Structure
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `context_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `hoc_wrapper_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
 ### Navigation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `deep_link_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `navigation_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
-| `screen_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
+| `navigation_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` | — |
+| `screen_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` | — |
 
 ### Platform
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` | — |
 
 ### Native Bridge
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/discriminator.go` | — |
+| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Lifecycle
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Framework-specific
 
 ### Expo Ecosystem
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `eas_build_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `expo_config_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `expo_router_specifics` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/navigation.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `eas_build_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `expo_config_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `expo_router_specifics` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/navigation.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml` | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/express.yaml` | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.feathers.md
+++ b/docs/coverage/detail/lang.jsts.framework.feathers.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.gatsby.md
+++ b/docs/coverage/detail/lang.jsts.framework.gatsby.md
@@ -6,43 +6,63 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 8
+- **Capability cells:** 13
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — |
-| `hook_recognition` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_loaders` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — | — |
 
 ### Server
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — | — |
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `route_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml` |
-| `router_pattern` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `route_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml` | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
 
 ### Build
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `static_generation` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `static_generation` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -13,21 +13,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Schema
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml` |
-| `schema_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml` | — |
+| `schema_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml` | — |
 
 ### Codegen
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `client_codegen` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `client_codegen` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
 
 ### Transport
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.hapi.md
+++ b/docs/coverage/detail/lang.jsts.framework.hapi.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.hono.md
+++ b/docs/coverage/detail/lang.jsts.framework.hono.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.ionic.md
+++ b/docs/coverage/detail/lang.jsts.framework.ionic.md
@@ -6,41 +6,64 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 6
+- **Capability cells:** 14
 
 ## Capabilities
 
 
+### Structure
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `context_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
 ### Navigation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `deep_link_extraction` | ❌ `missing` | — | — | — | — |
-| `navigation_extraction` | ❌ `missing` | — | — | — | — |
-| `screen_detection` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — | — |
 
 ### Platform
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `platform_branching` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — | — |
 
 ### Native Bridge
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `native_module_imports` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `state_management` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Lifecycle
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.koa.md
+++ b/docs/coverage/detail/lang.jsts.framework.koa.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.langchain.md
+++ b/docs/coverage/detail/lang.jsts.framework.langchain.md
@@ -13,21 +13,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Prompts
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `prompt_template_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `prompt_template_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` | — |
 
 ### Composition
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `chain_composition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` |
-| `tool_use_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `chain_composition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/langchain.yaml` | — |
+| `tool_use_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
 
 ### Tracking
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.marblejs.md
+++ b/docs/coverage/detail/lang.jsts.framework.marblejs.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nativescript.md
+++ b/docs/coverage/detail/lang.jsts.framework.nativescript.md
@@ -6,41 +6,64 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 6
+- **Capability cells:** 14
 
 ## Capabilities
 
 
+### Structure
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `context_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
 ### Navigation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `deep_link_extraction` | ❌ `missing` | — | — | — | — |
-| `navigation_extraction` | ❌ `missing` | — | — | — | — |
-| `screen_detection` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — | — |
 
 ### Platform
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `platform_branching` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — | — |
 
 ### Native Bridge
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `native_module_imports` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `state_management` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Lifecycle
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -6,52 +6,72 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 8
+- **Capability cells:** 13
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `hook_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_loaders` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
 
 ### Server
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `hydration_boundaries` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `server_components` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hydration_boundaries` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
+| `server_components` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
-| `router_pattern` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | — |
+| `router_pattern` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | — |
 
 ### Build
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `static_generation` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `static_generation` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Framework-specific
 
 ### Next.js Internals
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_runtime_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `next_config_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_runtime_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `next_config_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -6,43 +6,63 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 8
+- **Capability cells:** 13
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — |
-| `hook_recognition` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_loaders` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — | — |
 
 ### Server
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — | — |
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` |
-| `router_pattern` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
 
 ### Build
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `static_generation` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `static_generation` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.polka.md
+++ b/docs/coverage/detail/lang.jsts.framework.polka.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.react-native.md
+++ b/docs/coverage/detail/lang.jsts.framework.react-native.md
@@ -6,50 +6,73 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 6
+- **Capability cells:** 14
 
 ## Capabilities
 
 
+### Structure
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `context_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `hoc_wrapper_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
 ### Navigation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `deep_link_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
-| `navigation_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
-| `screen_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
+| `navigation_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` | — |
+| `screen_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` | — |
 
 ### Platform
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2666) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` | — |
 
 ### Native Bridge
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/discriminator.go` | — |
+| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Lifecycle
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Framework-specific
 
 ### React Native CLI
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `metro_config_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `native_link_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `metro_config_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `native_link_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -6,47 +6,55 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 7
+- **Capability cells:** 15
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
-| `hook_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
-| `jsx_template` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/extractors/javascript/extractor.go` | — |
+| `context_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `hoc_wrapper_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `hook_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/extractors/javascript/destructure_bindings.go` | — |
+| `jsx_template` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_fetching` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2554) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
-| `prop_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2665) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
-| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/discriminator.go` | — |
+| `data_fetching` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/destructure_bindings.go`<br>`internal/extractors/javascript/extractor.go` | — |
+| `prop_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2665) | `internal/extractors/javascript/navigation.go` | Covers only JSX navigation props (Link to/href, Navigate to, state object); generic React component prop extraction is not yet implemented. |
+| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/extractors/javascript/destructure_bindings.go`<br>`internal/extractors/javascript/zustand_store.go` | — |
 
 ### Navigation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `router_pattern` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `router_pattern` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/navigation.go` | — |
 
 ### Type System
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Lifecycle
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.remix.md
+++ b/docs/coverage/detail/lang.jsts.framework.remix.md
@@ -6,43 +6,63 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 8
+- **Capability cells:** 13
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — |
-| `hook_recognition` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_loaders` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — | — |
 
 ### Server
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — | — |
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` |
-| `router_pattern` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
 
 ### Build
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `static_generation` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `static_generation` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.restify.md
+++ b/docs/coverage/detail/lang.jsts.framework.restify.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -13,42 +13,42 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Validation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Middleware
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Observability
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ### Data
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.svelte.md
+++ b/docs/coverage/detail/lang.jsts.framework.svelte.md
@@ -6,56 +6,64 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 7
+- **Capability cells:** 15
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — |
-| `hook_recognition` | — `not_applicable` | — | — | — | — |
-| `jsx_template` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — | — |
+| `jsx_template` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_fetching` | ❌ `missing` | — | — | — | — |
-| `prop_extraction` | ❌ `missing` | — | — | — | — |
-| `state_management` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `router_pattern` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
 
 ### Type System
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Lifecycle
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Framework-specific
 
 ### Svelte Reactivity
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `reactive_statement_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `store_pattern_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `reactive_statement_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `store_pattern_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -6,43 +6,63 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 8
+- **Capability cells:** 13
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — |
-| `hook_recognition` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_loaders` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — | — |
 
 ### Server
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `hydration_boundaries` | ❌ `missing` | — | — | — | — |
-| `server_components` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — | — |
 
 ### Routing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` |
-| `router_pattern` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
 
 ### Build
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `static_generation` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `static_generation` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -13,21 +13,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### Schema
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` |
-| `schema_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/http_endpoint_trpc.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `procedure_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` | — |
+| `schema_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/http_endpoint_trpc.go` | — |
 
 ### Codegen
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `client_codegen` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `client_codegen` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
 
 ### Transport
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.vue.md
+++ b/docs/coverage/detail/lang.jsts.framework.vue.md
@@ -6,57 +6,65 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 7
+- **Capability cells:** 15
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — |
-| `hook_recognition` | ❌ `missing` | — | — | — | — |
-| `jsx_template` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+| `jsx_template` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `data_fetching` | ❌ `missing` | — | — | — | — |
-| `prop_extraction` | ❌ `missing` | — | — | — | — |
-| `state_management` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `router_pattern` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
 
 ### Type System
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
+| `type_alias_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Lifecycle
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/tests.go` | — |
 
 ## Framework-specific
 
 ### Vue Ecosystem
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `composition_api_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `pinia_pattern_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `scoped_style_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `composition_api_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `pinia_pattern_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `scoped_style_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.drizzle.md
+++ b/docs/coverage/detail/lang.jsts.orm.drizzle.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/drizzle.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/drizzle.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.knex.md
+++ b/docs/coverage/detail/lang.jsts.orm.knex.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/knex.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/knex.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
+++ b/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.mongoose.md
+++ b/docs/coverage/detail/lang.jsts.orm.mongoose.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mongoose.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mongoose.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.objection.md
+++ b/docs/coverage/detail/lang.jsts.orm.objection.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.prisma.md
+++ b/docs/coverage/detail/lang.jsts.orm.prisma.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/prisma/_manifest.yaml` |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/prisma.yaml`<br>`internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml`<br>`internal/engine/rules/prisma/_manifest.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/prisma/_manifest.yaml` | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/prisma.yaml`<br>`internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml`<br>`internal/engine/rules/prisma/_manifest.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.sequelize.md
+++ b/docs/coverage/detail/lang.jsts.orm.sequelize.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/sequelize.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/sequelize.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.typeorm.md
+++ b/docs/coverage/detail/lang.jsts.orm.typeorm.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/typeorm.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/typeorm.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/compose_desktop.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/compose_desktop.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/compose_multiplatform.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/compose_multiplatform.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/kmp.yaml`<br>`internal/engine/rules/kotlin/frameworks/kotlin_multiplatform_kmp_kmm.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/kmp.yaml`<br>`internal/engine/rules/kotlin/frameworks/kotlin_multiplatform_kmp_kmm.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml`<br>`internal/engine/spring_routes_kotlin.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes_kotlin.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml`<br>`internal/engine/spring_routes_kotlin.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes_kotlin.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.exposed.md
+++ b/docs/coverage/detail/lang.kotlin.orm.exposed.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/exposed.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/exposed.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/exposed.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/exposed.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.hibernate.md
+++ b/docs/coverage/detail/lang.kotlin.orm.hibernate.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.ktorm.md
+++ b/docs/coverage/detail/lang.kotlin.orm.ktorm.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.mongodb.md
+++ b/docs/coverage/detail/lang.kotlin.orm.mongodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.room.md
+++ b/docs/coverage/detail/lang.kotlin.orm.room.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/room_android.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/room_android.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/room_android.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/room_android.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.spring-data.md
+++ b/docs/coverage/detail/lang.kotlin.orm.spring-data.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
+++ b/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.lua.framework.lapis.md
+++ b/docs/coverage/detail/lang.lua.framework.lapis.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.lua.framework.openresty.md
+++ b/docs/coverage/detail/lang.lua.framework.openresty.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.cassandra.md
+++ b/docs/coverage/detail/lang.php.driver.cassandra.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/cassandra_php.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/cassandra_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.php.driver.dynamodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/dynamodb_php.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/dynamodb_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.elastic.md
+++ b/docs/coverage/detail/lang.php.driver.elastic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/elasticsearch_php.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/elasticsearch_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.mongodb.md
+++ b/docs/coverage/detail/lang.php.driver.mongodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/mongodb_php.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/mongodb_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.mysql.md
+++ b/docs/coverage/detail/lang.php.driver.mysql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/mysql_php.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/mysql_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.neo4j.md
+++ b/docs/coverage/detail/lang.php.driver.neo4j.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/neo4j.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.postgres.md
+++ b/docs/coverage/detail/lang.php.driver.postgres.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/postgresql_php.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/postgresql_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.redis.md
+++ b/docs/coverage/detail/lang.php.driver.redis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/redis_php.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/redis_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.sqlite.md
+++ b/docs/coverage/detail/lang.php.driver.sqlite.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/sqlite_php.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/sqlite_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/cakephp.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/cakephp.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/cakephp.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/cakephp.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/drupal.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/drupal.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/drupal.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/drupal.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/laminas.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/laminas.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/laminas.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/laminas.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/laravel.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/laravel.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/magento.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/magento.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/magento.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/magento.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/slim.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/slim.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/slim.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/slim.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/symfony.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/symfony.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/wordpress.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/wordpress.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/wordpress.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/wordpress.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/yii.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/yii.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/yii.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/yii.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.cycleorm.md
+++ b/docs/coverage/detail/lang.php.orm.cycleorm.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.doctrine.md
+++ b/docs/coverage/detail/lang.php.orm.doctrine.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/doctrine_orm.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/doctrine_orm.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.eloquent.md
+++ b/docs/coverage/detail/lang.php.orm.eloquent.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/eloquent_laravel_orm.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/eloquent_laravel_orm.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.propel.md
+++ b/docs/coverage/detail/lang.php.orm.propel.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/propel.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/propel.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/propel.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/propel.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.redbeanphp.md
+++ b/docs/coverage/detail/lang.php.orm.redbeanphp.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/redbeanphp.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/redbeanphp.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/redbeanphp.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/orms/redbeanphp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.cassandra.md
+++ b/docs/coverage/detail/lang.python.driver.cassandra.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/cassandra_py.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/cassandra_py.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.python.driver.dynamodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/dynamodb_py.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/dynamodb_py.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.elastic.md
+++ b/docs/coverage/detail/lang.python.driver.elastic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/elasticsearch_py.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/elasticsearch_py.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.mysql.md
+++ b/docs/coverage/detail/lang.python.driver.mysql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/mysql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/mysql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.neo4j.md
+++ b/docs/coverage/detail/lang.python.driver.neo4j.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/neo4j.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.postgres.md
+++ b/docs/coverage/detail/lang.python.driver.postgres.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/postgresql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/postgresql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.redis.md
+++ b/docs/coverage/detail/lang.python.driver.redis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/redis_py.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/redis_py.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.sqlite.md
+++ b/docs/coverage/detail/lang.python.driver.sqlite.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/sqlite_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/sqlite_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/bottle.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/bottle.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.celery.md
+++ b/docs/coverage/detail/lang.python.framework.celery.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/celery.yaml`<br>`internal/extractors/python/celery.go` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/celery.yaml`<br>`internal/extractors/python/celery.go` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -9,21 +9,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/django_drf_actions.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/drf_serializer_fields.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/django_drf_actions.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/drf_serializer_fields.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Framework-specific
 
 ### Django Internals
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `admin_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — |
-| `signal_handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | `internal/engine/django_signal_pubsub_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `admin_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `signal_handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | `internal/engine/django_signal_pubsub_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_routes.go`<br>`internal/engine/django_urlconf_nested.go`<br>`internal/engine/rules/python/frameworks/django.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_admin_routes.go`<br>`internal/engine/django_routes.go` |
-| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_imports_rewrite.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_routes.go`<br>`internal/engine/django_urlconf_nested.go`<br>`internal/engine/rules/python/frameworks/django.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_admin_routes.go`<br>`internal/engine/django_routes.go` | — |
+| `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_imports_rewrite.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.dramatiq.md
+++ b/docs/coverage/detail/lang.python.framework.dramatiq.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/dramatiq.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/dramatiq.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/fastapi.yaml` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/fastapi.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/fastapi.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/fastapi.yaml` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/fastapi.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/fastapi.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/flask.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/flask.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/flask.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/flask.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.langchain.md
+++ b/docs/coverage/detail/lang.python.framework.langchain.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/langchain.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/langchain.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/litestar.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/litestar.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pyramid.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pyramid.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pyramid.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pyramid.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/robyn.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/robyn.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/sanic.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/sanic.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/starlette.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/starlette.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/starlette.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/starlette.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/strawberry_python.yaml`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/strawberry_graphql.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/strawberry_python.yaml`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/tornado.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/tornado.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/tornado.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/tornado.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.alembic.md
+++ b/docs/coverage/detail/lang.python.orm.alembic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/alembic.yaml` |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/alembic.yaml` | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/beanie.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/beanie.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/beanie.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/beanie.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.django.md
+++ b/docs/coverage/detail/lang.python.orm.django.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/python/django_migration.go` |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/django_orm.yaml`<br>`internal/extractors/python/django_relational.go` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/python/django_migration.go` | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/django_orm.yaml`<br>`internal/extractors/python/django_relational.go` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/mongoengine.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/mongoengine.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/mongoengine.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/mongoengine.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.peewee.md
+++ b/docs/coverage/detail/lang.python.orm.peewee.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/peewee.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/peewee.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/peewee.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/peewee.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.pony.md
+++ b/docs/coverage/detail/lang.python.orm.pony.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/pony_orm.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/pony_orm.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/pony_orm.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/pony_orm.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.sqlalchemy.md
+++ b/docs/coverage/detail/lang.python.orm.sqlalchemy.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/alembic.yaml` |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/python/orms/sqlalchemy.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/alembic.yaml` | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/python/orms/sqlalchemy.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.sqlmodel.md
+++ b/docs/coverage/detail/lang.python.orm.sqlmodel.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/sqlmodel.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/sqlmodel.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.tortoise.md
+++ b/docs/coverage/detail/lang.python.orm.tortoise.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/tortoise_orm.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/orms/tortoise_orm.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/orm_queries_python.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.cassandra.md
+++ b/docs/coverage/detail/lang.ruby.driver.cassandra.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/cassandra_ruby.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/cassandra_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.ruby.driver.dynamodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/dynamodb_ruby.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/dynamodb_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.elastic.md
+++ b/docs/coverage/detail/lang.ruby.driver.elastic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.mysql.md
+++ b/docs/coverage/detail/lang.ruby.driver.mysql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/mysql_ruby.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/mysql_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.neo4j.md
+++ b/docs/coverage/detail/lang.ruby.driver.neo4j.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/neo4j.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.postgres.md
+++ b/docs/coverage/detail/lang.ruby.driver.postgres.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/pg_ruby.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/pg_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.redis.md
+++ b/docs/coverage/detail/lang.ruby.driver.redis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/redis_rb.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/redis_rb.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.sqlite.md
+++ b/docs/coverage/detail/lang.ruby.driver.sqlite.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/sqlite_ruby.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/sqlite_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/dry_rb.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/dry_rb.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/grape.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/grape.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/grape.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/grape.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/roda.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/roda.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/roda.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/roda.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/sinatra.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/sinatra.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.activerecord.md
+++ b/docs/coverage/detail/lang.ruby.orm.activerecord.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/activerecord.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/activerecord.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.datamapper.md
+++ b/docs/coverage/detail/lang.ruby.orm.datamapper.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.mongoid.md
+++ b/docs/coverage/detail/lang.ruby.orm.mongoid.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/mongoid.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/mongoid.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/mongoid.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/mongoid.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.rom-rb.md
+++ b/docs/coverage/detail/lang.ruby.orm.rom-rb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml`<br>`internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml`<br>`internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.sequel.md
+++ b/docs/coverage/detail/lang.ruby.orm.sequel.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/sequel.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/sequel.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/sequel.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/orms/sequel.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.cassandra.md
+++ b/docs/coverage/detail/lang.rust.driver.cassandra.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/cassandra_rust.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/cassandra_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.rust.driver.dynamodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/dynamodb_rust.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/dynamodb_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.elastic.md
+++ b/docs/coverage/detail/lang.rust.driver.elastic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/elasticsearch_rs.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/elasticsearch_rs.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.mongodb.md
+++ b/docs/coverage/detail/lang.rust.driver.mongodb.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/mongodb_mongodb.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/mongodb_mongodb.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.mysql.md
+++ b/docs/coverage/detail/lang.rust.driver.mysql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/mysql_rust.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/mysql_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.neo4j.md
+++ b/docs/coverage/detail/lang.rust.driver.neo4j.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/neo4j.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.postgres.md
+++ b/docs/coverage/detail/lang.rust.driver.postgres.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/postgresql_rust.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/postgresql_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.redis.md
+++ b/docs/coverage/detail/lang.rust.driver.redis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/redis_redis_rs.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/redis_redis_rs.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.sqlite.md
+++ b/docs/coverage/detail/lang.rust.driver.sqlite.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/sqlite_rust.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/sqlite_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go`<br>`internal/engine/rules/rust/frameworks/axum.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go`<br>`internal/engine/rules/rust/frameworks/axum.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/gotham.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/gotham.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/gotham.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/gotham.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/hyper.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/hyper.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/hyper.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/hyper.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/poem.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/poem.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/poem.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/poem.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go`<br>`internal/engine/rules/rust/frameworks/rocket.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go`<br>`internal/engine/rules/rust/frameworks/rocket.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tauri.md
+++ b/docs/coverage/detail/lang.rust.framework.tauri.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tauri.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tauri.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tide.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tide.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tide.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tide.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/warp.yaml` |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/warp.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/warp.yaml` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/warp.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.diesel.md
+++ b/docs/coverage/detail/lang.rust.orm.diesel.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/diesel.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/diesel.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/diesel.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/diesel.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.rbatis.md
+++ b/docs/coverage/detail/lang.rust.orm.rbatis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ❌ `missing` | — | — | — | — |
-| `query_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ❌ `missing` | — | — | — | — | — |
+| `query_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.rusqlite.md
+++ b/docs/coverage/detail/lang.rust.orm.rusqlite.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/rusqlite.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/rusqlite.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.seaorm.md
+++ b/docs/coverage/detail/lang.rust.orm.seaorm.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/seaorm.yaml` |
-| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/seaorm.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/seaorm.yaml` | — |
+| `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/seaorm.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.sqlx.md
+++ b/docs/coverage/detail/lang.rust.orm.sqlx.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/sqlx.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/sqlx.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/sqlx.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/orms/sqlx.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
-| `handler_attribution` | ❌ `missing` | — | — | — | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/cats_effect.yaml` |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/cats_effect.yaml` | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.play.md
+++ b/docs/coverage/detail/lang.scala.framework.play.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/play_framework.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/play_framework.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/play_framework.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/play_framework.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -9,12 +9,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
+| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
+| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.doobie.md
+++ b/docs/coverage/detail/lang.scala.orm.doobie.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/doobie.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/doobie.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/doobie.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/doobie.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.elastic4s.md
+++ b/docs/coverage/detail/lang.scala.orm.elastic4s.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/elastic4s.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/elastic4s.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/elastic4s.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/elastic4s.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.quill.md
+++ b/docs/coverage/detail/lang.scala.orm.quill.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/quill.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/quill.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/quill.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/quill.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.scalikejdbc.md
+++ b/docs/coverage/detail/lang.scala.orm.scalikejdbc.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.scanamo.md
+++ b/docs/coverage/detail/lang.scala.orm.scanamo.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | — `not_applicable` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scanamo.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scanamo.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | — `not_applicable` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scanamo.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/scanamo.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.slick.md
+++ b/docs/coverage/detail/lang.scala.orm.slick.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/slick.yaml` |
-| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/slick.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/slick.yaml` | — |
+| `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/orms/slick.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.swift.framework.vapor.md
+++ b/docs/coverage/detail/lang.swift.framework.vapor.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.amqp.md
+++ b/docs/coverage/detail/msg.broker.amqp.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
-| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` | — |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.azure-service-bus.md
+++ b/docs/coverage/detail/msg.broker.azure-service-bus.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ❌ `missing` | — | — | — | — |
-| `producer_extraction` | ❌ `missing` | — | — | — | — |
-| `topic_attribution` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ❌ `missing` | — | — | — | — | — |
+| `producer_extraction` | ❌ `missing` | — | — | — | — | — |
+| `topic_attribution` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.cloudevents.md
+++ b/docs/coverage/detail/msg.broker.cloudevents.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.debezium.md
+++ b/docs/coverage/detail/msg.broker.debezium.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` | — |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/debezium_cdc_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.eventbridge.md
+++ b/docs/coverage/detail/msg.broker.eventbridge.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.eventgrid.md
+++ b/docs/coverage/detail/msg.broker.eventgrid.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.gcp-pubsub.md
+++ b/docs/coverage/detail/msg.broker.gcp-pubsub.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` |
-| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` | — |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pubsub_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.kafka.md
+++ b/docs/coverage/detail/msg.broker.kafka.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go`<br>`internal/engine/kafka_wrapper_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go`<br>`internal/engine/kafka_wrapper_edges.go` | — |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/kafka_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.mqtt.md
+++ b/docs/coverage/detail/msg.broker.mqtt.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/event_bus_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.nats.md
+++ b/docs/coverage/detail/msg.broker.nats.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/nats_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/nats_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/nats_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/nats_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/nats_edges.go` | — |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/nats_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.pulsar.md
+++ b/docs/coverage/detail/msg.broker.pulsar.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` |
-| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` | — |
+| `producer_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/pulsar_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.rabbitmq.md
+++ b/docs/coverage/detail/msg.broker.rabbitmq.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` | — |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rabbitmq_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.redis.md
+++ b/docs/coverage/detail/msg.broker.redis.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` | — |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/redis_pubsub_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.sns.md
+++ b/docs/coverage/detail/msg.broker.sns.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` | — |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/iac_sns_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.broker.sqs.md
+++ b/docs/coverage/detail/msg.broker.sqs.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` | — |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sqs_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.bullmq.md
+++ b/docs/coverage/detail/msg.bullmq.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/topic_pass.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.celery.md
+++ b/docs/coverage/detail/msg.celery.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go`<br>`internal/extractors/python/celery.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go`<br>`internal/extractors/python/celery.go` | — |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/links/topic_pass.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.django-signals.md
+++ b/docs/coverage/detail/msg.django-signals.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_signal_pubsub_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_signal_pubsub_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_signal_pubsub_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_signal_pubsub_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_signal_pubsub_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_signal_pubsub_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.dramatiq.md
+++ b/docs/coverage/detail/msg.dramatiq.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ❌ `missing` | — | — | — | — |
-| `producer_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ❌ `missing` | — | — | — | — | — |
+| `producer_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.graphql-subscriptions.md
+++ b/docs/coverage/detail/msg.graphql-subscriptions.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go` |
-| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go` | — |
+| `topic_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.kafka-streams.md
+++ b/docs/coverage/detail/msg.kafka-streams.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ❌ `missing` | — | — | — | — |
-| `producer_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ❌ `missing` | — | — | — | — | — |
+| `producer_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.sidekiq.md
+++ b/docs/coverage/detail/msg.sidekiq.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ❌ `missing` | — | — | — | — |
-| `producer_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ❌ `missing` | — | — | — | — | — |
+| `producer_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.sse.md
+++ b/docs/coverage/detail/msg.sse.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sse_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sse_edges.go` |
-| `topic_attribution` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sse_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/sse_edges.go` | — |
+| `topic_attribution` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.webhook.md
+++ b/docs/coverage/detail/msg.webhook.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/webhooks_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/webhooks_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/webhooks_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/webhooks_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/webhooks_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/webhooks_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.websocket.md
+++ b/docs/coverage/detail/msg.websocket.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/websocket_edges.go` |
-| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/websocket_edges.go` |
-| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/websocket_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `consumer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/websocket_edges.go` | — |
+| `producer_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/websocket_edges.go` | — |
+| `topic_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/websocket_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.cargo.md
+++ b/docs/coverage/detail/pkg.cargo.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ❌ `missing` | — | — | — | — |
-| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ❌ `missing` | — | — | — | — | — |
+| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.composer.md
+++ b/docs/coverage/detail/pkg.composer.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ❌ `missing` | — | — | — | — |
-| `manifest_parsing` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ❌ `missing` | — | — | — | — | — |
+| `manifest_parsing` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.csproj.md
+++ b/docs/coverage/detail/pkg.csproj.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ❌ `missing` | — | — | — | — |
-| `manifest_parsing` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ❌ `missing` | — | — | — | — | — |
+| `manifest_parsing` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.gemfile.md
+++ b/docs/coverage/detail/pkg.gemfile.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ❌ `missing` | — | — | — | — |
-| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ❌ `missing` | — | — | — | — | — |
+| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.go-mod.md
+++ b/docs/coverage/detail/pkg.go-mod.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ⚠️ `partial` | — | — | — | — |
-| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ⚠️ `partial` | — | — | — | — | — |
+| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.gradle.md
+++ b/docs/coverage/detail/pkg.gradle.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ❌ `missing` | — | — | — | — |
-| `manifest_parsing` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ❌ `missing` | — | — | — | — | — |
+| `manifest_parsing` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.mix.md
+++ b/docs/coverage/detail/pkg.mix.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `manifest_parsing` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `manifest_parsing` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.npm.md
+++ b/docs/coverage/detail/pkg.npm.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ❌ `missing` | — | — | — | — |
-| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ❌ `missing` | — | — | — | — | — |
+| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.pipfile.md
+++ b/docs/coverage/detail/pkg.pipfile.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ❌ `missing` | — | — | — | — |
-| `manifest_parsing` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ❌ `missing` | — | — | — | — | — |
+| `manifest_parsing` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.pom.md
+++ b/docs/coverage/detail/pkg.pom.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.pubspec.md
+++ b/docs/coverage/detail/pkg.pubspec.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ❌ `missing` | — | — | — | — |
-| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ❌ `missing` | — | — | — | — | — |
+| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.pyproject.md
+++ b/docs/coverage/detail/pkg.pyproject.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `lockfile_parsing` | ❌ `missing` | — | — | — | — |
-| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `lockfile_parsing` | ❌ `missing` | — | — | — | — | — |
+| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.requirements.md
+++ b/docs/coverage/detail/pkg.requirements.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `manifest_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.sbt.md
+++ b/docs/coverage/detail/pkg.sbt.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `manifest_parsing` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `manifest_parsing` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.swift-package.md
+++ b/docs/coverage/detail/pkg.swift-package.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `manifest_parsing` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `manifest_parsing` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/http_endpoint_match.go` |
-| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go` |
-| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go`<br>`internal/engine/rules/graphql/frameworks/graphql_schema.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `cross_repo_linkage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/http_endpoint_match.go` | — |
+| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go` | — |
+| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/graphql_subscriptions.go`<br>`internal/engine/rules/graphql/frameworks/graphql_schema.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.grpc.md
+++ b/docs/coverage/detail/protocol.grpc.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
-| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
-| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `cross_repo_linkage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` | — |
+| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` | — |
+| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.jsonrpc.md
+++ b/docs/coverage/detail/protocol.jsonrpc.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ❌ `missing` | — | — | — | — |
-| `method_attribution` | ❌ `missing` | — | — | — | — |
-| `service_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `cross_repo_linkage` | ❌ `missing` | — | — | — | — | — |
+| `method_attribution` | ❌ `missing` | — | — | — | — | — |
+| `service_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.openapi.md
+++ b/docs/coverage/detail/protocol.openapi.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/http_endpoint_match.go` |
-| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/openapi/language.yaml` |
-| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/openapi/language.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `cross_repo_linkage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/http_endpoint_match.go` | — |
+| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/openapi/language.yaml` | — |
+| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/openapi/language.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.protobuf.md
+++ b/docs/coverage/detail/protocol.protobuf.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` |
-| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/proto` |
-| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/protobuf/_manifest.yaml`<br>`internal/extractors/proto` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `cross_repo_linkage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go` | — |
+| `method_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/proto` | — |
+| `service_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/protobuf/_manifest.yaml`<br>`internal/extractors/proto` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.soap.md
+++ b/docs/coverage/detail/protocol.soap.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `cross_repo_linkage` | ❌ `missing` | — | — | — | — |
-| `method_attribution` | ❌ `missing` | — | — | — | — |
-| `service_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `cross_repo_linkage` | ❌ `missing` | — | — | — | — | — |
+| `method_attribution` | ❌ `missing` | — | — | — | — | — |
+| `service_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.auth-java.md
+++ b/docs/coverage/detail/security.auth-java.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_policy` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_policy` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.auth-other.md
+++ b/docs/coverage/detail/security.auth-other.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_policy` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_policy` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.auth.basic.md
+++ b/docs/coverage/detail/security.auth.basic.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `secret_detection` | ❌ `missing` | — | — | — | — |
-| `sql_injection` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `secret_detection` | ❌ `missing` | — | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.auth.jwt.md
+++ b/docs/coverage/detail/security.auth.jwt.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `secret_detection` | ❌ `missing` | — | — | — | — |
-| `sql_injection` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `secret_detection` | ❌ `missing` | — | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.auth.oauth2.md
+++ b/docs/coverage/detail/security.auth.oauth2.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `secret_detection` | ❌ `missing` | — | — | — | — |
-| `sql_injection` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `secret_detection` | ❌ `missing` | — | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.auth.oidc.md
+++ b/docs/coverage/detail/security.auth.oidc.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `secret_detection` | ❌ `missing` | — | — | — | — |
-| `sql_injection` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `secret_detection` | ❌ `missing` | — | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.auth.saml.md
+++ b/docs/coverage/detail/security.auth.saml.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_policy` | ❌ `missing` | — | — | — | — |
-| `secret_detection` | ❌ `missing` | — | — | — | — |
-| `sql_injection` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_policy` | ❌ `missing` | — | — | — | — | — |
+| `secret_detection` | ❌ `missing` | — | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.auth.session.md
+++ b/docs/coverage/detail/security.auth.session.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` |
-| `secret_detection` | ❌ `missing` | — | — | — | — |
-| `sql_injection` | — `not_applicable` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_policy` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/java_auth_policy.go` | — |
+| `secret_detection` | ❌ `missing` | — | — | — | — | — |
+| `sql_injection` | — `not_applicable` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.csrf.md
+++ b/docs/coverage/detail/security.csrf.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_policy` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/_engine/csrf_heuristic_detector.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_policy` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/_engine/csrf_heuristic_detector.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.secrets.md
+++ b/docs/coverage/detail/security.secrets.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `secret_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/secrets/secrets.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `secret_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/secrets/secrets.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/security.sql-injection.md
+++ b/docs/coverage/detail/security.sql-injection.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `sql_injection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/_engine/sql_injection_detector.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `sql_injection` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/_engine/sql_injection_detector.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.assertj.md
+++ b/docs/coverage/detail/test.assertj.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.ava.md
+++ b/docs/coverage/detail/test.ava.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.behat.md
+++ b/docs/coverage/detail/test.behat.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.cargo-test.md
+++ b/docs/coverage/detail/test.cargo-test.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/test_patterns.yaml`<br>`internal/engine/tests_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.codeception.md
+++ b/docs/coverage/detail/test.codeception.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.criterion.md
+++ b/docs/coverage/detail/test.criterion.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.cucumber.md
+++ b/docs/coverage/detail/test.cucumber.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.cypress.md
+++ b/docs/coverage/detail/test.cypress.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.doctest.md
+++ b/docs/coverage/detail/test.doctest.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.exunit.md
+++ b/docs/coverage/detail/test.exunit.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/test_patterns.yaml`<br>`internal/engine/tests_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.fluentassertions.md
+++ b/docs/coverage/detail/test.fluentassertions.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.ginkgo.md
+++ b/docs/coverage/detail/test.ginkgo.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.go-testing.md
+++ b/docs/coverage/detail/test.go-testing.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/test_patterns.yaml`<br>`internal/engine/tests_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.gomega.md
+++ b/docs/coverage/detail/test.gomega.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.hypothesis.md
+++ b/docs/coverage/detail/test.hypothesis.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.jasmine.md
+++ b/docs/coverage/detail/test.jasmine.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.jest.md
+++ b/docs/coverage/detail/test.jest.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/jest.yaml`<br>`internal/engine/tests_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/jest.yaml`<br>`internal/engine/tests_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.junit4.md
+++ b/docs/coverage/detail/test.junit4.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/test_patterns.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/test_patterns.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.junit5.md
+++ b/docs/coverage/detail/test.junit5.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/junit5.yaml`<br>`internal/engine/tests_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/junit5.yaml`<br>`internal/engine/tests_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.minitest.md
+++ b/docs/coverage/detail/test.minitest.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/test_patterns.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/test_patterns.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.mocha.md
+++ b/docs/coverage/detail/test.mocha.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/test_patterns.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/test_patterns.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.mockall.md
+++ b/docs/coverage/detail/test.mockall.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.mockito.md
+++ b/docs/coverage/detail/test.mockito.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.mstest.md
+++ b/docs/coverage/detail/test.mstest.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/test_patterns.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/test_patterns.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.nose2.md
+++ b/docs/coverage/detail/test.nose2.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.nunit.md
+++ b/docs/coverage/detail/test.nunit.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/test_patterns.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/test_patterns.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.pest.md
+++ b/docs/coverage/detail/test.pest.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.phpunit.md
+++ b/docs/coverage/detail/test.phpunit.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/test_patterns.yaml`<br>`internal/engine/tests_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.playwright.md
+++ b/docs/coverage/detail/test.playwright.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.proptest.md
+++ b/docs/coverage/detail/test.proptest.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.pytest.md
+++ b/docs/coverage/detail/test.pytest.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pytest.yaml`<br>`internal/engine/tests_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pytest.yaml`<br>`internal/engine/tests_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.restassured.md
+++ b/docs/coverage/detail/test.restassured.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.rspec.md
+++ b/docs/coverage/detail/test.rspec.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/rspec.yaml`<br>`internal/engine/tests_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/rspec.yaml`<br>`internal/engine/tests_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.spock.md
+++ b/docs/coverage/detail/test.spock.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.streamdata.md
+++ b/docs/coverage/detail/test.streamdata.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.tap.md
+++ b/docs/coverage/detail/test.tap.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ❌ `missing` | — | — | — | — |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.testify.md
+++ b/docs/coverage/detail/test.testify.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/test_patterns.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/test_patterns.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.testng.md
+++ b/docs/coverage/detail/test.testng.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ❌ `missing` | — | — | — | — |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/test_patterns.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ❌ `missing` | — | — | — | — | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/test_patterns.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.unittest.md
+++ b/docs/coverage/detail/test.unittest.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/test_patterns.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/test_patterns.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.vitest.md
+++ b/docs/coverage/detail/test.vitest.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/test_patterns.yaml` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/test_patterns.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.xunit.md
+++ b/docs/coverage/detail/test.xunit.md
@@ -9,10 +9,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` |
-| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/test_patterns.yaml`<br>`internal/engine/tests_edges.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_graph` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/tests_edges.go` | — |
+| `target_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/test_patterns.yaml`<br>`internal/engine/tests_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9,16 +9,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/bazel/extractor.go"
-          ],
+          "cites": ["internal/extractors/bazel/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/bazel/parser.go"
-          ],
+          "cites": ["internal/extractors/bazel/parser.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -31,16 +27,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -53,16 +45,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -75,16 +63,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -97,16 +81,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -119,16 +99,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -141,16 +117,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -191,17 +163,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/golang/gomod.go"
-          ],
+          "cites": ["internal/extractors/golang/gomod.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/build_tools.yaml",
-            "internal/extractors/golang/gomod.go"
-          ],
+          "cites": ["internal/engine/rules/go/build_tools.yaml","internal/extractors/golang/gomod.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -214,17 +181,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml",
-            "internal/engine/rules/kotlin/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml","internal/engine/rules/kotlin/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -251,16 +213,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -273,16 +231,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/just/just.go"
-          ],
+          "cites": ["internal/extractors/just/just.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/just/just.go"
-          ],
+          "cites": ["internal/extractors/just/just.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -326,9 +280,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -341,16 +293,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -377,16 +325,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -399,16 +343,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -421,16 +361,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -471,16 +407,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -493,16 +425,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -515,16 +443,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -537,16 +461,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -562,9 +482,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -591,16 +509,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/scala/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/scala/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -613,16 +527,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -663,16 +573,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -688,9 +594,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -706,9 +610,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -721,16 +623,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -743,16 +641,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -765,16 +659,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -787,16 +677,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/buildkite.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/buildkite.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -809,16 +695,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/circleci.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/circleci.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -845,17 +727,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/github_actions.yaml",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/github_actions.yaml","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -868,16 +745,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -893,9 +766,7 @@
         },
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/cicd/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -908,16 +779,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/travis_ci.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/travis_ci.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -930,9 +797,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -941,20 +806,16 @@
       "id": "config.dotenv",
       "category": "platform",
       "language": "multi",
-      "label": ".env (names-only \u2014 values stripped at extraction boundary)",
+      "label": ".env (names-only — values stripped at extraction boundary)",
       "capabilities": {
         "env_resolution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -967,9 +828,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -982,9 +841,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -997,9 +854,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1023,9 +878,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1038,10 +891,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go",
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go","internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1054,9 +904,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1069,10 +917,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1113,16 +958,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1135,16 +976,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1157,16 +994,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1179,17 +1012,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/database_index/language.yaml",
-            "internal/extractors/sql"
-          ],
+          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1216,17 +1044,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/database_index/language.yaml",
-            "internal/extractors/sql"
-          ],
+          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1239,16 +1062,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1275,16 +1094,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/sql"
-          ],
+          "cites": ["internal/extractors/sql"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1297,17 +1112,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/docker/frameworks/docker_compose.yaml",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/engine/rules/docker/frameworks/docker_compose.yaml","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1320,17 +1130,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/docker/frameworks/dockerfile.yaml",
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/engine/rules/docker/frameworks/dockerfile.yaml","internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1343,16 +1148,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1365,17 +1166,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1402,16 +1198,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ansible/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ansible/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1438,16 +1230,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/cdk/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/cdk/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1460,16 +1248,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1482,16 +1266,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/pulumi/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/pulumi/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1504,16 +1284,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/serverless_edges.go"
-          ],
+          "cites": ["internal/engine/serverless_edges.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/serverless_edges.go"
-          ],
+          "cites": ["internal/engine/serverless_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1526,16 +1302,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl"
-          ],
+          "cites": ["internal/extractors/hcl"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl"
-          ],
+          "cites": ["internal/extractors/hcl"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1616,9 +1388,7 @@
       "capabilities": {
         "log_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/_engine/logging_config_extractor.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/logging_config_extractor.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1651,17 +1421,12 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/event_flow.go",
-            "internal/engine/process_flow.go"
-          ],
+          "cites": ["internal/engine/event_flow.go","internal/engine/process_flow.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1677,9 +1442,7 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/_engine/comment_marker_extractor.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml"],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
@@ -1712,9 +1475,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/extractor.go"
-          ],
+          "cites": ["internal/extractors/hcl/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1727,9 +1488,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/workflow_edges.go"
-          ],
+          "cites": ["internal/engine/workflow_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1753,9 +1512,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1768,9 +1525,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/extractor.go"
-          ],
+          "cites": ["internal/extractors/hcl/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1783,17 +1538,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/relationships.go"
-          ],
+          "cites": ["internal/extractors/hcl/relationships.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/extractor.go",
-            "internal/extractors/hcl/relationships.go"
-          ],
+          "cites": ["internal/extractors/hcl/extractor.go","internal/extractors/hcl/relationships.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1812,9 +1562,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/cassandra_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1833,9 +1581,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1854,9 +1600,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1875,9 +1619,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/mongodb_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1896,9 +1638,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/mysql_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1917,9 +1657,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1938,9 +1676,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/npgsql.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1959,9 +1695,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/redis_stackexchange.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1980,9 +1714,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/sqlite_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1998,24 +1730,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/aspnet_core_routes.go",
-            "internal/engine/rules/csharp/frameworks/asp_net_core.yaml"
-          ],
+          "cites": ["internal/engine/aspnet_core_routes.go","internal/engine/rules/csharp/frameworks/asp_net_core.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/aspnet_core_routes.go"
-          ],
+          "cites": ["internal/engine/aspnet_core_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/aspnet_core_routes.go"
-          ],
+          "cites": ["internal/engine/aspnet_core_routes.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2031,16 +1756,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2073,9 +1794,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/blazor_server.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/blazor_server.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2097,9 +1816,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2158,17 +1875,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/grpc_edges.go",
-            "internal/engine/rules/csharp/frameworks/grpc_net.yaml"
-          ],
+          "cites": ["internal/engine/grpc_edges.go","internal/engine/rules/csharp/frameworks/grpc_net.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/grpc_net.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/grpc_net.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2210,9 +1922,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/net_maui.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/net_maui.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2254,9 +1964,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/uno_platform.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/uno_platform.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2278,9 +1986,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/winforms.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/winforms.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2302,9 +2008,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/wpf.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/wpf.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2326,9 +2030,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/xamarin.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/xamarin.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2347,16 +2049,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/dapper.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/dapper.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2372,17 +2070,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/entity_framework_core.yaml",
-            "internal/engine/rules/csharp/orms/entity_framework_core.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/entity_framework_core.yaml","internal/engine/rules/csharp/orms/entity_framework_core.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2398,16 +2091,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2440,16 +2129,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/nhibernate.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/nhibernate.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2468,9 +2153,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2489,9 +2172,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2510,9 +2191,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2531,9 +2210,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/myxql.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/myxql.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2552,9 +2229,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2573,9 +2248,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/postgrex.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/postgrex.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2594,9 +2267,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/redix.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/redix.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2615,9 +2286,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/xandra.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/xandra.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2633,17 +2302,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/absinthe.yaml",
-            "internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml","internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/absinthe.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2662,16 +2326,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2733,9 +2393,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/nerves.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/nerves.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2757,9 +2415,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/oban.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/oban.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2778,17 +2434,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/phoenix_routes.go",
-            "internal/engine/rules/elixir/frameworks/phoenix.yaml"
-          ],
+          "cites": ["internal/engine/phoenix_routes.go","internal/engine/rules/elixir/frameworks/phoenix.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/phoenix_routes.go"
-          ],
+          "cites": ["internal/engine/phoenix_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2807,16 +2458,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2855,16 +2502,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2880,16 +2523,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2908,9 +2547,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/cassandra_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/cassandra_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2929,9 +2566,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/dynamodb_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/dynamodb_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2950,9 +2585,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/elasticsearch_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/elasticsearch_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2971,9 +2604,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/mongo_driver.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/mongo_driver.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -2992,9 +2623,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/mysql_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/mysql_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3013,9 +2642,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3034,9 +2661,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/go_redis.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/go_redis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3055,9 +2680,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlite_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlite_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3073,16 +2696,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/frameworks/beego.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/frameworks/beego.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3101,16 +2720,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/buffalo.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/buffalo.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3129,17 +2744,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go",
-            "internal/engine/rules/go/frameworks/chi.yaml"
-          ],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/chi.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go"
-          ],
+          "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3158,17 +2768,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go",
-            "internal/engine/rules/go/frameworks/echo.yaml"
-          ],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/echo.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go"
-          ],
+          "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3187,16 +2792,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/fasthttp.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/fasthttp.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3215,17 +2816,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go",
-            "internal/engine/rules/go/frameworks/fiber.yaml"
-          ],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/fiber.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go"
-          ],
+          "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3247,9 +2843,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/fyne.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/fyne.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3268,17 +2862,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go",
-            "internal/engine/rules/go/frameworks/gin.yaml"
-          ],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gin.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go"
-          ],
+          "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3297,16 +2886,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/go_zero.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/go_zero.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3328,9 +2913,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/gomobile.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/gomobile.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3349,17 +2932,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go",
-            "internal/engine/rules/go/frameworks/gorilla_mux.yaml"
-          ],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gorilla_mux.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go"
-          ],
+          "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3378,16 +2956,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/hertz.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/hertz.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3406,16 +2980,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_go_trio.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_go_trio.go"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_go_trio.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_go_trio.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3434,16 +3004,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/iris.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/iris.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3462,16 +3028,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/kratos.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/kratos.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3490,17 +3052,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go",
-            "internal/engine/rules/go/frameworks/net_http_stdlib.yaml"
-          ],
+          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/net_http_stdlib.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/go_routes.go"
-          ],
+          "cites": ["internal/engine/go_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3519,16 +3076,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/revel.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/frameworks/revel.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3547,16 +3100,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/bun.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/bun.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3572,16 +3121,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/orms/ent.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/ent.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3614,18 +3159,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/go/frameworks/gorm.yaml",
-            "internal/engine/rules/go/orms/gorm.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/go/frameworks/gorm.yaml","internal/engine/rules/go/orms/gorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3638,9 +3177,7 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/golang_migrate.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/golang_migrate.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -3665,9 +3202,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/pgx.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/pgx.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3680,23 +3215,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlc.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlc.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlc.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3712,16 +3241,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3777,10 +3302,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/android_jetpack_compose.yaml",
-            "internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/android_jetpack_compose.yaml","internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3802,9 +3324,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/android_sdk.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/android_sdk.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3823,17 +3343,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_annotation_routes.go",
-            "internal/engine/rules/java/frameworks/dropwizard.yaml"
-          ],
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/dropwizard.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_annotation_routes.go"
-          ],
+          "cites": ["internal/engine/java_annotation_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3852,16 +3367,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3900,16 +3411,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3945,24 +3452,17 @@
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_annotation_routes.go",
-            "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
-          ],
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_annotation_routes.go"
-          ],
+          "cites": ["internal/engine/java_annotation_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3984,9 +3484,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/langchain4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/langchain4j.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -4002,24 +3500,17 @@
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_annotation_routes.go",
-            "internal/engine/rules/java/frameworks/micronaut.yaml"
-          ],
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/micronaut.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_annotation_routes.go"
-          ],
+          "cites": ["internal/engine/java_annotation_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -4038,16 +3529,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/microprofile.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/microprofile.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -4066,16 +3553,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/play_framework.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/play_framework.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/play_framework.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/play_framework.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -4091,24 +3574,17 @@
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_annotation_routes.go",
-            "internal/engine/rules/java/frameworks/quarkus.yaml"
-          ],
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/quarkus.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_annotation_routes.go"
-          ],
+          "cites": ["internal/engine/java_annotation_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -4124,34 +3600,22 @@
       "capabilities": {
         "auth_coverage": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_synthesis.go",
-            "internal/engine/rules/java/frameworks/spring_boot.yaml",
-            "internal/engine/rules/java/frameworks/spring_mvc.yaml",
-            "internal/engine/spring_routes.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/java/frameworks/spring_boot.yaml","internal/engine/rules/java/frameworks/spring_mvc.yaml","internal/engine/spring_routes.go"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_annotation_routes.go",
-            "internal/engine/spring_routes.go"
-          ],
+          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/spring_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_annotation_params.go"
-          ],
+          "cites": ["internal/engine/java_annotation_params.go"],
           "verified_at": "2026-05-28"
         }
       },
@@ -4180,24 +3644,17 @@
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/frameworks/spring_webflux.yaml",
-            "internal/engine/spring_routes.go"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/spring_webflux.yaml","internal/engine/spring_routes.go"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/spring_routes.go"
-          ],
+          "cites": ["internal/engine/spring_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -4216,16 +3673,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/apache_struts.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/apache_struts.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -4244,16 +3697,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/vaadin.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/vaadin.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/vaadin.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/vaadin.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -4272,16 +3721,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/vert_x.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/frameworks/vert_x.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -4300,16 +3745,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/dynamodb_java.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/dynamodb_java.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4359,17 +3800,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/java/orms/hibernate_core.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/hibernate_core.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4385,16 +3821,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/jooq.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/jooq.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4410,16 +3842,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4435,16 +3863,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/mybatis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/mybatis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4460,16 +3884,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4485,16 +3905,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4510,16 +3926,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4535,17 +3947,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/java/orms/spring_data_jpa.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/spring_data_jpa.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4561,16 +3968,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4586,16 +3989,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_redis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_redis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4614,9 +4013,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4635,9 +4032,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4656,9 +4051,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4677,9 +4070,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4698,9 +4089,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4719,9 +4108,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4740,9 +4127,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4761,9 +4146,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/redis_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/redis_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4782,9 +4165,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4803,9 +4184,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4848,6 +4227,14 @@
           "component_extraction": {
             "status": "missing"
           },
+          "context_extraction": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
           "hook_recognition": {
             "status": "not_applicable"
           },
@@ -4856,6 +4243,10 @@
           }
         },
         "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
           "data_fetching": {
             "status": "missing"
           },
@@ -4869,6 +4260,36 @@
         "Navigation": {
           "router_pattern": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       },
@@ -4924,9 +4345,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/astro.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -4936,6 +4355,36 @@
         "Build": {
           "static_generation": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4954,9 +4403,7 @@
           },
           "main_renderer_split": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/electron.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/electron.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -4975,6 +4422,18 @@
       "language": "jsts",
       "label": "Expo",
       "capabilities": {
+        "Structure": {
+          "context_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
         "Navigation": {
           "deep_link_extraction": {
             "status": "missing",
@@ -4982,25 +4441,19 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -5012,12 +4465,46 @@
           }
         },
         "Data Flow": {
+          "branch_conditions": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "verified_at": "2026-05-28"
+          },
           "state_management": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5034,9 +4521,7 @@
           },
           "expo_router_specifics": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/navigation.go"
-            ],
+            "cites": ["internal/extractors/javascript/navigation.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5052,17 +4537,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/express.yaml",
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5074,9 +4554,7 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5092,16 +4570,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5175,9 +4649,7 @@
         "Routing": {
           "route_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -5188,6 +4660,36 @@
         "Build": {
           "static_generation": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5202,17 +4704,12 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/graphql/frameworks/apollo_server.yaml",
-              "internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"
-            ],
+            "cites": ["internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
-            ],
+            "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5261,16 +4758,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5293,6 +4786,16 @@
       "language": "jsts",
       "label": "Ionic",
       "capabilities": {
+        "Structure": {
+          "context_extraction": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
         "Navigation": {
           "deep_link_extraction": {
             "status": "missing"
@@ -5315,8 +4818,42 @@
           }
         },
         "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
           "state_management": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5331,16 +4868,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5366,9 +4899,7 @@
         "Prompts": {
           "prompt_template_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -5376,9 +4907,7 @@
         "Composition": {
           "chain_composition": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -5423,6 +4952,16 @@
       "language": "jsts",
       "label": "NativeScript",
       "capabilities": {
+        "Structure": {
+          "context_extraction": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
         "Navigation": {
           "deep_link_extraction": {
             "status": "missing"
@@ -5445,8 +4984,42 @@
           }
         },
         "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
           "state_management": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5461,34 +5034,26 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5530,16 +5095,12 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5547,6 +5108,36 @@
           "static_generation": {
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       },
@@ -5594,9 +5185,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -5606,6 +5195,36 @@
         "Build": {
           "static_generation": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5647,51 +5266,53 @@
         "Structure": {
           "component_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react.yaml"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "verified_at": "2026-05-28"
+          },
+          "context_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "hook_recognition": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react.yaml"
-            ],
+            "cites": ["internal/extractors/javascript/destructure_bindings.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "jsx_template": {
-            "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react.yaml"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
+          "branch_conditions": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "verified_at": "2026-05-28"
+          },
           "data_fetching": {
-            "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react.yaml"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2554",
+            "status": "full",
+            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "prop_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react.yaml"
-            ],
+            "cites": ["internal/extractors/javascript/navigation.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2665",
+            "notes": "Covers only JSX navigation props (Link to/href, Navigate to, state object); generic React component prop extraction is not yet implemented.",
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react.yaml"
-            ],
+            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/zustand_store.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -5699,9 +5320,38 @@
         "Navigation": {
           "router_pattern": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react.yaml"
-            ],
+            "cites": ["internal/extractors/javascript/navigation.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5714,6 +5364,18 @@
       "language": "jsts",
       "label": "React Native",
       "capabilities": {
+        "Structure": {
+          "context_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
         "Navigation": {
           "deep_link_extraction": {
             "status": "missing",
@@ -5721,25 +5383,19 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -5751,12 +5407,46 @@
           }
         },
         "Data Flow": {
+          "branch_conditions": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "verified_at": "2026-05-28"
+          },
           "state_management": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5805,9 +5495,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/remix.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -5817,6 +5505,36 @@
         "Build": {
           "static_generation": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5886,6 +5604,14 @@
           "component_extraction": {
             "status": "missing"
           },
+          "context_extraction": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
           "hook_recognition": {
             "status": "not_applicable"
           },
@@ -5894,6 +5620,10 @@
           }
         },
         "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
           "data_fetching": {
             "status": "missing"
           },
@@ -5907,6 +5637,36 @@
         "Navigation": {
           "router_pattern": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       },
@@ -5954,9 +5714,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -5966,6 +5724,36 @@
         "Build": {
           "static_generation": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5980,17 +5768,12 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_trpc.go",
-              "internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/http_endpoint_trpc.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_trpc.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -6014,6 +5797,14 @@
           "component_extraction": {
             "status": "missing"
           },
+          "context_extraction": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
           "hook_recognition": {
             "status": "missing"
           },
@@ -6022,6 +5813,10 @@
           }
         },
         "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          },
           "data_fetching": {
             "status": "missing"
           },
@@ -6035,6 +5830,36 @@
         "Navigation": {
           "router_pattern": {
             "status": "missing"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/tests.go"],
+            "verified_at": "2026-05-28"
           }
         }
       },
@@ -6066,16 +5891,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/drizzle.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/drizzle.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6094,9 +5915,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/knex.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/knex.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6112,16 +5931,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6137,16 +5952,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mongoose.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mongoose.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6176,25 +5987,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/prisma/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/prisma/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/prisma.yaml",
-            "internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml",
-            "internal/engine/rules/prisma/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/prisma.yaml","internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml","internal/engine/rules/prisma/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6210,16 +6013,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/sequelize.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/sequelize.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6235,16 +6034,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/typeorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/typeorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6263,9 +6058,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6287,9 +6080,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6311,9 +6102,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/compose_desktop.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/compose_desktop.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6335,9 +6124,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/compose_multiplatform.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/compose_multiplatform.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6359,9 +6146,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6380,16 +6165,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/http4k.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/http4k.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6431,10 +6212,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/kmp.yaml",
-            "internal/engine/rules/kotlin/frameworks/kotlin_multiplatform_kmp_kmm.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/kmp.yaml","internal/engine/rules/kotlin/frameworks/kotlin_multiplatform_kmp_kmm.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6453,16 +6231,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/ktor.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/ktor.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6481,16 +6255,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6509,16 +6279,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6534,24 +6300,17 @@
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml",
-            "internal/engine/spring_routes_kotlin.go"
-          ],
+          "cites": ["internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml","internal/engine/spring_routes_kotlin.go"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/spring_routes_kotlin.go"
-          ],
+          "cites": ["internal/engine/spring_routes_kotlin.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6570,16 +6329,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/exposed.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/exposed.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6595,16 +6350,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6620,16 +6371,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/ktorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/ktorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6645,16 +6392,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6670,16 +6413,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/room_android.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/room_android.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6695,16 +6434,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6720,16 +6455,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6770,9 +6501,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/cassandra_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/cassandra_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6791,9 +6520,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/dynamodb_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/dynamodb_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6812,9 +6539,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/elasticsearch_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/elasticsearch_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6833,9 +6558,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/mongodb_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/mongodb_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6854,9 +6577,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/mysql_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/mysql_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6875,9 +6596,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6896,9 +6615,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/postgresql_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/postgresql_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6917,9 +6634,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/redis_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/redis_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6938,9 +6653,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/sqlite_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/sqlite_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6956,16 +6669,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/cakephp.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/cakephp.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6984,16 +6693,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/codeigniter.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/codeigniter.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7012,16 +6717,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/drupal.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/drupal.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7040,16 +6741,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/laminas.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/laminas.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7068,17 +6765,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_php_producer.go",
-            "internal/engine/rules/php/frameworks/laravel.yaml"
-          ],
+          "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/laravel.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_php_producer.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_php_producer.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7117,16 +6809,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/magento.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/magento.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7165,16 +6853,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/frameworks/slim.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/frameworks/slim.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7193,17 +6877,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_php_producer.go",
-            "internal/engine/rules/php/frameworks/symfony.yaml"
-          ],
+          "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/symfony.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_php_producer.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_php_producer.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7222,16 +6901,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/wordpress.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/wordpress.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7250,16 +6925,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/yii.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/frameworks/yii.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7295,16 +6966,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/orms/doctrine_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/doctrine_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7320,16 +6987,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7345,16 +7008,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/propel.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/propel.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7370,16 +7029,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/redbeanphp.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/redbeanphp.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7398,9 +7053,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/cassandra_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/cassandra_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7419,9 +7072,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/dynamodb_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/dynamodb_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7440,9 +7091,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/elasticsearch_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/elasticsearch_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7461,10 +7110,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/mysql_py.yaml",
-            "internal/extractors/python/raw_sql_db_calls.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7483,9 +7129,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7504,10 +7148,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/postgresql_py.yaml",
-            "internal/extractors/python/raw_sql_db_calls.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7526,9 +7167,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/redis_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/redis_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7547,10 +7186,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/sqlite_py.yaml",
-            "internal/extractors/python/raw_sql_db_calls.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7566,16 +7202,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/aiohttp.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/aiohttp.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7594,16 +7226,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/bottle.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/bottle.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7625,10 +7253,7 @@
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/celery.yaml",
-            "internal/extractors/python/celery.go"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/celery.yaml","internal/extractors/python/celery.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7664,33 +7289,22 @@
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/django_drf_actions.go"
-          ],
+          "cites": ["internal/engine/django_drf_actions.go"],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_routes.go",
-            "internal/engine/django_urlconf_nested.go",
-            "internal/engine/rules/python/frameworks/django.yaml"
-          ],
+          "cites": ["internal/engine/django_routes.go","internal/engine/django_urlconf_nested.go","internal/engine/rules/python/frameworks/django.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_admin_routes.go",
-            "internal/engine/django_routes.go"
-          ],
+          "cites": ["internal/engine/django_admin_routes.go","internal/engine/django_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/django_imports_rewrite.go"
-          ],
+          "cites": ["internal/engine/django_imports_rewrite.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7703,25 +7317,17 @@
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/django_drf_actions.go"
-          ],
+          "cites": ["internal/engine/django_drf_actions.go"],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_drf_actions.go",
-            "internal/extractors/python/django_drf_actions.go"
-          ],
+          "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/django_drf_actions.go"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_drf_actions.go",
-            "internal/extractors/python/drf_serializer_fields.go"
-          ],
+          "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/drf_serializer_fields.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7736,9 +7342,7 @@
           },
           "signal_handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/django_signal_pubsub_edges.go"
-            ],
+            "cites": ["internal/engine/django_signal_pubsub_edges.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2739",
             "verified_at": "2026-05-28"
           }
@@ -7759,9 +7363,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/frameworks/dramatiq.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/dramatiq.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7797,24 +7399,17 @@
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/frameworks/fastapi.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_synthesis.go",
-            "internal/engine/rules/python/frameworks/fastapi.yaml"
-          ],
+          "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/fastapi.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/fastapi.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7833,17 +7428,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_synthesis.go",
-            "internal/engine/rules/python/frameworks/flask.yaml"
-          ],
+          "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/flask.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/flask.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/flask.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7885,9 +7475,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/frameworks/langchain.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/langchain.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7906,16 +7494,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/litestar.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/litestar.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7934,16 +7518,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/pyramid.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/pyramid.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7982,16 +7562,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/robyn.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/robyn.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8010,16 +7586,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/sanic.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/sanic.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8038,16 +7610,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/starlette.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/starlette.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8066,17 +7634,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/graphql/frameworks/strawberry_python.yaml",
-            "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
-          ],
+          "cites": ["internal/engine/rules/graphql/frameworks/strawberry_python.yaml","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8095,16 +7658,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/tornado.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/tornado.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8120,9 +7679,7 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/alembic.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -8144,16 +7701,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/beanie.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/beanie.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8166,24 +7719,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/python/django_migration.go"
-          ],
+          "cites": ["internal/extractors/python/django_migration.go"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/orms/django_orm.yaml",
-            "internal/extractors/python/django_relational.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/django_orm.yaml","internal/extractors/python/django_relational.go"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8199,16 +7745,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/mongoengine.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/mongoengine.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8224,16 +7766,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/peewee.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/peewee.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8249,16 +7787,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/pony_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/pony_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8271,24 +7805,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/alembic.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/python/orms/sqlalchemy.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/python/orms/sqlalchemy.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8304,16 +7831,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/orms/sqlmodel.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/sqlmodel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8329,16 +7852,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/orms/tortoise_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/tortoise_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8357,9 +7876,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/cassandra_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/cassandra_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8378,9 +7895,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8399,9 +7914,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8420,9 +7933,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/mysql_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/mysql_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8441,9 +7952,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8462,9 +7971,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/pg_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/pg_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8483,9 +7990,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/redis_rb.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/redis_rb.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8504,9 +8009,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/sqlite_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/sqlite_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8545,9 +8048,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/dry_rb.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/dry_rb.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8566,16 +8067,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/grape.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/grape.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8594,16 +8091,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/hanami.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/hanami.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8622,16 +8115,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/padrino.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/padrino.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8650,17 +8139,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_ruby_producer.go",
-            "internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"
-          ],
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_ruby_producer.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8679,16 +8163,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/roda.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/roda.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8707,17 +8187,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_ruby_producer.go",
-            "internal/engine/rules/ruby/frameworks/sinatra.yaml"
-          ],
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/sinatra.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_ruby_producer.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8736,16 +8211,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/orms/activerecord.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/activerecord.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8761,16 +8232,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8786,16 +8253,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/mongoid.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/mongoid.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8811,17 +8274,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml",
-            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml","internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8837,16 +8295,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/sequel.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/sequel.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8865,9 +8319,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/cassandra_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/cassandra_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8886,9 +8338,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/dynamodb_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/dynamodb_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8907,9 +8357,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/elasticsearch_rs.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/elasticsearch_rs.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8928,9 +8376,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/mongodb_mongodb.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/mongodb_mongodb.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8949,9 +8395,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/mysql_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/mysql_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8970,9 +8414,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8991,9 +8433,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/postgresql_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/postgresql_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9012,9 +8452,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/redis_redis_rs.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/redis_redis_rs.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9033,9 +8471,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/sqlite_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/sqlite_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9051,16 +8487,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/actix_web.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/actix_web.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9079,17 +8511,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_axum.go",
-            "internal/engine/rules/rust/frameworks/axum.yaml"
-          ],
+          "cites": ["internal/engine/http_endpoint_axum.go","internal/engine/rules/rust/frameworks/axum.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/http_endpoint_axum.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_axum.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9108,16 +8535,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/gotham.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/gotham.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9136,16 +8559,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/hyper.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/hyper.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9164,16 +8583,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/poem.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/poem.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9192,17 +8607,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rocket_routes.go",
-            "internal/engine/rules/rust/frameworks/rocket.yaml"
-          ],
+          "cites": ["internal/engine/rocket_routes.go","internal/engine/rules/rust/frameworks/rocket.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rocket_routes.go"
-          ],
+          "cites": ["internal/engine/rocket_routes.go"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9244,9 +8654,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/tauri.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/tauri.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9265,16 +8673,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/tide.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/tide.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9313,16 +8717,12 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/warp.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/frameworks/warp.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9341,16 +8741,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/diesel.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/diesel.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9386,9 +8782,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/rusqlite.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/rusqlite.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9404,16 +8798,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/seaorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/seaorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9429,16 +8819,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9454,16 +8840,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9505,9 +8887,7 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/cats_effect.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/cats_effect.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9526,16 +8906,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/finatra.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/finatra.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9554,16 +8930,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/http4s.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/http4s.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9582,16 +8954,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/lagom.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/lagom.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9610,16 +8978,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/play_framework.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/play_framework.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/play_framework.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/play_framework.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9638,16 +9002,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/scalatra.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/scalatra.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9666,16 +9026,12 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/zio.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/frameworks/zio.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9694,16 +9050,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/doobie.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/doobie.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9719,16 +9071,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/elastic4s.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/elastic4s.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9744,16 +9092,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/quill.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/quill.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9769,16 +9113,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9794,16 +9134,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scanamo.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scanamo.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9819,16 +9155,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/slick.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/slick.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9852,23 +9184,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9898,23 +9224,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9927,23 +9247,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/debezium_cdc_edges.go"
-          ],
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/debezium_cdc_edges.go"
-          ],
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/debezium_cdc_edges.go"
-          ],
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9956,23 +9270,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9985,23 +9293,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10014,23 +9316,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10043,24 +9339,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/kafka_edges.go"
-          ],
+          "cites": ["internal/engine/kafka_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/kafka_edges.go",
-            "internal/engine/kafka_wrapper_edges.go"
-          ],
+          "cites": ["internal/engine/kafka_edges.go","internal/engine/kafka_wrapper_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/kafka_edges.go"
-          ],
+          "cites": ["internal/engine/kafka_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10073,23 +9362,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10102,23 +9385,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/nats_edges.go"
-          ],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/nats_edges.go"
-          ],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/nats_edges.go"
-          ],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10131,23 +9408,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pulsar_edges.go"
-          ],
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pulsar_edges.go"
-          ],
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pulsar_edges.go"
-          ],
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10160,23 +9431,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10185,27 +9450,21 @@
       "id": "msg.broker.redis",
       "category": "message_broker",
       "language": "multi",
-      "label": "Redis pub/sub & streams",
+      "label": "Redis pub/sub \u0026 streams",
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10218,23 +9477,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10247,23 +9500,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sqs_edges.go"
-          ],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sqs_edges.go"
-          ],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/sqs_edges.go"
-          ],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10276,23 +9523,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/links/topic_pass.go"
-          ],
+          "cites": ["internal/links/topic_pass.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10305,24 +9546,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go",
-            "internal/extractors/python/celery.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/extractors/python/celery.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/links/topic_pass.go"
-          ],
+          "cites": ["internal/links/topic_pass.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10335,23 +9569,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_signal_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_signal_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/django_signal_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10378,23 +9606,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10435,16 +9657,12 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sse_edges.go"
-          ],
+          "cites": ["internal/engine/sse_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sse_edges.go"
-          ],
+          "cites": ["internal/engine/sse_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
@@ -10460,23 +9678,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/webhooks_edges.go"
-          ],
+          "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/webhooks_edges.go"
-          ],
+          "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/webhooks_edges.go"
-          ],
+          "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10489,23 +9701,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/websocket_edges.go"
-          ],
+          "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/websocket_edges.go"
-          ],
+          "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/websocket_edges.go"
-          ],
+          "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10521,9 +9727,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10567,9 +9771,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10585,9 +9787,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10628,9 +9828,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10657,9 +9855,7 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10675,9 +9871,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10693,9 +9887,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10708,9 +9900,7 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10745,24 +9935,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/http_endpoint_match.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_match.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go",
-            "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go","internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10775,23 +9958,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "full",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10821,23 +9998,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/http_endpoint_match.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_match.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/openapi/language.yaml"
-          ],
+          "cites": ["internal/engine/rules/openapi/language.yaml"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/openapi/language.yaml"
-          ],
+          "cites": ["internal/engine/rules/openapi/language.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10850,24 +10021,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/proto"
-          ],
+          "cites": ["internal/extractors/proto"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/protobuf/_manifest.yaml",
-            "internal/extractors/proto"
-          ],
+          "cites": ["internal/engine/rules/protobuf/_manifest.yaml","internal/extractors/proto"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10893,13 +10057,11 @@
       "id": "security.auth-java",
       "category": "security",
       "language": "java",
-      "label": "Auth policy resolver (Java/Kotlin \u2014 Phase 1 of #1942)",
+      "label": "Auth policy resolver (Java/Kotlin — Phase 1 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -10908,7 +10070,7 @@
       "id": "security.auth-other",
       "category": "security",
       "language": "multi",
-      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET \u2014 Phases 2-4 of #1942)",
+      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "missing",
@@ -10924,9 +10086,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -10945,9 +10105,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -10966,9 +10124,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -10987,9 +10143,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -11025,9 +10179,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -11046,9 +10198,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/_engine/csrf_heuristic_detector.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/csrf_heuristic_detector.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11061,9 +10211,7 @@
       "capabilities": {
         "secret_detection": {
           "status": "full",
-          "cites": [
-            "internal/secrets/secrets.go"
-          ],
+          "cites": ["internal/secrets/secrets.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11076,9 +10224,7 @@
       "capabilities": {
         "sql_injection": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/_engine/sql_injection_detector.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/sql_injection_detector.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11133,17 +10279,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/rust/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11226,17 +10367,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/elixir/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11277,17 +10413,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/go/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11342,17 +10473,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/frameworks/jest.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/jest.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11365,16 +10491,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11387,17 +10509,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/frameworks/junit5.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/junit5.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11410,16 +10527,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11432,16 +10545,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11482,16 +10591,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11518,16 +10623,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11554,17 +10655,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/php/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11605,17 +10701,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/pytest.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/pytest.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11642,17 +10733,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/rspec.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/rspec.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11707,16 +10793,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11732,9 +10814,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11747,16 +10827,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11769,16 +10845,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11791,17 +10863,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -28,7 +28,6 @@ records:
           symbols:
             - file: internal/extractors/javascript/extractor.go
               functions: [extractJSXRendersRelationships]
-            - file: internal/engine/rules/javascript_typescript/frameworks/react.yaml
           issues_implemented: ["2735"]
           verified_at: "2026-05-28"
         hook_recognition:
@@ -36,17 +35,30 @@ records:
           symbols:
             - file: internal/extractors/javascript/destructure_bindings.go
               functions: [isZustandHookName, isReactQueryHook]
-            - file: internal/engine/rules/javascript_typescript/frameworks/react.yaml
           issues_implemented: ["2735"]
           verified_at: "2026-05-28"
         jsx_template:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/javascript/extractor.go
               functions: [extractJSXRendersRelationships]
           tests:
             - file: internal/extractors/javascript/issue610_jsx_renders_test.go
-          issues_implemented: ["2665", "2735"]
+          issues_implemented: ["610", "2665", "2735"]
+          verified_at: "2026-05-28"
+        context_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/extractor.go
+              functions: [isContextFactory]
+          issues_implemented: ["611"]
+          verified_at: "2026-05-28"
+        hoc_wrapper_recognition:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/extractor.go
+              functions: [isFunctionWrapperCall]
+          issues_implemented: []
           verified_at: "2026-05-28"
       Data Flow:
         state_management:
@@ -71,7 +83,7 @@ records:
           issues_implemented: ["2632", "2656", "2661"]
           verified_at: "2026-05-28"
         data_fetching:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/javascript/extractor.go
               functions: [extractReactQueryHookCalls]
@@ -87,6 +99,12 @@ records:
             - file: internal/extractors/javascript/navigation.go
               functions: [jsxNavRouteFromAttrs, extractParamKeys]
           issues_implemented: ["2665"]
+          verified_at: "2026-05-28"
+        branch_conditions:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/discriminator.go
+          issues_implemented: ["2654", "2659", "2666"]
           verified_at: "2026-05-28"
       Navigation:
         router_pattern:
@@ -105,6 +123,42 @@ records:
             - file: internal/extractors/javascript/issue2671_react_router_nav_test.go
             - file: internal/extractors/javascript/issue2665_navigation_params_keys_test.go
           issues_implemented: ["2657", "2658", "2664", "2665", "2671"]
+          verified_at: "2026-05-28"
+      Type System:
+        interface_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/extractor.go
+              functions: [handleInterfaceDeclaration]
+          issues_implemented: ["1343"]
+          verified_at: "2026-05-28"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/extractor.go
+              functions: [handleTypeAliasDeclaration]
+          issues_implemented: ["1343"]
+          verified_at: "2026-05-28"
+        enum_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/extractor.go
+              functions: [handleEnumDeclaration]
+          issues_implemented: ["1343"]
+          verified_at: "2026-05-28"
+      Lifecycle:
+        state_setter_emission:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/extractor.go
+          issues_implemented: ["513"]
+          verified_at: "2026-05-28"
+      Testing:
+        tests_linkage:
+          status: full
+          symbols:
+            - file: internal/extractors/javascript/tests.go
+          issues_implemented: ["1726"]
           verified_at: "2026-05-28"
 
   lang.jsts.framework.react-native:

--- a/tools/coverage/schema.go
+++ b/tools/coverage/schema.go
@@ -143,13 +143,17 @@ type Record struct {
 	FrameworkSpecific map[string]map[string]Capability
 }
 
-// Capability is a single capability cell on a record.
+// Capability is a single capability cell on a record. Notes is an
+// optional free-form scope clarification surfaced on detail pages —
+// used when the capability's slug is broader than what the extractor
+// actually covers (e.g. React's prop_extraction is JSX-navigation only).
 type Capability struct {
 	Status      string   `json:"status"`
 	Cites       []string `json:"cites,omitempty"`
 	VerifiedAt  string   `json:"verified_at,omitempty"`
 	VerifiedSHA string   `json:"verified_sha,omitempty"`
 	Issue       string   `json:"issue,omitempty"`
+	Notes       string   `json:"notes,omitempty"`
 }
 
 // IsGrouped reports whether the record carries grouped capabilities.
@@ -191,11 +195,12 @@ func (r Record) MarshalJSON() ([]byte, error) {
 		VerifiedAt  string   `json:"verified_at,omitempty"`
 		VerifiedSHA string   `json:"verified_sha,omitempty"`
 		Issue       string   `json:"issue,omitempty"`
+		Notes       string   `json:"notes,omitempty"`
 	}
 	toWire := func(c Capability) capWire {
 		return capWire{
 			Status: c.Status, Cites: c.Cites, VerifiedAt: c.VerifiedAt,
-			VerifiedSHA: c.VerifiedSHA, Issue: c.Issue,
+			VerifiedSHA: c.VerifiedSHA, Issue: c.Issue, Notes: c.Notes,
 		}
 	}
 	out := struct {
@@ -439,6 +444,14 @@ var subcategoryCapabilities = map[string]map[string][]string{
 			"data_fetching",
 			"router_pattern",
 			"jsx_template",
+			"context_extraction",
+			"hoc_wrapper_recognition",
+			"branch_conditions",
+			"interface_extraction",
+			"type_alias_extraction",
+			"enum_extraction",
+			"state_setter_emission",
+			"tests_linkage",
 		},
 		"meta_framework": {
 			"server_components",
@@ -449,6 +462,11 @@ var subcategoryCapabilities = map[string]map[string][]string{
 			"component_extraction",
 			"hook_recognition",
 			"router_pattern",
+			"interface_extraction",
+			"type_alias_extraction",
+			"enum_extraction",
+			"state_setter_emission",
+			"tests_linkage",
 		},
 		"mobile": {
 			"navigation_extraction",
@@ -457,6 +475,14 @@ var subcategoryCapabilities = map[string]map[string][]string{
 			"screen_detection",
 			"deep_link_extraction",
 			"state_management",
+			"context_extraction",
+			"hoc_wrapper_recognition",
+			"branch_conditions",
+			"interface_extraction",
+			"type_alias_extraction",
+			"enum_extraction",
+			"state_setter_emission",
+			"tests_linkage",
 		},
 		"desktop": {
 			"ipc_extraction",
@@ -521,19 +547,22 @@ var subcategoryDisplay = map[string]string{
 // and column order in the pivot table both follow this slice.
 var subcategoryGroups = map[string][]capabilityGroup{
 	"ui_frontend": {
-		{Name: "Structure", Keys: []string{"component_extraction", "hook_recognition", "jsx_template"}},
-		{Name: "Data Flow", Keys: []string{"prop_extraction", "state_management", "data_fetching"}},
+		{Name: "Structure", Keys: []string{"component_extraction", "hook_recognition", "jsx_template", "context_extraction", "hoc_wrapper_recognition"}},
+		{Name: "Data Flow", Keys: []string{"prop_extraction", "state_management", "data_fetching", "branch_conditions"}},
 		{Name: "Navigation", Keys: []string{"router_pattern"}},
-		{Name: "Type System", Keys: []string{}},
-		{Name: "Lifecycle", Keys: []string{}},
-		{Name: "Testing", Keys: []string{}},
+		{Name: "Type System", Keys: []string{"interface_extraction", "type_alias_extraction", "enum_extraction"}},
+		{Name: "Lifecycle", Keys: []string{"state_setter_emission"}},
+		{Name: "Testing", Keys: []string{"tests_linkage"}},
 	},
 	"mobile": {
+		{Name: "Structure", Keys: []string{"context_extraction", "hoc_wrapper_recognition"}},
 		{Name: "Navigation", Keys: []string{"navigation_extraction", "deep_link_extraction", "screen_detection"}},
 		{Name: "Platform", Keys: []string{"platform_branching"}},
 		{Name: "Native Bridge", Keys: []string{"native_module_imports"}},
-		{Name: "Data Flow", Keys: []string{"state_management"}},
-		{Name: "Lifecycle", Keys: []string{}},
+		{Name: "Data Flow", Keys: []string{"state_management", "branch_conditions"}},
+		{Name: "Type System", Keys: []string{"interface_extraction", "type_alias_extraction", "enum_extraction"}},
+		{Name: "Lifecycle", Keys: []string{"state_setter_emission"}},
+		{Name: "Testing", Keys: []string{"tests_linkage"}},
 	},
 	"http_backend": {
 		{Name: "Routing", Keys: []string{"endpoint_synthesis", "handler_attribution", "route_extraction"}},
@@ -550,6 +579,9 @@ var subcategoryGroups = map[string][]capabilityGroup{
 		{Name: "Server", Keys: []string{"server_components", "hydration_boundaries"}},
 		{Name: "Routing", Keys: []string{"route_extraction", "router_pattern"}},
 		{Name: "Build", Keys: []string{"static_generation"}},
+		{Name: "Type System", Keys: []string{"interface_extraction", "type_alias_extraction", "enum_extraction"}},
+		{Name: "Lifecycle", Keys: []string{"state_setter_emission"}},
+		{Name: "Testing", Keys: []string{"tests_linkage"}},
 	},
 	"desktop": {
 		{Name: "Process", Keys: []string{"ipc_extraction", "main_renderer_split"}},

--- a/tools/coverage/store.go
+++ b/tools/coverage/store.go
@@ -352,6 +352,7 @@ func writeCapability(buf *bytes.Buffer, indent, key string, cap Capability) erro
 		{"status", cap.Status, true},
 		{"cites", cap.Cites, len(cap.Cites) > 0},
 		{"issue", cap.Issue, cap.Issue != ""},
+		{"notes", cap.Notes, cap.Notes != ""},
 		{"verified_at", cap.VerifiedAt, cap.VerifiedAt != ""},
 		{"verified_sha", cap.VerifiedSHA, cap.VerifiedSHA != ""},
 	}

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -63,13 +63,21 @@ func TestSubcategoryRenderKeysExcludesCategoryUnion(t *testing.T) {
 	// or middleware_coverage leaking into the UI Frontend table.
 	got := subcategoryRenderKeys("http_framework", "ui_frontend")
 	want := []string{
+		"branch_conditions",
 		"component_extraction",
+		"context_extraction",
 		"data_fetching",
+		"enum_extraction",
+		"hoc_wrapper_recognition",
 		"hook_recognition",
+		"interface_extraction",
 		"jsx_template",
 		"prop_extraction",
 		"router_pattern",
 		"state_management",
+		"state_setter_emission",
+		"tests_linkage",
+		"type_alias_extraction",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("render keys = %v, want %v", got, want)
@@ -81,16 +89,24 @@ func TestSubcategoryCapabilityKeysSorted(t *testing.T) {
 	// Must include all ui_frontend keys + category-wide keys, sorted, deduped.
 	want := []string{
 		"auth_coverage",
+		"branch_conditions",
 		"component_extraction",
+		"context_extraction",
 		"data_fetching",
 		"endpoint_synthesis",
+		"enum_extraction",
 		"handler_attribution",
+		"hoc_wrapper_recognition",
 		"hook_recognition",
+		"interface_extraction",
 		"jsx_template",
 		"middleware_coverage",
 		"prop_extraction",
 		"router_pattern",
 		"state_management",
+		"state_setter_emission",
+		"tests_linkage",
+		"type_alias_extraction",
 	}
 	if !reflect.DeepEqual(keys, want) {
 		t.Errorf("subcategoryCapabilityKeys ui_frontend = %v, want %v", keys, want)

--- a/tools/coverage/templates/detail.md.tmpl
+++ b/tools/coverage/templates/detail.md.tmpl
@@ -13,27 +13,27 @@ Auto-generated. Back to [summary](../summary.md).
 
 ### {{.Name}}
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 {{- range .CapList}}
-| `{{.Key}}` | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} |
+| `{{.Key}}` | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
 {{- end}}
 {{- end}}
 {{else}}
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 {{- range .CapList}}
-| `{{.Key}}` | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} |
+| `{{.Key}}` | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
 {{- end}}
 {{end}}
 {{if .FrameworkSpecific}}## Framework-specific
 {{range .FrameworkSpecific}}
 ### {{.Name}}
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 {{- range .CapList}}
-| `{{.Key}}` | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} |
+| `{{.Key}}` | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
 {{- end}}
 {{end}}
 {{end}}## Provenance

--- a/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.express.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.express.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` | — |
 
 ## Provenance
 

--- a/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` | — |
 
 ## Provenance
 

--- a/tools/coverage/testdata/fixture-out/detail/lang.python.framework.django-drf.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.python.framework.django-drf.md
@@ -9,11 +9,11 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-27` | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | `internal/engine/django_drf_actions.go` |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/engine/http_endpoint_synthesis.go` |
-| `handler_attribution` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-27` | — | [link](https://github.com/cajasmota/archigraph/issues/1942) | `internal/engine/django_drf_actions.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/engine/http_endpoint_synthesis.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/django_drf_actions.go` | — |
 
 ## Provenance
 

--- a/tools/coverage/testdata/fixture-out/detail/lang.python.framework.fastapi.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.python.framework.fastapi.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` | — |
 
 ## Provenance
 

--- a/tools/coverage/testdata/fixture-out/detail/lang.python.framework.flask.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.python.framework.flask.md
@@ -9,9 +9,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Capabilities
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites |
-|------------|--------|-------------|--------------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` |
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` | — |
 
 ## Provenance
 


### PR DESCRIPTION
## Summary

Closes #2751.

- **Schema**: extend `ui_frontend` taxonomy in `tools/coverage/schema.go` so Structure/Data Flow gain new keys and the previously-empty Type System / Lifecycle / Testing groups are populated. `mobile` and `meta_framework` get analogous expansions (Structure + Type System + Testing + Lifecycle on top of their existing groups). Capability cells gain an optional `notes` field for scope clarifications.
- **Registry**: React grows from 7 -> 15 cells across 6 groups; React Native grows from 8 -> 14 cells. `jsx_template` and `data_fetching` flip partial -> full, 8 new cells land for React (context/HOC/branch_conditions/interface/type_alias/enum/state_setter/tests_linkage), the stale Python-style `react.yaml` cite is dropped from every React cell, and `prop_extraction` gets a `notes` field clarifying the JSX-navigation-only scope. Vue/Angular/Svelte/Expo/Ionic/NativeScript/Astro/Gatsby/Next.js/Nuxt/Remix/SvelteKit also receive the new schema keys with honest statuses (mostly `missing` for framework-specific gaps; `tests_linkage` and the Type System triple are `full` everywhere because the JS/TS extractor is generic).
- **Capability map**: React entry in `tools/coverage/capability-map.yaml` expanded with symbol/function citations and `issues_implemented` arrays for every new cell.

## Test plan

- [x] `go test ./tools/coverage/` passes (subcategory tests updated to match the new render-key sets; golden fixture regenerated)
- [x] `go run ./tools/coverage validate` exits 0
- [x] `go run ./tools/coverage gen` is deterministic (registry + detail pages MD5-stable across consecutive runs)
- [x] React detail page renders 15 cells across 6 groups (Structure 5, Data Flow 4, Navigation 1, Type System 3, Lifecycle 1, Testing 1)
- [x] React Native detail page renders 14 cells across 7 groups
- [x] `by-category/http_framework.md` UI Frontend table shows the new group-digest columns for every ui_frontend record

🤖 Generated with [Claude Code](https://claude.com/claude-code)