### PR TITLE
feat(tools/coverage): capability dictionary — move taxonomy from Go to YAML (#2752)

### DIFF
--- a/tools/coverage/buckets.go
+++ b/tools/coverage/buckets.go
@@ -4,8 +4,8 @@ import "sort"
 
 // Bucket names. The four buckets group categories into the four
 // rendering lanes used by summary.md and the per-language pages
-// (issue #2725). The order here is the canonical render order:
-// Frameworks → Tools → ORMs → Other.
+// (issue #2725). Bucket → category membership and render order are
+// declared in capability-dictionary.yaml (#2752).
 const (
 	BucketFrameworks = "Frameworks"
 	BucketTools      = "Tools"
@@ -13,48 +13,25 @@ const (
 	BucketOther      = "Other"
 )
 
-// bucketOrder is the fixed display order for the four buckets. Used by
-// templates and the summary pivot table.
-var bucketOrder = []string{BucketFrameworks, BucketTools, BucketORMs, BucketOther}
-
-// categoryBucket maps a registry category to its bucket. Anything not
-// listed here falls into BucketOther (this matches the spec's "Other:
-// everything else" rule and means new categories ship as Other until
-// the maintainer classifies them explicitly).
-var categoryBucket = map[string]string{
-	// Frameworks
-	"http_framework": BucketFrameworks,
-	"web_framework":  BucketFrameworks,
-	"nav_framework":  BucketFrameworks,
-	"rpc_framework":  BucketFrameworks,
-	"graphql":        BucketFrameworks,
-
-	// Tools
-	"build_system":    BucketTools,
-	"build_tool":      BucketTools,
-	"package_manager": BucketTools,
-	"manifest":        BucketTools,
-	"linter":          BucketTools,
-	"formatter":       BucketTools,
-
-	// ORMs
-	"orm":            BucketORMs,
-	"query_builder":  BucketORMs,
-	"migration_tool": BucketORMs,
-}
+// bucketOrder snapshots the dictionary's bucket render order at package
+// init so the existing call sites in generate.go can iterate it
+// directly (`for _, b := range bucketOrder`). Going through dict() at
+// init time is safe because the dictionary's embedded fallback is
+// always available — the loader never fails for a well-formed binary.
+var bucketOrder = dict().BucketOrder()
 
 // bucketOf returns the bucket name for category. Unknown categories
-// fall through to BucketOther.
+// fall through to BucketOther (matches the spec's "Other: everything
+// else" rule so new categories ship as Other until they are explicitly
+// classified in the dictionary).
 func bucketOf(category string) string {
-	if b, ok := categoryBucket[category]; ok {
-		return b
-	}
-	return BucketOther
+	return dict().BucketForCategory(category)
 }
 
 // bucketCapabilityKeys returns the capability columns shown in a
-// bucket's per-language table. Derived from categoryCapabilities so
-// any new framework/orm/tool category automatically widens the union.
+// bucket's per-language table. Derived from the dictionary's bucket →
+// categories mapping so any new framework/orm/tool category
+// automatically widens the union.
 //
 // For BucketOther we return nil — the per-language Other section uses
 // a single "Status" digest column rather than per-capability columns.
@@ -63,11 +40,13 @@ func bucketCapabilityKeys(bucket string) []string {
 		return nil
 	}
 	seen := map[string]struct{}{}
-	for cat, b := range categoryBucket {
-		if b != bucket {
-			continue
-		}
-		for _, k := range categoryCapabilities[cat] {
+	d := dict()
+	b, ok := d.Buckets[bucket]
+	if !ok {
+		return nil
+	}
+	for _, cat := range b.Categories {
+		for _, k := range d.CategoryCapabilities(cat) {
 			seen[k] = struct{}{}
 		}
 	}

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -1,0 +1,259 @@
+# Capability dictionary — single source of truth for the coverage tool's
+# taxonomy (#2752). The `gen` and `validate` subcommands read this file
+# at startup; helpers in capability_dictionary.go expose typed queries
+# over it.
+#
+# Adding a new capability:
+#   1. Append it to the `capabilities` list on the appropriate
+#      subcategory (and the keys list of one of that subcategory's
+#      groups, when the subcategory has a group taxonomy).
+#   2. Re-run `go run ./tools/coverage validate` and `gen`.
+#
+# Zero Go code changes are required.
+
+$schema_version: 1
+
+# Buckets group registry categories into the four rendering lanes used
+# by summary.md and the per-language pages. Order governs display order
+# across the registry.
+buckets:
+  Frameworks:
+    order: 1
+    categories: [http_framework, web_framework, nav_framework, rpc_framework, graphql]
+  Tools:
+    order: 2
+    categories: [build_system, build_tool, package_manager, manifest, linter, formatter]
+  ORMs:
+    order: 3
+    categories: [orm, query_builder, migration_tool]
+  Other:
+    order: 4
+    categories: []
+
+# Registry categories. Each category lists its category-wide capability
+# keys (the flat allow-list used for records that opt out of the
+# subcategory refinement). When a category supports subcategories, the
+# `subcategory_order` slice fixes their render order.
+categories:
+  language:
+    capabilities: [call_line_precision, discriminates_on, navigates_to, core_extraction]
+  http_framework:
+    capabilities: [endpoint_synthesis, handler_attribution, auth_coverage, middleware_coverage]
+    subcategory_order: [http_backend, ui_frontend, meta_framework, mobile, desktop, rpc_framework, static_site, ai_integration]
+  orm:
+    capabilities: [model_extraction, query_attribution, migration_parsing]
+  message_broker:
+    capabilities: [producer_extraction, consumer_extraction, topic_attribution]
+  observability:
+    capabilities: [trace_extraction, metric_extraction, log_extraction]
+  build_system:
+    capabilities: [target_extraction, dependency_graph]
+  package_manager:
+    capabilities: [manifest_parsing, lockfile_parsing]
+  databases:
+    capabilities: [resource_extraction, dependency_attribution]
+  platform:
+    capabilities: [resource_extraction, dependency_attribution, file_parsing, env_resolution]
+  security:
+    capabilities: [auth_policy, secret_detection, sql_injection]
+  protocol:
+    capabilities: [service_extraction, method_attribution, cross_repo_linkage]
+  ci_cd:
+    capabilities: [file_parsing, env_resolution]
+
+# Subcategories carve a broad category into honest narrower lanes (e.g.
+# http_framework → ui_frontend, mobile, ...). Each subcategory declares:
+#   - display:         human-facing section heading
+#   - parent_category: the category it refines
+#   - capabilities:    full allow-list of capability keys for records
+#                      tagged with this subcategory
+#   - groups:          optional ordered group taxonomy; when present the
+#                      per-subcategory pivot table switches from per-
+#                      capability columns to per-group digest columns
+subcategories:
+  http_backend:
+    display: "Backend HTTP"
+    parent_category: http_framework
+    capabilities:
+      - endpoint_synthesis
+      - handler_attribution
+      - auth_coverage
+      - middleware_coverage
+      - route_extraction
+      - request_validation
+      - tests_linkage
+      - dto_extraction
+    groups:
+      - name: Routing
+        keys: [endpoint_synthesis, handler_attribution, route_extraction]
+      - name: Security
+        keys: [auth_coverage]
+      - name: Validation
+        keys: [request_validation, dto_extraction]
+      - name: Middleware
+        keys: [middleware_coverage]
+      - name: Testing
+        keys: [tests_linkage]
+      - name: Observability
+        keys: []
+      - name: Data
+        keys: []
+
+  ui_frontend:
+    display: "UI Frontend"
+    parent_category: http_framework
+    capabilities:
+      - component_extraction
+      - prop_extraction
+      - hook_recognition
+      - state_management
+      - data_fetching
+      - router_pattern
+      - jsx_template
+      - context_extraction
+      - hoc_wrapper_recognition
+      - branch_conditions
+      - interface_extraction
+      - type_alias_extraction
+      - enum_extraction
+      - state_setter_emission
+      - tests_linkage
+    groups:
+      - name: Structure
+        keys: [component_extraction, hook_recognition, jsx_template, context_extraction, hoc_wrapper_recognition]
+      - name: Data Flow
+        keys: [prop_extraction, state_management, data_fetching, branch_conditions]
+      - name: Navigation
+        keys: [router_pattern]
+      - name: Type System
+        keys: [interface_extraction, type_alias_extraction, enum_extraction]
+      - name: Lifecycle
+        keys: [state_setter_emission]
+      - name: Testing
+        keys: [tests_linkage]
+
+  meta_framework:
+    display: "Meta Framework"
+    parent_category: http_framework
+    capabilities:
+      - server_components
+      - data_loaders
+      - route_extraction
+      - hydration_boundaries
+      - static_generation
+      - component_extraction
+      - hook_recognition
+      - router_pattern
+      - interface_extraction
+      - type_alias_extraction
+      - enum_extraction
+      - state_setter_emission
+      - tests_linkage
+    groups:
+      - name: Structure
+        keys: [component_extraction, hook_recognition]
+      - name: Data Flow
+        keys: [data_loaders]
+      - name: Server
+        keys: [server_components, hydration_boundaries]
+      - name: Routing
+        keys: [route_extraction, router_pattern]
+      - name: Build
+        keys: [static_generation]
+      - name: Type System
+        keys: [interface_extraction, type_alias_extraction, enum_extraction]
+      - name: Lifecycle
+        keys: [state_setter_emission]
+      - name: Testing
+        keys: [tests_linkage]
+
+  mobile:
+    display: "Mobile"
+    parent_category: http_framework
+    capabilities:
+      - navigation_extraction
+      - native_module_imports
+      - platform_branching
+      - screen_detection
+      - deep_link_extraction
+      - state_management
+      - context_extraction
+      - hoc_wrapper_recognition
+      - branch_conditions
+      - interface_extraction
+      - type_alias_extraction
+      - enum_extraction
+      - state_setter_emission
+      - tests_linkage
+    groups:
+      - name: Structure
+        keys: [context_extraction, hoc_wrapper_recognition]
+      - name: Navigation
+        keys: [navigation_extraction, deep_link_extraction, screen_detection]
+      - name: Platform
+        keys: [platform_branching]
+      - name: Native Bridge
+        keys: [native_module_imports]
+      - name: Data Flow
+        keys: [state_management, branch_conditions]
+      - name: Type System
+        keys: [interface_extraction, type_alias_extraction, enum_extraction]
+      - name: Lifecycle
+        keys: [state_setter_emission]
+      - name: Testing
+        keys: [tests_linkage]
+
+  desktop:
+    display: "Desktop"
+    parent_category: http_framework
+    capabilities:
+      - ipc_extraction
+      - main_renderer_split
+      - native_module_imports
+    groups:
+      - name: Process
+        keys: [ipc_extraction, main_renderer_split]
+      - name: Native
+        keys: [native_module_imports]
+      - name: Updates
+        keys: []
+
+  rpc_framework:
+    display: "RPC Framework"
+    parent_category: http_framework
+    capabilities:
+      - procedure_extraction
+      - schema_extraction
+      - client_codegen
+    groups:
+      - name: Schema
+        keys: [schema_extraction, procedure_extraction]
+      - name: Codegen
+        keys: [client_codegen]
+      - name: Transport
+        keys: []
+
+  static_site:
+    display: "Static Site"
+    parent_category: http_framework
+    capabilities:
+      - build_extraction
+      - template_extraction
+    # No group taxonomy yet — the subcategory falls back to per-capability
+    # columns until one is declared.
+    groups: []
+
+  ai_integration:
+    display: "AI Integration"
+    parent_category: http_framework
+    capabilities:
+      - prompt_template_extraction
+      - chain_composition
+      - tool_use_detection
+    groups:
+      - name: Prompts
+        keys: [prompt_template_extraction]
+      - name: Composition
+        keys: [chain_composition, tool_use_detection]
+      - name: Tracking
+        keys: []

--- a/tools/coverage/capability_dictionary.go
+++ b/tools/coverage/capability_dictionary.go
@@ -1,0 +1,376 @@
+// Capability dictionary loader (#2752).
+//
+// The dictionary is the single source of truth for the coverage tool's
+// taxonomy: buckets, registry categories (and their flat capability
+// allow-lists), subcategories (and their per-subcategory capabilities
+// + ordered group taxonomies). It replaces the previously-hardcoded
+// maps in schema.go and buckets.go.
+//
+// The default dictionary ships embedded in the binary so the tool stays
+// standalone. LoadCapabilityDictionary reads any path off disk for
+// tests or alternate deployments.
+package main
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// defaultDictionaryPath is the on-disk location of the canonical
+// dictionary file relative to the repository root.
+const defaultDictionaryPath = "tools/coverage/capability-dictionary.yaml"
+
+//go:embed capability-dictionary.yaml
+var embeddedDictionary embed.FS
+
+// CapabilityDictionary is the in-memory representation of the YAML
+// dictionary. All consumers in this package go through the singleton
+// returned by dict(); LoadCapabilityDictionary is exported for tests
+// and for callers that want a fresh load from a specific path.
+type CapabilityDictionary struct {
+	SchemaVersion int                         `yaml:"$schema_version"`
+	Buckets       map[string]BucketEntry      `yaml:"buckets"`
+	Categories    map[string]CategoryEntry    `yaml:"categories"`
+	Subcategories map[string]SubcategoryEntry `yaml:"subcategories"`
+
+	// Derived state, populated by indexDerived after Unmarshal.
+	bucketOrder      []string                       // sorted by BucketEntry.Order
+	bucketOfCategory map[string]string              // category → bucket
+	subcatsByCat     map[string][]string            // category → ordered subcategory slugs
+	groupsBySubcat   map[string][]capabilityGroup   // subcategory → ordered groups
+	groupIndex       map[string]map[string][]string // subcategory → group name → keys
+}
+
+// BucketEntry is one bucket definition (render order + category list).
+type BucketEntry struct {
+	Order      int      `yaml:"order"`
+	Categories []string `yaml:"categories"`
+}
+
+// CategoryEntry is one registry category definition (flat capability
+// allow-list and, when applicable, the ordered subcategory render
+// sequence).
+type CategoryEntry struct {
+	Capabilities     []string `yaml:"capabilities"`
+	SubcategoryOrder []string `yaml:"subcategory_order"`
+}
+
+// SubcategoryEntry is one subcategory definition. Capabilities is the
+// full allow-list of keys (used by validation); Groups is the optional
+// ordered group taxonomy (used by rendering).
+type SubcategoryEntry struct {
+	Display        string                `yaml:"display"`
+	ParentCategory string                `yaml:"parent_category"`
+	Capabilities   []string              `yaml:"capabilities"`
+	Groups         []SubcategoryGroupDef `yaml:"groups"`
+}
+
+// SubcategoryGroupDef is one group bucket inside a subcategory.
+type SubcategoryGroupDef struct {
+	Name string   `yaml:"name"`
+	Keys []string `yaml:"keys"`
+}
+
+// LoadCapabilityDictionary reads and parses the dictionary at path. Use
+// dict() in normal code paths; this entry point exists for tests and
+// alternate deployments.
+func LoadCapabilityDictionary(path string) (*CapabilityDictionary, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read capability dictionary %s: %w", path, err)
+	}
+	return parseCapabilityDictionary(data, path)
+}
+
+// loadEmbeddedDictionary returns the dictionary baked into the binary.
+// Used as the fallback when the on-disk file is unavailable so the tool
+// still runs from any working directory.
+func loadEmbeddedDictionary() (*CapabilityDictionary, error) {
+	data, err := embeddedDictionary.ReadFile("capability-dictionary.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read embedded capability dictionary: %w", err)
+	}
+	return parseCapabilityDictionary(data, "capability-dictionary.yaml")
+}
+
+// parseCapabilityDictionary decodes raw YAML bytes and validates that
+// the schema version matches what this binary understands. Derived
+// indexes are populated before return so callers can rely on every
+// helper returning consistent results.
+func parseCapabilityDictionary(data []byte, path string) (*CapabilityDictionary, error) {
+	d := &CapabilityDictionary{}
+	if err := yaml.Unmarshal(data, d); err != nil {
+		return nil, fmt.Errorf("parse capability dictionary %s: %w", path, err)
+	}
+	if d.SchemaVersion != 1 {
+		return nil, fmt.Errorf("capability dictionary %s: unsupported $schema_version %d (want 1)", path, d.SchemaVersion)
+	}
+	d.indexDerived()
+	return d, nil
+}
+
+// indexDerived populates the read-only derived indexes used by helpers.
+func (d *CapabilityDictionary) indexDerived() {
+	// bucketOrder by ascending Order then name for ties.
+	names := make([]string, 0, len(d.Buckets))
+	for n := range d.Buckets {
+		names = append(names, n)
+	}
+	sort.SliceStable(names, func(i, j int) bool {
+		oi, oj := d.Buckets[names[i]].Order, d.Buckets[names[j]].Order
+		if oi != oj {
+			return oi < oj
+		}
+		return names[i] < names[j]
+	})
+	d.bucketOrder = names
+
+	d.bucketOfCategory = map[string]string{}
+	for bname, b := range d.Buckets {
+		for _, cat := range b.Categories {
+			d.bucketOfCategory[cat] = bname
+		}
+	}
+
+	d.subcatsByCat = map[string][]string{}
+	for cat, ce := range d.Categories {
+		if len(ce.SubcategoryOrder) > 0 {
+			out := make([]string, len(ce.SubcategoryOrder))
+			copy(out, ce.SubcategoryOrder)
+			d.subcatsByCat[cat] = out
+		}
+	}
+	// Fill in any subcategories that declare a parent_category but
+	// aren't listed in the category's subcategory_order (append in
+	// sorted order so determinism holds).
+	parentToSubs := map[string][]string{}
+	for slug, sc := range d.Subcategories {
+		parentToSubs[sc.ParentCategory] = append(parentToSubs[sc.ParentCategory], slug)
+	}
+	for cat, subs := range parentToSubs {
+		sort.Strings(subs)
+		known := map[string]bool{}
+		for _, s := range d.subcatsByCat[cat] {
+			known[s] = true
+		}
+		for _, s := range subs {
+			if !known[s] {
+				d.subcatsByCat[cat] = append(d.subcatsByCat[cat], s)
+				known[s] = true
+			}
+		}
+	}
+
+	d.groupsBySubcat = map[string][]capabilityGroup{}
+	d.groupIndex = map[string]map[string][]string{}
+	for slug, sc := range d.Subcategories {
+		if len(sc.Groups) == 0 {
+			continue
+		}
+		groups := make([]capabilityGroup, len(sc.Groups))
+		inner := map[string][]string{}
+		for i, g := range sc.Groups {
+			keys := make([]string, len(g.Keys))
+			copy(keys, g.Keys)
+			groups[i] = capabilityGroup{Name: g.Name, Keys: keys}
+			inner[g.Name] = keys
+		}
+		d.groupsBySubcat[slug] = groups
+		d.groupIndex[slug] = inner
+	}
+}
+
+// BucketOrder returns the render order of bucket names.
+func (d *CapabilityDictionary) BucketOrder() []string {
+	out := make([]string, len(d.bucketOrder))
+	copy(out, d.bucketOrder)
+	return out
+}
+
+// BucketForCategory returns the bucket that owns cat, falling back to
+// BucketOther for unmapped categories (matching the documented "Other:
+// everything else" rule so new categories ship as Other until they are
+// explicitly classified).
+func (d *CapabilityDictionary) BucketForCategory(cat string) string {
+	if b, ok := d.bucketOfCategory[cat]; ok {
+		return b
+	}
+	return BucketOther
+}
+
+// CategoryCapabilities returns the flat capability allow-list for cat,
+// or nil when the category is unknown.
+func (d *CapabilityDictionary) CategoryCapabilities(cat string) []string {
+	ce, ok := d.Categories[cat]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(ce.Capabilities))
+	copy(out, ce.Capabilities)
+	return out
+}
+
+// KnownCategories returns sorted category slugs.
+func (d *CapabilityDictionary) KnownCategories() []string {
+	out := make([]string, 0, len(d.Categories))
+	for k := range d.Categories {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// SubcategoryDisplay returns the human-facing heading for sub, or ""
+// when the subcategory has no entry (caller falls back to prettyKey).
+func (d *CapabilityDictionary) SubcategoryDisplay(sub string) string {
+	if sc, ok := d.Subcategories[sub]; ok {
+		return sc.Display
+	}
+	return ""
+}
+
+// SubcategoriesByCategory returns the canonical render order of
+// subcategory slugs for cat: the explicit subcategory_order list,
+// followed by any extra subcategories whose parent_category matches
+// (alphabetical).
+func (d *CapabilityDictionary) SubcategoriesByCategory(cat string) []string {
+	in, ok := d.subcatsByCat[cat]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+// HasSubcategory reports whether sub is declared for cat.
+func (d *CapabilityDictionary) HasSubcategory(cat, sub string) bool {
+	for _, s := range d.subcatsByCat[cat] {
+		if s == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// SubcategoryCapabilities returns the allow-list of keys for sub, or
+// nil when the subcategory is unknown.
+func (d *CapabilityDictionary) SubcategoryCapabilities(sub string) []string {
+	sc, ok := d.Subcategories[sub]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(sc.Capabilities))
+	copy(out, sc.Capabilities)
+	return out
+}
+
+// GroupsForSubcategory returns the ordered group taxonomy for sub, or
+// nil when none is declared.
+func (d *CapabilityDictionary) GroupsForSubcategory(sub string) []capabilityGroup {
+	in, ok := d.groupsBySubcat[sub]
+	if !ok {
+		return nil
+	}
+	out := make([]capabilityGroup, len(in))
+	for i, g := range in {
+		keys := make([]string, len(g.Keys))
+		copy(keys, g.Keys)
+		out[i] = capabilityGroup{Name: g.Name, Keys: keys}
+	}
+	return out
+}
+
+// GroupNames returns the declared group names for sub in canonical
+// render order, or nil when no group taxonomy exists.
+func (d *CapabilityDictionary) GroupNames(sub string) []string {
+	groups := d.groupsBySubcat[sub]
+	if len(groups) == 0 {
+		return nil
+	}
+	out := make([]string, len(groups))
+	for i, g := range groups {
+		out[i] = g.Name
+	}
+	return out
+}
+
+// GroupKeys returns the declared key list for (sub, group) or nil when
+// the group is not part of sub's taxonomy.
+func (d *CapabilityDictionary) GroupKeys(sub, group string) []string {
+	g, ok := d.groupIndex[sub]
+	if !ok {
+		return nil
+	}
+	keys, ok := g[group]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(keys))
+	copy(out, keys)
+	return out
+}
+
+// GroupForCapability returns the group name in sub's taxonomy that owns
+// key, or "" when key is not declared in any group.
+func (d *CapabilityDictionary) GroupForCapability(sub, key string) string {
+	for _, g := range d.groupsBySubcat[sub] {
+		for _, k := range g.Keys {
+			if k == key {
+				return g.Name
+			}
+		}
+	}
+	return ""
+}
+
+// HasGroup reports whether group is part of sub's taxonomy.
+func (d *CapabilityDictionary) HasGroup(sub, group string) bool {
+	if _, ok := d.groupIndex[sub]; !ok {
+		return false
+	}
+	_, ok := d.groupIndex[sub][group]
+	return ok
+}
+
+// dictionarySingleton caches the loaded dictionary for the lifetime of
+// the process. Loaded lazily from disk (when present) or the embedded
+// fallback so callers can fire-and-forget.
+var (
+	dictionarySingleton *CapabilityDictionary
+	dictionaryOnce      sync.Once
+	dictionaryErr       error
+)
+
+// dict returns the process-wide dictionary singleton. On first call it
+// tries the on-disk file at defaultDictionaryPath and falls back to the
+// embedded copy. Subsequent calls return the cached value. Errors are
+// fatal — the tool cannot operate without a taxonomy.
+func dict() *CapabilityDictionary {
+	dictionaryOnce.Do(func() {
+		if data, err := os.ReadFile(defaultDictionaryPath); err == nil {
+			d, perr := parseCapabilityDictionary(data, defaultDictionaryPath)
+			if perr == nil {
+				dictionarySingleton = d
+				return
+			}
+			dictionaryErr = perr
+			return
+		}
+		d, err := loadEmbeddedDictionary()
+		if err != nil {
+			dictionaryErr = err
+			return
+		}
+		dictionarySingleton = d
+	})
+	if dictionaryErr != nil {
+		panic(fmt.Sprintf("load capability dictionary: %v", dictionaryErr))
+	}
+	return dictionarySingleton
+}

--- a/tools/coverage/capability_dictionary_test.go
+++ b/tools/coverage/capability_dictionary_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestLoadCapabilityDictionaryFromDisk exercises LoadCapabilityDictionary
+// against the canonical file shipped with the tool.
+func TestLoadCapabilityDictionaryFromDisk(t *testing.T) {
+	d, err := LoadCapabilityDictionary(filepath.Join(repoRoot(t), defaultDictionaryPath))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if d.SchemaVersion != 1 {
+		t.Errorf("schema version = %d, want 1", d.SchemaVersion)
+	}
+	if got := d.BucketForCategory("http_framework"); got != BucketFrameworks {
+		t.Errorf("BucketForCategory(http_framework) = %q, want %q", got, BucketFrameworks)
+	}
+	if got := d.BucketForCategory("unknown_category"); got != BucketOther {
+		t.Errorf("BucketForCategory(unknown) = %q, want %q (fallback)", got, BucketOther)
+	}
+	if got := d.SubcategoryDisplay("ui_frontend"); got != "UI Frontend" {
+		t.Errorf("SubcategoryDisplay = %q, want %q", got, "UI Frontend")
+	}
+	wantUI := []string{"Structure", "Data Flow", "Navigation", "Type System", "Lifecycle", "Testing"}
+	if got := d.GroupNames("ui_frontend"); !reflect.DeepEqual(got, wantUI) {
+		t.Errorf("GroupNames(ui_frontend) = %v, want %v", got, wantUI)
+	}
+	if got := d.GroupForCapability("ui_frontend", "router_pattern"); got != "Navigation" {
+		t.Errorf("GroupForCapability = %q, want %q", got, "Navigation")
+	}
+	if got := d.GroupForCapability("ui_frontend", "nonexistent"); got != "" {
+		t.Errorf("GroupForCapability(nonexistent) = %q, want empty", got)
+	}
+	if !d.HasSubcategory("http_framework", "ui_frontend") {
+		t.Errorf("HasSubcategory(http_framework, ui_frontend) = false")
+	}
+	if d.HasSubcategory("http_framework", "bogus") {
+		t.Errorf("HasSubcategory(http_framework, bogus) = true")
+	}
+	if d.HasGroup("ui_frontend", "Navigation") != true {
+		t.Errorf("HasGroup(ui_frontend, Navigation) = false")
+	}
+	if d.HasGroup("ui_frontend", "BogusGroup") {
+		t.Errorf("HasGroup(ui_frontend, BogusGroup) = true")
+	}
+	// Subcategory render order — http_framework subcategories must
+	// follow the explicit subcategory_order from the dictionary.
+	wantOrder := []string{"http_backend", "ui_frontend", "meta_framework", "mobile", "desktop", "rpc_framework", "static_site", "ai_integration"}
+	if got := d.SubcategoriesByCategory("http_framework"); !reflect.DeepEqual(got, wantOrder) {
+		t.Errorf("SubcategoriesByCategory(http_framework) = %v, want %v", got, wantOrder)
+	}
+}
+
+// TestLoadCapabilityDictionaryMissingFile checks the error path for a
+// non-existent dictionary file.
+func TestLoadCapabilityDictionaryMissingFile(t *testing.T) {
+	if _, err := LoadCapabilityDictionary(filepath.Join(t.TempDir(), "missing.yaml")); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+// TestLoadCapabilityDictionaryRejectsWrongVersion ensures the loader
+// refuses dictionaries from an unknown schema version.
+func TestLoadCapabilityDictionaryRejectsWrongVersion(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "dict.yaml")
+	if err := os.WriteFile(tmp, []byte("$schema_version: 99\nbuckets: {}\ncategories: {}\nsubcategories: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadCapabilityDictionary(tmp); err == nil {
+		t.Fatalf("expected version error, got nil")
+	}
+}
+
+// TestEmbeddedDictionaryMatchesDisk ensures the YAML embedded into the
+// binary parses cleanly and reports the same bucket order as the on-
+// disk file. Guards against the build skipping the embed directive.
+func TestEmbeddedDictionaryMatchesDisk(t *testing.T) {
+	emb, err := loadEmbeddedDictionary()
+	if err != nil {
+		t.Fatalf("embedded: %v", err)
+	}
+	disk, err := LoadCapabilityDictionary(filepath.Join(repoRoot(t), defaultDictionaryPath))
+	if err != nil {
+		t.Fatalf("disk: %v", err)
+	}
+	if !reflect.DeepEqual(emb.BucketOrder(), disk.BucketOrder()) {
+		t.Errorf("bucket order mismatch: emb=%v disk=%v", emb.BucketOrder(), disk.BucketOrder())
+	}
+}
+
+// TestDictionarySingletonStable ensures dict() returns the same pointer
+// across calls so the load happens exactly once.
+func TestDictionarySingletonStable(t *testing.T) {
+	a := dict()
+	b := dict()
+	if a != b {
+		t.Errorf("dict() returned distinct pointers across calls: a=%p b=%p", a, b)
+	}
+}

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -659,8 +659,9 @@ func generate(reg *Registry, outRoot string) error {
 		}
 		var keys []string
 		if bucket == BucketOther {
-			keys = make([]string, len(categoryCapabilities[n]))
-			copy(keys, categoryCapabilities[n])
+			cats := dict().CategoryCapabilities(n)
+			keys = make([]string, len(cats))
+			copy(keys, cats)
 			sort.Strings(keys)
 		} else {
 			keys = bucketCapabilityKeys(bucket)
@@ -823,7 +824,7 @@ func buildBucketSection(bucket string, recs []recordView) bucketSection {
 	seen := map[string]bool{}
 	ordered := make([]string, 0, len(merged))
 	for _, c := range catList {
-		for _, s := range subcategoryOrder[c] {
+		for _, s := range dict().SubcategoriesByCategory(c) {
 			if merged[s] && !seen[s] {
 				ordered = append(ordered, s)
 				seen[s] = true

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -154,7 +154,7 @@ func cmdAdd(args []string, out io.Writer) error {
 	if err := validateID(*id); err != nil {
 		return err
 	}
-	if _, ok := categoryCapabilities[*cat]; !ok {
+	if !categoryIsKnown(*cat) {
 		return fmt.Errorf("add: unknown category %q (known: %v)", *cat, knownCategories())
 	}
 	if *sub != "" && !validSubcategory(*cat, *sub) {

--- a/tools/coverage/schema.go
+++ b/tools/coverage/schema.go
@@ -336,269 +336,12 @@ func capabilitiesAreGrouped(raw json.RawMessage) (bool, error) {
 	return false, nil
 }
 
-// categoryCapabilities maps each registry category to the set of
-// capability keys that are valid for that category. The validate
-// subcommand rejects unknown keys per category.
-var categoryCapabilities = map[string][]string{
-	"language": {
-		"call_line_precision",
-		"discriminates_on",
-		"navigates_to",
-		"core_extraction",
-	},
-	"http_framework": {
-		"endpoint_synthesis",
-		"handler_attribution",
-		"auth_coverage",
-		"middleware_coverage",
-	},
-	"orm": {
-		"model_extraction",
-		"query_attribution",
-		"migration_parsing",
-	},
-	"message_broker": {
-		"producer_extraction",
-		"consumer_extraction",
-		"topic_attribution",
-	},
-	"observability": {
-		"trace_extraction",
-		"metric_extraction",
-		"log_extraction",
-	},
-	"build_system": {
-		"target_extraction",
-		"dependency_graph",
-	},
-	"package_manager": {
-		"manifest_parsing",
-		"lockfile_parsing",
-	},
-	"databases": {
-		"resource_extraction",
-		"dependency_attribution",
-	},
-	"platform": {
-		"resource_extraction",
-		"dependency_attribution",
-		"file_parsing",
-		"env_resolution",
-	},
-	"security": {
-		"auth_policy",
-		"secret_detection",
-		"sql_injection",
-	},
-	"protocol": {
-		"service_extraction",
-		"method_attribution",
-		"cross_repo_linkage",
-	},
-	"ci_cd": {
-		"file_parsing",
-		"env_resolution",
-	},
-}
-
-// validCapabilityKey reports whether key is declared for category.
-func validCapabilityKey(category, key string) bool {
-	keys, ok := categoryCapabilities[category]
-	if !ok {
-		return false
-	}
-	for _, k := range keys {
-		if k == key {
-			return true
-		}
-	}
-	return false
-}
-
-// subcategoryCapabilities maps (category → subcategory → capability keys).
-// Records that opt in to a subcategory validate against the union of
-// that subcategory's keys and the category-wide keys, allowing fine-
-// grained capability vocabulary (e.g. React's component_extraction) to
-// coexist with the broad category lane (http_framework).
-//
-// Adding a new subcategory: drop a line here, list its capability keys,
-// re-run validate. The slugs are surfaced verbatim as section headers
-// in the by-language and by-category pages via prettyKey.
-var subcategoryCapabilities = map[string]map[string][]string{
-	"http_framework": {
-		"http_backend": {
-			"endpoint_synthesis",
-			"handler_attribution",
-			"auth_coverage",
-			"middleware_coverage",
-			"route_extraction",
-			"request_validation",
-			"tests_linkage",
-			"dto_extraction",
-		},
-		"ui_frontend": {
-			"component_extraction",
-			"prop_extraction",
-			"hook_recognition",
-			"state_management",
-			"data_fetching",
-			"router_pattern",
-			"jsx_template",
-			"context_extraction",
-			"hoc_wrapper_recognition",
-			"branch_conditions",
-			"interface_extraction",
-			"type_alias_extraction",
-			"enum_extraction",
-			"state_setter_emission",
-			"tests_linkage",
-		},
-		"meta_framework": {
-			"server_components",
-			"data_loaders",
-			"route_extraction",
-			"hydration_boundaries",
-			"static_generation",
-			"component_extraction",
-			"hook_recognition",
-			"router_pattern",
-			"interface_extraction",
-			"type_alias_extraction",
-			"enum_extraction",
-			"state_setter_emission",
-			"tests_linkage",
-		},
-		"mobile": {
-			"navigation_extraction",
-			"native_module_imports",
-			"platform_branching",
-			"screen_detection",
-			"deep_link_extraction",
-			"state_management",
-			"context_extraction",
-			"hoc_wrapper_recognition",
-			"branch_conditions",
-			"interface_extraction",
-			"type_alias_extraction",
-			"enum_extraction",
-			"state_setter_emission",
-			"tests_linkage",
-		},
-		"desktop": {
-			"ipc_extraction",
-			"main_renderer_split",
-			"native_module_imports",
-		},
-		"rpc_framework": {
-			"procedure_extraction",
-			"schema_extraction",
-			"client_codegen",
-		},
-		"static_site": {
-			"build_extraction",
-			"template_extraction",
-		},
-		"ai_integration": {
-			"prompt_template_extraction",
-			"chain_composition",
-			"tool_use_detection",
-		},
-	},
-}
-
-// subcategoryOrder is the canonical render order for subcategory
-// sub-sections under a bucket. Entries not listed here render
-// alphabetically after the canonical ones (see orderedSubcategories).
-var subcategoryOrder = map[string][]string{
-	"http_framework": {
-		"http_backend",
-		"ui_frontend",
-		"meta_framework",
-		"mobile",
-		"desktop",
-		"rpc_framework",
-		"static_site",
-		"ai_integration",
-	},
-}
-
-// subcategoryDisplay maps a subcategory slug to its human-facing section
-// heading. Slugs without an entry fall back to prettyKey of the slug.
-var subcategoryDisplay = map[string]string{
-	"http_backend":   "Backend HTTP",
-	"ui_frontend":    "UI Frontend",
-	"meta_framework": "Meta Framework",
-	"mobile":         "Mobile",
-	"desktop":        "Desktop",
-	"rpc_framework":  "RPC Framework",
-	"static_site":    "Static Site",
-	"ai_integration": "AI Integration",
-}
-
-// subcategoryGroups declares the canonical capability-group taxonomy
-// per subcategory: subcategory → group name → ordered capability keys.
-// Group names are exact strings (case + spacing preserved); they appear
-// verbatim as section headings on detail pages and as column headers on
-// pivot tables. Capability keys must also be declared in
-// subcategoryCapabilities for their (category, subcategory) so the
-// allow-list and the taxonomy stay in sync.
-//
-// Groups are listed in display order — render order on the detail page
-// and column order in the pivot table both follow this slice.
-var subcategoryGroups = map[string][]capabilityGroup{
-	"ui_frontend": {
-		{Name: "Structure", Keys: []string{"component_extraction", "hook_recognition", "jsx_template", "context_extraction", "hoc_wrapper_recognition"}},
-		{Name: "Data Flow", Keys: []string{"prop_extraction", "state_management", "data_fetching", "branch_conditions"}},
-		{Name: "Navigation", Keys: []string{"router_pattern"}},
-		{Name: "Type System", Keys: []string{"interface_extraction", "type_alias_extraction", "enum_extraction"}},
-		{Name: "Lifecycle", Keys: []string{"state_setter_emission"}},
-		{Name: "Testing", Keys: []string{"tests_linkage"}},
-	},
-	"mobile": {
-		{Name: "Structure", Keys: []string{"context_extraction", "hoc_wrapper_recognition"}},
-		{Name: "Navigation", Keys: []string{"navigation_extraction", "deep_link_extraction", "screen_detection"}},
-		{Name: "Platform", Keys: []string{"platform_branching"}},
-		{Name: "Native Bridge", Keys: []string{"native_module_imports"}},
-		{Name: "Data Flow", Keys: []string{"state_management", "branch_conditions"}},
-		{Name: "Type System", Keys: []string{"interface_extraction", "type_alias_extraction", "enum_extraction"}},
-		{Name: "Lifecycle", Keys: []string{"state_setter_emission"}},
-		{Name: "Testing", Keys: []string{"tests_linkage"}},
-	},
-	"http_backend": {
-		{Name: "Routing", Keys: []string{"endpoint_synthesis", "handler_attribution", "route_extraction"}},
-		{Name: "Security", Keys: []string{"auth_coverage"}},
-		{Name: "Validation", Keys: []string{"request_validation", "dto_extraction"}},
-		{Name: "Middleware", Keys: []string{"middleware_coverage"}},
-		{Name: "Testing", Keys: []string{"tests_linkage"}},
-		{Name: "Observability", Keys: []string{}},
-		{Name: "Data", Keys: []string{}},
-	},
-	"meta_framework": {
-		{Name: "Structure", Keys: []string{"component_extraction", "hook_recognition"}},
-		{Name: "Data Flow", Keys: []string{"data_loaders"}},
-		{Name: "Server", Keys: []string{"server_components", "hydration_boundaries"}},
-		{Name: "Routing", Keys: []string{"route_extraction", "router_pattern"}},
-		{Name: "Build", Keys: []string{"static_generation"}},
-		{Name: "Type System", Keys: []string{"interface_extraction", "type_alias_extraction", "enum_extraction"}},
-		{Name: "Lifecycle", Keys: []string{"state_setter_emission"}},
-		{Name: "Testing", Keys: []string{"tests_linkage"}},
-	},
-	"desktop": {
-		{Name: "Process", Keys: []string{"ipc_extraction", "main_renderer_split"}},
-		{Name: "Native", Keys: []string{"native_module_imports"}},
-		{Name: "Updates", Keys: []string{}},
-	},
-	"rpc_framework": {
-		{Name: "Schema", Keys: []string{"schema_extraction", "procedure_extraction"}},
-		{Name: "Codegen", Keys: []string{"client_codegen"}},
-		{Name: "Transport", Keys: []string{}},
-	},
-	"ai_integration": {
-		{Name: "Prompts", Keys: []string{"prompt_template_extraction"}},
-		{Name: "Composition", Keys: []string{"chain_composition", "tool_use_detection"}},
-		{Name: "Tracking", Keys: []string{}},
-	},
-}
+// The capability taxonomy — buckets, registry categories (and their
+// flat allow-lists), subcategories (and their per-subcategory allow-
+// lists + ordered group taxonomies) — lives in capability-dictionary
+// .yaml (loaded via dict()). The functions below are thin queries on
+// top of that single source of truth so adding a new capability is a
+// YAML edit with zero Go change (#2752).
 
 // capabilityGroup pairs a group name with its ordered capability keys.
 // Render order follows the slice; templates do not re-sort.
@@ -607,50 +350,41 @@ type capabilityGroup struct {
 	Keys []string
 }
 
+// validCapabilityKey reports whether key is declared as a category-wide
+// capability for category.
+func validCapabilityKey(category, key string) bool {
+	for _, k := range dict().CategoryCapabilities(category) {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
 // groupsForSubcategory returns the canonical group taxonomy for sub or
 // nil when the subcategory has no declared taxonomy (e.g. static_site).
 func groupsForSubcategory(sub string) []capabilityGroup {
-	return subcategoryGroups[sub]
+	return dict().GroupsForSubcategory(sub)
 }
 
 // groupForCapability returns the canonical group name that owns key in
 // sub's taxonomy, or "" when the key is not declared in any group. Used
 // by migration and validation to enforce capability-belongs-to-group.
 func groupForCapability(sub, key string) string {
-	for _, g := range subcategoryGroups[sub] {
-		for _, k := range g.Keys {
-			if k == key {
-				return g.Name
-			}
-		}
-	}
-	return ""
+	return dict().GroupForCapability(sub, key)
 }
 
 // groupAllowedKeys returns the declared keys for (sub, group) or nil
 // when group is not part of sub's taxonomy. Validation uses this to
 // reject keys placed under the wrong group within a record.
 func groupAllowedKeys(sub, group string) []string {
-	for _, g := range subcategoryGroups[sub] {
-		if g.Name == group {
-			return g.Keys
-		}
-	}
-	return nil
+	return dict().GroupKeys(sub, group)
 }
 
 // knownGroupNames returns the declared group names for sub in canonical
 // render order, or nil when sub has no group taxonomy.
 func knownGroupNames(sub string) []string {
-	groups := subcategoryGroups[sub]
-	if len(groups) == 0 {
-		return nil
-	}
-	out := make([]string, len(groups))
-	for i, g := range groups {
-		out[i] = g.Name
-	}
-	return out
+	return dict().GroupNames(sub)
 }
 
 // validGroupName reports whether group is part of sub's taxonomy. The
@@ -660,37 +394,25 @@ func validGroupName(sub, group string) bool {
 	if group == uncategorizedGroup {
 		return true
 	}
-	for _, g := range subcategoryGroups[sub] {
-		if g.Name == group {
-			return true
-		}
-	}
-	return false
+	return dict().HasGroup(sub, group)
 }
 
 // knownSubcategories returns the sorted subcategory slugs declared for
-// category. Empty slice if category has no subcategory map.
+// category. Empty slice if the category has no subcategories.
 func knownSubcategories(category string) []string {
-	m, ok := subcategoryCapabilities[category]
-	if !ok {
+	subs := dict().SubcategoriesByCategory(category)
+	if len(subs) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
+	out := make([]string, len(subs))
+	copy(out, subs)
 	sort.Strings(out)
 	return out
 }
 
 // validSubcategory reports whether sub is declared for category.
 func validSubcategory(category, sub string) bool {
-	m, ok := subcategoryCapabilities[category]
-	if !ok {
-		return false
-	}
-	_, ok = m[sub]
-	return ok
+	return dict().HasSubcategory(category, sub)
 }
 
 // validCapabilityKeyForSubcategory reports whether key is in the union
@@ -701,15 +423,10 @@ func validCapabilityKeyForSubcategory(category, sub, key string) bool {
 	if validCapabilityKey(category, key) {
 		return true
 	}
-	m, ok := subcategoryCapabilities[category]
-	if !ok {
+	if !dict().HasSubcategory(category, sub) {
 		return false
 	}
-	keys, ok := m[sub]
-	if !ok {
-		return false
-	}
-	for _, k := range keys {
+	for _, k := range dict().SubcategoryCapabilities(sub) {
 		if k == key {
 			return true
 		}
@@ -725,18 +442,15 @@ func validCapabilityKeyForSubcategory(category, sub, key string) bool {
 // carry category-level cells; those are surfaced on the per-record
 // detail page but suppressed in the per-language summary table.
 func subcategoryRenderKeys(category, sub string) []string {
-	m, ok := subcategoryCapabilities[category]
-	if !ok {
+	if !dict().HasSubcategory(category, sub) {
 		return nil
 	}
-	keys, ok := m[sub]
-	if !ok {
+	keys := dict().SubcategoryCapabilities(sub)
+	if keys == nil {
 		return nil
 	}
-	out := make([]string, len(keys))
-	copy(out, keys)
-	sort.Strings(out)
-	return out
+	sort.Strings(keys)
+	return keys
 }
 
 // subcategoryCapabilityKeys returns the merged sorted capability key
@@ -745,11 +459,11 @@ func subcategoryRenderKeys(category, sub string) []string {
 // declared at either level pass the allow-list check.
 func subcategoryCapabilityKeys(category, sub string) []string {
 	seen := map[string]struct{}{}
-	for _, k := range categoryCapabilities[category] {
+	for _, k := range dict().CategoryCapabilities(category) {
 		seen[k] = struct{}{}
 	}
-	if m, ok := subcategoryCapabilities[category]; ok {
-		for _, k := range m[sub] {
+	if dict().HasSubcategory(category, sub) {
+		for _, k := range dict().SubcategoryCapabilities(sub) {
 			seen[k] = struct{}{}
 		}
 	}
@@ -762,10 +476,11 @@ func subcategoryCapabilityKeys(category, sub string) []string {
 }
 
 // orderedSubcategories returns the subcategory slugs that have records
-// in subs, ordered by subcategoryOrder[category] first then alphabetical
-// for any extras. Slugs in order but absent from subs are dropped.
+// in subs, ordered by the dictionary's canonical sequence for category
+// first then alphabetical for any extras. Slugs in order but absent
+// from subs are dropped.
 func orderedSubcategories(category string, subs map[string]bool) []string {
-	canon := subcategoryOrder[category]
+	canon := dict().SubcategoriesByCategory(category)
 	out := make([]string, 0, len(subs))
 	for _, s := range canon {
 		if subs[s] {
@@ -790,7 +505,7 @@ func orderedSubcategories(category string, subs map[string]bool) []string {
 // back to prettyKey when no display string is registered so brand-new
 // subcategories render reasonably without code changes.
 func subcategoryHeading(sub string) string {
-	if d, ok := subcategoryDisplay[sub]; ok {
+	if d := dict().SubcategoryDisplay(sub); d != "" {
 		return d
 	}
 	return prettyKey(sub)
@@ -799,12 +514,14 @@ func subcategoryHeading(sub string) string {
 // knownCategories returns sorted category names. Used by views and
 // validation error messages.
 func knownCategories() []string {
-	out := make([]string, 0, len(categoryCapabilities))
-	for k := range categoryCapabilities {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
+	return dict().KnownCategories()
+}
+
+// categoryIsKnown reports whether category is declared in the dictionary.
+// Replaces previous direct map lookups against categoryCapabilities.
+func categoryIsKnown(category string) bool {
+	_, ok := dict().Categories[category]
+	return ok
 }
 
 // validateID returns nil if id matches the stable-slug pattern.

--- a/tools/coverage/validate.go
+++ b/tools/coverage/validate.go
@@ -51,7 +51,7 @@ func validateRegistry(reg *Registry, repoRoot string) *ValidationResult {
 
 		if rec.Category == "" {
 			res.Errors = append(res.Errors, prefix+": category is empty")
-		} else if _, ok := categoryCapabilities[rec.Category]; !ok {
+		} else if !categoryIsKnown(rec.Category) {
 			res.Errors = append(res.Errors, fmt.Sprintf("%s: unknown category %q (known: %v)", prefix, rec.Category, knownCategories()))
 		}
 		if rec.Subcategory != "" {


### PR DESCRIPTION
## Summary
- Moves the coverage tool's taxonomy (buckets, categories, subcategories, group taxonomies, capability allow-lists) out of hardcoded Go maps in `tools/coverage/schema.go` and `tools/coverage/buckets.go` into a single data file: `tools/coverage/capability-dictionary.yaml`.
- Adds `tools/coverage/capability_dictionary.go` — typed `CapabilityDictionary` struct, `LoadCapabilityDictionary(path)`, embedded fallback, and a process-wide singleton (`dict()`) that loads lazily and caches the indexed result.
- Preserves every existing helper signature (`validCapabilityKey`, `validSubcategory`, `knownGroupNames`, `groupForCapability`, `bucketOf`, `bucketCapabilityKeys`, `orderedSubcategories`, `subcategoryHeading`, …) so all callers in `generate.go` / `validate.go` / `main.go` / `store.go` work unchanged; only the backing data source changes.
- Adding a new capability is now a one-edit YAML change: append a slug to a subcategory's `capabilities` list and to the appropriate group's `keys` list. Zero Go code change.

Closes #2752.

## Test plan
- [x] `go test ./tools/coverage/` — passes (all existing tests + new `capability_dictionary_test.go` covering disk load, missing-file error, wrong schema version, embedded dictionary parity, singleton stability)
- [x] `go run ./tools/coverage gen` — produces byte-identical output to pre-migration (`git diff --stat docs/coverage/` reports zero changes)
- [x] `go run ./tools/coverage validate` — exits 0
- [x] `go vet ./tools/coverage/` — clean
- [x] Determinism preserved (`TestGenDeterministic` + golden `TestGenGoldenSummary`)