### PR TITLE
docs(agents): coverage matrix update rule + subdirectory AGENTS.md audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,46 @@ and PR wiring it into `internal/mcp/server.go`), not from this file.
 - ADRs in `docs/adrs/`, numbered sequentially
 - Quality fixtures in `internal/quality/golden/`; must hold 100% must-have recall on every PR
 
+## Coverage matrix update — mandatory for capability-changing PRs
+
+When your PR adds, modifies, or fixes a capability that's tracked in the coverage matrix, the PR MUST also update `docs/coverage/registry.json` to reflect the change. The matrix is the source of truth for archigraph's capabilities; PRs that ship code without updating the matrix create drift that erodes the matrix's value.
+
+### When this applies
+- A new framework / ORM / tool / protocol gets extraction support → add a new record OR update an existing one
+- An existing capability's status changes (e.g. partial → full) → update the cell
+- A new capability is implemented that doesn't fit any existing taxonomy slot → propose extending the schema in a separate small PR first, then the implementation PR uses the new key
+- A bug fix that materially changes what a capability does → update the cell's notes + verified_at
+
+### When this does NOT apply
+- Pure refactors that don't change behavior
+- Bug fixes that don't change what we extract (e.g. fixing a panic, not a capability)
+- Docs / test-only changes
+- Tooling changes that don't touch extractors
+
+### How to update
+1. Identify the affected record(s): `go run ./tools/coverage list --json | jq ...`
+2. For each capability changed:
+   - `go run ./tools/coverage update <record-id> --capability <key> --status <s> --cites <paths,...>` (the tool auto-places into the canonical group)
+   - OR edit `docs/coverage/registry.json` directly + run `go run ./tools/coverage validate` to confirm
+3. If the capability is implemented in identifiable functions, update `tools/coverage/capability-map.yaml` with file + functions + issues_implemented
+4. Set `verified_at` to today's date
+5. `go run ./tools/coverage gen` to regenerate `docs/coverage/*.md`
+6. `git add docs/coverage/registry.json docs/coverage/capability-map.yaml docs/coverage/` and commit alongside your code changes
+
+### Enforcement
+- The CI workflow at `.github/workflows/coverage-docs.yml` rejects PRs that change `docs/coverage.json` (or related files) without regenerating docs
+- Reviewers should flag capability-changing PRs that don't touch the registry
+- A future enhancement (#2741 Phase 3) will scan PR body for `implements-capability:` tags and auto-update `verified_at`
+
+### Examples
+- PR adds Rails ORM extraction → updates `lang.ruby.orm.activerecord` record's relevant capability from missing → full
+- PR fixes Django DRF endpoint attribution → updates `lang.python.framework.django-drf` `handler_attribution` cell's verified_at + cites
+- PR ships a new framework synthesizer → may need to add a new record `lang.X.framework.Y` (use `go run ./tools/coverage add`)
+- PR extends the JS extractor with React Context detection → updates `lang.jsts.framework.react` `Structure.context_extraction` cell (which exists thanks to #2751)
+
+### Coverage tool CLI quick-reference
+`go run ./tools/coverage <subcommand>` — supported subcommands: `list`, `get`, `add`, `update`, `gaps`, `stats`, `validate`, `gen`, `discover`, `map-status`. See `tools/coverage/AGENTS.md` for tooling-specific conventions and `docs/coverage/summary.md` for the rendered matrix.
+
 ## Coordinator role
 - Dispatch implementation work to subagents; do not edit code directly when acting as coordinator
 - One PR per scope; small focused changes
@@ -30,6 +70,7 @@ and PR wiring it into `internal/mcp/server.go`), not from this file.
 - Graph format: `internal/graph/fbreader/` + `internal/graph/fbwriter/`
 - Per-framework rule packs: `internal/engine/rules/*.yaml`
 - Quality / orphan audit: `internal/quality/audit/`
+- Capability coverage matrix: `docs/coverage/registry.json` + `docs/coverage/summary.md` (generated); tooling in `tools/coverage/`
 
 ## Tests + gates
 - `go test ./...` is the baseline gate

--- a/internal/engine/AGENTS.md
+++ b/internal/engine/AGENTS.md
@@ -1,0 +1,35 @@
+# Engine passes — agent guide
+
+Cross-cutting and framework-specific passes that synthesise higher-order edges (HTTP endpoints, ORM queries, message topics, process flows) from raw extractor output.
+
+## Conventions
+
+- **Pass naming** is `<framework>_<concern>.go` — for example `phoenix_routes_test.go`, `http_endpoint_csharp_client.go`, `django_model_cross_refs_test.go`. Stay consistent so passes group sensibly in `ls`.
+- **HTTP endpoint resolution is centralised** in `http_endpoint_resolve.go` + `http_endpoint_synthesis.go`. Per-framework passes emit candidate endpoints; the resolver merges, normalises paths (`http_path_normalize.go`), and deduplicates. Do not emit final `http_endpoint` entities from a per-framework pass — feed candidates to the resolver.
+- **Pass signatures are guarded** by `pass_signature_guard_test.go` — keep pass entry points stable.
+- **Declarative framework support** lives under `internal/engine/rules/*.yaml`. Prefer a YAML rule pack over Go code when the framework can be described declaratively (routes, decorators, naming patterns). Reach for Go only for behaviour the rule schema cannot express.
+
+## YAML rule packs
+
+- One directory per framework / concern under `internal/engine/rules/<name>/`.
+- Validated by `internal/engine/rules/_engine/` at load time — broken YAML fails fast.
+- Rule packs are the preferred extension point for new frameworks. Adding a pack does NOT require touching Go in this directory if the existing `_engine` runner handles your patterns.
+
+## Process flows + workflows
+
+- DAG construction: `process_flow_dag.go`
+- Workflow edge synthesis (Temporal / Cadence / Step Functions): `workflow_edges.go`
+- Broker entries (Kafka / SQS / Pub-Sub): see `process_flow_broker_entry_test.go` for invariants.
+
+## Coverage matrix update
+
+When a new framework synthesizer lands — or an existing one materially changes what it emits — update `docs/coverage/registry.json` in the same PR. See the root `AGENTS.md` for the workflow. Typical engine PRs that trigger an update:
+
+- New framework pass (Phoenix routes, Rails controllers, ASP.NET attribute routing, etc.) → add or update the `lang.<lang>.framework.<name>` record with `handler_attribution` / `route_synthesis` cells filled in
+- New broker / topic pass → update the relevant `runtime.messaging.<name>` record
+- HTTP resolver improvements that change cross-language linking → may require updating cites on multiple framework records
+
+## Related
+
+- Per-language extractors that feed these passes: `internal/extractors/AGENTS.md`
+- Cross-repo linker (consumes synthesised endpoints): `internal/links/AGENTS.md`

--- a/internal/extractors/AGENTS.md
+++ b/internal/extractors/AGENTS.md
@@ -1,0 +1,30 @@
+# Language extractors — agent guide
+
+Per-language extractors that lift source into archigraph entities + edges. One sibling directory per language; everything else is shared scaffolding.
+
+## Conventions
+
+- **Directory name = canonical language slug.** Use the short, project-wide slug (e.g. `jsts` for TypeScript/JavaScript, `csharp` for C#, `golang` for Go). Do **not** introduce a new spelling — check existing siblings before naming a new one.
+- **Tree-sitter is the parser.** All extractors go through `github.com/smacker/go-tree-sitter` (see `internal/treesitter/`). Avoid hand-rolled regex parsing.
+- **Entity kinds come from `internal/types/kinds.go`.** Never invent a kind string at the extractor site — if you need a new one, add it to `kinds.go` first.
+- **Resolver slices** live alongside the extractor (class-hierarchy, import-path aliases, framework edges). Cross-cutting engine passes consume the resolver output; do not synthesise HTTP / ORM edges directly inside the extractor.
+
+## Tests
+
+- Golden fixtures: `testdata/` per language; assert deterministic byte-identical output.
+- Cross-language invariants (orphans, hierarchy soundness) run in `internal/quality/`. Bug-rate parity gate applies to every PR.
+
+## Coverage matrix update
+
+If your change adds or modifies extraction for a framework / ORM / protocol tracked in the matrix, you **must** update `docs/coverage/registry.json` in the same PR. See the root `AGENTS.md` "Coverage matrix update" section for the canonical workflow — do not duplicate it here.
+
+Typical extractor PRs that trigger an update:
+- New framework support (e.g. add a `lang.<lang>.framework.<name>` record)
+- New ORM detection (`lang.<lang>.orm.<name>`)
+- Materially improved capability (missing → partial → full) — bump `verified_at` + add cites pointing at the new code paths
+
+## Related
+
+- Cross-cutting passes that consume extractor output: `internal/engine/AGENTS.md`
+- Cross-repo + cross-language linkers: `internal/links/AGENTS.md`
+- Custom extractor wiring: `internal/extractors/custom_registry.go` (see #1086)

--- a/internal/links/AGENTS.md
+++ b/internal/links/AGENTS.md
@@ -1,0 +1,28 @@
+# Cross-repo + cross-language linkers — agent guide
+
+The linker layer turns synthesised endpoints, topics, and gRPC services into cross-repo / cross-language edges. Each strategy is an independent pass over candidate pairs with a confidence score.
+
+## Conventions
+
+- **One pass per transport.** `http_pass.go`, `grpc_pass.go`, `topic_pass.go`, `openapi_pass.go`, `import_pass.go`, `sameas_pass.go`, `label_pass.go`, `string_pass.go`. Keep new strategies in their own file with a focused `_test.go`.
+- **Candidates → confidence → resolution.** `candidates.go` builds pair sets; `confidence.go` scores them; the pass emits edges only above the confidence threshold. Don't bypass the scoring layer.
+- **Phantom edges** (`phantom_edges.go`) flag dangling references when no producer/consumer match is found. Use them rather than silently dropping unresolved links.
+- **Telemetry.** Passes record per-strategy hit counts; the `live_fixture_test.go` + `scale_stress_test.go` gates assert no regression. New strategies should add their counter to telemetry.
+
+## When to add a new resolve strategy
+
+- A new transport / protocol that doesn't fit `http`, `grpc`, `topic`, `openapi`, `import`, `sameas`, `label`, `string`.
+- A materially different matching heuristic (e.g. URL templates, OpenAPI `operationId`, content-type negotiation). Prefer extending an existing pass via a sub-strategy if the transport is the same.
+
+## Coverage matrix update
+
+A new resolve strategy often expands what the matrix can claim about a framework. After landing, check whether any `lang.<lang>.framework.<name>` or `runtime.<...>` records gain cites — if so, update `docs/coverage/registry.json` per the root `AGENTS.md` "Coverage matrix update" workflow.
+
+Examples:
+- A new gRPC bidi-stream resolver may upgrade `runtime.realtime.grpc` from partial → full.
+- An OpenAPI-driven cross-repo linker may add cites to many framework records simultaneously.
+
+## Related
+
+- Producers of the entities linked here: `internal/engine/AGENTS.md`
+- Per-language candidate emitters: `internal/extractors/AGENTS.md`

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,0 +1,35 @@
+# Skills — agent guide
+
+Each skill is a focused, independently-invokable capability published to agent hosts as `/skill-name`. Skills are markdown-first; the runtime reads `SKILL.md` and any per-pass prompts under `prompts/`.
+
+## File conventions
+
+- One directory per skill: `skills/<skill-name>/`
+- Required: `SKILL.md` with YAML frontmatter (`name`, `description`, optional `args`)
+- Optional siblings:
+  - `prompts/` — per-pass prompt fragments referenced from `SKILL.md`
+  - `templates/` — output templates the skill fills in
+  - `conventions/` — shared rules referenced from multiple passes
+  - `examples/` — worked examples shown to the user
+  - `snippets/` — reusable prose fragments
+  - `output-templates/` — final emitted artefacts
+
+## Naming
+
+- Use the `archigraph-<concern>` prefix for skills that operate on an archigraph-indexed group (e.g. `archigraph-tech-docs`, `archigraph-security-audit`).
+- Skills that are agent-host utilities (not archigraph-specific) drop the prefix (e.g. `extend-convention`, `using-archigraph`).
+- The skill ID must match the directory name and the frontmatter `name`.
+
+## Installation
+
+Skills are picked up from `skills/<name>/SKILL.md` by the agent host. There is no separate install step in this repo — landing a new directory ships the skill.
+
+## When to update vs create
+
+- **Update an existing skill** if the new behaviour fits the skill's stated scope (check the frontmatter `description`). Most additions should be updates.
+- **Create a new skill** only when the concern is genuinely separable — a new skill earns its keep if it can be invoked without the others.
+- The skill chain in `skills/README.md` shows the canonical execution order; new skills must declare where they slot in.
+
+## Coverage matrix update
+
+Skill changes typically do not touch the capability matrix — skills are agent-facing tooling, not extraction code. If a skill change exposes a new archigraph CLI verb or MCP tool that materially changes capability surface, follow the root `AGENTS.md` "Coverage matrix update" workflow.

--- a/tools/coverage/AGENTS.md
+++ b/tools/coverage/AGENTS.md
@@ -1,0 +1,40 @@
+# Coverage tooling — agent guide
+
+The `coverage` command maintains the archigraph capabilities registry at `docs/coverage/registry.json` and regenerates the per-language / per-category markdown views. It is the source of truth for "what does archigraph extract today?"
+
+## Hard rules
+
+- **Standalone dev tool.** No imports from `internal/*` are allowed — pure file I/O + YAML/JSON. This keeps the tool buildable independent of the indexer and lets it run from any worktree without a daemon.
+- **Determinism.** Every `gen` invocation must produce byte-identical output for the same input. The pre-commit gen workflow + CI (`.github/workflows/coverage-docs.yml`) compare regenerated docs against the committed copy.
+- **Schema is data-driven.** The capability taxonomy lives in `capability-dictionary.yaml` (post-#2752). Do not hardcode capability keys in Go; load them from the dictionary.
+
+## Files
+
+- `main.go` — CLI dispatcher; subcommands: `list`, `get`, `add`, `update`, `gaps`, `stats`, `validate`, `gen`, `discover`, `map-status`
+- `schema.go` — registry + record shape
+- `store.go` — load / save / canonical ordering of `registry.json`
+- `validate.go` — schema invariants (referential integrity, status enum, dictionary key conformance)
+- `capability_map.go` + `capability-map.yaml` — capability → file/function mapping for traceability
+- `validate_map.go` — verifies `capability-map.yaml` references real files
+- `generate.go` + `templates/` — markdown rendering of `docs/coverage/{summary.md,by-language/,by-category/,detail/}`
+- `discover.go` / `map_status.go` — bootstrap helpers
+- `buckets.go` / `languages.go` / `views.go` — projection helpers used by templates
+
+## Extending the schema
+
+Because the taxonomy is data-driven:
+
+1. Open `capability-dictionary.yaml` and add the new capability key under the right group, with description + status enum if non-default.
+2. Run `go run ./tools/coverage validate` — it will fail on any record that doesn't yet have a value for the new key (defaulting to `missing` is fine, but it must be explicit if the dictionary marks it required).
+3. Update existing records in `docs/coverage/registry.json` via `go run ./tools/coverage update ...` rather than editing JSON by hand when possible — the tool guarantees canonical placement.
+4. Regenerate: `go run ./tools/coverage gen`.
+5. Commit the dictionary + registry + regenerated docs together. Splitting them across PRs breaks the CI gate.
+
+## Templates
+
+- Templates live in `templates/` and use Go's `text/template`.
+- Keep them deterministic: sort every map / slice before iterating. The `gen_test.go` snapshot test will catch nondeterministic ordering.
+
+## Coverage matrix update rule
+
+The root `AGENTS.md` "Coverage matrix update" section is **the** rule for capability-changing PRs across the repo. Tooling changes inside this directory generally do NOT require a matrix update unless they alter the schema (in which case the schema PR + record migration must ship together).


### PR DESCRIPTION
## Summary
- Adds a mandatory "Coverage matrix update" rule to the root `AGENTS.md` so capability-changing PRs must refresh `docs/coverage/registry.json` (and the capability map) in the same PR. Includes the when/when-not split, the step-by-step workflow, enforcement notes, and concrete examples.
- Cross-references the new coverage CLI (`go run ./tools/coverage <subcommand>`) and the rendered matrix in `docs/coverage/summary.md` from the root "Where things live" section.
- Seeds focused `AGENTS.md` files in the subdirectories where conventions are non-obvious and the coverage rule has direct touch-points:
  - `internal/extractors/AGENTS.md` — naming slug, tree-sitter discipline, kind contract, resolver slices
  - `internal/engine/AGENTS.md` — pass naming, HTTP resolver centralisation, YAML rule packs
  - `internal/links/AGENTS.md` — one pass per transport, confidence pipeline, phantom edges
  - `tools/coverage/AGENTS.md` — no `internal/*` imports, determinism, data-driven schema, how to extend
  - `skills/AGENTS.md` — file conventions, naming, update-vs-create
- Each subdirectory file cross-references the root rule rather than duplicating it.

## Coordination
- This PR only touches `AGENTS.md` files. It does NOT touch `tools/coverage/*.go`, the schema, templates, `docs/coverage/`, `registry.json`, or `capability-map.yaml` — those are owned by the parallel #2752 work.
- Skipped creating `AGENTS.md` in `docs/coverage/` to avoid colliding with the parallel agent's generated output (the root + tooling files already cover the "do not edit generated docs" warning).
- Skipped creating `AGENTS.md` in directories where it would add no convention-specific value (e.g. `internal/types/`, `internal/store/`, `internal/registry/`, `internal/version/`).

## Test plan
- [ ] Render `AGENTS.md` and each new subdirectory `AGENTS.md` in GitHub markdown preview — no broken links / formatting glitches
- [ ] Confirm cited paths exist: `docs/coverage/registry.json`, `docs/coverage/summary.md`, `tools/coverage/capability-map.yaml`, `.github/workflows/coverage-docs.yml`, `internal/types/kinds.go`, `internal/engine/rules/`, `internal/engine/http_endpoint_resolve.go`
- [ ] Verify subdirectory files do not duplicate the root coverage-update rule; they only link back to it