### PR TITLE
feat(tools/coverage): subcategorize 135 framework records across 12 languages (#2750)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,6 +11,48 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
 |---|---|---|---|---|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | — | — | — | — | — | — | — | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | — | — | — | — | — | — | — | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | — | — | — | — | — | — | — | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | — | — | — | — | — | — | — | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | — | — | — | — | — | — | — | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | — | — | — | — | — | — | — | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | — | — | — | — | — | — | — | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | — | — | — | — | — | — | — | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | — | — | — | — | — | — | — | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | — | — | — | — | — | — | — | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | — | — | — | — | — | — | — | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | — | — | — | — | — | — | — | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | — | — | — | — | — | — | — | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | — | — | — | — | — | — | — | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | — | — | — | — | — | — | — | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | — | — | — | — | — | — | — | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | |
 | [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
@@ -23,12 +65,85 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
 | [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | — | — | — | — | — | — | — | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | — | — | — | — | — | — | — | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | — | — | — | — | — | — | — | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | — | — | — | — | — | — | — | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | — | — | — | — | — | — | — | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | — | — | — | — | — | — | — | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | — | — | — | — | — | — | — | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | — | — | — | — | — | — | — | |
+| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | — | — | — | — | — | — | — | |
+| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | — | — | — | — | — | — | — | |
+| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | — | — | — | — | — | — | — | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | — | — | — | — | — | — | — | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | — | — | — | — | — | — | — | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | — | — | — | — | — | — | — | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | — | — | — | — | — | — | — | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | — | — | — | — | — | — | — | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | — | — | — | — | — | — | — | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | — | — | — | — | — | — | — | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | — | — | — | — | — | — | — | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | — | — | — | — | — | — | — | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | — | — | — | — | — | — | — | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | — | — | — | — | — | — | — | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | — | — | — | — | — | — | — | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | — | — | — | — | — | — | — | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | — | — | — | — | — | — | — | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | — | — | — | — | — | — | — | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | — | — | — | — | — | — | — | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | — | — | — | — | — | — | — | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | — | — | — | — | — | — | — | |
+| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | — | — | — | — | — | — | — | |
 
 
 ## UI Frontend
 
 | Language | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Notes |
 |---|---|---|---|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
@@ -39,35 +154,53 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
 
 
 ## Mobile
 
 | Language | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
 | [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
 
 
 ## Desktop
 
 | Language | Name | Process | Native | Updates | Notes |
 |---|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | |
+| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | |
+| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | |
+| [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | ❌ 0/2 | ❌ 0/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | ❌ 0/2 | ❌ 0/1 | — | |
+| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | |
+| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | |
+| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | |
 
 
 ## RPC Framework
 
 | Language | Name | Schema | Codegen | Transport | Notes |
 |---|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | |
 
@@ -76,145 +209,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Prompts | Composition | Tracking | Notes |
 |---|---|---|---|---|---|
+| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ❌ 0/1 | ❌ 0/2 | — | |
 | [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ⚠️ 0/1 | ❌ 0/2 | — | |
-
-
-## Other
-
-| Language | Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | — | — | ⚠️ | — | |
-| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | ⚠️ | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ | ✅ | ✅ | ❌ | |
-| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | — | — | ⚠️ | — | |
-| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | — | ❌ | — | — | |
-| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | — | — | ⚠️ | — | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ | ❌ | ❌ | ❌ | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ | ❌ | ❌ | ❌ | |
-| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ | ❌ | ❌ | ❌ | |
-| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ | ❌ | ❌ | ❌ | |
-| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | — | — | ⚠️ | — | |
-| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | — | — | ⚠️ | — | |
-| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | — | — | ⚠️ | — | |
-| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | — | — | ⚠️ | — | |
-| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ | ❌ | ❌ | ❌ | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ | ❌ | ❌ | ❌ | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | — | — | ⚠️ | — | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | — | — | ⚠️ | — | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ | ✅ | ✅ | ❌ | |
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ | ✅ | ✅ | ❌ | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ | ❌ | ❌ | ❌ | |
-| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ❌ | ✅ | ✅ | ❌ | |
-| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ❌ | ✅ | ✅ | ❌ | |
-| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | ❌ | ✅ | ✅ | ❌ | |
-| [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | — | — | ⚠️ | — | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ❌ | ✅ | ✅ | ❌ | |
-| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ❌ | ✅ | ✅ | ❌ | |
-| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | ❌ | ✅ | ✅ | ❌ | |
-| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | ❌ | ✅ | ✅ | ❌ | |
-| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | — | — | ⚠️ | — | |
-| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ❌ | ✅ | ✅ | ❌ | |
-| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ | ❌ | ❌ | ❌ | |
-| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | — | — | ⚠️ | — | |
-| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | — | — | ⚠️ | — | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ | ✅ | ✅ | ❌ | |
-| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ❌ | ❌ | ❌ | ❌ | |
-| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ | ❌ | ❌ | ❌ | |
-| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | — | — | ⚠️ | — | |
-| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ | ✅ | ✅ | ⚠️ | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | — | — | ⚠️ | — | |
-| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | — | — | ⚠️ | — | |
-| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | — | — | ⚠️ | — | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ | ❌ | ❌ | ❌ | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | — | — | ⚠️ | — | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | — | — | ⚠️ | — | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ | ✅ | ✅ | ❌ | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | — | — | ⚠️ | — | |
-| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | — | ❌ | — | — | |
-| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | — | ❌ | — | — | |
-| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ❌ | ✅ | ✅ | ❌ | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ | ❌ | ❌ | ❌ | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ | ❌ | ❌ | ❌ | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ❌ | ✅ | ✅ | ❌ | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ | ✅ | ✅ | ❌ | |
-| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | — | — | ✅ | — | |
-| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ | ❌ | ❌ | ❌ | |
-| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | — | — | ⚠️ | — | |
-| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ | ❌ | ❌ | ❌ | |
-| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ❌ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ | ❌ | ❌ | ❌ | |
-| [python](../by-language/python.md) | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | — | — | ⚠️ | — | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ❌ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ❌ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ | ❌ | ❌ | ❌ | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ❌ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ❌ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ❌ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ❌ | ✅ | ✅ | ❌ | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ | ✅ | ✅ | ❌ | |
-| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ | ❌ | ❌ | ❌ | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ | ✅ | ✅ | ❌ | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ | ✅ | ✅ | ❌ | |
-| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ | ✅ | ✅ | ❌ | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ❌ | ✅ | ✅ | ❌ | |
-| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | — | — | ⚠️ | — | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ❌ | ✅ | ✅ | ❌ | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ❌ | ✅ | ✅ | ❌ | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ❌ | ✅ | ✅ | ❌ | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ | ❌ | ❌ | ❌ | |
-| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | — | — | ⚠️ | — | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ | ❌ | ❌ | ❌ | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ❌ | ✅ | ✅ | ❌ | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ | ❌ | ❌ | ❌ | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | — | — | ⚠️ | — | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | — | ❌ | — | — | |
+| [python](../by-language/python.md) | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/1 | ❌ 0/2 | — | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -7,23 +7,51 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | — | — | ⚠️ | — | |
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ | ✅ | ✅ | ⚠️ | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | — | — | ⚠️ | — | |
-| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | — | ❌ | — | — | |
-| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | — | — | ⚠️ | — | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ | ❌ | ❌ | ❌ | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ | ❌ | ❌ | ❌ | |
-| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ | ❌ | ❌ | ❌ | |
-| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Uno Platform](../detail/lang.csharp.framework.uno.md) | — | — | ⚠️ | — | |
-| [WPF](../detail/lang.csharp.framework.wpf.md) | — | — | ⚠️ | — | |
-| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | — | — | ⚠️ | — | |
-| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | — | — | ⚠️ | — | |
-| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | — | — | — | — | — | — | — | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | — | — | — | — | — | — | — | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | — | — | — | — | — | — | — | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | — | — | — | — | — | — | — | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | — | — | — | — | — | — | — | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | — | — | — | — | — | — | — | |
+
+
+### UI Frontend
+
+| Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+
+
+### Mobile
+
+| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+
+
+### Desktop
+
+| Name | Process | Native | Updates | Notes |
+|---|---|---|---|---|
+| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | |
+| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | |
+| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | |
+
+
+### RPC Framework
+
+| Name | Schema | Codegen | Transport | Notes |
+|---|---|---|---|---|
+| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -7,17 +7,27 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | — | — | ⚠️ | — | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | — | — | ⚠️ | — | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ | ❌ | ❌ | ❌ | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | — | — | — | — | — | — | — | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | — | — | — | — | — | — | — | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | — | — | — | — | — | — | — | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | — | — | — | — | — | — | — | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | — | — | — | — | — | — | — | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | — | — | — | — | — | — | — | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | — | — | — | — | — | — | — | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | — | — | — | — | — | — | — | |
+
+
+### Meta Framework
+
+| Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -7,25 +7,41 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Beego](../detail/lang.go.framework.beego.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Buffalo](../detail/lang.go.framework.buffalo.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Echo](../detail/lang.go.framework.echo.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Fiber](../detail/lang.go.framework.fiber.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | — | — | ⚠️ | — | |
-| [Gin](../detail/lang.go.framework.gin.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Huma](../detail/lang.go.framework.huma.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Iris](../detail/lang.go.framework.iris.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Revel](../detail/lang.go.framework.revel.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [chi](../detail/lang.go.framework.chi.md) | ❌ | ✅ | ✅ | ❌ | |
-| [fasthttp](../detail/lang.go.framework.fasthttp.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [go-zero](../detail/lang.go.framework.go-zero.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | — | — | ⚠️ | — | |
-| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ❌ | ✅ | ✅ | ❌ | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Beego](../detail/lang.go.framework.beego.md) | — | — | — | — | — | — | — | |
+| [Buffalo](../detail/lang.go.framework.buffalo.md) | — | — | — | — | — | — | — | |
+| [Echo](../detail/lang.go.framework.echo.md) | — | — | — | — | — | — | — | |
+| [Fiber](../detail/lang.go.framework.fiber.md) | — | — | — | — | — | — | — | |
+| [Gin](../detail/lang.go.framework.gin.md) | — | — | — | — | — | — | — | |
+| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | — | — | — | — | — | — | — | |
+| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | — | — | — | — | — | — | — | |
+| [Huma](../detail/lang.go.framework.huma.md) | — | — | — | — | — | — | — | |
+| [Iris](../detail/lang.go.framework.iris.md) | — | — | — | — | — | — | — | |
+| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | — | — | — | — | — | — | — | |
+| [Revel](../detail/lang.go.framework.revel.md) | — | — | — | — | — | — | — | |
+| [chi](../detail/lang.go.framework.chi.md) | — | — | — | — | — | — | — | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | — | — | — | — | — | — | — | |
+| [go-zero](../detail/lang.go.framework.go-zero.md) | — | — | — | — | — | — | — | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | — | — | — | — | — | — | — | |
+
+
+### Mobile
+
+| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+
+
+### Desktop
+
+| Name | Process | Native | Updates | Notes |
+|---|---|---|---|---|
+| [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | ❌ 0/2 | ❌ 0/1 | — | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -7,27 +7,55 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | — | — | ⚠️ | — | |
-| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | — | — | ⚠️ | — | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Helidon](../detail/lang.java.framework.helidon.md) | ❌ | ❌ | ❌ | ❌ | |
-| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ | ❌ | ❌ | ❌ | |
-| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | — | — | ⚠️ | — | |
-| [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [Play Framework](../detail/lang.java.framework.play.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ | ✅ | ✅ | ⚠️ | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | — | — | — | — | — | — | — | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | — | — | — | — | — | — | — | |
+| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | — | — | — | — | — | — | — | |
+| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | — | — | — | — | — | — | — | |
+| [Helidon](../detail/lang.java.framework.helidon.md) | — | — | — | — | — | — | — | |
+| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | — | — | — | — | — | — | — | |
+| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | — | — | — | — | — | — | — | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | — | — | — | — | — | — | — | |
+| [Micronaut](../detail/lang.java.framework.micronaut.md) | — | — | — | — | — | — | — | |
+| [Quarkus](../detail/lang.java.framework.quarkus.md) | — | — | — | — | — | — | — | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | — | — | — | — | — | — | — | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | — | — | — | — | — | — | — | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | — | — | — | — | — | — | — | |
+
+
+### UI Frontend
+
+| Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+
+
+### Meta Framework
+
+| Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+
+
+### Mobile
+
+| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+
+
+### AI Integration
+
+| Name | Prompts | Composition | Tracking | Notes |
+|---|---|---|---|---|
+| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ❌ 0/1 | ❌ 0/2 | — | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -7,20 +7,36 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | — | — | ⚠️ | — | |
-| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | — | — | ⚠️ | — | |
-| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | — | — | ⚠️ | — | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | — | — | ⚠️ | — | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | — | — | ⚠️ | — | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | — | — | ⚠️ | — | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | — | — | — | — | — | — | — | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | — | — | — | — | — | — | — | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | — | — | — | — | — | — | — | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | — | — | — | — | — | — | — | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | — | — | — | — | — | — | — | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | — | — | — | — | — | — | — | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | — | — | — | — | — | — | — | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | — | — | — | — | — | — | — | |
+
+
+### Mobile
+
+| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+
+
+### Desktop
+
+| Name | Process | Native | Updates | Notes |
+|---|---|---|---|---|
+| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | |
+| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | |
+
 
 ## ORMs
 

--- a/docs/coverage/by-language/lua.md
+++ b/docs/coverage/by-language/lua.md
@@ -7,7 +7,10 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Lapis](../detail/lang.lua.framework.lapis.md) | — | ❌ | — | — | |
-| [OpenResty](../detail/lang.lua.framework.openresty.md) | — | ❌ | — | — | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Lapis](../detail/lang.lua.framework.lapis.md) | — | — | — | — | — | — | — | |
+| [OpenResty](../detail/lang.lua.framework.openresty.md) | — | — | — | — | — | — | — | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -7,20 +7,24 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [CakePHP](../detail/lang.php.framework.cakephp.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Drupal](../detail/lang.php.framework.drupal.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Magento](../detail/lang.php.framework.magento.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Slim](../detail/lang.php.framework.slim.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | ❌ | ✅ | ✅ | ❌ | |
-| [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Yii](../detail/lang.php.framework.yii.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [CakePHP](../detail/lang.php.framework.cakephp.md) | — | — | — | — | — | — | — | |
+| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | — | — | — | — | — | — | — | |
+| [Drupal](../detail/lang.php.framework.drupal.md) | — | — | — | — | — | — | — | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | — | — | — | — | — | — | — | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | — | — | — | — | — | — | — | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | — | — | — | — | — | — | — | |
+| [Magento](../detail/lang.php.framework.magento.md) | — | — | — | — | — | — | — | |
+| [Phalcon](../detail/lang.php.framework.phalcon.md) | — | — | — | — | — | — | — | |
+| [Slim](../detail/lang.php.framework.slim.md) | — | — | — | — | — | — | — | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | — | — | — | — | — | — | — | |
+| [WordPress](../detail/lang.php.framework.wordpress.md) | — | — | — | — | — | — | — | |
+| [Yii](../detail/lang.php.framework.yii.md) | — | — | — | — | — | — | — | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -7,28 +7,38 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Celery (task queue)](../detail/lang.python.framework.celery.md) | — | — | ✅ | — | |
-| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Django](../detail/lang.python.framework.django.md) | ⚠️ | ✅ | ✅ | ⚠️ | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | — | — | ⚠️ | — | |
-| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ | ❌ | ❌ | ❌ | |
-| [FastAPI](../detail/lang.python.framework.fastapi.md) | ⚠️ | ✅ | ✅ | ❌ | |
-| [Flask](../detail/lang.python.framework.flask.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Hug](../detail/lang.python.framework.hug.md) | ❌ | ❌ | ❌ | ❌ | |
-| [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | — | — | ⚠️ | — | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Pyramid](../detail/lang.python.framework.pyramid.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Quart](../detail/lang.python.framework.quart.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Starlette](../detail/lang.python.framework.starlette.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Tornado](../detail/lang.python.framework.tornado.md) | ❌ | ✅ | ✅ | ❌ | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ | ✅ | ✅ | ❌ | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Bottle](../detail/lang.python.framework.bottle.md) | — | — | — | — | — | — | — | |
+| [Celery (task queue)](../detail/lang.python.framework.celery.md) | — | — | — | — | — | — | — | |
+| [CherryPy](../detail/lang.python.framework.cherrypy.md) | — | — | — | — | — | — | — | |
+| [Django](../detail/lang.python.framework.django.md) | — | — | — | — | — | — | — | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | — | — | — | — | — | — | — | |
+| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | — | — | — | — | — | — | — | |
+| [Falcon](../detail/lang.python.framework.falcon.md) | — | — | — | — | — | — | — | |
+| [FastAPI](../detail/lang.python.framework.fastapi.md) | — | — | — | — | — | — | — | |
+| [Flask](../detail/lang.python.framework.flask.md) | — | — | — | — | — | — | — | |
+| [Hug](../detail/lang.python.framework.hug.md) | — | — | — | — | — | — | — | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | — | — | — | — | — | — | — | |
+| [Pyramid](../detail/lang.python.framework.pyramid.md) | — | — | — | — | — | — | — | |
+| [Quart](../detail/lang.python.framework.quart.md) | — | — | — | — | — | — | — | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | — | — | — | — | — | — | — | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | — | — | — | — | — | — | — | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | — | — | — | — | — | — | — | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | — | — | — | — | — | — | — | |
+| [Tornado](../detail/lang.python.framework.tornado.md) | — | — | — | — | — | — | — | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | — | — | — | — | — | — | — | |
+
+
+### AI Integration
+
+| Name | Prompts | Composition | Tracking | Notes |
+|---|---|---|---|---|
+| [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/1 | ❌ 0/2 | — | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -7,16 +7,20 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Grape](../detail/lang.ruby.framework.grape.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Padrino](../detail/lang.ruby.framework.padrino.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Roda](../detail/lang.ruby.framework.roda.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ❌ | ✅ | ✅ | ❌ | |
-| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | — | — | ⚠️ | — | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | — | — | — | — | — | — | — | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | — | — | — | — | — | — | — | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | — | — | — | — | — | — | — | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | — | — | — | — | — | — | — | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | — | — | — | — | — | — | — | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | — | — | — | — | — | — | — | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | — | — | — | — | — | — | — | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | — | — | — | — | — | — | — | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -7,19 +7,29 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Axum](../detail/lang.rust.framework.axum.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Poem](../detail/lang.rust.framework.poem.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | ❌ | ✅ | ✅ | ❌ | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | — | — | ⚠️ | — | |
-| [Tide](../detail/lang.rust.framework.tide.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Warp](../detail/lang.rust.framework.warp.md) | ❌ | ✅ | ✅ | ❌ | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Actix Web](../detail/lang.rust.framework.actix.md) | — | — | — | — | — | — | — | |
+| [Axum](../detail/lang.rust.framework.axum.md) | — | — | — | — | — | — | — | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | — | — | — | — | — | — | — | |
+| [Poem](../detail/lang.rust.framework.poem.md) | — | — | — | — | — | — | — | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | — | — | — | — | — | — | — | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | — | — | — | — | — | — | — | |
+| [Tide](../detail/lang.rust.framework.tide.md) | — | — | — | — | — | — | — | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | — | — | — | — | — | — | — | |
+| [Warp](../detail/lang.rust.framework.warp.md) | — | — | — | — | — | — | — | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | — | — | — | — | — | — | — | |
+
+
+### Desktop
+
+| Name | Process | Native | Updates | Notes |
+|---|---|---|---|---|
+| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -7,17 +7,27 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Cask](../detail/lang.scala.framework.cask.md) | ❌ | ❌ | ❌ | ❌ | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | — | — | ⚠️ | — | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | ❌ | ⚠️ | ⚠️ | ❌ | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | — | — | — | — | — | — | — | |
+| [Cask](../detail/lang.scala.framework.cask.md) | — | — | — | — | — | — | — | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | — | — | — | — | — | — | — | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | — | — | — | — | — | — | — | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | — | — | — | — | — | — | — | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | — | — | — | — | — | — | — | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | — | — | — | — | — | — | — | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | — | — | — | — | — | — | — | |
+
+
+### Meta Framework
+
+| Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/swift.md
+++ b/docs/coverage/by-language/swift.md
@@ -7,9 +7,13 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
-| Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
-|---|---|---|---|---|---|
-| [Vapor](../detail/lang.swift.framework.vapor.md) | — | ❌ | — | — | |
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [Vapor](../detail/lang.swift.framework.vapor.md) | — | — | — | — | — | — | — | |
+
 
 ## Tools
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -5,16 +5,56 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** UI Frontend
+- **Capability cells:** 15
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/blazor_server.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+| `jsx_template` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -5,16 +5,56 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** UI Frontend
+- **Capability cells:** 15
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+| `jsx_template` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor.md
@@ -5,13 +5,56 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Subcategory:** UI Frontend
+- **Capability cells:** 15
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+| `jsx_template` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** RPC Framework
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Schema
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/grpc_edges.go`<br>`internal/engine/rules/csharp/frameworks/grpc_net.yaml` | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/grpc_net.yaml` | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
+| `procedure_extraction` | ❌ `missing` | — | — | — | — | — |
+| `schema_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Codegen
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `client_codegen` | ❌ `missing` | — | — | — | — | — |
+
+### Transport
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.csharp.framework.net-maui.md
+++ b/docs/coverage/detail/lang.csharp.framework.net-maui.md
@@ -5,16 +5,65 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 14
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/net_maui.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.csharp.framework.uno.md
+++ b/docs/coverage/detail/lang.csharp.framework.uno.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Desktop
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Process
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/uno_platform.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `ipc_extraction` | ❌ `missing` | — | — | — | — | — |
+| `main_renderer_split` | ❌ `missing` | — | — | — | — | — |
+
+### Native
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Updates
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.winforms.md
+++ b/docs/coverage/detail/lang.csharp.framework.winforms.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Desktop
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Process
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/winforms.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `ipc_extraction` | ❌ `missing` | — | — | — | — | — |
+| `main_renderer_split` | ❌ `missing` | — | — | — | — | — |
+
+### Native
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Updates
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.wpf.md
+++ b/docs/coverage/detail/lang.csharp.framework.wpf.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Desktop
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Process
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/wpf.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `ipc_extraction` | ❌ `missing` | — | — | — | — | — |
+| `main_renderer_split` | ❌ `missing` | — | — | — | — | — |
+
+### Native
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Updates
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.xamarin.md
+++ b/docs/coverage/detail/lang.csharp.framework.xamarin.md
@@ -5,16 +5,65 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 14
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/xamarin.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
@@ -5,16 +5,64 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Meta Framework
+- **Capability cells:** 13
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml` | — |
-| `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml` | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — | — |
+
+### Server
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — | — |
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `route_extraction` | ❌ `missing` | — | — | — | — | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+
+### Build
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `static_generation` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.fyne.md
+++ b/docs/coverage/detail/lang.go.framework.fyne.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Desktop
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Process
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fyne.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `ipc_extraction` | ❌ `missing` | — | — | — | — | — |
+| `main_renderer_split` | ❌ `missing` | — | — | — | — | — |
+
+### Native
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Updates
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.gomobile.md
+++ b/docs/coverage/detail/lang.go.framework.gomobile.md
@@ -5,16 +5,65 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 14
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/gomobile.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.android-jetpack.md
+++ b/docs/coverage/detail/lang.java.framework.android-jetpack.md
@@ -5,16 +5,65 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 14
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/android_jetpack_compose.yaml`<br>`internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.android-sdk.md
+++ b/docs/coverage/detail/lang.java.framework.android-sdk.md
@@ -5,16 +5,65 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 14
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/android_sdk.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.gwt.md
+++ b/docs/coverage/detail/lang.java.framework.gwt.md
@@ -5,16 +5,56 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** UI Frontend
+- **Capability cells:** 15
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml` | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml` | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+| `jsx_template` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.langchain4j.md
+++ b/docs/coverage/detail/lang.java.framework.langchain4j.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** AI Integration
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Prompts
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/langchain4j.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `prompt_template_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Composition
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `chain_composition` | ❌ `missing` | — | — | — | — | — |
+| `tool_use_detection` | ❌ `missing` | — | — | — | — | — |
+
+### Tracking
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.play.md
+++ b/docs/coverage/detail/lang.java.framework.play.md
@@ -5,16 +5,64 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Meta Framework
+- **Capability cells:** 13
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/play_framework.yaml` | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/play_framework.yaml` | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — | — |
+
+### Server
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — | — |
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `route_extraction` | ❌ `missing` | — | — | — | — | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+
+### Build
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `static_generation` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.java.framework.vaadin.md
+++ b/docs/coverage/detail/lang.java.framework.vaadin.md
@@ -5,16 +5,56 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** UI Frontend
+- **Capability cells:** 15
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vaadin.yaml` | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vaadin.yaml` | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+| `jsx_template` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `data_fetching` | ❌ `missing` | — | — | — | — | — |
+| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Desktop
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Process
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/compose_desktop.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `ipc_extraction` | ❌ `missing` | — | — | — | — | — |
+| `main_renderer_split` | ❌ `missing` | — | — | — | — | — |
+
+### Native
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Updates
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Desktop
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Process
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/compose_multiplatform.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `ipc_extraction` | ❌ `missing` | — | — | — | — | — |
+| `main_renderer_split` | ❌ `missing` | — | — | — | — | — |
+
+### Native
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Updates
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -5,16 +5,65 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 14
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -5,16 +5,65 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Mobile
+- **Capability cells:** 14
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/kmp.yaml`<br>`internal/engine/rules/kotlin/frameworks/kotlin_multiplatform_kmp_kmm.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `context_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `deep_link_extraction` | ❌ `missing` | — | — | — | — | — |
+| `navigation_extraction` | ❌ `missing` | — | — | — | — | — |
+| `screen_detection` | ❌ `missing` | — | — | — | — | — |
+
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `platform_branching` | ❌ `missing` | — | — | — | — | — |
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `branch_conditions` | ❌ `missing` | — | — | — | — | — |
+| `state_management` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.lua.framework.lapis.md
+++ b/docs/coverage/detail/lang.lua.framework.lapis.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/lang.lua.framework.openresty.md
+++ b/docs/coverage/detail/lang.lua.framework.openresty.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.celery.md
+++ b/docs/coverage/detail/lang.python.framework.celery.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.dramatiq.md
+++ b/docs/coverage/detail/lang.python.framework.dramatiq.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.langchain.md
+++ b/docs/coverage/detail/lang.python.framework.langchain.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** AI Integration
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Prompts
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/langchain.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `prompt_template_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Composition
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `chain_composition` | ❌ `missing` | — | — | — | — | — |
+| `tool_use_detection` | ❌ `missing` | — | — | — | — | — |
+
+### Tracking
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.tauri.md
+++ b/docs/coverage/detail/lang.rust.framework.tauri.md
@@ -5,16 +5,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Desktop
+- **Capability cells:** 3
 
 ## Capabilities
 
+
+### Process
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tauri.yaml` | — |
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `ipc_extraction` | ❌ `missing` | — | — | — | — | — |
+| `main_renderer_split` | ❌ `missing` | — | — | — | — | — |
+
+### Native
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `native_module_imports` | ❌ `missing` | — | — | — | — | — |
+
+### Updates
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.scala.framework.play.md
+++ b/docs/coverage/detail/lang.scala.framework.play.md
@@ -5,16 +5,64 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 4
+- **Subcategory:** Meta Framework
+- **Capability cells:** 13
 
 ## Capabilities
 
+
+### Structure
+
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
-| `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/play_framework.yaml` | — |
-| `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/play_framework.yaml` | — |
-| `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `data_loaders` | ❌ `missing` | — | — | — | — | — |
+
+### Server
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hydration_boundaries` | ❌ `missing` | — | — | — | — | — |
+| `server_components` | ❌ `missing` | — | — | — | — | — |
+
+### Routing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `route_extraction` | ❌ `missing` | — | — | — | — | — |
+| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+
+### Build
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `static_generation` | ❌ `missing` | — | — | — | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | — | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | — | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | — | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `state_setter_emission` | ❌ `missing` | — | — | — | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 4
 
 ## Capabilities

--- a/docs/coverage/detail/lang.swift.framework.vapor.md
+++ b/docs/coverage/detail/lang.swift.framework.vapor.md
@@ -5,6 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [swift](../by-language/swift.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
 - **Capability cells:** 1
 
 ## Capabilities

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9,12 +9,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/extractors/bazel/extractor.go"],
+          "cites": [
+            "internal/extractors/bazel/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/bazel/parser.go"],
+          "cites": [
+            "internal/extractors/bazel/parser.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -27,12 +31,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -45,12 +53,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -63,12 +75,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -81,12 +97,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/php/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/php/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -99,12 +119,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
+          "cites": [
+            "internal/extractors/dockerfile/dockerfile.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
+          "cites": [
+            "internal/extractors/dockerfile/dockerfile.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -117,12 +141,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -163,12 +191,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/extractors/golang/gomod.go"],
+          "cites": [
+            "internal/extractors/golang/gomod.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/go/build_tools.yaml","internal/extractors/golang/gomod.go"],
+          "cites": [
+            "internal/engine/rules/go/build_tools.yaml",
+            "internal/extractors/golang/gomod.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -181,12 +214,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/java/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/build_tools.yaml","internal/engine/rules/kotlin/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/java/build_tools.yaml",
+            "internal/engine/rules/kotlin/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -213,12 +251,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -231,12 +273,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/extractors/just/just.go"],
+          "cites": [
+            "internal/extractors/just/just.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/just/just.go"],
+          "cites": [
+            "internal/extractors/just/just.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -280,7 +326,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -293,12 +341,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/java/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/java/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -325,12 +377,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -343,12 +399,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -361,12 +421,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -407,12 +471,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -425,12 +493,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -443,12 +515,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -461,12 +537,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -482,7 +562,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -509,12 +591,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -527,12 +613,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -573,12 +663,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -594,7 +688,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -610,7 +706,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -623,12 +721,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -641,12 +743,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -659,12 +765,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -677,12 +787,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/buildkite.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/buildkite.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -695,12 +809,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/circleci.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/circleci.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -727,12 +845,17 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/github_actions.yaml","internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/github_actions.yaml",
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -745,12 +868,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -766,7 +893,9 @@
         },
         "file_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/cicd/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -779,12 +908,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/travis_ci.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/travis_ci.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -797,7 +930,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -806,16 +941,20 @@
       "id": "config.dotenv",
       "category": "platform",
       "language": "multi",
-      "label": ".env (names-only — values stripped at extraction boundary)",
+      "label": ".env (names-only \u2014 values stripped at extraction boundary)",
       "capabilities": {
         "env_resolution": {
           "status": "full",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -828,7 +967,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -841,7 +982,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -854,7 +997,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -878,7 +1023,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -891,7 +1038,10 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/config/discover.go","internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/config/discover.go",
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -904,7 +1054,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -917,7 +1069,10 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/config/discover.go","internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/config/discover.go",
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -958,12 +1113,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/iac_sns_edges.go"],
+          "cites": [
+            "internal/engine/iac_sns_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -976,12 +1135,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -994,12 +1157,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1012,12 +1179,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
+          "cites": [
+            "internal/engine/rules/database_index/language.yaml",
+            "internal/extractors/sql"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1044,12 +1216,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
+          "cites": [
+            "internal/engine/rules/database_index/language.yaml",
+            "internal/extractors/sql"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1062,12 +1239,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1094,12 +1275,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/extractors/sql"],
+          "cites": [
+            "internal/extractors/sql"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1112,12 +1297,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/docker/frameworks/docker_compose.yaml","internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/engine/rules/docker/frameworks/docker_compose.yaml",
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1130,12 +1320,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
+          "cites": [
+            "internal/extractors/dockerfile/dockerfile.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/docker/frameworks/dockerfile.yaml","internal/extractors/dockerfile/dockerfile.go"],
+          "cites": [
+            "internal/engine/rules/docker/frameworks/dockerfile.yaml",
+            "internal/extractors/dockerfile/dockerfile.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1148,12 +1343,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1166,12 +1365,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml","internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml",
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1198,12 +1402,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/ansible/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/ansible/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1230,12 +1438,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/cdk/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/cdk/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1248,12 +1460,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1266,12 +1482,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/pulumi/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/pulumi/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1284,12 +1504,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/serverless_edges.go"],
+          "cites": [
+            "internal/engine/serverless_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/serverless_edges.go"],
+          "cites": [
+            "internal/engine/serverless_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1302,12 +1526,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/hcl"],
+          "cites": [
+            "internal/extractors/hcl"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/hcl"],
+          "cites": [
+            "internal/extractors/hcl"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1388,7 +1616,9 @@
       "capabilities": {
         "log_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/_engine/logging_config_extractor.yaml"],
+          "cites": [
+            "internal/engine/rules/_engine/logging_config_extractor.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1421,12 +1651,17 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
           "status": "full",
-          "cites": ["internal/engine/event_flow.go","internal/engine/process_flow.go"],
+          "cites": [
+            "internal/engine/event_flow.go",
+            "internal/engine/process_flow.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1442,7 +1677,9 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml"],
+          "cites": [
+            "internal/engine/rules/_engine/comment_marker_extractor.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
@@ -1475,7 +1712,9 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/hcl/extractor.go"],
+          "cites": [
+            "internal/extractors/hcl/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1488,7 +1727,9 @@
       "capabilities": {
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/workflow_edges.go"],
+          "cites": [
+            "internal/engine/workflow_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1512,7 +1753,9 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1525,7 +1768,9 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/hcl/extractor.go"],
+          "cites": [
+            "internal/extractors/hcl/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1538,12 +1783,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/hcl/relationships.go"],
+          "cites": [
+            "internal/extractors/hcl/relationships.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/hcl/extractor.go","internal/extractors/hcl/relationships.go"],
+          "cites": [
+            "internal/extractors/hcl/extractor.go",
+            "internal/extractors/hcl/relationships.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1562,7 +1812,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/cassandra_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1581,7 +1833,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1600,7 +1854,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1619,7 +1875,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/mongodb_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1638,7 +1896,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/mysql_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1657,7 +1917,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1676,7 +1938,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/npgsql.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1695,7 +1959,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/redis_stackexchange.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1714,7 +1980,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/sqlite_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1722,6 +1990,7 @@
     {
       "id": "lang.csharp.framework.aspnet-core",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "csharp",
       "label": "ASP.NET Core",
       "capabilities": {
@@ -1730,17 +1999,24 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/aspnet_core_routes.go","internal/engine/rules/csharp/frameworks/asp_net_core.yaml"],
+          "cites": [
+            "internal/engine/aspnet_core_routes.go",
+            "internal/engine/rules/csharp/frameworks/asp_net_core.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/aspnet_core_routes.go"],
+          "cites": [
+            "internal/engine/aspnet_core_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/aspnet_core_routes.go"],
+          "cites": [
+            "internal/engine/aspnet_core_routes.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1748,6 +2024,7 @@
     {
       "id": "lang.csharp.framework.aspnet-mvc",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "csharp",
       "label": "ASP.NET MVC (legacy)",
       "capabilities": {
@@ -1756,12 +2033,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -1772,61 +2053,205 @@
     {
       "id": "lang.csharp.framework.blazor",
       "category": "http_framework",
+      "subcategory": "ui_frontend",
       "language": "csharp",
       "label": "Blazor Server / WebAssembly",
       "capabilities": {
-        "endpoint_synthesis": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          },
+          "jsx_template": {
+            "status": "missing"
+          },
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
+        },
+        "Data Flow": {
+          "prop_extraction": {
+            "status": "missing"
+          },
+          "state_management": {
+            "status": "missing"
+          },
+          "data_fetching": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
+        },
+        "Navigation": {
+          "router_pattern": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.framework.blazor-server",
       "category": "http_framework",
+      "subcategory": "ui_frontend",
       "language": "csharp",
       "label": "Blazor Server",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          },
+          "jsx_template": {
+            "status": "missing"
+          },
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "Data Flow": {
+          "prop_extraction": {
+            "status": "missing"
+          },
+          "state_management": {
+            "status": "missing"
+          },
+          "data_fetching": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/frameworks/blazor_server.yaml"],
-          "verified_at": "2026-05-28"
+        "Navigation": {
+          "router_pattern": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.framework.blazor-wasm",
       "category": "http_framework",
+      "subcategory": "ui_frontend",
       "language": "csharp",
       "label": "Blazor WebAssembly",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          },
+          "jsx_template": {
+            "status": "missing"
+          },
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "Data Flow": {
+          "prop_extraction": {
+            "status": "missing"
+          },
+          "state_management": {
+            "status": "missing"
+          },
+          "data_fetching": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/frameworks/blazor_webassembly.yaml"],
-          "verified_at": "2026-05-28"
+        "Navigation": {
+          "router_pattern": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.framework.carter",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "csharp",
       "label": "Carter",
       "capabilities": {
@@ -1847,6 +2272,7 @@
     {
       "id": "lang.csharp.framework.fastendpoints",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "csharp",
       "label": "FastEndpoints",
       "capabilities": {
@@ -1867,30 +2293,29 @@
     {
       "id": "lang.csharp.framework.grpc-net",
       "category": "http_framework",
+      "subcategory": "rpc_framework",
       "language": "csharp",
       "label": "grpc-dotnet",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Schema": {
+          "schema_extraction": {
+            "status": "missing"
+          },
+          "procedure_extraction": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "partial",
-          "cites": ["internal/engine/grpc_edges.go","internal/engine/rules/csharp/frameworks/grpc_net.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/frameworks/grpc_net.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "missing"
+        "Codegen": {
+          "client_codegen": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.framework.nancyfx",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "csharp",
       "label": "NancyFX",
       "capabilities": {
@@ -1911,28 +2336,74 @@
     {
       "id": "lang.csharp.framework.net-maui",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "csharp",
       "label": ".NET MAUI",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Structure": {
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "Navigation": {
+          "navigation_extraction": {
+            "status": "missing"
+          },
+          "deep_link_extraction": {
+            "status": "missing"
+          },
+          "screen_detection": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/frameworks/net_maui.yaml"],
-          "verified_at": "2026-05-28"
+        "Platform": {
+          "platform_branching": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing"
+          }
+        },
+        "Data Flow": {
+          "state_management": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.framework.servicestack",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "csharp",
       "label": "ServiceStack",
       "capabilities": {
@@ -1953,88 +2424,133 @@
     {
       "id": "lang.csharp.framework.uno",
       "category": "http_framework",
+      "subcategory": "desktop",
       "language": "csharp",
       "label": "Uno Platform",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Process": {
+          "ipc_extraction": {
+            "status": "missing"
+          },
+          "main_renderer_split": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/frameworks/uno_platform.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.framework.winforms",
       "category": "http_framework",
+      "subcategory": "desktop",
       "language": "csharp",
       "label": "Windows Forms",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Process": {
+          "ipc_extraction": {
+            "status": "missing"
+          },
+          "main_renderer_split": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/frameworks/winforms.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.framework.wpf",
       "category": "http_framework",
+      "subcategory": "desktop",
       "language": "csharp",
       "label": "WPF",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Process": {
+          "ipc_extraction": {
+            "status": "missing"
+          },
+          "main_renderer_split": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/frameworks/wpf.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.framework.xamarin",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "csharp",
       "label": "Xamarin",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Structure": {
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "Navigation": {
+          "navigation_extraction": {
+            "status": "missing"
+          },
+          "deep_link_extraction": {
+            "status": "missing"
+          },
+          "screen_detection": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/frameworks/xamarin.yaml"],
-          "verified_at": "2026-05-28"
+        "Platform": {
+          "platform_branching": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing"
+          }
+        },
+        "Data Flow": {
+          "state_management": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -2049,12 +2565,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/dapper.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/dapper.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2070,12 +2590,17 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/csharp/frameworks/entity_framework_core.yaml","internal/engine/rules/csharp/orms/entity_framework_core.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/frameworks/entity_framework_core.yaml",
+            "internal/engine/rules/csharp/orms/entity_framework_core.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2091,12 +2616,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2129,12 +2658,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/nhibernate.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/nhibernate.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2153,7 +2686,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2172,7 +2707,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2191,7 +2728,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2210,7 +2749,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/myxql.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/myxql.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2229,7 +2770,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2248,7 +2791,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/postgrex.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/postgrex.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2267,7 +2812,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/redix.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/redix.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2286,7 +2833,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/xandra.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/xandra.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2294,6 +2843,7 @@
     {
       "id": "lang.elixir.framework.absinthe",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "elixir",
       "label": "Absinthe (GraphQL)",
       "capabilities": {
@@ -2302,12 +2852,17 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml","internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/absinthe.yaml",
+            "internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/absinthe.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2318,6 +2873,7 @@
     {
       "id": "lang.elixir.framework.ash",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "elixir",
       "label": "Ash Framework",
       "capabilities": {
@@ -2326,12 +2882,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2342,6 +2902,7 @@
     {
       "id": "lang.elixir.framework.bandit",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "elixir",
       "label": "Bandit",
       "capabilities": {
@@ -2362,6 +2923,7 @@
     {
       "id": "lang.elixir.framework.cowboy",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "elixir",
       "label": "Cowboy",
       "capabilities": {
@@ -2382,6 +2944,7 @@
     {
       "id": "lang.elixir.framework.nerves",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "elixir",
       "label": "Nerves (embedded)",
       "capabilities": {
@@ -2393,7 +2956,9 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/nerves.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/nerves.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2404,6 +2969,7 @@
     {
       "id": "lang.elixir.framework.oban",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "elixir",
       "label": "Oban (job queue)",
       "capabilities": {
@@ -2415,7 +2981,9 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/oban.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/oban.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2426,6 +2994,7 @@
     {
       "id": "lang.elixir.framework.phoenix",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "elixir",
       "label": "Phoenix",
       "capabilities": {
@@ -2434,12 +3003,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/phoenix_routes.go","internal/engine/rules/elixir/frameworks/phoenix.yaml"],
+          "cites": [
+            "internal/engine/phoenix_routes.go",
+            "internal/engine/rules/elixir/frameworks/phoenix.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/phoenix_routes.go"],
+          "cites": [
+            "internal/engine/phoenix_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2450,30 +3024,71 @@
     {
       "id": "lang.elixir.framework.phoenix-liveview",
       "category": "http_framework",
+      "subcategory": "meta_framework",
       "language": "elixir",
       "label": "Phoenix LiveView",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml"],
-          "verified_at": "2026-05-28"
+        "Data Flow": {
+          "data_loaders": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/elixir/frameworks/phoenix_liveview.yaml"],
-          "verified_at": "2026-05-28"
+        "Server": {
+          "server_components": {
+            "status": "missing"
+          },
+          "hydration_boundaries": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "missing"
+        "Routing": {
+          "route_extraction": {
+            "status": "missing"
+          },
+          "router_pattern": {
+            "status": "missing"
+          }
+        },
+        "Build": {
+          "static_generation": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.framework.plug",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "elixir",
       "label": "Plug",
       "capabilities": {
@@ -2502,12 +3117,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2523,12 +3142,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2547,7 +3170,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/cassandra_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/cassandra_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2566,7 +3191,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/dynamodb_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/dynamodb_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2585,7 +3212,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/elasticsearch_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/elasticsearch_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2604,7 +3233,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/mongo_driver.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/mongo_driver.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2623,7 +3254,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/mysql_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/mysql_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2642,7 +3275,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2661,7 +3296,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/go_redis.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/go_redis.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2680,7 +3317,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlite_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlite_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -2688,6 +3327,7 @@
     {
       "id": "lang.go.framework.beego",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Beego",
       "capabilities": {
@@ -2696,12 +3336,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/beego.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/beego.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2712,6 +3356,7 @@
     {
       "id": "lang.go.framework.buffalo",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Buffalo",
       "capabilities": {
@@ -2720,12 +3365,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/buffalo.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/buffalo.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2736,6 +3385,7 @@
     {
       "id": "lang.go.framework.chi",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "chi",
       "capabilities": {
@@ -2744,12 +3394,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/chi.yaml"],
+          "cites": [
+            "internal/engine/go_routes.go",
+            "internal/engine/rules/go/frameworks/chi.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go"],
+          "cites": [
+            "internal/engine/go_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2760,6 +3415,7 @@
     {
       "id": "lang.go.framework.echo",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Echo",
       "capabilities": {
@@ -2768,12 +3424,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/echo.yaml"],
+          "cites": [
+            "internal/engine/go_routes.go",
+            "internal/engine/rules/go/frameworks/echo.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go"],
+          "cites": [
+            "internal/engine/go_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2784,6 +3445,7 @@
     {
       "id": "lang.go.framework.fasthttp",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "fasthttp",
       "capabilities": {
@@ -2792,12 +3454,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/fasthttp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/fasthttp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2808,6 +3474,7 @@
     {
       "id": "lang.go.framework.fiber",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Fiber",
       "capabilities": {
@@ -2816,12 +3483,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/fiber.yaml"],
+          "cites": [
+            "internal/engine/go_routes.go",
+            "internal/engine/rules/go/frameworks/fiber.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go"],
+          "cites": [
+            "internal/engine/go_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2832,28 +3504,29 @@
     {
       "id": "lang.go.framework.fyne",
       "category": "http_framework",
+      "subcategory": "desktop",
       "language": "go",
       "label": "Fyne (desktop GUI)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Process": {
+          "ipc_extraction": {
+            "status": "missing"
+          },
+          "main_renderer_split": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/fyne.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.go.framework.gin",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Gin",
       "capabilities": {
@@ -2862,12 +3535,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gin.yaml"],
+          "cites": [
+            "internal/engine/go_routes.go",
+            "internal/engine/rules/go/frameworks/gin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go"],
+          "cites": [
+            "internal/engine/go_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2878,6 +3556,7 @@
     {
       "id": "lang.go.framework.go-zero",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "go-zero",
       "capabilities": {
@@ -2886,12 +3565,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/go_zero.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/go_zero.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2902,28 +3585,74 @@
     {
       "id": "lang.go.framework.gomobile",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "go",
       "label": "gomobile (mobile bindings)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Structure": {
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "Navigation": {
+          "navigation_extraction": {
+            "status": "missing"
+          },
+          "deep_link_extraction": {
+            "status": "missing"
+          },
+          "screen_detection": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/gomobile.yaml"],
-          "verified_at": "2026-05-28"
+        "Platform": {
+          "platform_branching": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing"
+          }
+        },
+        "Data Flow": {
+          "state_management": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.go.framework.gorilla-mux",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Gorilla Mux",
       "capabilities": {
@@ -2932,12 +3661,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gorilla_mux.yaml"],
+          "cites": [
+            "internal/engine/go_routes.go",
+            "internal/engine/rules/go/frameworks/gorilla_mux.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go"],
+          "cites": [
+            "internal/engine/go_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2948,6 +3682,7 @@
     {
       "id": "lang.go.framework.hertz",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Hertz (CloudWeGo)",
       "capabilities": {
@@ -2956,12 +3691,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/hertz.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/hertz.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2972,6 +3711,7 @@
     {
       "id": "lang.go.framework.huma",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Huma",
       "capabilities": {
@@ -2980,12 +3720,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_go_trio.go"],
+          "cites": [
+            "internal/engine/http_endpoint_go_trio.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_go_trio.go"],
+          "cites": [
+            "internal/engine/http_endpoint_go_trio.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -2996,6 +3740,7 @@
     {
       "id": "lang.go.framework.iris",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Iris",
       "capabilities": {
@@ -3004,12 +3749,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/iris.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/iris.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3020,6 +3769,7 @@
     {
       "id": "lang.go.framework.kratos",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Kratos (Bilibili)",
       "capabilities": {
@@ -3028,12 +3778,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/kratos.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/kratos.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3044,6 +3798,7 @@
     {
       "id": "lang.go.framework.net-http",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "net/http (stdlib)",
       "capabilities": {
@@ -3052,12 +3807,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/net_http_stdlib.yaml"],
+          "cites": [
+            "internal/engine/go_routes.go",
+            "internal/engine/rules/go/frameworks/net_http_stdlib.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/go_routes.go"],
+          "cites": [
+            "internal/engine/go_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3068,6 +3828,7 @@
     {
       "id": "lang.go.framework.revel",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "go",
       "label": "Revel",
       "capabilities": {
@@ -3076,12 +3837,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/revel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
+          "cites": [
+            "internal/engine/rules/go/frameworks/revel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3100,12 +3865,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/bun.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/bun.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3121,12 +3890,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/go/orms/ent.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/ent.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3159,12 +3932,18 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/go/frameworks/gorm.yaml","internal/engine/rules/go/orms/gorm.yaml"],
+          "cites": [
+            "internal/engine/orm_field_edges.go",
+            "internal/engine/rules/go/frameworks/gorm.yaml",
+            "internal/engine/rules/go/orms/gorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3177,7 +3956,9 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/golang_migrate.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/golang_migrate.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -3202,7 +3983,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/pgx.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/pgx.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3215,17 +3998,23 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlc.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlc.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlc.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3241,12 +4030,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlx.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlx.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3271,6 +4064,7 @@
     {
       "id": "lang.java.framework.akka-http",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Akka HTTP (Java DSL)",
       "capabilities": {
@@ -3291,50 +4085,141 @@
     {
       "id": "lang.java.framework.android-jetpack",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "java",
       "label": "Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Structure": {
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "Navigation": {
+          "navigation_extraction": {
+            "status": "missing"
+          },
+          "deep_link_extraction": {
+            "status": "missing"
+          },
+          "screen_detection": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/android_jetpack_compose.yaml","internal/engine/rules/java/frameworks/android_jetpack_viewmodel_livedata_room_navigation_hilt.yaml"],
-          "verified_at": "2026-05-28"
+        "Platform": {
+          "platform_branching": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing"
+          }
+        },
+        "Data Flow": {
+          "state_management": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.framework.android-sdk",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "java",
       "label": "Android SDK (Activity/Fragment routing)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Structure": {
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "Navigation": {
+          "navigation_extraction": {
+            "status": "missing"
+          },
+          "deep_link_extraction": {
+            "status": "missing"
+          },
+          "screen_detection": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/android_sdk.yaml"],
-          "verified_at": "2026-05-28"
+        "Platform": {
+          "platform_branching": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing"
+          }
+        },
+        "Data Flow": {
+          "state_management": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.framework.dropwizard",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Dropwizard",
       "capabilities": {
@@ -3343,12 +4228,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/dropwizard.yaml"],
+          "cites": [
+            "internal/engine/java_annotation_routes.go",
+            "internal/engine/rules/java/frameworks/dropwizard.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go"],
+          "cites": [
+            "internal/engine/java_annotation_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3359,30 +4249,73 @@
     {
       "id": "lang.java.framework.gwt",
       "category": "http_framework",
+      "subcategory": "ui_frontend",
       "language": "java",
       "label": "Google Web Toolkit (GWT)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          },
+          "jsx_template": {
+            "status": "missing"
+          },
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml"],
-          "verified_at": "2026-05-28"
+        "Data Flow": {
+          "prop_extraction": {
+            "status": "missing"
+          },
+          "state_management": {
+            "status": "missing"
+          },
+          "data_fetching": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/gwt_google_web_toolkit.yaml"],
-          "verified_at": "2026-05-28"
+        "Navigation": {
+          "router_pattern": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "missing"
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.framework.helidon",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Helidon",
       "capabilities": {
@@ -3403,6 +4336,7 @@
     {
       "id": "lang.java.framework.jakarta-ee",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Jakarta EE (Servlet / EE Platform)",
       "capabilities": {
@@ -3411,12 +4345,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3427,6 +4365,7 @@
     {
       "id": "lang.java.framework.javalin",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Javalin",
       "capabilities": {
@@ -3447,22 +4386,30 @@
     {
       "id": "lang.java.framework.jaxrs",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "JAX-RS / Jakarta REST",
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
+          "cites": [
+            "internal/engine/java_annotation_routes.go",
+            "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go"],
+          "cites": [
+            "internal/engine/java_annotation_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3473,44 +4420,52 @@
     {
       "id": "lang.java.framework.langchain4j",
       "category": "http_framework",
+      "subcategory": "ai_integration",
       "language": "java",
       "label": "LangChain4J (LLM agent framework)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Prompts": {
+          "prompt_template_extraction": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/langchain4j.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Composition": {
+          "chain_composition": {
+            "status": "missing"
+          },
+          "tool_use_detection": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.framework.micronaut",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Micronaut",
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/micronaut.yaml"],
+          "cites": [
+            "internal/engine/java_annotation_routes.go",
+            "internal/engine/rules/java/frameworks/micronaut.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go"],
+          "cites": [
+            "internal/engine/java_annotation_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3521,6 +4476,7 @@
     {
       "id": "lang.java.framework.microprofile",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Eclipse MicroProfile",
       "capabilities": {
@@ -3529,12 +4485,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/microprofile.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/microprofile.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3545,46 +4505,94 @@
     {
       "id": "lang.java.framework.play",
       "category": "http_framework",
+      "subcategory": "meta_framework",
       "language": "java",
       "label": "Play Framework",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/play_framework.yaml"],
-          "verified_at": "2026-05-28"
+        "Data Flow": {
+          "data_loaders": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/play_framework.yaml"],
-          "verified_at": "2026-05-28"
+        "Server": {
+          "server_components": {
+            "status": "missing"
+          },
+          "hydration_boundaries": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "missing"
+        "Routing": {
+          "route_extraction": {
+            "status": "missing"
+          },
+          "router_pattern": {
+            "status": "missing"
+          }
+        },
+        "Build": {
+          "static_generation": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.framework.quarkus",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Quarkus",
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/quarkus.yaml"],
+          "cites": [
+            "internal/engine/java_annotation_routes.go",
+            "internal/engine/rules/java/frameworks/quarkus.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go"],
+          "cites": [
+            "internal/engine/java_annotation_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3595,27 +4603,40 @@
     {
       "id": "lang.java.framework.spring-boot",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Spring Boot / Spring MVC",
       "capabilities": {
         "auth_coverage": {
           "status": "full",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/java/frameworks/spring_boot.yaml","internal/engine/rules/java/frameworks/spring_mvc.yaml","internal/engine/spring_routes.go"],
+          "cites": [
+            "internal/engine/http_endpoint_synthesis.go",
+            "internal/engine/rules/java/frameworks/spring_boot.yaml",
+            "internal/engine/rules/java/frameworks/spring_mvc.yaml",
+            "internal/engine/spring_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/java_annotation_routes.go","internal/engine/spring_routes.go"],
+          "cites": [
+            "internal/engine/java_annotation_routes.go",
+            "internal/engine/spring_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/java_annotation_params.go"],
+          "cites": [
+            "internal/engine/java_annotation_params.go"
+          ],
           "verified_at": "2026-05-28"
         }
       },
@@ -3639,22 +4660,30 @@
     {
       "id": "lang.java.framework.spring-webflux",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Spring WebFlux (reactive)",
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/frameworks/spring_webflux.yaml","internal/engine/spring_routes.go"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/spring_webflux.yaml",
+            "internal/engine/spring_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/spring_routes.go"],
+          "cites": [
+            "internal/engine/spring_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3665,6 +4694,7 @@
     {
       "id": "lang.java.framework.struts",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Apache Struts",
       "capabilities": {
@@ -3673,12 +4703,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/apache_struts.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/apache_struts.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3689,30 +4723,73 @@
     {
       "id": "lang.java.framework.vaadin",
       "category": "http_framework",
+      "subcategory": "ui_frontend",
       "language": "java",
       "label": "Vaadin (UI-as-server)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          },
+          "jsx_template": {
+            "status": "missing"
+          },
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/vaadin.yaml"],
-          "verified_at": "2026-05-28"
+        "Data Flow": {
+          "prop_extraction": {
+            "status": "missing"
+          },
+          "state_management": {
+            "status": "missing"
+          },
+          "data_fetching": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/vaadin.yaml"],
-          "verified_at": "2026-05-28"
+        "Navigation": {
+          "router_pattern": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "missing"
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.framework.vertx",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "java",
       "label": "Vert.x",
       "capabilities": {
@@ -3721,12 +4798,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/vert_x.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/vert_x.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -3745,12 +4826,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/dynamodb_java.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/dynamodb_java.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3800,12 +4885,17 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/hibernate_core.yaml"],
+          "cites": [
+            "internal/engine/orm_field_edges.go",
+            "internal/engine/rules/java/orms/hibernate_core.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3821,12 +4911,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/jooq.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/jooq.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3842,12 +4936,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3863,12 +4961,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/mybatis.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/mybatis.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3884,12 +4986,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3905,12 +5011,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3926,12 +5036,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3947,12 +5061,17 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/spring_data_jpa.yaml"],
+          "cites": [
+            "internal/engine/orm_field_edges.go",
+            "internal/engine/rules/java/orms/spring_data_jpa.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3968,12 +5087,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3989,12 +5112,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_redis.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_redis.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4013,7 +5140,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4032,7 +5161,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4051,7 +5182,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4070,7 +5203,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4089,7 +5224,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4108,7 +5245,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4127,7 +5266,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4146,7 +5287,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/redis_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/redis_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4165,7 +5308,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4184,7 +5329,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4265,17 +5412,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4288,7 +5441,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -4345,7 +5500,9 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/astro.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -4360,17 +5517,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4383,7 +5546,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -4403,7 +5568,9 @@
           },
           "main_renderer_split": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/electron.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/electron.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -4425,12 +5592,16 @@
         "Structure": {
           "context_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4441,19 +5612,25 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -4467,12 +5644,16 @@
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "cites": [
+              "internal/extractors/javascript/discriminator.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -4480,31 +5661,41 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -4521,7 +5712,9 @@
           },
           "expo_router_specifics": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/navigation.go"],
+            "cites": [
+              "internal/extractors/javascript/navigation.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -4537,12 +5730,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/express.yaml",
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4554,7 +5752,9 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -4570,12 +5770,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4649,7 +5853,9 @@
         "Routing": {
           "route_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -4665,17 +5871,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4688,7 +5900,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -4704,12 +5918,17 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"],
+            "cites": [
+              "internal/engine/rules/graphql/frameworks/apollo_server.yaml",
+              "internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
+            "cites": [
+              "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4758,12 +5977,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4829,17 +6052,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4852,7 +6081,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -4868,12 +6099,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4899,7 +6134,9 @@
         "Prompts": {
           "prompt_template_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -4907,7 +6144,9 @@
         "Composition": {
           "chain_composition": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -4995,17 +6234,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5018,7 +6263,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5034,26 +6281,34 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5095,12 +6350,16 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5113,17 +6372,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5136,7 +6401,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5185,7 +6452,9 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -5200,17 +6469,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5223,7 +6498,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5266,53 +6543,73 @@
         "Structure": {
           "component_extraction": {
             "status": "partial",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "context_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "hook_recognition": {
             "status": "partial",
-            "cites": ["internal/extractors/javascript/destructure_bindings.go"],
+            "cites": [
+              "internal/extractors/javascript/destructure_bindings.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "jsx_template": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "cites": [
+              "internal/extractors/javascript/discriminator.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "data_fetching": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/destructure_bindings.go",
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "prop_extraction": {
             "status": "partial",
-            "cites": ["internal/extractors/javascript/navigation.go"],
+            "cites": [
+              "internal/extractors/javascript/navigation.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2665",
             "notes": "Covers only JSX navigation props (Link to/href, Navigate to, state object); generic React component prop extraction is not yet implemented.",
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/zustand_store.go"],
+            "cites": [
+              "internal/extractors/javascript/destructure_bindings.go",
+              "internal/extractors/javascript/zustand_store.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -5320,38 +6617,50 @@
         "Navigation": {
           "router_pattern": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/navigation.go"],
+            "cites": [
+              "internal/extractors/javascript/navigation.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5367,12 +6676,16 @@
         "Structure": {
           "context_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5383,19 +6696,25 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -5409,12 +6728,16 @@
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "cites": [
+              "internal/extractors/javascript/discriminator.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -5422,31 +6745,41 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5495,7 +6828,9 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/remix.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -5510,17 +6845,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5533,7 +6874,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5642,17 +6985,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5665,7 +7014,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5714,7 +7065,9 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -5729,17 +7082,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5752,7 +7111,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5768,12 +7129,17 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
+            "cites": [
+              "internal/engine/http_endpoint_trpc.go",
+              "internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/http_endpoint_trpc.go"],
+            "cites": [
+              "internal/engine/http_endpoint_trpc.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -5835,17 +7201,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5858,7 +7230,9 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -5891,12 +7265,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/drizzle.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/drizzle.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5915,7 +7293,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/knex.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/knex.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5931,12 +7311,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5952,12 +7336,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mongoose.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mongoose.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5987,17 +7375,25 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/prisma/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/prisma/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/prisma.yaml","internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml","internal/engine/rules/prisma/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/prisma.yaml",
+            "internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml",
+            "internal/engine/rules/prisma/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6013,12 +7409,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/sequelize.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/sequelize.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6034,12 +7434,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/typeorm.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/typeorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6047,6 +7451,7 @@
     {
       "id": "lang.kotlin.framework.arrow",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "kotlin",
       "label": "Arrow (functional Kotlin)",
       "capabilities": {
@@ -6058,7 +7463,9 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6069,72 +7476,118 @@
     {
       "id": "lang.kotlin.framework.compose",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "kotlin",
       "label": "Jetpack Compose (Android UI)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Structure": {
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "Navigation": {
+          "navigation_extraction": {
+            "status": "missing"
+          },
+          "deep_link_extraction": {
+            "status": "missing"
+          },
+          "screen_detection": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/android_jetpack_compose.yaml"],
-          "verified_at": "2026-05-28"
+        "Platform": {
+          "platform_branching": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing"
+          }
+        },
+        "Data Flow": {
+          "state_management": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.framework.compose-desktop",
       "category": "http_framework",
+      "subcategory": "desktop",
       "language": "kotlin",
       "label": "Compose Desktop",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Process": {
+          "ipc_extraction": {
+            "status": "missing"
+          },
+          "main_renderer_split": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/compose_desktop.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.framework.compose-multiplatform",
       "category": "http_framework",
+      "subcategory": "desktop",
       "language": "kotlin",
       "label": "Compose Multiplatform",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Process": {
+          "ipc_extraction": {
+            "status": "missing"
+          },
+          "main_renderer_split": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/compose_multiplatform.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.framework.coroutines",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "kotlin",
       "label": "kotlinx.coroutines (structured concurrency)",
       "capabilities": {
@@ -6146,7 +7599,9 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6157,6 +7612,7 @@
     {
       "id": "lang.kotlin.framework.http4k",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "kotlin",
       "label": "http4k",
       "capabilities": {
@@ -6165,12 +7621,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/http4k.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/http4k.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6181,6 +7641,7 @@
     {
       "id": "lang.kotlin.framework.javalin",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "kotlin",
       "label": "Javalin (Kotlin)",
       "capabilities": {
@@ -6201,28 +7662,74 @@
     {
       "id": "lang.kotlin.framework.kmp",
       "category": "http_framework",
+      "subcategory": "mobile",
       "language": "kotlin",
       "label": "Kotlin Multiplatform (KMP / KMM)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Structure": {
+          "context_extraction": {
+            "status": "missing"
+          },
+          "hoc_wrapper_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
+        "Navigation": {
+          "navigation_extraction": {
+            "status": "missing"
+          },
+          "deep_link_extraction": {
+            "status": "missing"
+          },
+          "screen_detection": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/kmp.yaml","internal/engine/rules/kotlin/frameworks/kotlin_multiplatform_kmp_kmm.yaml"],
-          "verified_at": "2026-05-28"
+        "Platform": {
+          "platform_branching": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native Bridge": {
+          "native_module_imports": {
+            "status": "missing"
+          }
+        },
+        "Data Flow": {
+          "state_management": {
+            "status": "missing"
+          },
+          "branch_conditions": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.framework.ktor",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "kotlin",
       "label": "Ktor",
       "capabilities": {
@@ -6231,12 +7738,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/ktor.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/ktor.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6247,6 +7758,7 @@
     {
       "id": "lang.kotlin.framework.micronaut",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "kotlin",
       "label": "Micronaut (Kotlin)",
       "capabilities": {
@@ -6255,12 +7767,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6271,6 +7787,7 @@
     {
       "id": "lang.kotlin.framework.quarkus",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "kotlin",
       "label": "Quarkus (Kotlin)",
       "capabilities": {
@@ -6279,12 +7796,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6295,22 +7816,30 @@
     {
       "id": "lang.kotlin.framework.spring-boot",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "kotlin",
       "label": "Spring Boot (Kotlin)",
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml","internal/engine/spring_routes_kotlin.go"],
+          "cites": [
+            "internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml",
+            "internal/engine/spring_routes_kotlin.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/spring_routes_kotlin.go"],
+          "cites": [
+            "internal/engine/spring_routes_kotlin.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6329,12 +7858,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/exposed.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/exposed.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6350,12 +7883,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6371,12 +7908,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/ktorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/ktorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6392,12 +7933,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6413,12 +7958,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/room_android.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/room_android.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6434,12 +7983,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6455,12 +8008,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6468,6 +8025,7 @@
     {
       "id": "lang.lua.framework.lapis",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "lua",
       "label": "Lapis",
       "capabilities": {
@@ -6479,6 +8037,7 @@
     {
       "id": "lang.lua.framework.openresty",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "lua",
       "label": "OpenResty",
       "capabilities": {
@@ -6501,7 +8060,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/cassandra_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/cassandra_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6520,7 +8081,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/dynamodb_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/dynamodb_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6539,7 +8102,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/elasticsearch_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/elasticsearch_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6558,7 +8123,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/mongodb_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/mongodb_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6577,7 +8144,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/mysql_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/mysql_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6596,7 +8165,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6615,7 +8186,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/postgresql_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/postgresql_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6634,7 +8207,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/redis_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/redis_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6653,7 +8228,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/sqlite_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/sqlite_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6661,6 +8238,7 @@
     {
       "id": "lang.php.framework.cakephp",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "CakePHP",
       "capabilities": {
@@ -6669,12 +8247,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/cakephp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/cakephp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6685,6 +8267,7 @@
     {
       "id": "lang.php.framework.codeigniter",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "CodeIgniter",
       "capabilities": {
@@ -6693,12 +8276,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/codeigniter.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/codeigniter.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6709,6 +8296,7 @@
     {
       "id": "lang.php.framework.drupal",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "Drupal",
       "capabilities": {
@@ -6717,12 +8305,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/drupal.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/drupal.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6733,6 +8325,7 @@
     {
       "id": "lang.php.framework.laminas",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "Laminas (formerly Zend)",
       "capabilities": {
@@ -6741,12 +8334,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/laminas.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/laminas.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6757,6 +8354,7 @@
     {
       "id": "lang.php.framework.laravel",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "Laravel",
       "capabilities": {
@@ -6765,12 +8363,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/laravel.yaml"],
+          "cites": [
+            "internal/engine/http_endpoint_php_producer.go",
+            "internal/engine/rules/php/frameworks/laravel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_php_producer.go"],
+          "cites": [
+            "internal/engine/http_endpoint_php_producer.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6781,6 +8384,7 @@
     {
       "id": "lang.php.framework.lumen",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "Lumen",
       "capabilities": {
@@ -6801,6 +8405,7 @@
     {
       "id": "lang.php.framework.magento",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "Magento",
       "capabilities": {
@@ -6809,12 +8414,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/magento.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/magento.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6825,6 +8434,7 @@
     {
       "id": "lang.php.framework.phalcon",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "Phalcon",
       "capabilities": {
@@ -6845,6 +8455,7 @@
     {
       "id": "lang.php.framework.slim",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "Slim",
       "capabilities": {
@@ -6853,12 +8464,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/slim.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/slim.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6869,6 +8484,7 @@
     {
       "id": "lang.php.framework.symfony",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "Symfony",
       "capabilities": {
@@ -6877,12 +8493,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/symfony.yaml"],
+          "cites": [
+            "internal/engine/http_endpoint_php_producer.go",
+            "internal/engine/rules/php/frameworks/symfony.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_php_producer.go"],
+          "cites": [
+            "internal/engine/http_endpoint_php_producer.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6893,6 +8514,7 @@
     {
       "id": "lang.php.framework.wordpress",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "WordPress",
       "capabilities": {
@@ -6901,12 +8523,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/wordpress.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/wordpress.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6917,6 +8543,7 @@
     {
       "id": "lang.php.framework.yii",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "php",
       "label": "Yii",
       "capabilities": {
@@ -6925,12 +8552,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/yii.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
+          "cites": [
+            "internal/engine/rules/php/frameworks/yii.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -6966,12 +8597,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/orms/doctrine_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/doctrine_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6987,12 +8622,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7008,12 +8647,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/propel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/propel.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7029,12 +8672,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/redbeanphp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/redbeanphp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7053,7 +8700,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/cassandra_py.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/cassandra_py.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7072,7 +8721,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/dynamodb_py.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/dynamodb_py.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7091,7 +8742,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/elasticsearch_py.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/elasticsearch_py.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7110,7 +8763,10 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+          "cites": [
+            "internal/engine/rules/python/orms/mysql_py.yaml",
+            "internal/extractors/python/raw_sql_db_calls.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7129,7 +8785,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7148,7 +8806,10 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+          "cites": [
+            "internal/engine/rules/python/orms/postgresql_py.yaml",
+            "internal/extractors/python/raw_sql_db_calls.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7167,7 +8828,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/redis_py.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/redis_py.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7186,7 +8849,10 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+          "cites": [
+            "internal/engine/rules/python/orms/sqlite_py.yaml",
+            "internal/extractors/python/raw_sql_db_calls.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7194,6 +8860,7 @@
     {
       "id": "lang.python.framework.aiohttp",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "aiohttp",
       "capabilities": {
@@ -7202,12 +8869,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/aiohttp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/aiohttp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7218,6 +8889,7 @@
     {
       "id": "lang.python.framework.bottle",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Bottle",
       "capabilities": {
@@ -7226,12 +8898,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/bottle.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/bottle.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7242,6 +8918,7 @@
     {
       "id": "lang.python.framework.celery",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Celery (task queue)",
       "capabilities": {
@@ -7253,7 +8930,10 @@
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/celery.yaml","internal/extractors/python/celery.go"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/celery.yaml",
+            "internal/extractors/python/celery.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7264,6 +8944,7 @@
     {
       "id": "lang.python.framework.cherrypy",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "CherryPy",
       "capabilities": {
@@ -7284,27 +8965,39 @@
     {
       "id": "lang.python.framework.django",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Django",
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/django_drf_actions.go"],
+          "cites": [
+            "internal/engine/django_drf_actions.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/django_routes.go","internal/engine/django_urlconf_nested.go","internal/engine/rules/python/frameworks/django.yaml"],
+          "cites": [
+            "internal/engine/django_routes.go",
+            "internal/engine/django_urlconf_nested.go",
+            "internal/engine/rules/python/frameworks/django.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/django_admin_routes.go","internal/engine/django_routes.go"],
+          "cites": [
+            "internal/engine/django_admin_routes.go",
+            "internal/engine/django_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/django_imports_rewrite.go"],
+          "cites": [
+            "internal/engine/django_imports_rewrite.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7312,22 +9005,31 @@
     {
       "id": "lang.python.framework.django-drf",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Django REST Framework",
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/django_drf_actions.go"],
+          "cites": [
+            "internal/engine/django_drf_actions.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/django_drf_actions.go"],
+          "cites": [
+            "internal/engine/django_drf_actions.go",
+            "internal/extractors/python/django_drf_actions.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/drf_serializer_fields.go"],
+          "cites": [
+            "internal/engine/django_drf_actions.go",
+            "internal/extractors/python/drf_serializer_fields.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7342,7 +9044,9 @@
           },
           "signal_handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/django_signal_pubsub_edges.go"],
+            "cites": [
+              "internal/engine/django_signal_pubsub_edges.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2739",
             "verified_at": "2026-05-28"
           }
@@ -7352,6 +9056,7 @@
     {
       "id": "lang.python.framework.dramatiq",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Dramatiq (task queue)",
       "capabilities": {
@@ -7363,7 +9068,9 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/frameworks/dramatiq.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/dramatiq.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7374,6 +9081,7 @@
     {
       "id": "lang.python.framework.falcon",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Falcon",
       "capabilities": {
@@ -7394,22 +9102,30 @@
     {
       "id": "lang.python.framework.fastapi",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "FastAPI",
       "capabilities": {
         "auth_coverage": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/fastapi.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/fastapi.yaml"],
+          "cites": [
+            "internal/engine/http_endpoint_synthesis.go",
+            "internal/engine/rules/python/frameworks/fastapi.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/fastapi.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7420,6 +9136,7 @@
     {
       "id": "lang.python.framework.flask",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Flask",
       "capabilities": {
@@ -7428,12 +9145,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/flask.yaml"],
+          "cites": [
+            "internal/engine/http_endpoint_synthesis.go",
+            "internal/engine/rules/python/frameworks/flask.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/flask.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/flask.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7444,6 +9166,7 @@
     {
       "id": "lang.python.framework.hug",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Hug",
       "capabilities": {
@@ -7464,28 +9187,29 @@
     {
       "id": "lang.python.framework.langchain",
       "category": "http_framework",
+      "subcategory": "ai_integration",
       "language": "python",
       "label": "LangChain (LLM agent framework)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Prompts": {
+          "prompt_template_extraction": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/frameworks/langchain.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Composition": {
+          "chain_composition": {
+            "status": "missing"
+          },
+          "tool_use_detection": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.python.framework.litestar",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Litestar",
       "capabilities": {
@@ -7494,12 +9218,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/litestar.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/litestar.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7510,6 +9238,7 @@
     {
       "id": "lang.python.framework.pyramid",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Pyramid",
       "capabilities": {
@@ -7518,12 +9247,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/pyramid.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/pyramid.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7534,6 +9267,7 @@
     {
       "id": "lang.python.framework.quart",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Quart",
       "capabilities": {
@@ -7554,6 +9288,7 @@
     {
       "id": "lang.python.framework.robyn",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Robyn",
       "capabilities": {
@@ -7562,12 +9297,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/robyn.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/robyn.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7578,6 +9317,7 @@
     {
       "id": "lang.python.framework.sanic",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Sanic",
       "capabilities": {
@@ -7586,12 +9326,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/sanic.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/sanic.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7602,6 +9346,7 @@
     {
       "id": "lang.python.framework.starlette",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Starlette",
       "capabilities": {
@@ -7610,12 +9355,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/starlette.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/starlette.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7626,6 +9375,7 @@
     {
       "id": "lang.python.framework.strawberry-graphql",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Strawberry GraphQL",
       "capabilities": {
@@ -7634,12 +9384,17 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/graphql/frameworks/strawberry_python.yaml","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
+          "cites": [
+            "internal/engine/rules/graphql/frameworks/strawberry_python.yaml",
+            "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7650,6 +9405,7 @@
     {
       "id": "lang.python.framework.tornado",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "python",
       "label": "Tornado",
       "capabilities": {
@@ -7658,12 +9414,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/tornado.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/tornado.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -7679,7 +9439,9 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/alembic.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -7701,12 +9463,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/beanie.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/beanie.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7719,17 +9485,24 @@
       "capabilities": {
         "migration_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/python/django_migration.go"],
+          "cites": [
+            "internal/extractors/python/django_migration.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/orms/django_orm.yaml","internal/extractors/python/django_relational.go"],
+          "cites": [
+            "internal/engine/rules/python/orms/django_orm.yaml",
+            "internal/extractors/python/django_relational.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
+          "cites": [
+            "internal/engine/orm_queries_python.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7745,12 +9518,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/mongoengine.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/mongoengine.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7766,12 +9543,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/peewee.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/peewee.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7787,12 +9568,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/pony_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/pony_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7805,17 +9590,24 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/alembic.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/python/orms/sqlalchemy.yaml"],
+          "cites": [
+            "internal/engine/orm_field_edges.go",
+            "internal/engine/rules/python/orms/sqlalchemy.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
+          "cites": [
+            "internal/engine/orm_queries_python.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7831,12 +9623,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/orms/sqlmodel.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/sqlmodel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
+          "cites": [
+            "internal/engine/orm_queries_python.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7852,12 +9648,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/orms/tortoise_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/tortoise_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_python.go"],
+          "cites": [
+            "internal/engine/orm_queries_python.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7876,7 +9676,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/cassandra_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/cassandra_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7895,7 +9697,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7914,7 +9718,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7933,7 +9739,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/mysql_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/mysql_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7952,7 +9760,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7971,7 +9781,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/pg_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/pg_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7990,7 +9802,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/redis_rb.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/redis_rb.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8009,7 +9823,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/sqlite_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/sqlite_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8017,6 +9833,7 @@
     {
       "id": "lang.ruby.framework.cuba",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "ruby",
       "label": "Cuba",
       "capabilities": {
@@ -8037,6 +9854,7 @@
     {
       "id": "lang.ruby.framework.dry-rb",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "ruby",
       "label": "dry-rb (ecosystem)",
       "capabilities": {
@@ -8048,7 +9866,9 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/frameworks/dry_rb.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/dry_rb.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8059,6 +9879,7 @@
     {
       "id": "lang.ruby.framework.grape",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "ruby",
       "label": "Grape",
       "capabilities": {
@@ -8067,12 +9888,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/grape.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/grape.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8083,6 +9908,7 @@
     {
       "id": "lang.ruby.framework.hanami",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "ruby",
       "label": "Hanami",
       "capabilities": {
@@ -8091,12 +9917,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/hanami.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/hanami.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8107,6 +9937,7 @@
     {
       "id": "lang.ruby.framework.padrino",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "ruby",
       "label": "Padrino",
       "capabilities": {
@@ -8115,12 +9946,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/padrino.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/padrino.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8131,6 +9966,7 @@
     {
       "id": "lang.ruby.framework.rails",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "ruby",
       "label": "Ruby on Rails",
       "capabilities": {
@@ -8139,12 +9975,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"],
+          "cites": [
+            "internal/engine/http_endpoint_ruby_producer.go",
+            "internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+          "cites": [
+            "internal/engine/http_endpoint_ruby_producer.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8155,6 +9996,7 @@
     {
       "id": "lang.ruby.framework.roda",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "ruby",
       "label": "Roda",
       "capabilities": {
@@ -8163,12 +10005,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/roda.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/roda.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8179,6 +10025,7 @@
     {
       "id": "lang.ruby.framework.sinatra",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "ruby",
       "label": "Sinatra",
       "capabilities": {
@@ -8187,12 +10034,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/sinatra.yaml"],
+          "cites": [
+            "internal/engine/http_endpoint_ruby_producer.go",
+            "internal/engine/rules/ruby/frameworks/sinatra.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+          "cites": [
+            "internal/engine/http_endpoint_ruby_producer.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8211,12 +10063,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/orms/activerecord.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/activerecord.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8232,12 +10088,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8253,12 +10113,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/mongoid.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/mongoid.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8274,12 +10138,17 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml","internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml",
+            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8295,12 +10164,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/sequel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/sequel.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8319,7 +10192,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/cassandra_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/cassandra_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8338,7 +10213,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/dynamodb_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/dynamodb_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8357,7 +10234,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/elasticsearch_rs.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/elasticsearch_rs.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8376,7 +10255,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/mongodb_mongodb.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/mongodb_mongodb.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8395,7 +10276,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/mysql_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/mysql_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8414,7 +10297,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8433,7 +10318,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/postgresql_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/postgresql_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8452,7 +10339,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/redis_redis_rs.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/redis_redis_rs.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8471,7 +10360,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/sqlite_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/sqlite_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8479,6 +10370,7 @@
     {
       "id": "lang.rust.framework.actix",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "Actix Web",
       "capabilities": {
@@ -8487,12 +10379,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/actix_web.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/actix_web.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8503,6 +10399,7 @@
     {
       "id": "lang.rust.framework.axum",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "Axum",
       "capabilities": {
@@ -8511,12 +10408,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_axum.go","internal/engine/rules/rust/frameworks/axum.yaml"],
+          "cites": [
+            "internal/engine/http_endpoint_axum.go",
+            "internal/engine/rules/rust/frameworks/axum.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/http_endpoint_axum.go"],
+          "cites": [
+            "internal/engine/http_endpoint_axum.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8527,6 +10429,7 @@
     {
       "id": "lang.rust.framework.gotham",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "Gotham",
       "capabilities": {
@@ -8535,12 +10438,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/gotham.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/gotham.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8551,6 +10458,7 @@
     {
       "id": "lang.rust.framework.hyper",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "hyper",
       "capabilities": {
@@ -8559,12 +10467,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/hyper.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/hyper.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8575,6 +10487,7 @@
     {
       "id": "lang.rust.framework.poem",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "Poem",
       "capabilities": {
@@ -8583,12 +10496,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/poem.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/poem.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8599,6 +10516,7 @@
     {
       "id": "lang.rust.framework.rocket",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "Rocket",
       "capabilities": {
@@ -8607,12 +10525,17 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rocket_routes.go","internal/engine/rules/rust/frameworks/rocket.yaml"],
+          "cites": [
+            "internal/engine/rocket_routes.go",
+            "internal/engine/rules/rust/frameworks/rocket.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rocket_routes.go"],
+          "cites": [
+            "internal/engine/rocket_routes.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8623,6 +10546,7 @@
     {
       "id": "lang.rust.framework.salvo",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "Salvo",
       "capabilities": {
@@ -8643,28 +10567,29 @@
     {
       "id": "lang.rust.framework.tauri",
       "category": "http_framework",
+      "subcategory": "desktop",
       "language": "rust",
       "label": "Tauri (desktop)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "not_applicable"
+        "Process": {
+          "ipc_extraction": {
+            "status": "missing"
+          },
+          "main_renderer_split": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "not_applicable"
-        },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/frameworks/tauri.yaml"],
-          "verified_at": "2026-05-28"
-        },
-        "middleware_coverage": {
-          "status": "not_applicable"
+        "Native": {
+          "native_module_imports": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.rust.framework.tide",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "Tide",
       "capabilities": {
@@ -8673,12 +10598,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/tide.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/tide.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8689,6 +10618,7 @@
     {
       "id": "lang.rust.framework.tower",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "Tower (service abstraction)",
       "capabilities": {
@@ -8709,6 +10639,7 @@
     {
       "id": "lang.rust.framework.warp",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "rust",
       "label": "Warp",
       "capabilities": {
@@ -8717,12 +10648,16 @@
         },
         "endpoint_synthesis": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/warp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/frameworks/warp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8741,12 +10676,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/diesel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/diesel.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8782,7 +10721,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/rusqlite.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/rusqlite.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8798,12 +10739,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/seaorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/seaorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8819,12 +10764,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/sqlx.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/sqlx.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8832,6 +10781,7 @@
     {
       "id": "lang.scala.framework.akka-http",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "scala",
       "label": "Akka HTTP / Pekko HTTP",
       "capabilities": {
@@ -8840,12 +10790,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8856,6 +10810,7 @@
     {
       "id": "lang.scala.framework.cask",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "scala",
       "label": "Cask",
       "capabilities": {
@@ -8876,6 +10831,7 @@
     {
       "id": "lang.scala.framework.cats-effect",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "scala",
       "label": "Cats Effect (concurrency runtime)",
       "capabilities": {
@@ -8887,7 +10843,9 @@
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/cats_effect.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/cats_effect.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8898,6 +10856,7 @@
     {
       "id": "lang.scala.framework.finatra",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "scala",
       "label": "Finatra (Twitter Finagle)",
       "capabilities": {
@@ -8906,12 +10865,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/finatra.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/finatra.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8922,6 +10885,7 @@
     {
       "id": "lang.scala.framework.http4s",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "scala",
       "label": "http4s",
       "capabilities": {
@@ -8930,12 +10894,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/http4s.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/http4s.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8946,6 +10914,7 @@
     {
       "id": "lang.scala.framework.lagom",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "scala",
       "label": "Lagom",
       "capabilities": {
@@ -8954,12 +10923,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/lagom.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/lagom.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -8970,30 +10943,71 @@
     {
       "id": "lang.scala.framework.play",
       "category": "http_framework",
+      "subcategory": "meta_framework",
       "language": "scala",
       "label": "Play Framework (Scala)",
       "capabilities": {
-        "auth_coverage": {
-          "status": "missing"
+        "Structure": {
+          "component_extraction": {
+            "status": "missing"
+          },
+          "hook_recognition": {
+            "status": "missing"
+          }
         },
-        "endpoint_synthesis": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/play_framework.yaml"],
-          "verified_at": "2026-05-28"
+        "Data Flow": {
+          "data_loaders": {
+            "status": "missing"
+          }
         },
-        "handler_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/play_framework.yaml"],
-          "verified_at": "2026-05-28"
+        "Server": {
+          "server_components": {
+            "status": "missing"
+          },
+          "hydration_boundaries": {
+            "status": "missing"
+          }
         },
-        "middleware_coverage": {
-          "status": "missing"
+        "Routing": {
+          "route_extraction": {
+            "status": "missing"
+          },
+          "router_pattern": {
+            "status": "missing"
+          }
+        },
+        "Build": {
+          "static_generation": {
+            "status": "missing"
+          }
+        },
+        "Type System": {
+          "interface_extraction": {
+            "status": "missing"
+          },
+          "type_alias_extraction": {
+            "status": "missing"
+          },
+          "enum_extraction": {
+            "status": "missing"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.scala.framework.scalatra",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "scala",
       "label": "Scalatra",
       "capabilities": {
@@ -9002,12 +11016,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/scalatra.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/scalatra.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9018,6 +11036,7 @@
     {
       "id": "lang.scala.framework.zio-http",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "scala",
       "label": "ZIO HTTP / ZIO",
       "capabilities": {
@@ -9026,12 +11045,16 @@
         },
         "endpoint_synthesis": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/zio.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "handler_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/frameworks/zio.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "middleware_coverage": {
@@ -9050,12 +11073,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/doobie.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/doobie.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9071,12 +11098,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/elastic4s.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/elastic4s.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9092,12 +11123,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/quill.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/quill.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9113,12 +11148,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9134,12 +11173,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/scanamo.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/scanamo.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9155,12 +11198,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/slick.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/slick.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9168,6 +11215,7 @@
     {
       "id": "lang.swift.framework.vapor",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "swift",
       "label": "Vapor",
       "capabilities": {
@@ -9184,17 +11232,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9224,17 +11278,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9247,17 +11307,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/debezium_cdc_edges.go"],
+          "cites": [
+            "internal/engine/debezium_cdc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/debezium_cdc_edges.go"],
+          "cites": [
+            "internal/engine/debezium_cdc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/debezium_cdc_edges.go"],
+          "cites": [
+            "internal/engine/debezium_cdc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9270,17 +11336,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9293,17 +11365,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9316,17 +11394,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/pubsub_edges.go"],
+          "cites": [
+            "internal/engine/pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/pubsub_edges.go"],
+          "cites": [
+            "internal/engine/pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/pubsub_edges.go"],
+          "cites": [
+            "internal/engine/pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9339,17 +11423,24 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/kafka_edges.go"],
+          "cites": [
+            "internal/engine/kafka_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/kafka_edges.go","internal/engine/kafka_wrapper_edges.go"],
+          "cites": [
+            "internal/engine/kafka_edges.go",
+            "internal/engine/kafka_wrapper_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/kafka_edges.go"],
+          "cites": [
+            "internal/engine/kafka_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9362,17 +11453,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9385,17 +11482,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/nats_edges.go"],
+          "cites": [
+            "internal/engine/nats_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/nats_edges.go"],
+          "cites": [
+            "internal/engine/nats_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/nats_edges.go"],
+          "cites": [
+            "internal/engine/nats_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9408,17 +11511,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/pulsar_edges.go"],
+          "cites": [
+            "internal/engine/pulsar_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/pulsar_edges.go"],
+          "cites": [
+            "internal/engine/pulsar_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/pulsar_edges.go"],
+          "cites": [
+            "internal/engine/pulsar_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9431,17 +11540,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9450,21 +11565,27 @@
       "id": "msg.broker.redis",
       "category": "message_broker",
       "language": "multi",
-      "label": "Redis pub/sub \u0026 streams",
+      "label": "Redis pub/sub & streams",
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9477,17 +11598,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/iac_sns_edges.go"],
+          "cites": [
+            "internal/engine/iac_sns_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/iac_sns_edges.go"],
+          "cites": [
+            "internal/engine/iac_sns_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/iac_sns_edges.go"],
+          "cites": [
+            "internal/engine/iac_sns_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9500,17 +11627,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/sqs_edges.go"],
+          "cites": [
+            "internal/engine/sqs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/sqs_edges.go"],
+          "cites": [
+            "internal/engine/sqs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/sqs_edges.go"],
+          "cites": [
+            "internal/engine/sqs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9523,17 +11656,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": [
+            "internal/links/topic_pass.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9546,17 +11685,24 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/extractors/python/celery.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go",
+            "internal/extractors/python/celery.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": [
+            "internal/links/topic_pass.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9569,17 +11715,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/django_signal_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/django_signal_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/django_signal_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9606,17 +11758,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9657,12 +11815,16 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/sse_edges.go"],
+          "cites": [
+            "internal/engine/sse_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/sse_edges.go"],
+          "cites": [
+            "internal/engine/sse_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
@@ -9678,17 +11840,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/webhooks_edges.go"],
+          "cites": [
+            "internal/engine/webhooks_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/webhooks_edges.go"],
+          "cites": [
+            "internal/engine/webhooks_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/webhooks_edges.go"],
+          "cites": [
+            "internal/engine/webhooks_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9701,17 +11869,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/websocket_edges.go"],
+          "cites": [
+            "internal/engine/websocket_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/websocket_edges.go"],
+          "cites": [
+            "internal/engine/websocket_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/websocket_edges.go"],
+          "cites": [
+            "internal/engine/websocket_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9727,7 +11901,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9771,7 +11947,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9787,7 +11965,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9828,7 +12008,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9855,7 +12037,9 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9871,7 +12055,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9887,7 +12073,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9900,7 +12088,9 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9935,17 +12125,24 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": ["internal/engine/http_endpoint_match.go"],
+          "cites": [
+            "internal/engine/http_endpoint_match.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go","internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go",
+            "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9958,17 +12155,23 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "full",
-          "cites": ["internal/engine/grpc_edges.go"],
+          "cites": [
+            "internal/engine/grpc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/engine/grpc_edges.go"],
+          "cites": [
+            "internal/engine/grpc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": ["internal/engine/grpc_edges.go"],
+          "cites": [
+            "internal/engine/grpc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -9998,17 +12201,23 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": ["internal/engine/http_endpoint_match.go"],
+          "cites": [
+            "internal/engine/http_endpoint_match.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/openapi/language.yaml"],
+          "cites": [
+            "internal/engine/rules/openapi/language.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/openapi/language.yaml"],
+          "cites": [
+            "internal/engine/rules/openapi/language.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10021,17 +12230,24 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": ["internal/engine/grpc_edges.go"],
+          "cites": [
+            "internal/engine/grpc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/proto"],
+          "cites": [
+            "internal/extractors/proto"
+          ],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/protobuf/_manifest.yaml","internal/extractors/proto"],
+          "cites": [
+            "internal/engine/rules/protobuf/_manifest.yaml",
+            "internal/extractors/proto"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10057,11 +12273,13 @@
       "id": "security.auth-java",
       "category": "security",
       "language": "java",
-      "label": "Auth policy resolver (Java/Kotlin — Phase 1 of #1942)",
+      "label": "Auth policy resolver (Java/Kotlin \u2014 Phase 1 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10070,7 +12288,7 @@
       "id": "security.auth-other",
       "category": "security",
       "language": "multi",
-      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)",
+      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET \u2014 Phases 2-4 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "missing",
@@ -10086,7 +12304,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -10105,7 +12325,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -10124,7 +12346,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -10143,7 +12367,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -10179,7 +12405,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -10198,7 +12426,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": ["internal/engine/rules/_engine/csrf_heuristic_detector.yaml"],
+          "cites": [
+            "internal/engine/rules/_engine/csrf_heuristic_detector.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10211,7 +12441,9 @@
       "capabilities": {
         "secret_detection": {
           "status": "full",
-          "cites": ["internal/secrets/secrets.go"],
+          "cites": [
+            "internal/secrets/secrets.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10224,7 +12456,9 @@
       "capabilities": {
         "sql_injection": {
           "status": "full",
-          "cites": ["internal/engine/rules/_engine/sql_injection_detector.yaml"],
+          "cites": [
+            "internal/engine/rules/_engine/sql_injection_detector.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10279,12 +12513,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/rust/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10367,12 +12606,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/elixir/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/elixir/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10413,12 +12657,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/go/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/go/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10473,12 +12722,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/jest.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/frameworks/jest.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10491,12 +12745,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/java/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10509,12 +12767,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/frameworks/junit5.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/junit5.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10527,12 +12790,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10545,12 +12812,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10591,12 +12862,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10623,12 +12898,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10655,12 +12934,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/php/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10701,12 +12985,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/pytest.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/pytest.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10733,12 +13022,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/frameworks/rspec.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/rspec.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10793,12 +13087,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/go/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10814,7 +13112,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/java/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10827,12 +13127,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/python/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10845,12 +13149,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -10863,12 +13171,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/csharp/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }


### PR DESCRIPTION
## Summary

Closes #2750. Backfills `subcategory` on every `http_framework` record that wasn't already tagged — 135 records across Java, Python, Go, C#, Kotlin, PHP, Rust, Ruby, Elixir, Scala, Lua, Swift. The rendered `docs/coverage/by-language/*.md` pages now have Frameworks broken into Backend HTTP / UI Frontend / Mobile / Desktop / Meta Framework / RPC Framework / AI Integration sub-sections, matching the pattern jsts records have used since #2735.

For records moved to a non-`http_backend` subcategory the capability shape is rebuilt as the canonical grouped skeleton for that subcategory (every cell `missing`), again following the jsts precedent. Records that remain `http_backend` keep their flat capabilities — the four category-wide keys (`endpoint_synthesis`, `handler_attribution`, `auth_coverage`, `middleware_coverage`) are all valid under `http_backend`.

No edits to `tools/coverage/capability-dictionary.yaml` were needed — every assignment maps to a subcategory that already exists in the dictionary. This PR therefore exercises the architectural payoff of #2752 without itself touching Go code: it is a pure registry + regenerated docs change.

### Per-language counts

| Language | Records | Subcategories |
|---|---|---|
| Java | 19 | http_backend, ui_frontend, meta_framework, mobile, ai_integration (5) |
| Python | 20 | http_backend, ai_integration (2) |
| Go | 17 | http_backend, mobile, desktop (3) |
| C# | 15 | http_backend, ui_frontend, mobile, desktop, rpc_framework (5) |
| Kotlin | 12 | http_backend, mobile, desktop (3) |
| PHP | 12 | http_backend (1) |
| Rust | 11 | http_backend, desktop (2) |
| Elixir | 9 | http_backend, meta_framework (2) |
| Scala | 9 | http_backend, meta_framework (2) |
| Ruby | 8 | http_backend (1) |
| Lua | 2 | http_backend (1) |
| Swift | 1 | http_backend (1) |
| **Total** | **135** | — |

### Judgment calls worth flagging

A handful of records do not fit any current subcategory cleanly. They are assigned to the closest available lane; the alternative is to introduce single-use subcategories which would dilute the taxonomy.

- **Java/GWT**, **Java/Vaadin** → `ui_frontend`. Both render browser UI from a Java API (GWT via Java→JS compilation; Vaadin via server-rendered components). Closest fit.
- **Java/Play**, **Scala/Play** → `meta_framework`. Full-stack server-rendered framework with view templates + routing + data loaders.
- **Elixir/Phoenix LiveView** → `meta_framework`. Same reasoning as Play — full-stack server-rendered reactive UI.
- **Java/LangChain4J**, **Python/LangChain** → `ai_integration`.
- **Python/Celery**, **Python/Dramatiq**, **Elixir/Oban** → `http_backend`. Task queues, not HTTP frameworks. No `job_queue` subcategory exists yet; `http_backend` is the closest lane until one lands.
- **Elixir/Nerves** → `http_backend`. Embedded Elixir platform — no `embedded` subcategory exists yet; `http_backend` is the closest lane.
- **Kotlin/Arrow**, **Kotlin/Coroutines**, **Scala/Cats Effect**, **Ruby/dry-rb** → `http_backend`. Backend toolkits / concurrency libraries rather than HTTP frameworks per se, but their primary deployment surface is backend HTTP services.
- **Kotlin/KMP** → `mobile`. Multiplatform, but Mobile (KMM) is its primary use.
- **C#/Uno** → `desktop`. Cross-platform (desktop + mobile + web), but Desktop is its most distinctive lane.
- **Go/gomobile** → `mobile` (Android/iOS bindings). **Go/Fyne** → `desktop` (cross-platform GUI toolkit).
- **Rust/Tower**, **Rust/Hyper** → `http_backend` (service abstraction / low-level HTTP).
- **Swift/Vapor** → `http_backend`. Vapor is a server-side Swift HTTP framework, not a mobile framework. (The issue text suggested `mobile` but that would mis-classify the only Swift record in the registry.)
- **Lua/Lapis**, **Lua/OpenResty** → `http_backend`. Both serve HTTP from Lua via OpenResty/nginx.

Record-level free-form notes were considered but the `Record` schema in `tools/coverage/schema.go` does not declare a top-level `notes` field, and adding one is out of scope for a mechanical backfill — these judgments are documented here in the PR description instead.

### Pre-merge state

- `go run ./tools/coverage validate` → exits 0 (warnings only — capability-map and stale-verification, all pre-existing and unchanged by this PR).
- `go run ./tools/coverage gen` → regenerates 501 records deterministically (second run is a no-op).
- `go test ./tools/coverage/` → PASS.

## Test plan

- [ ] `go run ./tools/coverage validate` exits 0
- [ ] `go run ./tools/coverage gen` produces a clean working tree (determinism)
- [ ] `go test ./tools/coverage/` passes
- [ ] Spot-check `docs/coverage/by-language/{java,python,go,csharp,kotlin,rust,elixir,scala}.md` — each has Frameworks split into the expected sub-sections
- [ ] Records still carry `category: http_framework` (subcategorization is additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)