### PR TITLE
feat(substrate): Phase 1A effect classification for T2 languages (#2765)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,34 +11,34 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
@@ -79,28 +79,28 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — | — | — | — | — | — | |
 | [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — | — | — | — | — | — | |
-| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
+| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
@@ -120,32 +120,32 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | — | — | — | — | — | — | |
 
 
@@ -153,10 +153,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
@@ -169,7 +169,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 | [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
@@ -177,15 +177,15 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ## Mobile
 
 | Language | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 | [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
@@ -193,31 +193,31 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ## Desktop
 
 | Language | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 | [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
 | [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
+| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ## RPC Framework
 
 | Language | Name | Schema | Codegen | Transport | Substrate | Notes |
 |---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/6 | |
+| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/10 | |
 | [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | — | |
 | [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | — | |
 

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -12,35 +12,35 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
 
 
 ### UI Frontend
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
+| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -12,45 +12,45 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
 
 
 ### UI Frontend
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ### Mobile
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
+| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ### RPC Framework
 
 | Name | Schema | Codegen | Transport | Substrate | Notes |
 |---|---|---|---|---|---|
-| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/6 | |
+| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/10 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -12,21 +12,21 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
 
 
 ### Meta Framework
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -12,30 +12,30 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
 
 
 ### Mobile
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
-| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
+| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ## ORMs

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -12,18 +12,18 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
+| [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -12,14 +12,14 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -12,23 +12,23 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | ✅ 3/3 | |
+| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -12,21 +12,21 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
 
 
 ### Meta Framework
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.qt.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.qt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 21
+- **Capability cells:** 25
 
 ## Capabilities
 
@@ -60,12 +60,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.ros.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ros.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 6
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,9 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.unreal-engine.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.unreal-engine.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 6
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,9 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_c_cpp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 21
+- **Capability cells:** 25
 
 ## Capabilities
 
@@ -60,12 +60,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 21
+- **Capability cells:** 25
 
 ## Capabilities
 
@@ -60,12 +60,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 21
+- **Capability cells:** 25
 
 ## Capabilities
 
@@ -60,12 +60,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 9
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -33,12 +33,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.net-maui.md
+++ b/docs/coverage/detail/lang.csharp.framework.net-maui.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 20
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -69,12 +69,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.uno.md
+++ b/docs/coverage/detail/lang.csharp.framework.uno.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 6
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,9 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.winforms.md
+++ b/docs/coverage/detail/lang.csharp.framework.winforms.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 6
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,9 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.wpf.md
+++ b/docs/coverage/detail/lang.csharp.framework.wpf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 6
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,9 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.xamarin.md
+++ b/docs/coverage/detail/lang.csharp.framework.xamarin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 20
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -69,12 +69,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_csharp.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 19
+- **Capability cells:** 23
 
 ## Capabilities
 
@@ -68,12 +68,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_elixir.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -55,14 +55,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_golang.go`<br>`internal/links/effect_propagation.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_golang.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_golang.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_golang.go`<br>`internal/links/effect_propagation.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_golang.go`<br>`internal/links/effect_propagation.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_golang.go`<br>`internal/links/effect_propagation.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_golang.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_golang.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -55,14 +55,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_java.go`<br>`internal/links/effect_propagation.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_java.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_java.go`<br>`internal/links/effect_propagation.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_java.go`<br>`internal/links/effect_propagation.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_java.go`<br>`internal/links/effect_propagation.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_java.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -61,14 +61,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_jsts.go`<br>`internal/links/effect_propagation.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_jsts.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_jsts.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_jsts.go`<br>`internal/links/effect_propagation.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_jsts.go`<br>`internal/links/effect_propagation.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_jsts.go`<br>`internal/links/effect_propagation.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_jsts.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 6
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,9 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 6
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,9 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 20
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -69,12 +69,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 20
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -69,12 +69,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_kotlin.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_php.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -55,14 +55,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_python.go`<br>`internal/links/effect_propagation.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_python.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_python.go`<br>`internal/links/effect_propagation.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_python.go`<br>`internal/links/effect_propagation.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/substrate/effect_sinks_python.go`<br>`internal/links/effect_propagation.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_python.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_ruby.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tauri.md
+++ b/docs/coverage/detail/lang.rust.framework.tauri.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 6
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,9 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_rust.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.play.md
+++ b/docs/coverage/detail/lang.scala.framework.play.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 19
+- **Capability cells:** 23
 
 ## Capabilities
 
@@ -68,12 +68,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Capability cells:** 14
 
 ## Capabilities
 
@@ -54,12 +54,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/types/confidence.go`<br>`internal/graph/graph.go`<br>`internal/mcp/tools.go` | — |
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go`<br>`internal/mcp/dead_code.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/substrate/entry_points_scala.go`<br>`internal/substrate/entry_points.go`<br>`internal/links/reachability.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9,16 +9,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/bazel/extractor.go"
-          ],
+          "cites": ["internal/extractors/bazel/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/bazel/parser.go"
-          ],
+          "cites": ["internal/extractors/bazel/parser.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -31,16 +27,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -53,16 +45,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -75,16 +63,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -97,16 +81,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -119,16 +99,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -141,16 +117,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -191,17 +163,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/golang/gomod.go"
-          ],
+          "cites": ["internal/extractors/golang/gomod.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/build_tools.yaml",
-            "internal/extractors/golang/gomod.go"
-          ],
+          "cites": ["internal/engine/rules/go/build_tools.yaml","internal/extractors/golang/gomod.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -214,17 +181,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml",
-            "internal/engine/rules/kotlin/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml","internal/engine/rules/kotlin/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -251,16 +213,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -273,16 +231,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/just/just.go"
-          ],
+          "cites": ["internal/extractors/just/just.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/just/just.go"
-          ],
+          "cites": ["internal/extractors/just/just.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -326,9 +280,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -341,16 +293,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -377,16 +325,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -399,16 +343,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -421,16 +361,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -471,16 +407,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -493,16 +425,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -515,16 +443,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -537,16 +461,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -562,9 +482,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -591,16 +509,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/scala/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/scala/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -613,16 +527,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -663,16 +573,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -688,9 +594,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -706,9 +610,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -721,16 +623,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -743,16 +641,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -765,16 +659,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -787,16 +677,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/buildkite.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/buildkite.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -809,16 +695,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/circleci.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/circleci.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -845,17 +727,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/github_actions.yaml",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/github_actions.yaml","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -868,16 +745,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -893,9 +766,7 @@
         },
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/cicd/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -908,16 +779,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/travis_ci.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/travis_ci.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -930,9 +797,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -941,20 +806,16 @@
       "id": "config.dotenv",
       "category": "platform",
       "language": "multi",
-      "label": ".env (names-only \u2014 values stripped at extraction boundary)",
+      "label": ".env (names-only — values stripped at extraction boundary)",
       "capabilities": {
         "env_resolution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -967,9 +828,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -982,9 +841,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -997,9 +854,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1023,9 +878,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1038,10 +891,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go",
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go","internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1054,9 +904,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1069,10 +917,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1113,16 +958,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1135,16 +976,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1157,16 +994,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1179,17 +1012,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/database_index/language.yaml",
-            "internal/extractors/sql"
-          ],
+          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1216,17 +1044,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/database_index/language.yaml",
-            "internal/extractors/sql"
-          ],
+          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1239,16 +1062,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1275,16 +1094,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/sql"
-          ],
+          "cites": ["internal/extractors/sql"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1297,17 +1112,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/docker/frameworks/docker_compose.yaml",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/engine/rules/docker/frameworks/docker_compose.yaml","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1320,17 +1130,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/docker/frameworks/dockerfile.yaml",
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/engine/rules/docker/frameworks/dockerfile.yaml","internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1343,16 +1148,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1365,17 +1166,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1402,16 +1198,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ansible/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ansible/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1438,16 +1230,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/cdk/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/cdk/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1460,16 +1248,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1482,16 +1266,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/pulumi/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/pulumi/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1504,16 +1284,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/serverless_edges.go"
-          ],
+          "cites": ["internal/engine/serverless_edges.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/serverless_edges.go"
-          ],
+          "cites": ["internal/engine/serverless_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1526,16 +1302,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl"
-          ],
+          "cites": ["internal/extractors/hcl"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl"
-          ],
+          "cites": ["internal/extractors/hcl"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1616,9 +1388,7 @@
       "capabilities": {
         "log_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/_engine/logging_config_extractor.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/logging_config_extractor.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1651,17 +1421,12 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/event_flow.go",
-            "internal/engine/process_flow.go"
-          ],
+          "cites": ["internal/engine/event_flow.go","internal/engine/process_flow.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1677,9 +1442,7 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/_engine/comment_marker_extractor.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml"],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
@@ -1712,9 +1475,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/extractor.go"
-          ],
+          "cites": ["internal/extractors/hcl/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1727,9 +1488,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/workflow_edges.go"
-          ],
+          "cites": ["internal/engine/workflow_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1753,9 +1512,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1768,9 +1525,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/extractor.go"
-          ],
+          "cites": ["internal/extractors/hcl/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1783,17 +1538,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/relationships.go"
-          ],
+          "cites": ["internal/extractors/hcl/relationships.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/extractor.go",
-            "internal/extractors/hcl/relationships.go"
-          ],
+          "cites": ["internal/extractors/hcl/extractor.go","internal/extractors/hcl/relationships.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1892,59 +1642,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -1976,59 +1721,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2060,59 +1800,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2144,59 +1879,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2228,59 +1958,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2312,59 +2037,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2396,59 +2116,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2480,59 +2195,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2564,59 +2274,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2648,59 +2353,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2732,59 +2432,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2816,59 +2511,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -2939,59 +2629,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -3023,59 +2708,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -3107,59 +2787,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -3186,32 +2861,39 @@
           }
         },
         "Substrate": {
-          "reachability_analysis": {
+          "confidence_overlay": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -3238,32 +2920,39 @@
           }
         },
         "Substrate": {
-          "reachability_analysis": {
+          "confidence_overlay": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_c_cpp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -3474,9 +3163,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/cassandra_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3495,9 +3182,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3516,9 +3201,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3537,9 +3220,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/mongodb_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3558,9 +3239,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/mysql_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3579,9 +3258,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3600,9 +3277,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/npgsql.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3621,9 +3296,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/redis_stackexchange.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3642,9 +3315,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/sqlite_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3659,17 +3330,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/aspnet_core_routes.go",
-              "internal/engine/rules/csharp/frameworks/asp_net_core.yaml"
-            ],
+            "cites": ["internal/engine/aspnet_core_routes.go","internal/engine/rules/csharp/frameworks/asp_net_core.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/aspnet_core_routes.go"
-            ],
+            "cites": ["internal/engine/aspnet_core_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -3681,66 +3347,59 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/aspnet_core_routes.go"
-            ],
+            "cites": ["internal/engine/aspnet_core_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -3756,16 +3415,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
-            ],
+            "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
-            ],
+            "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -3780,59 +3435,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -3903,59 +3553,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4026,59 +3671,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4149,59 +3789,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4233,59 +3868,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4317,59 +3947,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4396,59 +4021,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4480,59 +4100,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4604,59 +4219,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4688,59 +4298,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4767,32 +4372,39 @@
           }
         },
         "Substrate": {
-          "reachability_analysis": {
+          "confidence_overlay": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4819,32 +4431,39 @@
           }
         },
         "Substrate": {
-          "reachability_analysis": {
+          "confidence_overlay": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4871,32 +4490,39 @@
           }
         },
         "Substrate": {
-          "reachability_analysis": {
+          "confidence_overlay": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -4968,59 +4594,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_csharp.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5037,16 +4658,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/dapper.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/dapper.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5062,17 +4679,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/entity_framework_core.yaml",
-            "internal/engine/rules/csharp/orms/entity_framework_core.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/entity_framework_core.yaml","internal/engine/rules/csharp/orms/entity_framework_core.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5088,16 +4700,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5130,16 +4738,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/nhibernate.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/nhibernate.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5158,9 +4762,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5179,9 +4781,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5200,9 +4800,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5221,9 +4819,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/myxql.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/myxql.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5242,9 +4838,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5263,9 +4857,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/postgrex.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/postgrex.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5284,9 +4876,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/redix.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/redix.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5305,9 +4895,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/xandra.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/xandra.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5322,17 +4910,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/absinthe.yaml",
-              "internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml","internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/absinthe.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5347,59 +4930,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5415,16 +4993,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5439,59 +5013,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5523,59 +5092,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5607,59 +5171,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5678,9 +5237,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/nerves.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/nerves.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5695,59 +5252,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5766,9 +5318,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/oban.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/oban.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5783,59 +5333,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5851,17 +5396,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/phoenix_routes.go",
-              "internal/engine/rules/elixir/frameworks/phoenix.yaml"
-            ],
+            "cites": ["internal/engine/phoenix_routes.go","internal/engine/rules/elixir/frameworks/phoenix.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/phoenix_routes.go"
-            ],
+            "cites": ["internal/engine/phoenix_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5876,59 +5416,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -5997,59 +5532,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6081,59 +5611,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_elixir.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6150,16 +5675,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6175,16 +5696,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6203,9 +5720,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/cassandra_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/cassandra_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6224,9 +5739,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/dynamodb_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/dynamodb_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6245,9 +5758,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/elasticsearch_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/elasticsearch_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6266,9 +5777,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/mongo_driver.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/mongo_driver.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6287,9 +5796,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/mysql_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/mysql_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6308,9 +5815,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6329,9 +5834,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/go_redis.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/go_redis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6350,9 +5853,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlite_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlite_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6367,16 +5868,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/go/frameworks/beego.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/go/frameworks/beego.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6393,29 +5890,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6431,16 +5916,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/buffalo.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/buffalo.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6457,29 +5938,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6495,17 +5964,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/chi.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/chi.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6522,29 +5986,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6560,17 +6012,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/echo.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/echo.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6587,29 +6034,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6625,16 +6060,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/fasthttp.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/fasthttp.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6651,29 +6082,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6689,17 +6108,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/fiber.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/fiber.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6716,29 +6130,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6776,17 +6178,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/gin.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gin.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6803,80 +6200,47 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_golang.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_golang.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_golang.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
             "verified_at": "2026-05-28"
           },
-          "http_effect": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_golang.go",
-              "internal/links/effect_propagation.go"
-            ],
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_golang.go"],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "fs_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_golang.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_golang.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_golang.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6892,16 +6256,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/go_zero.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/go_zero.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6918,29 +6278,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7014,29 +6362,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7052,17 +6388,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/gorilla_mux.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gorilla_mux.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7079,29 +6410,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7117,16 +6436,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/hertz.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/hertz.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7143,29 +6458,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7181,16 +6484,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_go_trio.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_go_trio.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_go_trio.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_go_trio.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7207,29 +6506,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7245,16 +6532,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/iris.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/iris.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7271,29 +6554,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7309,16 +6580,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/kratos.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/kratos.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7335,29 +6602,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7373,17 +6628,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/net_http_stdlib.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/net_http_stdlib.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7400,29 +6650,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7438,16 +6676,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/revel.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/revel.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7464,29 +6698,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7503,16 +6725,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/bun.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/bun.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7528,16 +6746,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/orms/ent.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/ent.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7570,18 +6784,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/go/frameworks/gorm.yaml",
-            "internal/engine/rules/go/orms/gorm.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/go/frameworks/gorm.yaml","internal/engine/rules/go/orms/gorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7594,9 +6802,7 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/golang_migrate.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/golang_migrate.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -7621,9 +6827,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/pgx.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/pgx.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7636,23 +6840,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlc.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlc.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlc.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7668,16 +6866,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -7727,29 +6921,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7823,29 +7005,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7919,29 +7089,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7957,17 +7115,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/rules/java/frameworks/dropwizard.yaml"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/dropwizard.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7984,29 +7137,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8079,29 +7220,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8135,29 +7264,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8173,16 +7290,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8199,29 +7312,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8255,29 +7356,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8293,26 +7382,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8324,29 +7406,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8384,26 +7454,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/rules/java/frameworks/micronaut.yaml"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/micronaut.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8415,29 +7478,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8453,16 +7504,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/microprofile.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/microprofile.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8479,29 +7526,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8581,26 +7616,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/rules/java/frameworks/quarkus.yaml"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/quarkus.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8612,29 +7640,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8650,118 +7666,73 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_synthesis.go",
-              "internal/engine/rules/java/frameworks/spring_boot.yaml",
-              "internal/engine/rules/java/frameworks/spring_mvc.yaml",
-              "internal/engine/spring_routes.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/java/frameworks/spring_boot.yaml","internal/engine/rules/java/frameworks/spring_mvc.yaml","internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/spring_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_annotation_params.go"
-            ],
+            "cites": ["internal/engine/java_annotation_params.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_java.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_java.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_java.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
             "verified_at": "2026-05-28"
           },
-          "http_effect": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_java.go",
-              "internal/links/effect_propagation.go"
-            ],
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "fs_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_java.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_java.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_java.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8793,26 +7764,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/java/frameworks/spring_webflux.yaml",
-              "internal/engine/spring_routes.go"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/spring_webflux.yaml","internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/spring_routes.go"
-            ],
+            "cites": ["internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8824,29 +7788,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8862,16 +7814,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/apache_struts.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/apache_struts.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8888,29 +7836,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8983,29 +7919,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9021,16 +7945,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/vert_x.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/vert_x.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9047,29 +7967,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9086,16 +7994,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/dynamodb_java.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/dynamodb_java.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9145,17 +8049,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/java/orms/hibernate_core.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/hibernate_core.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9171,16 +8070,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/jooq.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/jooq.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9196,16 +8091,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9221,16 +8112,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/mybatis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/mybatis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9246,16 +8133,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9271,16 +8154,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9296,16 +8175,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9321,17 +8196,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/java/orms/spring_data_jpa.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/spring_data_jpa.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9347,16 +8217,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9372,16 +8238,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_redis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_redis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9400,9 +8262,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9421,9 +8281,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9442,9 +8300,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9463,9 +8319,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9484,9 +8338,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9505,9 +8357,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9526,9 +8376,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9547,9 +8395,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/redis_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/redis_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9568,9 +8414,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9589,9 +8433,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -9624,29 +8466,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9701,23 +8531,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9730,38 +8554,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9818,9 +8628,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/astro.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -9835,23 +8643,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9864,9 +8666,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9886,9 +8686,7 @@
           },
           "main_renderer_split": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/electron.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/electron.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -9910,16 +8708,12 @@
         "Structure": {
           "context_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9930,25 +8724,19 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -9962,16 +8750,12 @@
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/discriminator.go"
-            ],
+            "cites": ["internal/extractors/javascript/discriminator.go"],
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -9979,70 +8763,48 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10059,9 +8821,7 @@
           },
           "expo_router_specifics": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/navigation.go"
-            ],
+            "cites": ["internal/extractors/javascript/navigation.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10077,17 +8837,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/express.yaml",
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10099,38 +8854,24 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10146,16 +8887,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10172,29 +8909,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10228,29 +8953,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10287,9 +9000,7 @@
         "Routing": {
           "route_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -10305,23 +9016,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10334,9 +9039,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10352,17 +9055,12 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/graphql/frameworks/apollo_server.yaml",
-              "internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"
-            ],
+            "cites": ["internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
-            ],
+            "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10402,29 +9100,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10440,16 +9126,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10466,29 +9148,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10544,23 +9214,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10573,38 +9237,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10620,16 +9270,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10646,29 +9292,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10684,9 +9318,7 @@
         "Prompts": {
           "prompt_template_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -10694,9 +9326,7 @@
         "Composition": {
           "chain_composition": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -10735,29 +9365,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10813,23 +9431,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10842,38 +9454,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10889,63 +9487,43 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10987,16 +9565,12 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11009,23 +9583,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11038,9 +9606,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11089,9 +9655,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -11106,23 +9670,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11135,9 +9693,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11171,29 +9727,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11209,73 +9753,53 @@
         "Structure": {
           "component_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "context_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "hook_recognition": {
             "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/destructure_bindings.go"
-            ],
+            "cites": ["internal/extractors/javascript/destructure_bindings.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "jsx_template": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/discriminator.go"
-            ],
+            "cites": ["internal/extractors/javascript/discriminator.go"],
             "verified_at": "2026-05-28"
           },
           "data_fetching": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/destructure_bindings.go",
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "prop_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/navigation.go"
-            ],
+            "cites": ["internal/extractors/javascript/navigation.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2665",
             "notes": "Covers only JSX navigation props (Link to/href, Navigate to, state object); generic React component prop extraction is not yet implemented.",
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/destructure_bindings.go",
-              "internal/extractors/javascript/zustand_store.go"
-            ],
+            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/zustand_store.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -11283,130 +9807,85 @@
         "Navigation": {
           "router_pattern": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/navigation.go"
-            ],
+            "cites": ["internal/extractors/javascript/navigation.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_jsts.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_jsts.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_jsts.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
             "verified_at": "2026-05-28"
           },
-          "http_effect": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_jsts.go",
-              "internal/links/effect_propagation.go"
-            ],
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_jsts.go"],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "fs_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_jsts.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_jsts.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_jsts.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11422,16 +9901,12 @@
         "Structure": {
           "context_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11442,25 +9917,19 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -11474,16 +9943,12 @@
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/discriminator.go"
-            ],
+            "cites": ["internal/extractors/javascript/discriminator.go"],
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -11491,70 +9956,48 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11603,9 +10046,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/remix.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -11620,23 +10061,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11649,9 +10084,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11685,29 +10118,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11741,29 +10162,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11818,23 +10227,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11847,38 +10250,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11927,9 +10316,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -11944,23 +10331,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11973,9 +10354,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11991,17 +10370,12 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_trpc.go",
-              "internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/http_endpoint_trpc.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_trpc.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -12063,23 +10437,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12092,38 +10460,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -12156,16 +10510,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/drizzle.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/drizzle.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12184,9 +10534,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/knex.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/knex.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12202,16 +10550,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12227,16 +10571,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mongoose.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mongoose.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12266,25 +10606,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/prisma/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/prisma/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/prisma.yaml",
-            "internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml",
-            "internal/engine/rules/prisma/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/prisma.yaml","internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml","internal/engine/rules/prisma/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12300,16 +10632,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/sequelize.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/sequelize.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12325,16 +10653,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/typeorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/typeorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12352,9 +10676,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12369,59 +10691,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -12493,59 +10810,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -12572,32 +10884,39 @@
           }
         },
         "Substrate": {
-          "reachability_analysis": {
+          "confidence_overlay": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -12624,32 +10943,39 @@
           }
         },
         "Substrate": {
-          "reachability_analysis": {
+          "confidence_overlay": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -12668,9 +10994,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12685,59 +11009,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -12753,16 +11072,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/http4k.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/http4k.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12777,59 +11092,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -12861,59 +11171,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -12985,59 +11290,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -13053,16 +11353,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/ktor.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/ktor.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13077,59 +11373,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -13145,16 +11436,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13169,59 +11456,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -13237,16 +11519,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13261,59 +11539,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -13329,26 +11602,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml",
-              "internal/engine/spring_routes_kotlin.go"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml","internal/engine/spring_routes_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/spring_routes_kotlin.go"
-            ],
+            "cites": ["internal/engine/spring_routes_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13358,59 +11624,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_kotlin.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -13427,16 +11688,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/exposed.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/exposed.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13452,16 +11709,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13477,16 +11730,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/ktorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/ktorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13502,16 +11751,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13527,16 +11772,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/room_android.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/room_android.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13552,16 +11793,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13577,16 +11814,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13633,9 +11866,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/cassandra_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/cassandra_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13654,9 +11885,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/dynamodb_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/dynamodb_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13675,9 +11904,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/elasticsearch_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/elasticsearch_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13696,9 +11923,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/mongodb_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/mongodb_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13717,9 +11942,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/mysql_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/mysql_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13738,9 +11961,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13759,9 +11980,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/postgresql_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/postgresql_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13780,9 +11999,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/redis_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/redis_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13801,9 +12018,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/sqlite_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/sqlite_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13818,16 +12033,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/cakephp.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/cakephp.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13842,59 +12053,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -13910,16 +12116,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/codeigniter.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/codeigniter.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13934,59 +12136,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14002,16 +12199,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/drupal.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/drupal.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14026,59 +12219,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14094,16 +12282,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/laminas.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/laminas.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14118,59 +12302,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14186,17 +12365,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_php_producer.go",
-              "internal/engine/rules/php/frameworks/laravel.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/laravel.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_php_producer.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_php_producer.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14211,59 +12385,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14295,59 +12464,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14363,16 +12527,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/magento.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/magento.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14387,59 +12547,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14471,59 +12626,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14539,16 +12689,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/php/frameworks/slim.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/php/frameworks/slim.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14563,59 +12709,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14631,17 +12772,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_php_producer.go",
-              "internal/engine/rules/php/frameworks/symfony.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/symfony.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_php_producer.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_php_producer.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14656,59 +12792,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14724,16 +12855,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/wordpress.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/wordpress.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14748,59 +12875,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14816,16 +12938,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/yii.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/yii.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14840,59 +12958,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_php.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -14926,16 +13039,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/orms/doctrine_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/doctrine_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14951,16 +13060,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14976,16 +13081,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/propel.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/propel.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15001,16 +13102,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/redbeanphp.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/redbeanphp.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15029,9 +13126,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/cassandra_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/cassandra_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15050,9 +13145,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/dynamodb_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/dynamodb_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15071,9 +13164,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/elasticsearch_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/elasticsearch_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15092,10 +13183,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/mysql_py.yaml",
-            "internal/extractors/python/raw_sql_db_calls.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15114,9 +13202,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15135,10 +13221,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/postgresql_py.yaml",
-            "internal/extractors/python/raw_sql_db_calls.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15157,9 +13240,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/redis_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/redis_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15178,10 +13259,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/sqlite_py.yaml",
-            "internal/extractors/python/raw_sql_db_calls.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15196,16 +13274,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/aiohttp.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/aiohttp.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15222,29 +13296,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15260,16 +13322,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/bottle.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/bottle.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15286,29 +13344,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15327,10 +13373,7 @@
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/celery.yaml",
-              "internal/extractors/python/celery.go"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/celery.yaml","internal/extractors/python/celery.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15347,29 +13390,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15403,29 +13434,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15441,66 +13460,43 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/django_routes.go",
-              "internal/engine/django_urlconf_nested.go",
-              "internal/engine/rules/python/frameworks/django.yaml"
-            ],
+            "cites": ["internal/engine/django_routes.go","internal/engine/django_urlconf_nested.go","internal/engine/rules/python/frameworks/django.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/django_admin_routes.go",
-              "internal/engine/django_routes.go"
-            ],
+            "cites": ["internal/engine/django_admin_routes.go","internal/engine/django_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/django_drf_actions.go"
-            ],
+            "cites": ["internal/engine/django_drf_actions.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/django_imports_rewrite.go"
-            ],
+            "cites": ["internal/engine/django_imports_rewrite.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15516,27 +13512,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/django_drf_actions.go",
-              "internal/extractors/python/django_drf_actions.go"
-            ],
+            "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/django_drf_actions.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/django_drf_actions.go",
-              "internal/extractors/python/drf_serializer_fields.go"
-            ],
+            "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/drf_serializer_fields.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/django_drf_actions.go"
-            ],
+            "cites": ["internal/engine/django_drf_actions.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15548,80 +13536,47 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_python.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_python.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_python.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
             "verified_at": "2026-05-28"
           },
-          "http_effect": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_python.go",
-              "internal/links/effect_propagation.go"
-            ],
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "fs_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_python.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effect_sinks_python.go",
-              "internal/links/effect_propagation.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15634,9 +13589,7 @@
           },
           "signal_handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/django_signal_pubsub_edges.go"
-            ],
+            "cites": ["internal/engine/django_signal_pubsub_edges.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2739",
             "verified_at": "2026-05-28"
           }
@@ -15656,9 +13609,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/python/frameworks/dramatiq.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/dramatiq.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15675,29 +13626,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15731,29 +13670,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15769,26 +13696,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_synthesis.go",
-              "internal/engine/rules/python/frameworks/fastapi.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/fastapi.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/fastapi.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/python/frameworks/fastapi.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15800,29 +13720,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15838,17 +13746,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_synthesis.go",
-              "internal/engine/rules/python/frameworks/flask.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/flask.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/flask.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/flask.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15865,29 +13768,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15921,29 +13812,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15981,16 +13860,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/litestar.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/litestar.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16007,29 +13882,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -16045,16 +13908,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/pyramid.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/pyramid.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16071,29 +13930,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -16127,29 +13974,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -16165,16 +14000,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/robyn.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/robyn.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16191,29 +14022,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -16229,16 +14048,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/sanic.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/sanic.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16255,29 +14070,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -16293,16 +14096,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/starlette.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/starlette.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16319,29 +14118,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -16357,17 +14144,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/graphql/frameworks/strawberry_python.yaml",
-              "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
-            ],
+            "cites": ["internal/engine/rules/graphql/frameworks/strawberry_python.yaml","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16384,29 +14166,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -16422,16 +14192,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/tornado.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/tornado.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16448,29 +14214,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -16484,9 +14238,7 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/alembic.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -16508,16 +14260,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/beanie.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/beanie.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16530,24 +14278,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/python/django_migration.go"
-          ],
+          "cites": ["internal/extractors/python/django_migration.go"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/orms/django_orm.yaml",
-            "internal/extractors/python/django_relational.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/django_orm.yaml","internal/extractors/python/django_relational.go"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16563,16 +14304,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/mongoengine.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/mongoengine.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16588,16 +14325,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/peewee.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/peewee.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16613,16 +14346,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/pony_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/pony_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16635,24 +14364,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/alembic.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/python/orms/sqlalchemy.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/python/orms/sqlalchemy.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16668,16 +14390,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/orms/sqlmodel.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/sqlmodel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16693,16 +14411,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/orms/tortoise_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/tortoise_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16721,9 +14435,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/cassandra_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/cassandra_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16742,9 +14454,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16763,9 +14473,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16784,9 +14492,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/mysql_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/mysql_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16805,9 +14511,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16826,9 +14530,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/pg_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/pg_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16847,9 +14549,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/redis_rb.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/redis_rb.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16868,9 +14568,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/sqlite_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/sqlite_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16901,59 +14599,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -16972,9 +14665,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/dry_rb.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/dry_rb.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16989,59 +14680,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -17057,16 +14743,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/grape.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/grape.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17081,59 +14763,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -17149,16 +14826,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/hanami.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/hanami.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17173,59 +14846,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -17241,16 +14909,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/padrino.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/padrino.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17265,59 +14929,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -17333,17 +14992,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_ruby_producer.go",
-              "internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_ruby_producer.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17358,59 +15012,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -17426,16 +15075,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/roda.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/roda.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17450,59 +15095,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -17518,17 +15158,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_ruby_producer.go",
-              "internal/engine/rules/ruby/frameworks/sinatra.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/sinatra.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_ruby_producer.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17543,59 +15178,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_ruby.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -17612,16 +15242,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/orms/activerecord.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/activerecord.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17637,16 +15263,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17662,16 +15284,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/mongoid.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/mongoid.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17687,17 +15305,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml",
-            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml","internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17713,16 +15326,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/sequel.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/sequel.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17741,9 +15350,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/cassandra_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/cassandra_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17762,9 +15369,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/dynamodb_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/dynamodb_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17783,9 +15388,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/elasticsearch_rs.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/elasticsearch_rs.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17804,9 +15407,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/mongodb_mongodb.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/mongodb_mongodb.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17825,9 +15426,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/mysql_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/mysql_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17846,9 +15445,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17867,9 +15464,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/postgresql_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/postgresql_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17888,9 +15483,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/redis_redis_rs.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/redis_redis_rs.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17909,9 +15502,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/sqlite_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/sqlite_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17926,16 +15517,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/actix_web.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/actix_web.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17950,59 +15537,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18018,17 +15600,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_axum.go",
-              "internal/engine/rules/rust/frameworks/axum.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_axum.go","internal/engine/rules/rust/frameworks/axum.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_axum.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_axum.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18043,59 +15620,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18111,16 +15683,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/gotham.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/gotham.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18135,59 +15703,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18203,16 +15766,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/hyper.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/hyper.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18227,59 +15786,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18295,16 +15849,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/poem.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/poem.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18319,59 +15869,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18387,17 +15932,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rocket_routes.go",
-              "internal/engine/rules/rust/frameworks/rocket.yaml"
-            ],
+            "cites": ["internal/engine/rocket_routes.go","internal/engine/rules/rust/frameworks/rocket.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rocket_routes.go"
-            ],
+            "cites": ["internal/engine/rocket_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18412,59 +15952,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18496,59 +16031,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18575,32 +16105,39 @@
           }
         },
         "Substrate": {
-          "reachability_analysis": {
+          "confidence_overlay": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18616,16 +16153,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/tide.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/tide.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18640,59 +16173,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18724,59 +16252,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18792,16 +16315,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/warp.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/warp.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18816,59 +16335,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_rust.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -18885,16 +16399,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/diesel.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/diesel.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18930,9 +16440,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/rusqlite.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/rusqlite.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18948,16 +16456,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/seaorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/seaorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18973,16 +16477,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18997,16 +16497,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -19021,59 +16517,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -19105,59 +16596,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -19176,9 +16662,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/cats_effect.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/cats_effect.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -19193,59 +16677,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -19261,16 +16740,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/finatra.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/finatra.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -19285,59 +16760,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -19353,16 +16823,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/http4s.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/http4s.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -19377,59 +16843,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -19445,16 +16906,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/lagom.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/lagom.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -19469,59 +16926,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -19590,59 +17042,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -19658,16 +17105,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/scalatra.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/scalatra.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -19682,59 +17125,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -19750,16 +17188,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/zio.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/zio.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -19774,59 +17208,54 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
+          "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go"
-            ],
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
             "status": "full",
-            "cites": [
-              "internal/substrate/entry_points_scala.go",
-              "internal/substrate/entry_points.go",
-              "internal/links/reachability.go",
-              "internal/mcp/dead_code.go"
-            ],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
-          "confidence_overlay": {
+          "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/types/confidence.go",
-              "internal/graph/graph.go",
-              "internal/mcp/tools.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -19843,16 +17272,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/doobie.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/doobie.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19868,16 +17293,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/elastic4s.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/elastic4s.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19893,16 +17314,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/quill.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/quill.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19918,16 +17335,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19943,16 +17356,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scanamo.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scanamo.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19968,16 +17377,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/slick.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/slick.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20004,23 +17409,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20050,23 +17449,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20079,23 +17472,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/debezium_cdc_edges.go"
-          ],
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/debezium_cdc_edges.go"
-          ],
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/debezium_cdc_edges.go"
-          ],
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20108,23 +17495,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20137,23 +17518,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20166,23 +17541,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20195,24 +17564,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/kafka_edges.go"
-          ],
+          "cites": ["internal/engine/kafka_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/kafka_edges.go",
-            "internal/engine/kafka_wrapper_edges.go"
-          ],
+          "cites": ["internal/engine/kafka_edges.go","internal/engine/kafka_wrapper_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/kafka_edges.go"
-          ],
+          "cites": ["internal/engine/kafka_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20225,23 +17587,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20254,23 +17610,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/nats_edges.go"
-          ],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/nats_edges.go"
-          ],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/nats_edges.go"
-          ],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20283,23 +17633,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pulsar_edges.go"
-          ],
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pulsar_edges.go"
-          ],
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pulsar_edges.go"
-          ],
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20312,23 +17656,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20337,27 +17675,21 @@
       "id": "msg.broker.redis",
       "category": "message_broker",
       "language": "multi",
-      "label": "Redis pub/sub & streams",
+      "label": "Redis pub/sub \u0026 streams",
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20370,23 +17702,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20399,23 +17725,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sqs_edges.go"
-          ],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sqs_edges.go"
-          ],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/sqs_edges.go"
-          ],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20428,23 +17748,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/links/topic_pass.go"
-          ],
+          "cites": ["internal/links/topic_pass.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20457,24 +17771,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go",
-            "internal/extractors/python/celery.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/extractors/python/celery.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/links/topic_pass.go"
-          ],
+          "cites": ["internal/links/topic_pass.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20487,23 +17794,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_signal_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_signal_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/django_signal_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20530,23 +17831,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20587,16 +17882,12 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sse_edges.go"
-          ],
+          "cites": ["internal/engine/sse_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sse_edges.go"
-          ],
+          "cites": ["internal/engine/sse_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
@@ -20612,23 +17903,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/webhooks_edges.go"
-          ],
+          "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/webhooks_edges.go"
-          ],
+          "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/webhooks_edges.go"
-          ],
+          "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20641,23 +17926,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/websocket_edges.go"
-          ],
+          "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/websocket_edges.go"
-          ],
+          "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/websocket_edges.go"
-          ],
+          "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20673,9 +17952,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20719,9 +17996,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20737,9 +18012,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20780,9 +18053,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20809,9 +18080,7 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20827,9 +18096,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20845,9 +18112,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20860,9 +18125,7 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20897,24 +18160,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/http_endpoint_match.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_match.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go",
-            "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go","internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20927,23 +18183,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "full",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20973,23 +18223,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/http_endpoint_match.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_match.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/openapi/language.yaml"
-          ],
+          "cites": ["internal/engine/rules/openapi/language.yaml"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/openapi/language.yaml"
-          ],
+          "cites": ["internal/engine/rules/openapi/language.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21002,24 +18246,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/proto"
-          ],
+          "cites": ["internal/extractors/proto"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/protobuf/_manifest.yaml",
-            "internal/extractors/proto"
-          ],
+          "cites": ["internal/engine/rules/protobuf/_manifest.yaml","internal/extractors/proto"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21045,13 +18282,11 @@
       "id": "security.auth-java",
       "category": "security",
       "language": "java",
-      "label": "Auth policy resolver (Java/Kotlin \u2014 Phase 1 of #1942)",
+      "label": "Auth policy resolver (Java/Kotlin — Phase 1 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21060,7 +18295,7 @@
       "id": "security.auth-other",
       "category": "security",
       "language": "multi",
-      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET \u2014 Phases 2-4 of #1942)",
+      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "missing",
@@ -21076,9 +18311,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -21097,9 +18330,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -21118,9 +18349,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -21139,9 +18368,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -21177,9 +18404,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -21198,9 +18423,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/_engine/csrf_heuristic_detector.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/csrf_heuristic_detector.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21213,9 +18436,7 @@
       "capabilities": {
         "secret_detection": {
           "status": "full",
-          "cites": [
-            "internal/secrets/secrets.go"
-          ],
+          "cites": ["internal/secrets/secrets.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21228,9 +18449,7 @@
       "capabilities": {
         "sql_injection": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/_engine/sql_injection_detector.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/sql_injection_detector.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21299,17 +18518,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/rust/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21448,17 +18662,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/elixir/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21499,17 +18708,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/go/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21578,17 +18782,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/frameworks/jest.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/jest.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21601,16 +18800,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21623,17 +18818,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/frameworks/junit5.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/junit5.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21646,16 +18836,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21668,16 +18854,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21718,16 +18900,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21754,16 +18932,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21790,17 +18964,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/php/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21841,17 +19010,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/pytest.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/pytest.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21878,17 +19042,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/rspec.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/rspec.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21943,16 +19102,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21968,9 +19123,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -21983,16 +19136,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -22005,16 +19154,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -22027,17 +19172,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }

--- a/internal/substrate/effect_sinks_c_cpp.go
+++ b/internal/substrate/effect_sinks_c_cpp.go
@@ -1,0 +1,183 @@
+// C / C++ effect-sink sniffer (#2765 Phase 1A T2).
+//
+// Recognises sink primitives in plain C and modern C++. The C and C++
+// substrates share one sniffer because they share extension space
+// (#2732) and most sink primitives — libpq, MySQL C API, libcurl, the
+// POSIX/stdio file primitives, and the POSIX process primitives — are
+// callable from either language. C++-only primitives (std::ifstream /
+// std::ofstream, std::filesystem) are included via separate alternates.
+//
+//   - http_out  : `curl_easy_perform`, `curl_easy_setopt(..., CURLOPT_URL, ...)`,
+//                 `curl_multi_perform`, cpp-httplib `httplib::Client`,
+//                 Boost.Beast, POCO `HTTPClientSession`
+//   - db_read   : libpq `PQexec(... , "SELECT ...")`, `PQexecParams`,
+//                 `PQprepare`, MySQL C `mysql_query("SELECT...")`,
+//                 SQLite `sqlite3_prepare_v2(... "SELECT" ...)` /
+//                 `sqlite3_step` after a SELECT, ODBC `SQLExecDirect`
+//   - db_write  : libpq PQexec/PQexecParams with INSERT|UPDATE|DELETE,
+//                 MySQL `mysql_query("INSERT|UPDATE|DELETE...")`, SQLite
+//                 with non-SELECT, generic `PQexec` (assumed write at low
+//                 confidence when SQL keyword cannot be recognised)
+//   - fs_read   : `fopen(..., "r")`, `freopen(..., "r")`, `read`, `pread`,
+//                 `open(..., O_RDONLY)`, std::ifstream, std::filesystem::
+//                 directory_iterator / read_symlink
+//   - fs_write  : `fopen(..., "w"|"a"|"x"|...)`, `freopen("w"...)`,
+//                 `write`, `pwrite`, `open(..., O_WRONLY|O_CREAT...)`,
+//                 `mkdir`, `rmdir`, `unlink`, `rename`, `chmod`,
+//                 `std::ofstream`, `std::filesystem::create_directory*`,
+//                 `std::filesystem::remove*`
+//   - mutation  : `this->member = ...` assignment inside a member
+//                 function. C-style struct mutation via `obj.field = ...`
+//                 is too noisy without alias analysis; deferred to
+//                 Phase 4.
+//
+// Function attribution uses the nearest preceding `name(...) {` header
+// on a line. C and C++ grammars admit many declaration shapes — we accept
+// the canonical "return-type name(...)" forms and let the substrate's
+// line-based attribution handle the rest.
+package substrate
+
+import "regexp"
+
+func init() { RegisterEffectSniffer("c-cpp", sniffEffectsCCPP) }
+
+// ccppFuncHeaderRe matches a function definition header. We accept any
+// line that ends with `name(...args) {` (with optional trailing `const`,
+// `noexcept`, `override`, etc., absorbed by allowing a brace anywhere on
+// the same line OR on the next line — for the next-line case the
+// nearest-header heuristic still picks the right function).
+//
+// Capture group 1 is the bare function name.
+var ccppFuncHeaderRe = regexp.MustCompile(
+	`(?m)^\s*(?:[A-Za-z_][\w*&:<>,\s]+\s+)` + // return type (with qualifiers, pointers, refs, namespaces)
+		`(?:[A-Za-z_][\w:]*::)?` + // optional class qualifier
+		`([A-Za-z_][\w]*)\s*\([^;{]*\)\s*` + // name + params
+		`(?:const\s+)?(?:noexcept(?:\([^)]*\))?\s+)?(?:override\s+)?(?:final\s+)?(?:->[^{;]+)?\s*` +
+		`\{`,
+)
+
+// ccppHTTPRe matches outbound HTTP primitives.
+var ccppHTTPRe = regexp.MustCompile(
+	`\bcurl_easy_perform\s*\(` +
+		`|\bcurl_easy_setopt\s*\([^,]+,\s*CURLOPT_URL\b` +
+		`|\bcurl_multi_perform\s*\(` +
+		`|\bhttplib\s*::\s*(?:Client|SSLClient)\b` +
+		`|\bboost\s*::\s*beast\s*::\s*http\b` +
+		`|\bPoco\s*::\s*Net\s*::\s*HTTPClientSession\b`,
+)
+
+// ccppDBReadRe matches database read primitives. We use SQL-keyword
+// matching to disambiguate read vs write where the same API is used for
+// both (PQexec, mysql_query, sqlite3_prepare_v2).
+var ccppDBReadRe = regexp.MustCompile(
+	`\bPQexec(?:Params|Prepared)?\s*\(\s*[^,]+,\s*"(?i:\s*(?:SELECT|WITH)\b)` +
+		`|\bmysql_query\s*\(\s*[^,]+,\s*"(?i:\s*(?:SELECT|WITH)\b)` +
+		`|\bsqlite3_prepare_v2\s*\(\s*[^,]+,\s*"(?i:\s*(?:SELECT|WITH)\b)` +
+		`|\bSQLExecDirect\s*\(\s*[^,]+,\s*\(?\s*(?:SQLCHAR\s*\*\s*\)\s*)?"(?i:\s*(?:SELECT|WITH)\b)`,
+)
+
+// ccppDBWriteRe matches database write primitives.
+var ccppDBWriteRe = regexp.MustCompile(
+	`\bPQexec(?:Params|Prepared)?\s*\(\s*[^,]+,\s*"(?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)` +
+		`|\bmysql_query\s*\(\s*[^,]+,\s*"(?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)` +
+		`|\bsqlite3_prepare_v2\s*\(\s*[^,]+,\s*"(?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)` +
+		`|\bsqlite3_exec\s*\(`,
+)
+
+// ccppDBExecRe matches generic `PQexec` / `mysql_query` calls where the
+// SQL keyword could not be matched (variable, multi-line, concatenated).
+// Classified as both db_read and db_write at low confidence.
+var ccppDBExecRe = regexp.MustCompile(
+	`\b(?:PQexec|mysql_query|sqlite3_exec)\s*\(`,
+)
+
+// ccppFSReadRe matches read-only filesystem primitives.
+var ccppFSReadRe = regexp.MustCompile(
+	`\bfopen\s*\(\s*[^,)]+\s*,\s*"r[bt+]?"` +
+		`|\bfreopen\s*\(\s*[^,)]+\s*,\s*"r[bt+]?"` +
+		`|\b(?:read|pread)\s*\(\s*[^,)]+\s*,` +
+		`|\bopen\s*\(\s*[^,)]+\s*,\s*O_RDONLY\b` +
+		`|\bstd\s*::\s*ifstream\s+[A-Za-z_]` +
+		`|\bstd\s*::\s*filesystem\s*::\s*(?:directory_iterator|recursive_directory_iterator|read_symlink|exists|file_size|status)\b` +
+		`|\bstat\s*\(`,
+)
+
+// ccppFSWriteRe matches write filesystem primitives.
+var ccppFSWriteRe = regexp.MustCompile(
+	`\bfopen\s*\(\s*[^,)]+\s*,\s*"(?:w|a|x)[bt+]?"` +
+		`|\bfreopen\s*\(\s*[^,)]+\s*,\s*"(?:w|a|x)[bt+]?"` +
+		`|\b(?:write|pwrite)\s*\(\s*[^,)]+\s*,` +
+		`|\bopen\s*\(\s*[^,)]+\s*,\s*(?:O_WRONLY|O_CREAT|O_RDWR|O_APPEND|O_TRUNC)` +
+		`|\b(?:mkdir|rmdir|unlink|rename|chmod|chown|symlink|link|truncate|ftruncate)\s*\(` +
+		`|\bstd\s*::\s*ofstream\s+[A-Za-z_]` +
+		`|\bstd\s*::\s*filesystem\s*::\s*(?:create_directory|create_directories|remove|remove_all|rename|copy|copy_file|resize_file|permissions)\b`,
+)
+
+// ccppProcessRe matches process-spawn primitives (modelled as fs_write).
+var ccppProcessRe = regexp.MustCompile(
+	`\b(?:system|popen|execv|execve|execvp|execvpe|execl|execlp|execle|fork|vfork|posix_spawn|posix_spawnp)\s*\(`,
+)
+
+// ccppMutationRe matches `this->member = ...` assignment.
+var ccppMutationRe = regexp.MustCompile(
+	`\bthis\s*->\s*[A-Za-z_][\w]*\s*=(?:[^=])`,
+)
+
+func sniffEffectsCCPP(content string) []EffectMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanCCPPFuncHeaders(content)
+	var out []EffectMatch
+	out = appendCCPPMatches(out, content, headers, ccppHTTPRe, EffectHTTPOut, "libcurl/cpp-httplib/Boost.Beast", 1.0)
+	out = appendCCPPMatches(out, content, headers, ccppDBReadRe, EffectDBRead, "libpq/mysql/sqlite/odbc(SELECT)", 1.0)
+	out = appendCCPPMatches(out, content, headers, ccppDBWriteRe, EffectDBWrite, "libpq/mysql/sqlite(WRITE)", 1.0)
+	out = appendCCPPMatches(out, content, headers, ccppDBExecRe, EffectDBWrite, "PQexec/mysql_query(generic)", 0.6)
+	out = appendCCPPMatches(out, content, headers, ccppFSReadRe, EffectFSRead, "fopen(r)/read/ifstream", 1.0)
+	out = appendCCPPMatches(out, content, headers, ccppFSWriteRe, EffectFSWrite, "fopen(w)/write/ofstream", 1.0)
+	out = appendCCPPMatches(out, content, headers, ccppProcessRe, EffectFSWrite, "system/exec/posix_spawn", 0.9)
+	out = appendCCPPMatches(out, content, headers, ccppMutationRe, EffectMutation, "this->field=", 0.7)
+	return out
+}
+
+func scanCCPPFuncHeaders(content string) []funcHeader {
+	var hs []funcHeader
+	for _, m := range ccppFuncHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if ccppControlKeyword(name) {
+			continue
+		}
+		hs = append(hs, funcHeader{Line: lineOfOffset(content, m[0]), Name: name})
+	}
+	return hs
+}
+
+// ccppControlKeyword rejects keywords that the conservative header regex
+// can accidentally match (e.g. `if (...)` or `while (...)` introducing a
+// block). The "return-type name(...) {" shape collides with control-flow
+// when the return type slot eats the keyword's left-hand neighbour.
+func ccppControlKeyword(s string) bool {
+	switch s {
+	case "if", "else", "for", "while", "switch", "case", "catch", "try", "do", "return", "throw", "new", "delete", "sizeof", "typeid", "decltype", "static_assert":
+		return true
+	}
+	return false
+}
+
+func appendCCPPMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect, sink string, conf float64) []EffectMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/effect_sinks_csharp.go
+++ b/internal/substrate/effect_sinks_csharp.go
@@ -1,0 +1,169 @@
+// C# effect-sink sniffer (#2765 Phase 1A T2).
+//
+// Recognises C# sink primitives:
+//
+//   - http_out  : HttpClient.GetAsync / PostAsync / PutAsync / DeleteAsync
+//                 / SendAsync / GetStringAsync / GetStreamAsync, WebClient
+//                 .Download* / .Upload*, RestClient (RestSharp) .Execute*,
+//                 HttpWebRequest.Create
+//   - db_read   : Entity Framework DbSet `.Find / .FindAsync / .First /
+//                 .FirstOrDefault / .Single / .SingleOrDefault / .Where /
+//                 .ToList / .ToArray / .Count / .Any / .Include /
+//                 .AsQueryable / .FromSqlRaw / .FromSqlInterpolated`,
+//                 raw ADO.NET `SqlCommand.ExecuteReader / ExecuteScalar`,
+//                 Dapper `Query / QueryAsync / QueryFirst / QuerySingle`
+//   - db_write  : EF DbSet `.Add / .AddAsync / .AddRange / .Update /
+//                 .UpdateRange / .Remove / .RemoveRange / .Attach`, EF
+//                 `SaveChanges / SaveChangesAsync / ExecuteSqlRaw /
+//                 ExecuteSqlInterpolated`, ADO.NET SqlCommand
+//                 `.ExecuteNonQuery`, Dapper `Execute / ExecuteAsync`
+//   - fs_read   : File.ReadAllText / .ReadAllBytes / .ReadAllLines /
+//                 .ReadLines / .OpenRead / .OpenText, Directory.Get*,
+//                 new FileStream(..., FileMode.Open, FileAccess.Read),
+//                 StreamReader ctor
+//   - fs_write  : File.WriteAllText / .WriteAllBytes / .WriteAllLines /
+//                 .AppendAllText / .AppendAllLines / .Delete / .Move /
+//                 .Copy / .Create / .CreateText, Directory.CreateDirectory
+//                 / .Delete / .Move, FileStream with FileMode.Create or
+//                 FileAccess.Write, StreamWriter ctor
+//   - mutation  : `this.<Property|field> = ...` assignment inside a method
+//
+// Function attribution uses the nearest preceding method header — same
+// shape as the Java sniffer with C#-specific keyword set.
+package substrate
+
+import "regexp"
+
+func init() { RegisterEffectSniffer("csharp", sniffEffectsCSharp) }
+
+// csharpMethodHeaderRe matches a C# method signature header. Conservative
+// — requires a modifier (public/private/protected/internal/static/...) or
+// async, the return type, the method name, and the opening parenthesis.
+// Constructors are captured by csharpCtorHeaderRe.
+var csharpMethodHeaderRe = regexp.MustCompile(
+	`(?m)^\s*` +
+		`(?:(?:public|private|protected|internal|static|virtual|override|abstract|sealed|async|unsafe|new|extern|partial|readonly|\[[^\]]+\])\s+)+` +
+		`(?:<[^>]+>\s+)?` +
+		`[A-Za-z_][\w<>\[\],?.\s]*\s+` +
+		`([A-Za-z_][\w]*)\s*\(`,
+)
+
+// csharpCtorHeaderRe matches constructor declarations.
+var csharpCtorHeaderRe = regexp.MustCompile(
+	`(?m)^\s*(?:public|private|protected|internal)\s+([A-Z][\w]*)\s*\(`,
+)
+
+// csharpHTTPRe matches outbound HTTP primitives.
+var csharpHTTPRe = regexp.MustCompile(
+	`\b(?:httpClient|_httpClient|client|_client|http)\s*\.\s*(?:GetAsync|PostAsync|PutAsync|PatchAsync|DeleteAsync|HeadAsync|SendAsync|GetStringAsync|GetStreamAsync|GetByteArrayAsync|PostAsJsonAsync|PutAsJsonAsync|PatchAsJsonAsync)\s*\(` +
+		`|\bnew\s+HttpClient\s*\(` +
+		`|\b(?:HttpClient|HttpRequestMessage|HttpWebRequest|WebClient|RestClient)\s*\.\s*(?:Create|Default)\b` +
+		`|\bnew\s+(?:RestClient|RestRequest|WebClient|HttpWebRequest)\s*\(` +
+		`|\.\s*Execute(?:Async)?\s*<[^>]+>\s*\(` +
+		`|\b(?:WebClient|HttpClient)\s*\.\s*(?:DownloadString|DownloadData|DownloadFile|UploadString|UploadData|UploadFile)\b`,
+)
+
+// csharpDBReadRe matches EF / Dapper / ADO.NET read primitives.
+var csharpDBReadRe = regexp.MustCompile(
+	`\.\s*(?:Find|FindAsync|First|FirstAsync|FirstOrDefault|FirstOrDefaultAsync|Single|SingleAsync|SingleOrDefault|SingleOrDefaultAsync|Where|Any|AnyAsync|All|Count|CountAsync|LongCount|LongCountAsync|ToList|ToListAsync|ToArray|ToArrayAsync|ToDictionary|Include|ThenInclude|AsQueryable|AsNoTracking|FromSqlRaw|FromSqlInterpolated|SqlQuery)\s*[\(<]` +
+		`|\.\s*(?:ExecuteReader|ExecuteReaderAsync|ExecuteScalar|ExecuteScalarAsync)\s*\(` +
+		`|\.\s*(?:Query|QueryAsync|QueryFirst|QueryFirstAsync|QueryFirstOrDefault|QueryFirstOrDefaultAsync|QuerySingle|QuerySingleAsync|QuerySingleOrDefault|QuerySingleOrDefaultAsync|QueryMultiple|QueryMultipleAsync)\s*[\(<]`,
+)
+
+// csharpDBWriteRe matches EF / Dapper / ADO.NET write primitives.
+var csharpDBWriteRe = regexp.MustCompile(
+	`\.\s*(?:Add|AddAsync|AddRange|AddRangeAsync|Update|UpdateRange|Remove|RemoveRange|Attach|AttachRange|Entry)\s*\(` +
+		`|\.\s*(?:SaveChanges|SaveChangesAsync|ExecuteSqlRaw|ExecuteSqlRawAsync|ExecuteSqlInterpolated|ExecuteSqlInterpolatedAsync|ExecuteUpdate|ExecuteUpdateAsync|ExecuteDelete|ExecuteDeleteAsync)\s*\(` +
+		`|\.\s*(?:ExecuteNonQuery|ExecuteNonQueryAsync)\s*\(` +
+		`|\.\s*(?:Execute|ExecuteAsync|ExecuteScalar)\s*\(\s*["@$]`,
+)
+
+// csharpFSReadRe matches read-only filesystem primitives.
+var csharpFSReadRe = regexp.MustCompile(
+	`\bFile\s*\.\s*(?:ReadAllText|ReadAllTextAsync|ReadAllBytes|ReadAllBytesAsync|ReadAllLines|ReadAllLinesAsync|ReadLines|ReadLinesAsync|OpenRead|OpenText|Exists)\s*\(` +
+		`|\bDirectory\s*\.\s*(?:GetFiles|GetDirectories|GetFileSystemEntries|EnumerateFiles|EnumerateDirectories|EnumerateFileSystemEntries|Exists)\s*\(` +
+		`|\bnew\s+(?:StreamReader|FileStream\s*\([^)]*FileMode\.Open|BinaryReader)\s*\(`,
+)
+
+// csharpFSWriteRe matches write filesystem primitives.
+var csharpFSWriteRe = regexp.MustCompile(
+	`\bFile\s*\.\s*(?:WriteAllText|WriteAllTextAsync|WriteAllBytes|WriteAllBytesAsync|WriteAllLines|WriteAllLinesAsync|AppendAllText|AppendAllTextAsync|AppendAllLines|Delete|Move|Copy|Create|CreateText|OpenWrite|SetAttributes|SetCreationTime|SetLastWriteTime|Replace)\s*\(` +
+		`|\bDirectory\s*\.\s*(?:CreateDirectory|Delete|Move)\s*\(` +
+		`|\bnew\s+(?:StreamWriter|FileStream\s*\([^)]*FileMode\.(?:Create|CreateNew|Append)|BinaryWriter)\s*\(`,
+)
+
+// csharpProcessRe matches process-spawn primitives (modelled as fs_write).
+var csharpProcessRe = regexp.MustCompile(
+	`\bProcess\s*\.\s*Start\s*\(` +
+		`|\bnew\s+Process\s*\(\s*\)\s*\.\s*Start\b` +
+		`|\bProcessStartInfo\s*\(`,
+)
+
+// csharpMutationRe matches `this.<Member> = ...` assignment.
+var csharpMutationRe = regexp.MustCompile(
+	`\bthis\s*\.\s*[A-Za-z_][\w]*\s*=(?:[^=])`,
+)
+
+func sniffEffectsCSharp(content string) []EffectMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanCSharpFuncHeaders(content)
+	var out []EffectMatch
+	out = appendCSharpMatches(out, content, headers, csharpHTTPRe, EffectHTTPOut, "HttpClient/WebClient/RestSharp", 1.0)
+	out = appendCSharpMatches(out, content, headers, csharpDBReadRe, EffectDBRead, "ef/dapper/ado.read", 0.85)
+	out = appendCSharpMatches(out, content, headers, csharpDBWriteRe, EffectDBWrite, "ef/dapper/ado.write", 0.85)
+	out = appendCSharpMatches(out, content, headers, csharpFSReadRe, EffectFSRead, "File.Read/Directory.Get", 1.0)
+	out = appendCSharpMatches(out, content, headers, csharpFSWriteRe, EffectFSWrite, "File.Write/Directory.Create", 1.0)
+	out = appendCSharpMatches(out, content, headers, csharpProcessRe, EffectFSWrite, "Process.Start", 0.9)
+	out = appendCSharpMatches(out, content, headers, csharpMutationRe, EffectMutation, "this.field=", 0.7)
+	return out
+}
+
+func scanCSharpFuncHeaders(content string) []funcHeader {
+	var hs []funcHeader
+	add := func(name string, off int) {
+		if name == "" || csharpControlKeyword(name) {
+			return
+		}
+		hs = append(hs, funcHeader{Line: lineOfOffset(content, off), Name: name})
+	}
+	for _, m := range csharpMethodHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		add(content[m[2]:m[3]], m[0])
+	}
+	for _, m := range csharpCtorHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		add(content[m[2]:m[3]], m[0])
+	}
+	return hs
+}
+
+// csharpControlKeyword rejects control-flow tokens that the conservative
+// method regex can accidentally match.
+func csharpControlKeyword(s string) bool {
+	switch s {
+	case "if", "else", "for", "foreach", "while", "switch", "catch", "try", "do", "return", "throw", "new", "lock", "using", "fixed", "checked", "unchecked", "yield", "await", "this", "base":
+		return true
+	}
+	return false
+}
+
+func appendCSharpMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect, sink string, conf float64) []EffectMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/effect_sinks_elixir.go
+++ b/internal/substrate/effect_sinks_elixir.go
@@ -1,0 +1,146 @@
+// Elixir effect-sink sniffer (#2765 Phase 1A T2).
+//
+// Recognises Elixir sink primitives:
+//
+//   - http_out  : HTTPoison.<get|post|put|patch|delete|head|request>,
+//                 Tesla.<verb> / Tesla.Client, Finch.build / Finch.request,
+//                 Mint.HTTP, Req.<verb> / Req.new, :httpc.request
+//   - db_read   : Ecto `Repo.all / Repo.get / Repo.get_by / Repo.one /
+//                 Repo.stream / Repo.preload / Repo.aggregate /
+//                 Repo.exists?`, `from(... in ..., select: ...) |> Repo.all`,
+//                 raw `Ecto.Adapters.SQL.query` with SELECT
+//   - db_write  : Ecto `Repo.insert / Repo.insert! / Repo.insert_all /
+//                 Repo.update / Repo.update! / Repo.update_all /
+//                 Repo.delete / Repo.delete! / Repo.delete_all /
+//                 Repo.transaction / Repo.insert_or_update`
+//   - fs_read   : `File.read / File.read! / File.stream! / File.open` (no
+//                 :write mode), File.exists?, File.ls, File.dir?, IO.read
+//   - fs_write  : `File.write / File.write! / File.cp / File.cp_r /
+//                 File.rm / File.rm_rf / File.mkdir / File.mkdir_p /
+//                 File.rename`, File.open with `[:write|:append|:exclusive]`
+//   - mutation  : `var = ...` rebinding is not a side-effect in Elixir
+//                 (immutable bindings); we approximate "mutation" via
+//                 `Agent.update / GenServer.cast / :ets.insert /
+//                 :persistent_term.put / Process.put` — observable state
+//                 mutations to OTP / runtime state.
+//
+// Function attribution uses the nearest preceding `def` / `defp` /
+// `defmacro` / `defmacrop` header.
+package substrate
+
+import "regexp"
+
+func init() { RegisterEffectSniffer("elixir", sniffEffectsElixir) }
+
+// elixirFuncHeaderRe matches `def name(` / `defp name(` / `defmacro(p)?`.
+// Capture group 1 is the bare function name.
+var elixirFuncHeaderRe = regexp.MustCompile(
+	`(?m)^\s*def(?:p|macro|macrop)?\s+([A-Za-z_][\w]*[!?]?)\s*[\(,\sdo]`,
+)
+
+// elixirHTTPRe matches outbound HTTP primitives.
+var elixirHTTPRe = regexp.MustCompile(
+	`\bHTTPoison\s*\.\s*(?:get|get!|post|post!|put|put!|patch|patch!|delete|delete!|head|options|request|request!)\s*\(` +
+		`|\bTesla\s*\.\s*(?:get|post|put|patch|delete|head|options|request|client)\s*\(` +
+		`|\bFinch\s*\.\s*(?:build|request|stream)\s*\(` +
+		`|\bReq\s*\.\s*(?:get|post|put|patch|delete|head|new|request|request!)\s*\(` +
+		`|\bMint\s*\.\s*HTTP\b` +
+		`|\b:httpc\s*\.\s*request\s*\(` +
+		`|\b:hackney\s*\.\s*request\s*\(`,
+)
+
+// elixirDBReadRe matches Ecto read primitives.
+var elixirDBReadRe = regexp.MustCompile(
+	`\b(?:[A-Z]\w*\.)?Repo\s*\.\s*(?:all|get|get!|get_by|get_by!|one|one!|stream|preload|aggregate|exists\?|reload|reload!|in_transaction\?)\s*\(` +
+		`|\b(?:[A-Z]\w*\.)?Repo\s*\.\s*(?:all|stream)\b`,
+)
+
+// elixirRawSelectRe matches raw SQL adapter SELECT.
+var elixirRawSelectRe = regexp.MustCompile(
+	`\bEcto\s*\.\s*Adapters\s*\.\s*SQL\s*\.\s*query[!]?\s*\(\s*[^,]+,\s*"(?i:\s*(?:SELECT|WITH)\b)`,
+)
+
+// elixirDBWriteRe matches Ecto write primitives.
+var elixirDBWriteRe = regexp.MustCompile(
+	`\b(?:[A-Z]\w*\.)?Repo\s*\.\s*(?:insert|insert!|insert_all|insert_or_update|insert_or_update!|update|update!|update_all|delete|delete!|delete_all|transaction)\s*\(`,
+)
+
+// elixirRawWriteRe matches raw SQL adapter INSERT/UPDATE/DELETE.
+var elixirRawWriteRe = regexp.MustCompile(
+	`\bEcto\s*\.\s*Adapters\s*\.\s*SQL\s*\.\s*query[!]?\s*\(\s*[^,]+,\s*"(?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)`,
+)
+
+// elixirFSReadRe matches read-only filesystem primitives.
+var elixirFSReadRe = regexp.MustCompile(
+	`\bFile\s*\.\s*(?:read|read!|stream!|exists\?|ls|ls!|dir\?|regular\?|stat|stat!|lstat|lstat!)\s*\(` +
+		`|\bFile\s*\.\s*open\s*\(\s*[^,)]+\s*\)` + // no mode arg defaults to read
+		`|\bFile\s*\.\s*open\s*\(\s*[^,)]+,\s*\[:read\]` +
+		`|\bIO\s*\.\s*read\s*\(`,
+)
+
+// elixirFSWriteRe matches write filesystem primitives.
+var elixirFSWriteRe = regexp.MustCompile(
+	`\bFile\s*\.\s*(?:write|write!|cp|cp!|cp_r|cp_r!|rm|rm!|rm_rf|rm_rf!|mkdir|mkdir!|mkdir_p|mkdir_p!|rename|rename!|touch|touch!|chmod|chmod!|chown|chown!)\s*\(` +
+		`|\bFile\s*\.\s*open\s*\(\s*[^,)]+,\s*\[(?:[^]]*:write|[^]]*:append|[^]]*:exclusive)`,
+)
+
+// elixirProcessRe matches process-spawn primitives.
+var elixirProcessRe = regexp.MustCompile(
+	`\bSystem\s*\.\s*(?:cmd|shell|find_executable)\s*\(` +
+		`|\bPort\s*\.\s*open\s*\(\s*\{:spawn`,
+)
+
+// elixirMutationRe matches OTP / runtime observable mutations. Elixir's
+// immutable bindings mean there is no `=`-as-mutation primitive; the
+// substrate's mutation effect tracks side-effects on shared state.
+var elixirMutationRe = regexp.MustCompile(
+	`\bAgent\s*\.\s*(?:update|update!|cast|get_and_update|get_and_update!)\s*\(` +
+		`|\bGenServer\s*\.\s*(?:cast|call)\s*\(` +
+		`|\b:ets\s*\.\s*(?:insert|insert_new|update_element|update_counter|delete|delete_all_objects|delete_object|new)\s*\(` +
+		`|\b:persistent_term\s*\.\s*(?:put|erase)\s*\(` +
+		`|\bProcess\s*\.\s*(?:put|delete)\s*\(`,
+)
+
+func sniffEffectsElixir(content string) []EffectMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanElixirFuncHeaders(content)
+	var out []EffectMatch
+	out = appendElixirMatches(out, content, headers, elixirHTTPRe, EffectHTTPOut, "HTTPoison/Tesla/Finch/Req", 1.0)
+	out = appendElixirMatches(out, content, headers, elixirDBReadRe, EffectDBRead, "Repo.read", 0.9)
+	out = appendElixirMatches(out, content, headers, elixirRawSelectRe, EffectDBRead, "SQL.query(SELECT)", 1.0)
+	out = appendElixirMatches(out, content, headers, elixirDBWriteRe, EffectDBWrite, "Repo.write", 0.9)
+	out = appendElixirMatches(out, content, headers, elixirRawWriteRe, EffectDBWrite, "SQL.query(WRITE)", 1.0)
+	out = appendElixirMatches(out, content, headers, elixirFSReadRe, EffectFSRead, "File.read/IO.read", 1.0)
+	out = appendElixirMatches(out, content, headers, elixirFSWriteRe, EffectFSWrite, "File.write/File.cp", 1.0)
+	out = appendElixirMatches(out, content, headers, elixirProcessRe, EffectFSWrite, "System.cmd/Port.open", 0.9)
+	out = appendElixirMatches(out, content, headers, elixirMutationRe, EffectMutation, "Agent/GenServer/:ets", 0.85)
+	return out
+}
+
+func scanElixirFuncHeaders(content string) []funcHeader {
+	var hs []funcHeader
+	for _, m := range elixirFuncHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		hs = append(hs, funcHeader{Line: lineOfOffset(content, m[0]), Name: content[m[2]:m[3]]})
+	}
+	return hs
+}
+
+func appendElixirMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect, sink string, conf float64) []EffectMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/effect_sinks_kotlin.go
+++ b/internal/substrate/effect_sinks_kotlin.go
@@ -1,0 +1,140 @@
+// Kotlin effect-sink sniffer (#2765 Phase 1A T2).
+//
+// Recognises Kotlin sink primitives. Kotlin code typically runs on the
+// JVM and pulls from the Java ecosystem, so we accept Java-shaped sinks
+// (RestTemplate, Files, JPA) in addition to Kotlin-native libraries
+// (Ktor HttpClient, Exposed DSL, kotlinx.coroutines IO):
+//
+//   - http_out  : Ktor `HttpClient { }.get|post|put|delete|request`,
+//                 OkHttp `OkHttpClient().newCall(...).execute()`,
+//                 RestTemplate / WebClient / HttpClient (JVM),
+//                 Fuel `<verb>(...)`, Retrofit interface `@GET/@POST` calls
+//   - db_read   : JPA / Hibernate (`em.find / em.createQuery`, JpaRepo
+//                 `findBy*/get*/count*/exists*`), Exposed `select / .selectAll
+//                 / Table.select`, R2DBC `databaseClient.sql("SELECT")`,
+//                 Spring Data `findBy*`
+//   - db_write  : JPA `em.persist / merge / remove`, JpaRepo `save*/delete*`,
+//                 Exposed `Table.insert / .update / .deleteWhere`, R2DBC
+//                 INSERT/UPDATE/DELETE shapes
+//   - fs_read   : File("...").readText / readLines / readBytes / inputStream,
+//                 Files.readAllBytes / readAllLines / lines, Paths.get,
+//                 BufferedReader(FileReader(...))
+//   - fs_write  : File("...").writeText / appendText / writeBytes /
+//                 outputStream / delete / renameTo / mkdir(s), Files.write
+//                 / writeString / newOutputStream / createFile /
+//                 createDirectories / delete / move / copy
+//   - mutation  : `this.<field> = ...` assignment inside a method
+//
+// Function attribution uses the nearest preceding `fun name(` header
+// (with optional visibility, suspend, inline, infix, operator, override,
+// open, final, abstract qualifiers).
+package substrate
+
+import "regexp"
+
+func init() { RegisterEffectSniffer("kotlin", sniffEffectsKotlin) }
+
+// kotlinFuncHeaderRe matches `fun name(` (with optional modifiers and
+// generic parameters). Capture group 1 is the function name.
+var kotlinFuncHeaderRe = regexp.MustCompile(
+	`(?m)^\s*(?:(?:public|private|protected|internal|open|final|abstract|override|inline|infix|operator|tailrec|external|suspend|@[A-Za-z_][\w]*(?:\([^)]*\))?)\s+)*` +
+		`fun\s+(?:<[^>]+>\s+)?(?:[A-Za-z_][\w<>?,.\[\]\s]*\.)?` +
+		`([A-Za-z_][\w]*)\s*\(`,
+)
+
+// kotlinHTTPRe matches outbound HTTP primitives (Ktor + OkHttp + JVM
+// HTTP clients + Retrofit shapes).
+var kotlinHTTPRe = regexp.MustCompile(
+	`\bHttpClient\s*\([^)]*\)\s*\.\s*(?:get|post|put|patch|delete|head|options|request|prepareGet|prepareRequest|use)\b` +
+		`|\b(?:client|httpClient)\s*\.\s*(?:get|post|put|patch|delete|head|options|request|sendAsync|send)\s*[\({<]` +
+		`|\bOkHttpClient\s*\(\s*\)\s*\.\s*newCall\s*\(` +
+		`|\b(?:restTemplate|webClient)\s*\.\s*(?:getForObject|getForEntity|postForObject|postForEntity|put|patch|delete|exchange|execute|send)\s*\(` +
+		`|\bFuel\s*\.\s*(?:get|post|put|patch|delete|head|request|upload|download)\s*\(` +
+		`|\bnew\s+OkHttpClient\b` +
+		`|\bRetrofit\s*\.\s*Builder\b`,
+)
+
+// kotlinDBReadRe matches JPA / Exposed / R2DBC read primitives.
+var kotlinDBReadRe = regexp.MustCompile(
+	`\b(?:entityManager|em)\s*\.\s*(?:find|getReference|createQuery|createNamedQuery|createNativeQuery)\s*\(` +
+		`|\.\s*(?:findById|findAll|findBy[A-Z]\w*|findOne|getOne|count(?:By[A-Z]\w*)?|exists(?:ById|By[A-Z]\w*)?)\s*\(` +
+		`|\b(?:[A-Z]\w*)\s*\.\s*(?:select|selectAll|selectBatched|join|innerJoin|leftJoin)\s*\(` +
+		`|\bdatabaseClient\s*\.\s*sql\s*\(\s*"(?i:\s*(?:SELECT|WITH)\b)` +
+		`|\.\s*executeQuery\s*\(`,
+)
+
+// kotlinDBWriteRe matches JPA / Exposed / R2DBC write primitives.
+var kotlinDBWriteRe = regexp.MustCompile(
+	`\b(?:entityManager|em)\s*\.\s*(?:persist|merge|remove|refresh|flush)\s*\(` +
+		`|\.\s*(?:save|saveAll|saveAndFlush|delete(?:All|ById|InBatch)?|deleteBy[A-Z]\w*|updateBy[A-Z]\w*|insert)\s*\(` +
+		`|\b(?:[A-Z]\w*)\s*\.\s*(?:insert|update|deleteWhere|deleteAll|batchInsert|replace|upsert)\s*[\({]` +
+		`|\bdatabaseClient\s*\.\s*sql\s*\(\s*"(?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)` +
+		`|\.\s*executeUpdate\s*\(`,
+)
+
+// kotlinFSReadRe matches read-only filesystem primitives.
+var kotlinFSReadRe = regexp.MustCompile(
+	`\bFile\s*\([^)]+\)\s*\.\s*(?:readText|readLines|readBytes|inputStream|bufferedReader|forEachLine|useLines|exists|isFile|isDirectory|length|listFiles)\b` +
+		`|\bFiles\s*\.\s*(?:readAllBytes|readAllLines|readString|lines|newInputStream|newBufferedReader|exists|isReadable|size|getAttribute|readAttributes|isDirectory|isRegularFile|list|walk|find)\s*\(` +
+		`|\bnew\s+(?:FileInputStream|FileReader|BufferedReader\s*\(\s*FileReader|Scanner\s*\(\s*File)\s*\(`,
+)
+
+// kotlinFSWriteRe matches write filesystem primitives.
+var kotlinFSWriteRe = regexp.MustCompile(
+	`\bFile\s*\([^)]+\)\s*\.\s*(?:writeText|appendText|writeBytes|appendBytes|outputStream|bufferedWriter|printWriter|delete|deleteRecursively|renameTo|mkdir|mkdirs|setReadable|setWritable|setExecutable|copyTo|copyRecursively)\b` +
+		`|\bFiles\s*\.\s*(?:write|writeString|newOutputStream|newBufferedWriter|createFile|createDirectory|createDirectories|delete|deleteIfExists|move|copy|setAttribute|setPosixFilePermissions)\s*\(` +
+		`|\bnew\s+(?:FileOutputStream|FileWriter|PrintWriter\s*\(\s*File)\s*\(`,
+)
+
+// kotlinProcessRe matches process-spawn primitives (modelled as fs_write).
+var kotlinProcessRe = regexp.MustCompile(
+	`\bProcessBuilder\s*\(` +
+		`|\bRuntime\s*\.\s*getRuntime\s*\(\s*\)\s*\.\s*exec\s*\(`,
+)
+
+// kotlinMutationRe matches `this.<field> = ...` assignment.
+var kotlinMutationRe = regexp.MustCompile(
+	`\bthis\s*\.\s*[A-Za-z_][\w]*\s*=(?:[^=])`,
+)
+
+func sniffEffectsKotlin(content string) []EffectMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanKotlinFuncHeaders(content)
+	var out []EffectMatch
+	out = appendKotlinMatches(out, content, headers, kotlinHTTPRe, EffectHTTPOut, "Ktor/OkHttp/RestTemplate", 1.0)
+	out = appendKotlinMatches(out, content, headers, kotlinDBReadRe, EffectDBRead, "jpa/exposed/r2dbc.read", 0.85)
+	out = appendKotlinMatches(out, content, headers, kotlinDBWriteRe, EffectDBWrite, "jpa/exposed/r2dbc.write", 0.85)
+	out = appendKotlinMatches(out, content, headers, kotlinFSReadRe, EffectFSRead, "File.read/Files.read", 1.0)
+	out = appendKotlinMatches(out, content, headers, kotlinFSWriteRe, EffectFSWrite, "File.write/Files.write", 1.0)
+	out = appendKotlinMatches(out, content, headers, kotlinProcessRe, EffectFSWrite, "ProcessBuilder", 0.9)
+	out = appendKotlinMatches(out, content, headers, kotlinMutationRe, EffectMutation, "this.field=", 0.7)
+	return out
+}
+
+func scanKotlinFuncHeaders(content string) []funcHeader {
+	var hs []funcHeader
+	for _, m := range kotlinFuncHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		hs = append(hs, funcHeader{Line: lineOfOffset(content, m[0]), Name: content[m[2]:m[3]]})
+	}
+	return hs
+}
+
+func appendKotlinMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect, sink string, conf float64) []EffectMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/effect_sinks_php.go
+++ b/internal/substrate/effect_sinks_php.go
@@ -1,0 +1,165 @@
+// PHP effect-sink sniffer (#2765 Phase 1A T2).
+//
+// Recognises PHP sink primitives:
+//
+//   - http_out  : curl_exec / curl_setopt(CURLOPT_URL) chains, Guzzle
+//                 (`$client->request|get|post|...`, `new GuzzleHttp\Client`),
+//                 `file_get_contents("http://...")`, Symfony HttpClient,
+//                 WordPress `wp_remote_get|post`
+//   - db_read   : PDO `->query / ->prepare / ->execute` paired with
+//                 SELECT-shaped SQL, mysqli `->query / ->prepare` (SELECT),
+//                 Eloquent `::all / ::find / ::where / ::first / ::get /
+//                 ::count / ::exists`, Doctrine `->find / ->findBy /
+//                 ->findOneBy / ->createQuery`, raw `mysql_query("SELECT")`
+//   - db_write  : Eloquent `::create / ::update / ::delete / ::insert /
+//                 ::save / ::firstOrCreate / ::updateOrCreate`, Doctrine
+//                 `->persist / ->remove / ->flush`, PDO/mysqli execute
+//                 with INSERT|UPDATE|DELETE SQL, `mysql_query("INSERT")`
+//   - fs_read   : file_get_contents (non-URL), fopen("r"), fread, file,
+//                 readfile, scandir, glob, is_file, is_dir, is_readable
+//   - fs_write  : file_put_contents, fopen("w"/"a"/"x"), fwrite, fputs,
+//                 unlink, rename, mkdir, rmdir, chmod, touch, copy
+//   - mutation  : `$this->prop = ...` assignment inside a method
+//
+// Function attribution uses the nearest preceding `function name(` header.
+package substrate
+
+import "regexp"
+
+func init() { RegisterEffectSniffer("php", sniffEffectsPHP) }
+
+// phpFuncHeaderRe matches `function name(` (with optional visibility /
+// static / abstract / final / & return-by-ref). Capture group 1 is the
+// method name.
+var phpFuncHeaderRe = regexp.MustCompile(
+	`(?m)^\s*(?:(?:public|private|protected|static|final|abstract)\s+)*` +
+		`function\s*&?\s*([A-Za-z_][\w]*)\s*\(`,
+)
+
+// phpHTTPRe matches outbound HTTP primitives.
+var phpHTTPRe = regexp.MustCompile(
+	`\bcurl_exec\s*\(` +
+		`|\bcurl_setopt\s*\([^,]+,\s*CURLOPT_URL\b` +
+		`|->\s*(?:request|get|post|put|patch|delete|head|options|send|sendAsync)\s*\(\s*['"](?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|https?://)` +
+		`|\bnew\s+(?:GuzzleHttp\\)?Client\b` +
+		`|\bfile_get_contents\s*\(\s*['"]https?://` +
+		`|\b(?:wp_remote_get|wp_remote_post|wp_remote_request|wp_safe_remote_get)\s*\(` +
+		`|->\s*(?:get|post|put|patch|delete|head)\s*\(\s*['"]https?://` +
+		`|\bHttpClient\s*::\s*create\b`,
+)
+
+// phpDBReadRe matches Eloquent / Doctrine / PDO / mysqli read primitives.
+var phpDBReadRe = regexp.MustCompile(
+	`::\s*(?:all|find|findOrFail|findMany|where|whereIn|whereHas|first|firstOrFail|get|count|exists|pluck|chunk|cursor|with|select|orderBy|groupBy)\s*\(` +
+		`|->\s*(?:find|findBy|findOneBy|findAll|findOneOrNullBy|createQuery|createQueryBuilder|getRepository|getReference)\s*\(` +
+		`|->\s*(?:fetchAll|fetchAssoc|fetchOne|fetchColumn|fetch|fetchObject|rowCount)\s*\(` +
+		`|->\s*query\s*\(\s*['"](?i:\s*(?:SELECT|WITH)\b)` +
+		`|\bmysql_query\s*\(\s*['"](?i:\s*(?:SELECT|WITH)\b)`,
+)
+
+// phpDBWriteRe matches Eloquent / Doctrine / PDO / mysqli write
+// primitives.
+var phpDBWriteRe = regexp.MustCompile(
+	`::\s*(?:create|update|delete|insert|insertOrIgnore|upsert|firstOrCreate|updateOrCreate|destroy|truncate|save|push)\s*\(` +
+		`|->\s*(?:save|update|delete|insert|push|increment|decrement|forceDelete|restore|persist|remove|flush|merge)\s*\(` +
+		`|->\s*(?:exec|execute)\s*\(\s*['"](?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)` +
+		`|\bmysql_query\s*\(\s*['"](?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)`,
+)
+
+// phpFSReadRe matches read-only filesystem primitives. We match
+// `file_get_contents` / `file` calls unconditionally and filter out the
+// http(s)-URL form post-match in sniffEffectsPHP — RE2 has no negative
+// lookahead, so the disambiguation moves out of the regex.
+var phpFSReadRe = regexp.MustCompile(
+	`\b(?:file_get_contents|file)\s*\(` +
+		`|\bfopen\s*\(\s*[^,)]+\s*,\s*['"](?:r|rb|rt|r\+)['"]` +
+		`|\b(?:fread|fgets|fgetss|fgetc|fgetcsv|readfile|scandir|glob|opendir|is_file|is_dir|is_readable|stat|lstat|filesize|filemtime|file_exists|realpath)\s*\(`,
+)
+
+// phpFSReadURLRe identifies a `file_get_contents("http://...")` or
+// `file("https://...")` call so the FS-read sniffer can drop it (the HTTP
+// sniffer already classified it as http_out).
+var phpFSReadURLRe = regexp.MustCompile(
+	`^\s*(?:file_get_contents|file)\s*\(\s*['"]https?://`,
+)
+
+// phpFSWriteRe matches write filesystem primitives.
+var phpFSWriteRe = regexp.MustCompile(
+	`\b(?:file_put_contents|fwrite|fputs|fputcsv|unlink|rename|mkdir|rmdir|chmod|chown|chgrp|touch|copy|symlink|link|tempnam)\s*\(` +
+		`|\bfopen\s*\(\s*[^,)]+\s*,\s*['"](?:w|wb|wt|a|ab|at|x|xb|xt|w\+|a\+|x\+)['"]`,
+)
+
+// phpProcessRe matches process-spawn primitives (modelled as fs_write).
+var phpProcessRe = regexp.MustCompile(
+	`\b(?:exec|system|shell_exec|passthru|proc_open|popen|pcntl_exec)\s*\(`,
+)
+
+// phpMutationRe matches `$this->prop = ...` assignment.
+var phpMutationRe = regexp.MustCompile(
+	`\$this\s*->\s*[A-Za-z_][\w]*\s*=(?:[^=])`,
+)
+
+func sniffEffectsPHP(content string) []EffectMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanPHPFuncHeaders(content)
+	var out []EffectMatch
+	out = appendPHPMatches(out, content, headers, phpHTTPRe, EffectHTTPOut, "curl/Guzzle/wp_remote", 1.0)
+	out = appendPHPMatches(out, content, headers, phpDBReadRe, EffectDBRead, "eloquent/doctrine/pdo.read", 0.85)
+	out = appendPHPMatches(out, content, headers, phpDBWriteRe, EffectDBWrite, "eloquent/doctrine/pdo.write", 0.85)
+	out = appendPHPFSReadMatches(out, content, headers)
+	out = appendPHPMatches(out, content, headers, phpFSWriteRe, EffectFSWrite, "file_put_contents/fwrite", 1.0)
+	out = appendPHPMatches(out, content, headers, phpProcessRe, EffectFSWrite, "exec/system/proc_open", 0.9)
+	out = appendPHPMatches(out, content, headers, phpMutationRe, EffectMutation, "$this->prop=", 0.7)
+	return out
+}
+
+func scanPHPFuncHeaders(content string) []funcHeader {
+	var hs []funcHeader
+	for _, m := range phpFuncHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		hs = append(hs, funcHeader{Line: lineOfOffset(content, m[0]), Name: content[m[2]:m[3]]})
+	}
+	return hs
+}
+
+// appendPHPFSReadMatches walks phpFSReadRe matches and drops any
+// `file_get_contents("http://...")` / `file("https://...")` instance —
+// already classified as http_out. RE2's lack of negative lookahead forces
+// this filter into Go rather than the regex.
+func appendPHPFSReadMatches(out []EffectMatch, content string, headers []funcHeader) []EffectMatch {
+	for _, m := range phpFSReadRe.FindAllStringIndex(content, -1) {
+		snippet := content[m[0]:m[1]]
+		if phpFSReadURLRe.MatchString(snippet) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     EffectFSRead,
+			Sink:       "file_get_contents/fopen(r)",
+			Confidence: 1.0,
+		})
+	}
+	return out
+}
+
+func appendPHPMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect, sink string, conf float64) []EffectMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/effect_sinks_ruby.go
+++ b/internal/substrate/effect_sinks_ruby.go
@@ -1,0 +1,149 @@
+// Ruby effect-sink sniffer (#2765 Phase 1A T2).
+//
+// Recognises Ruby sink primitives:
+//
+//   - http_out  : Net::HTTP.<get|post|start|...>, HTTParty.<verb>, RestClient
+//                 .<verb>, Faraday.<verb>, Excon.<verb>, open-uri's
+//                 URI.open / URI.parse(...).open
+//   - db_read   : ActiveRecord `.where / .find / .find_by / .find_each /
+//                 .all / .first / .last / .pluck / .count / .exists?`,
+//                 raw `connection.execute("SELECT ...")`, `ActiveRecord::
+//                 Base.connection.exec_query`
+//   - db_write  : ActiveRecord `.create / .create! / .update / .update! /
+//                 .update_all / .destroy / .destroy_all / .delete /
+//                 .delete_all / .save / .save! / .insert / .insert_all /
+//                 .upsert / .upsert_all`, raw `connection.execute(
+//                 "INSERT|UPDATE|DELETE ...")`
+//   - fs_read   : File.read / .open (default "r"), File.readlines, IO.read,
+//                 Dir.entries / .glob / .[], Pathname#read
+//   - fs_write  : File.write / .open with "w"/"a"/"x"/binary modes,
+//                 File.delete / .unlink / .rename, FileUtils.cp / .mv /
+//                 .rm / .mkdir / .mkdir_p
+//   - mutation  : `@ivar = ...` instance-variable assignment inside a
+//                 method body. Excludes `==` comparisons.
+//
+// Function attribution uses the nearest preceding `def` header — the
+// same heuristic the other sniffers use. Ruby's indentation-free grammar
+// makes this slightly less precise than Python but accurate enough for
+// the substrate's needs.
+package substrate
+
+import "regexp"
+
+func init() { RegisterEffectSniffer("ruby", sniffEffectsRuby) }
+
+// rubyFuncHeaderRe matches `def name` or `def self.name`. Capture group 1
+// is the bare method name.
+var rubyFuncHeaderRe = regexp.MustCompile(
+	`(?m)^\s*def\s+(?:self\s*\.\s*)?([A-Za-z_][\w]*[!?=]?)\b`,
+)
+
+// rubyHTTPRe matches outbound HTTP primitives.
+var rubyHTTPRe = regexp.MustCompile(
+	`\bNet::HTTP\s*\.\s*(?:get|get_response|post|post_form|start|put|delete|head|patch|request)\b` +
+		`|\bHTTParty\s*\.\s*(?:get|post|put|patch|delete|head|options)\s*\(` +
+		`|\bRestClient\s*\.\s*(?:get|post|put|patch|delete|head)\s*\(` +
+		`|\bFaraday\s*\.\s*(?:get|post|put|patch|delete|head|new)\b` +
+		`|\bExcon\s*\.\s*(?:get|post|put|patch|delete|head|new)\b` +
+		`|\bURI\s*\.\s*(?:open|parse)\s*\([^)]*\)\s*\.\s*(?:read|open)\b` +
+		`|\bopen-uri\b`,
+)
+
+// rubyDBReadRe matches ActiveRecord and raw read primitives.
+var rubyDBReadRe = regexp.MustCompile(
+	`\.\s*(?:where|find|find_by|find_each|find_in_batches|all|first|last|pluck|count|exists\?|any\?|many\?|none\?|take|select|joins|includes|preload|eager_load|references|distinct|order|group|having|limit|offset)\s*[\(.]` +
+		`|\.\s*find\s*\(\s*[A-Za-z_0-9:]` +
+		`|\bconnection\s*\.\s*(?:execute|exec_query|select_all|select_one|select_value|select_values|select_rows)\s*\(`,
+)
+
+// rubyCursorSelectRe pairs raw `execute("SELECT ...")` calls as reads.
+var rubyCursorSelectRe = regexp.MustCompile(
+	`\.\s*execute\s*\(\s*['"](?i:\s*(?:SELECT|WITH)\b)`,
+)
+
+// rubyDBWriteRe matches ActiveRecord and raw write primitives.
+var rubyDBWriteRe = regexp.MustCompile(
+	`\.\s*(?:create|create!|update|update!|update_all|update_column|update_columns|destroy|destroy!|destroy_all|delete|delete_all|save|save!|insert|insert_all|insert_all!|upsert|upsert_all|increment!|decrement!|touch|toggle!)\s*[\(.!]?` +
+		`|\.\s*save\s*$`,
+)
+
+// rubyCursorWriteRe matches raw INSERT/UPDATE/DELETE executes.
+var rubyCursorWriteRe = regexp.MustCompile(
+	`\.\s*execute\s*\(\s*['"](?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)`,
+)
+
+// rubyFSReadRe matches read-only filesystem primitives.
+var rubyFSReadRe = regexp.MustCompile(
+	`\bFile\s*\.\s*(?:read|readlines|open\s*\(\s*[^,)]+\s*\)|foreach)\b` +
+		`|\bFile\s*\.\s*open\s*\(\s*[^,)]+\s*,\s*['"](?:r|rb|rt)['"]` +
+		`|\bIO\s*\.\s*(?:read|readlines|foreach)\b` +
+		`|\bDir\s*\.\s*(?:entries|glob|\[|children|each|foreach)\b` +
+		`|\bPathname\b[^=]*\.\s*read\b`,
+)
+
+// rubyFSWriteRe matches write filesystem primitives.
+var rubyFSWriteRe = regexp.MustCompile(
+	`\bFile\s*\.\s*(?:write|delete|unlink|rename|chmod|chown|truncate)\b` +
+		`|\bFile\s*\.\s*open\s*\(\s*[^,)]+\s*,\s*['"](?:w|wb|wt|a|ab|at|x|xb|r\+|w\+|a\+)['"]` +
+		`|\bFileUtils\s*\.\s*(?:cp|cp_r|mv|rm|rm_rf|rm_f|mkdir|mkdir_p|chmod|chown|touch|ln|ln_s)\b` +
+		`|\bIO\s*\.\s*write\b`,
+)
+
+// rubyProcessRe matches process-spawn primitives. We classify these as
+// fs_write under the substrate's "external side-effect" interpretation
+// — Process.spawn / system / exec / backticks can mutate the host.
+var rubyProcessRe = regexp.MustCompile(
+	`\bProcess\s*\.\s*(?:spawn|exec|fork|kill|wait|detach)\b` +
+		`|\bKernel\s*\.\s*(?:system|exec|spawn)\b` +
+		`|^\s*system\s*\(`,
+)
+
+// rubyMutationRe matches `@ivar = ...` instance-variable assignment.
+// Excludes `==` by requiring a non-`=` continuation.
+var rubyMutationRe = regexp.MustCompile(
+	`@[A-Za-z_][\w]*\s*=(?:[^=])`,
+)
+
+func sniffEffectsRuby(content string) []EffectMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanRubyFuncHeaders(content)
+	var out []EffectMatch
+	out = appendRubyMatches(out, content, headers, rubyHTTPRe, EffectHTTPOut, "Net::HTTP/HTTParty/Faraday", 1.0)
+	out = appendRubyMatches(out, content, headers, rubyDBReadRe, EffectDBRead, "activerecord.read", 0.85)
+	out = appendRubyMatches(out, content, headers, rubyCursorSelectRe, EffectDBRead, "connection.execute(SELECT)", 1.0)
+	out = appendRubyMatches(out, content, headers, rubyDBWriteRe, EffectDBWrite, "activerecord.write", 0.85)
+	out = appendRubyMatches(out, content, headers, rubyCursorWriteRe, EffectDBWrite, "connection.execute(WRITE)", 1.0)
+	out = appendRubyMatches(out, content, headers, rubyFSReadRe, EffectFSRead, "File.read/IO.read", 1.0)
+	out = appendRubyMatches(out, content, headers, rubyFSWriteRe, EffectFSWrite, "File.write/FileUtils", 1.0)
+	out = appendRubyMatches(out, content, headers, rubyProcessRe, EffectFSWrite, "Process.spawn/system", 0.9)
+	out = appendRubyMatches(out, content, headers, rubyMutationRe, EffectMutation, "@ivar=", 0.7)
+	return out
+}
+
+func scanRubyFuncHeaders(content string) []funcHeader {
+	var hs []funcHeader
+	for _, m := range rubyFuncHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		hs = append(hs, funcHeader{Line: lineOfOffset(content, m[0]), Name: content[m[2]:m[3]]})
+	}
+	return hs
+}
+
+func appendRubyMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect, sink string, conf float64) []EffectMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/effect_sinks_rust.go
+++ b/internal/substrate/effect_sinks_rust.go
@@ -1,0 +1,142 @@
+// Rust effect-sink sniffer (#2765 Phase 1A T2).
+//
+// Recognises Rust sink primitives:
+//
+//   - http_out  : reqwest::Client / reqwest::get / .get|post|put|patch|
+//                 delete().send(), hyper Client::request, surf::<verb>,
+//                 ureq::get/post, isahc::<verb>
+//   - db_read   : sqlx `query!` / `query_as!` / `query / query_as`
+//                 with SELECT-shaped SQL or fetch_*, Diesel `.load /
+//                 .first / .get_result / .get_results / .find / .filter
+//                 ... .load`, sea-orm `.find / .find_by_id / .all / .one`
+//   - db_write  : sqlx `execute / fetch_one` on INSERT/UPDATE/DELETE,
+//                 Diesel `.insert_into / .update / .delete / .execute`,
+//                 sea-orm `.insert / .update / .delete / .save`
+//   - fs_read   : std::fs::read / read_to_string / read_dir / File::open,
+//                 tokio::fs equivalents, std::path::Path::exists
+//   - fs_write  : std::fs::write / create_dir(_all) / remove_file /
+//                 remove_dir(_all) / rename / set_permissions /
+//                 File::create, tokio::fs::write, std::process::Command
+//   - mutation  : `self.field = ...` assignment inside a method
+//
+// Function attribution uses the nearest preceding `fn name(` header. The
+// Rust grammar's strict `fn` keyword + visibility makes this very precise.
+package substrate
+
+import "regexp"
+
+func init() { RegisterEffectSniffer("rust", sniffEffectsRust) }
+
+// rustFuncHeaderRe matches `fn name(` (with optional pub / pub(...) /
+// async / const / unsafe / extern qualifiers). Capture group 1 is the
+// function name.
+var rustFuncHeaderRe = regexp.MustCompile(
+	`(?m)^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+|const\s+|unsafe\s+|extern\s+(?:"[^"]*"\s+)?)*` +
+		`fn\s+([A-Za-z_][\w]*)\s*[<(]`,
+)
+
+// rustHTTPRe matches outbound HTTP primitives.
+var rustHTTPRe = regexp.MustCompile(
+	`\breqwest\s*::\s*(?:get|Client\s*::\s*new|Client\s*::\s*builder|blocking\s*::\s*(?:get|Client))\b` +
+		`|\bhyper\s*::\s*Client\b` +
+		`|\bClient\s*::\s*new\s*\(\s*\)\s*\.\s*(?:get|post|put|patch|delete|head|request)\s*\(` +
+		`|\b(?:surf|ureq|isahc)\s*::\s*(?:get|post|put|patch|delete|head|connect)\s*\(` +
+		`|\.\s*(?:get|post|put|patch|delete|head)\s*\(\s*"https?://` +
+		`|\.\s*send\s*\(\s*\)\s*\.\s*await\b`,
+)
+
+// rustDBReadRe matches sqlx / Diesel / sea-orm read primitives.
+var rustDBReadRe = regexp.MustCompile(
+	`\bsqlx\s*::\s*query(?:_as|_scalar)?(?:_unchecked)?\s*[!\(]` +
+		`|\.\s*(?:fetch_all|fetch_one|fetch_optional|fetch)\s*\(` +
+		`|\bdiesel\s*::\s*(?:select|sql_query)\b` +
+		`|\.\s*(?:load|first|get_result|get_results|find|filter|select|order|group_by|limit|offset|inner_join|left_join|on)\s*\(` +
+		`|\.\s*(?:find_by_id|find_also_related|find_with_related|all|one|stream|paginate)\s*\(`,
+)
+
+// rustSqlxSelectRe matches sqlx `query!("SELECT ...")` literals.
+var rustSqlxSelectRe = regexp.MustCompile(
+	`\bsqlx\s*::\s*query(?:_as|_scalar)?(?:_unchecked)?\s*!?\s*\(\s*r?"(?i:\s*(?:SELECT|WITH)\b)`,
+)
+
+// rustDBWriteRe matches sqlx / Diesel / sea-orm write primitives.
+var rustDBWriteRe = regexp.MustCompile(
+	`\.\s*(?:execute|execute_many)\s*\(` +
+		`|\bdiesel\s*::\s*(?:insert_into|update|delete|insert_or_ignore_into|replace_into)\b` +
+		`|\.\s*(?:insert|update|delete|save|save_active|insert_many|update_many|exec|exec_with_returning)\s*\(`,
+)
+
+// rustSqlxWriteRe matches sqlx `query!("INSERT/UPDATE/DELETE ...")`.
+var rustSqlxWriteRe = regexp.MustCompile(
+	`\bsqlx\s*::\s*query(?:_as|_scalar)?(?:_unchecked)?\s*!?\s*\(\s*r?"(?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)`,
+)
+
+// rustFSReadRe matches read-only filesystem primitives.
+var rustFSReadRe = regexp.MustCompile(
+	`\b(?:std|tokio)\s*::\s*fs\s*::\s*(?:read|read_to_string|read_dir|read_link|metadata|symlink_metadata|canonicalize)\s*\(` +
+		`|\bFile\s*::\s*open\s*\(` +
+		`|\bOpenOptions\s*::\s*new\s*\(\s*\)\s*\.\s*read\s*\(\s*true\b`,
+)
+
+// rustFSWriteRe matches write filesystem primitives.
+var rustFSWriteRe = regexp.MustCompile(
+	`\b(?:std|tokio)\s*::\s*fs\s*::\s*(?:write|create_dir|create_dir_all|remove_file|remove_dir|remove_dir_all|rename|set_permissions|copy|hard_link|symlink|symlink_dir|symlink_file)\s*\(` +
+		`|\bFile\s*::\s*create\s*\(` +
+		`|\bOpenOptions\s*::\s*new\s*\(\s*\)\s*\.\s*(?:write|append|create)\s*\(\s*true\b`,
+)
+
+// rustProcessRe matches process-spawn primitives (modelled as fs_write).
+var rustProcessRe = regexp.MustCompile(
+	`\bstd\s*::\s*process\s*::\s*Command\s*::\s*new\b` +
+		`|\btokio\s*::\s*process\s*::\s*Command\s*::\s*new\b` +
+		`|\bCommand\s*::\s*new\s*\([^)]+\)\s*\.\s*(?:arg|args|spawn|output|status)\b`,
+)
+
+// rustMutationRe matches `self.field = ...` assignment.
+var rustMutationRe = regexp.MustCompile(
+	`\bself\s*\.\s*[A-Za-z_][\w]*\s*=(?:[^=])`,
+)
+
+func sniffEffectsRust(content string) []EffectMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanRustFuncHeaders(content)
+	var out []EffectMatch
+	out = appendRustMatches(out, content, headers, rustHTTPRe, EffectHTTPOut, "reqwest/hyper/surf", 1.0)
+	out = appendRustMatches(out, content, headers, rustDBReadRe, EffectDBRead, "sqlx/diesel/sea-orm.read", 0.85)
+	out = appendRustMatches(out, content, headers, rustSqlxSelectRe, EffectDBRead, "sqlx::query!(SELECT)", 1.0)
+	out = appendRustMatches(out, content, headers, rustDBWriteRe, EffectDBWrite, "sqlx/diesel/sea-orm.write", 0.85)
+	out = appendRustMatches(out, content, headers, rustSqlxWriteRe, EffectDBWrite, "sqlx::query!(WRITE)", 1.0)
+	out = appendRustMatches(out, content, headers, rustFSReadRe, EffectFSRead, "std::fs::read/File::open", 1.0)
+	out = appendRustMatches(out, content, headers, rustFSWriteRe, EffectFSWrite, "std::fs::write/File::create", 1.0)
+	out = appendRustMatches(out, content, headers, rustProcessRe, EffectFSWrite, "process::Command", 0.9)
+	out = appendRustMatches(out, content, headers, rustMutationRe, EffectMutation, "self.field=", 0.7)
+	return out
+}
+
+func scanRustFuncHeaders(content string) []funcHeader {
+	var hs []funcHeader
+	for _, m := range rustFuncHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		hs = append(hs, funcHeader{Line: lineOfOffset(content, m[0]), Name: content[m[2]:m[3]]})
+	}
+	return hs
+}
+
+func appendRustMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect, sink string, conf float64) []EffectMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/effect_sinks_scala.go
+++ b/internal/substrate/effect_sinks_scala.go
@@ -1,0 +1,139 @@
+// Scala effect-sink sniffer (#2765 Phase 1A T2).
+//
+// Recognises Scala sink primitives. Scala interoperates with the JVM and
+// commonly draws sinks from both Scala-native libraries (Slick, Doobie,
+// sttp, akka-http, http4s) and Java libraries (JPA, Files, java.io):
+//
+//   - http_out  : sttp `basicRequest.get(uri"...").send(backend)`, akka-http
+//                 `Http().singleRequest`, http4s `Client.expect / .run /
+//                 .stream`, dispatch, requests-scala (`requests.get/post`)
+//   - db_read   : Slick `query.result / .filter / .map`, Doobie `sql"
+//                 SELECT...".query`, raw `Statement.executeQuery`, JPA
+//                 `em.find / em.createQuery`, Quill `quote(query[T])`
+//   - db_write  : Slick `query += / .insertOrUpdate / .delete`, Doobie
+//                 `sql"INSERT/UPDATE/DELETE...".update`, JPA `em.persist
+//                 / merge / remove`, raw `executeUpdate`
+//   - fs_read   : `scala.io.Source.fromFile`, `Files.readAllBytes /
+//                 readAllLines`, `new FileInputStream / new FileReader`,
+//                 `os.read / os.list / os-lib`
+//   - fs_write  : `Files.write / writeString / createFile / delete /
+//                 move / copy`, `new FileOutputStream / new FileWriter`,
+//                 `os.write / os.remove / os.makeDir / os.move / os.copy`,
+//                 `PrintWriter`
+//   - mutation  : `this.<field> = ...` assignment in a class body
+//
+// Function attribution uses the nearest preceding `def name(` header.
+package substrate
+
+import "regexp"
+
+func init() { RegisterEffectSniffer("scala", sniffEffectsScala) }
+
+// scalaFuncHeaderRe matches `def name` (with optional modifiers and type
+// parameters). Capture group 1 is the bare function name. Scala allows
+// `def name = ...` (no parens) for parameterless methods; the regex
+// accepts either `(`, `[`, `:`, or `=` immediately after the name.
+var scalaFuncHeaderRe = regexp.MustCompile(
+	`(?m)^\s*(?:(?:override|final|implicit|private|protected|inline|transparent|sealed|abstract|@[A-Za-z_][\w]*(?:\([^)]*\))?)\s+)*` +
+		`def\s+([A-Za-z_][\w]*)\s*[\[\(:=]`,
+)
+
+// scalaHTTPRe matches outbound HTTP primitives.
+var scalaHTTPRe = regexp.MustCompile(
+	`\bbasicRequest\s*\.\s*(?:get|post|put|patch|delete|head|options)\s*\(` +
+		`|\.\s*send\s*\(\s*backend\s*\)` +
+		`|\bHttp\s*\(\s*\)\s*\.\s*singleRequest\b` +
+		`|\bHttpRequest\s*\(` +
+		`|\b(?:Client|client)\s*\.\s*(?:expect|run|stream|fetch|fetchAs|stream_)\s*\[` +
+		`|\bdispatch\s*\.\s*(?:url|Http)\b` +
+		`|\brequests\s*\.\s*(?:get|post|put|patch|delete|head|options|send)\s*\(` +
+		`|\bsttp\s*\.\s*client3\b`,
+)
+
+// scalaDBReadRe matches Slick / Doobie / Quill / JPA read primitives.
+var scalaDBReadRe = regexp.MustCompile(
+	`\.\s*(?:result|resultSet|filter|map|sortBy|take|drop|groupBy|join|joinLeft|joinRight)\s*[\(\.]` +
+		`|\.\s*query\s*\[[^\]]+\]\s*\.\s*to\b` +
+		`|\bsql"(?i:\s*(?:SELECT|WITH)\b)` +
+		`|\b(?:entityManager|em)\s*\.\s*(?:find|getReference|createQuery|createNamedQuery|createNativeQuery)\s*\(` +
+		`|\bquote\s*\(\s*query\s*\[` +
+		`|\.\s*executeQuery\s*\(`,
+)
+
+// scalaDBWriteRe matches Slick / Doobie / Quill / JPA write primitives.
+var scalaDBWriteRe = regexp.MustCompile(
+	`\.\s*(?:\+=|\+\+=|insertOrUpdate|insertAll|delete|deleteWhere|update|forceInsert|forceInsertAll)\s*[\(\.]` +
+		`|\bsql"(?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)` +
+		`|\b(?:entityManager|em)\s*\.\s*(?:persist|merge|remove|refresh|flush)\s*\(` +
+		`|\.\s*executeUpdate\s*\(` +
+		`|\.\s*(?:insert|update|delete)\s*\.\s*returning\b`,
+)
+
+// scalaFSReadRe matches read-only filesystem primitives.
+var scalaFSReadRe = regexp.MustCompile(
+	`\bSource\s*\.\s*fromFile\s*\(` +
+		`|\bFiles\s*\.\s*(?:readAllBytes|readAllLines|readString|lines|newInputStream|newBufferedReader|exists|isReadable|size|getAttribute|readAttributes|isDirectory|isRegularFile|list|walk|find)\s*\(` +
+		`|\bnew\s+(?:FileInputStream|FileReader|BufferedReader\s*\(\s*new\s+FileReader|Scanner\s*\(\s*new\s+File)\s*\(` +
+		`|\bos\s*\.\s*(?:read|list|exists|isDir|isFile|stat|walk)\b`,
+)
+
+// scalaFSWriteRe matches write filesystem primitives.
+var scalaFSWriteRe = regexp.MustCompile(
+	`\bFiles\s*\.\s*(?:write|writeString|newOutputStream|newBufferedWriter|createFile|createDirectory|createDirectories|delete|deleteIfExists|move|copy|setAttribute|setPosixFilePermissions)\s*\(` +
+		`|\bnew\s+(?:FileOutputStream|FileWriter|PrintWriter\s*\(\s*new\s+File)\s*\(` +
+		`|\bos\s*\.\s*(?:write|remove|makeDir|makeDir\.all|move|copy|truncate|symlink|hardlink)\b`,
+)
+
+// scalaProcessRe matches process-spawn primitives (modelled as fs_write).
+var scalaProcessRe = regexp.MustCompile(
+	`\bProcess\s*\(\s*"` +
+		`|\bRuntime\s*\.\s*getRuntime\s*\(\s*\)\s*\.\s*exec\s*\(` +
+		`|\bsys\s*\.\s*process\s*\.\s*Process\b`,
+)
+
+// scalaMutationRe matches `this.<field> = ...` assignment.
+var scalaMutationRe = regexp.MustCompile(
+	`\bthis\s*\.\s*[A-Za-z_][\w]*\s*=(?:[^=])`,
+)
+
+func sniffEffectsScala(content string) []EffectMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanScalaFuncHeaders(content)
+	var out []EffectMatch
+	out = appendScalaMatches(out, content, headers, scalaHTTPRe, EffectHTTPOut, "sttp/akka-http/http4s/requests", 1.0)
+	out = appendScalaMatches(out, content, headers, scalaDBReadRe, EffectDBRead, "slick/doobie/quill.read", 0.8)
+	out = appendScalaMatches(out, content, headers, scalaDBWriteRe, EffectDBWrite, "slick/doobie/quill.write", 0.85)
+	out = appendScalaMatches(out, content, headers, scalaFSReadRe, EffectFSRead, "Source.fromFile/Files.read", 1.0)
+	out = appendScalaMatches(out, content, headers, scalaFSWriteRe, EffectFSWrite, "Files.write/os.write", 1.0)
+	out = appendScalaMatches(out, content, headers, scalaProcessRe, EffectFSWrite, "Process/sys.process", 0.9)
+	out = appendScalaMatches(out, content, headers, scalaMutationRe, EffectMutation, "this.field=", 0.7)
+	return out
+}
+
+func scanScalaFuncHeaders(content string) []funcHeader {
+	var hs []funcHeader
+	for _, m := range scalaFuncHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		hs = append(hs, funcHeader{Line: lineOfOffset(content, m[0]), Name: content[m[2]:m[3]]})
+	}
+	return hs
+}
+
+func appendScalaMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect, sink string, conf float64) []EffectMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/effects_test.go
+++ b/internal/substrate/effects_test.go
@@ -13,6 +13,14 @@ func TestEffectRegistry_T1Languages(t *testing.T) {
 	}
 }
 
+func TestEffectRegistry_T2Languages(t *testing.T) {
+	for _, lang := range []string{"ruby", "php", "rust", "csharp", "kotlin", "elixir", "scala", "c-cpp"} {
+		if EffectSnifferFor(lang) == nil {
+			t.Errorf("expected effect sniffer registered for %q", lang)
+		}
+	}
+}
+
 func TestEffectSet_AddUnion(t *testing.T) {
 	var s EffectSet
 	if !s.IsEmpty() {
@@ -224,6 +232,372 @@ func (r *Repo) SetName(n string) {
 	mustHave(t, byEffect, EffectFSRead, "ReadConfig")
 	mustHave(t, byEffect, EffectFSWrite, "WriteLog")
 	mustHave(t, byEffect, EffectMutation, "SetName")
+}
+
+func TestSniffEffectsRuby_PrimitiveCoverage(t *testing.T) {
+	const src = `
+require "net/http"
+
+class UserService
+  def call_remote
+    Net::HTTP.get(URI("https://api.example.com/u"))
+  end
+
+  def load_users
+    User.where(active: true)
+  end
+
+  def save_user(u)
+    u.save!
+  end
+
+  def write_log(msg)
+    File.write("log.txt", msg)
+  end
+
+  def read_config
+    File.read("config.json")
+  end
+
+  def assign(x)
+    @x = x
+  end
+end
+`
+	got := sniffEffectsRuby(src)
+	if len(got) == 0 {
+		t.Fatal("expected ruby matches; got none")
+	}
+	byEffect := groupByEffect(got)
+	mustHave(t, byEffect, EffectHTTPOut, "call_remote")
+	mustHave(t, byEffect, EffectDBRead, "load_users")
+	mustHave(t, byEffect, EffectDBWrite, "save_user")
+	mustHave(t, byEffect, EffectFSWrite, "write_log")
+	mustHave(t, byEffect, EffectFSRead, "read_config")
+	mustHave(t, byEffect, EffectMutation, "assign")
+}
+
+func TestSniffEffectsPHP_PrimitiveCoverage(t *testing.T) {
+	const src = `<?php
+class UserService {
+    public function callRemote() {
+        $c = new GuzzleHttp\Client();
+        return $c->get('https://api.example.com/u');
+    }
+
+    public function loadUsers() {
+        return User::where('active', true)->get();
+    }
+
+    public function saveUser($u) {
+        $u->save();
+    }
+
+    public function readConfig() {
+        return file_get_contents('config.json');
+    }
+
+    public function writeLog($msg) {
+        file_put_contents('log.txt', $msg);
+    }
+
+    public function assign($x) {
+        $this->x = $x;
+    }
+}
+`
+	got := sniffEffectsPHP(src)
+	if len(got) == 0 {
+		t.Fatal("expected php matches; got none")
+	}
+	byEffect := groupByEffect(got)
+	mustHave(t, byEffect, EffectHTTPOut, "callRemote")
+	mustHave(t, byEffect, EffectDBRead, "loadUsers")
+	mustHave(t, byEffect, EffectDBWrite, "saveUser")
+	mustHave(t, byEffect, EffectFSRead, "readConfig")
+	mustHave(t, byEffect, EffectFSWrite, "writeLog")
+	mustHave(t, byEffect, EffectMutation, "assign")
+}
+
+func TestSniffEffectsRust_PrimitiveCoverage(t *testing.T) {
+	const src = `
+use std::fs;
+
+pub struct Svc { name: String }
+
+impl Svc {
+    pub async fn call_remote(&self) {
+        let _ = reqwest::get("https://x").await;
+    }
+
+    pub async fn load_users(&self, pool: &Pool) {
+        let _ = sqlx::query!("SELECT * FROM users").fetch_all(pool).await;
+    }
+
+    pub async fn save_user(&self, pool: &Pool) {
+        let _ = sqlx::query!("INSERT INTO users (name) VALUES ($1)", "x").execute(pool).await;
+    }
+
+    pub fn read_config(&self) -> String {
+        std::fs::read_to_string("config.json").unwrap()
+    }
+
+    pub fn write_log(&self, b: &[u8]) {
+        std::fs::write("log.txt", b).unwrap();
+    }
+
+    pub fn set_name(&mut self, n: String) {
+        self.name = n;
+    }
+}
+`
+	got := sniffEffectsRust(src)
+	if len(got) == 0 {
+		t.Fatal("expected rust matches; got none")
+	}
+	byEffect := groupByEffect(got)
+	mustHave(t, byEffect, EffectHTTPOut, "call_remote")
+	mustHave(t, byEffect, EffectDBRead, "load_users")
+	mustHave(t, byEffect, EffectDBWrite, "save_user")
+	mustHave(t, byEffect, EffectFSRead, "read_config")
+	mustHave(t, byEffect, EffectFSWrite, "write_log")
+	mustHave(t, byEffect, EffectMutation, "set_name")
+}
+
+func TestSniffEffectsCSharp_PrimitiveCoverage(t *testing.T) {
+	const src = `
+using System.IO;
+using System.Net.Http;
+
+public class UserService {
+    private HttpClient _httpClient = new HttpClient();
+    public string name;
+
+    public async Task<string> CallRemote() {
+        return await _httpClient.GetStringAsync("https://x");
+    }
+
+    public async Task<List<User>> LoadUsers(DbContext ctx) {
+        return await ctx.Users.Where(u => u.Active).ToListAsync();
+    }
+
+    public async Task SaveUser(DbContext ctx, User u) {
+        ctx.Users.Add(u);
+        await ctx.SaveChangesAsync();
+    }
+
+    public string ReadConfig() {
+        return File.ReadAllText("config.json");
+    }
+
+    public void WriteLog(string msg) {
+        File.WriteAllText("log.txt", msg);
+    }
+
+    public void SetName(string n) {
+        this.name = n;
+    }
+}
+`
+	got := sniffEffectsCSharp(src)
+	if len(got) == 0 {
+		t.Fatal("expected csharp matches; got none")
+	}
+	byEffect := groupByEffect(got)
+	mustHave(t, byEffect, EffectHTTPOut, "CallRemote")
+	mustHave(t, byEffect, EffectDBRead, "LoadUsers")
+	mustHave(t, byEffect, EffectDBWrite, "SaveUser")
+	mustHave(t, byEffect, EffectFSRead, "ReadConfig")
+	mustHave(t, byEffect, EffectFSWrite, "WriteLog")
+	mustHave(t, byEffect, EffectMutation, "SetName")
+}
+
+func TestSniffEffectsKotlin_PrimitiveCoverage(t *testing.T) {
+	const src = `
+import java.io.File
+import java.nio.file.Files
+
+class UserService {
+    var name: String = ""
+
+    suspend fun callRemote(client: HttpClient): String {
+        return client.get("https://x")
+    }
+
+    fun loadUsers(em: EntityManager): List<User> {
+        return em.createQuery("from User").resultList as List<User>
+    }
+
+    fun saveUser(em: EntityManager, u: User) {
+        em.persist(u)
+    }
+
+    fun readConfig(): String {
+        return File("config.json").readText()
+    }
+
+    fun writeLog(msg: String) {
+        File("log.txt").writeText(msg)
+    }
+
+    fun setName(n: String) {
+        this.name = n
+    }
+}
+`
+	got := sniffEffectsKotlin(src)
+	if len(got) == 0 {
+		t.Fatal("expected kotlin matches; got none")
+	}
+	byEffect := groupByEffect(got)
+	mustHave(t, byEffect, EffectHTTPOut, "callRemote")
+	mustHave(t, byEffect, EffectDBRead, "loadUsers")
+	mustHave(t, byEffect, EffectDBWrite, "saveUser")
+	mustHave(t, byEffect, EffectFSRead, "readConfig")
+	mustHave(t, byEffect, EffectFSWrite, "writeLog")
+	mustHave(t, byEffect, EffectMutation, "setName")
+}
+
+func TestSniffEffectsElixir_PrimitiveCoverage(t *testing.T) {
+	const src = `
+defmodule UserService do
+  def call_remote do
+    HTTPoison.get("https://x")
+  end
+
+  def load_users do
+    Repo.all(User)
+  end
+
+  def save_user(u) do
+    Repo.insert(u)
+  end
+
+  def read_config do
+    File.read!("config.json")
+  end
+
+  def write_log(msg) do
+    File.write!("log.txt", msg)
+  end
+
+  def update_cache(k, v) do
+    Agent.update(:cache, fn s -> Map.put(s, k, v) end)
+  end
+end
+`
+	got := sniffEffectsElixir(src)
+	if len(got) == 0 {
+		t.Fatal("expected elixir matches; got none")
+	}
+	byEffect := groupByEffect(got)
+	mustHave(t, byEffect, EffectHTTPOut, "call_remote")
+	mustHave(t, byEffect, EffectDBRead, "load_users")
+	mustHave(t, byEffect, EffectDBWrite, "save_user")
+	mustHave(t, byEffect, EffectFSRead, "read_config")
+	mustHave(t, byEffect, EffectFSWrite, "write_log")
+	mustHave(t, byEffect, EffectMutation, "update_cache")
+}
+
+func TestSniffEffectsScala_PrimitiveCoverage(t *testing.T) {
+	const src = `
+import scala.io.Source
+import java.nio.file.Files
+
+class UserService {
+  var name: String = ""
+
+  def callRemote(): Unit = {
+    basicRequest.get(uri"https://x").send(backend)
+  }
+
+  def loadUsers(em: EntityManager): List[User] = {
+    em.createQuery("from User").getResultList.asInstanceOf[List[User]]
+  }
+
+  def saveUser(em: EntityManager, u: User): Unit = {
+    em.persist(u)
+  }
+
+  def readConfig(): String = {
+    Source.fromFile("config.json").mkString
+  }
+
+  def writeLog(msg: String): Unit = {
+    Files.writeString(java.nio.file.Paths.get("log.txt"), msg)
+  }
+
+  def setName(n: String): Unit = {
+    this.name = n
+  }
+}
+`
+	got := sniffEffectsScala(src)
+	if len(got) == 0 {
+		t.Fatal("expected scala matches; got none")
+	}
+	byEffect := groupByEffect(got)
+	mustHave(t, byEffect, EffectHTTPOut, "callRemote")
+	mustHave(t, byEffect, EffectDBRead, "loadUsers")
+	mustHave(t, byEffect, EffectDBWrite, "saveUser")
+	mustHave(t, byEffect, EffectFSRead, "readConfig")
+	mustHave(t, byEffect, EffectFSWrite, "writeLog")
+	mustHave(t, byEffect, EffectMutation, "setName")
+}
+
+func TestSniffEffectsCCPP_PrimitiveCoverage(t *testing.T) {
+	const src = `
+#include <cstdio>
+#include <curl/curl.h>
+#include <libpq-fe.h>
+
+class UserService {
+public:
+    int count;
+
+    void call_remote() {
+        CURL *c = curl_easy_init();
+        curl_easy_setopt(c, CURLOPT_URL, "https://x");
+        curl_easy_perform(c);
+    }
+
+    void load_users(PGconn *conn) {
+        PGresult *r = PQexec(conn, "SELECT * FROM users");
+        (void)r;
+    }
+
+    void save_user(PGconn *conn) {
+        PGresult *r = PQexec(conn, "INSERT INTO users (name) VALUES ('x')");
+        (void)r;
+    }
+
+    void read_config() {
+        FILE *f = fopen("config.json", "r");
+        (void)f;
+    }
+
+    void write_log(const char *msg) {
+        FILE *f = fopen("log.txt", "w");
+        (void)f;
+        (void)msg;
+    }
+
+    void set_count(int n) {
+        this->count = n;
+    }
+};
+`
+	got := sniffEffectsCCPP(src)
+	if len(got) == 0 {
+		t.Fatal("expected c-cpp matches; got none")
+	}
+	byEffect := groupByEffect(got)
+	mustHave(t, byEffect, EffectHTTPOut, "call_remote")
+	mustHave(t, byEffect, EffectDBRead, "load_users")
+	mustHave(t, byEffect, EffectDBWrite, "save_user")
+	mustHave(t, byEffect, EffectFSRead, "read_config")
+	mustHave(t, byEffect, EffectFSWrite, "write_log")
+	mustHave(t, byEffect, EffectMutation, "set_count")
 }
 
 func groupByEffect(ms []EffectMatch) map[Effect]map[string]bool {

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -264,6 +264,10 @@ subcategories:
       - confidence_overlay
       - reachability_analysis
       - dead_code_detection
+      - db_effect
+      - http_effect
+      - fs_effect
+      - mutation_effect
     groups:
       - name: Process
         keys: [ipc_extraction, main_renderer_split]
@@ -272,7 +276,7 @@ subcategories:
       - name: Updates
         keys: []
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect]
 
   rpc_framework:
     display: "RPC Framework"

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -383,7 +383,7 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2766"]
-<<<<<<< HEAD
+          verified_at: "2026-05-28"
         db_effect:
           status: partial
           symbols:
@@ -419,9 +419,7 @@ records:
             - file: internal/links/effect_propagation.go
               functions: [runEffectPropagationPass]
           issues_implemented: ["2764"]
-=======
           verified_at: "2026-05-28"
->>>>>>> bfbd7c5b (feat(substrate): Phase 1B reachability + dead-code for T1 languages (#2766))
 
   lang.python.framework.flask:
     capabilities:
@@ -656,7 +654,7 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2766"]
-<<<<<<< HEAD
+          verified_at: "2026-05-28"
         db_effect:
           status: partial
           symbols:
@@ -692,9 +690,7 @@ records:
             - file: internal/links/effect_propagation.go
               functions: [runEffectPropagationPass]
           issues_implemented: ["2764"]
-=======
           verified_at: "2026-05-28"
->>>>>>> bfbd7c5b (feat(substrate): Phase 1B reachability + dead-code for T1 languages (#2766))
 
   lang.go.framework.gin:
     capabilities:
@@ -815,6 +811,42 @@ records:
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
           verified_at: "2026-05-28"
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_ruby.go
+              functions: [sniffEffectsRuby, appendRubyMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        http_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_ruby.go
+              functions: [sniffEffectsRuby]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        fs_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_ruby.go
+              functions: [sniffEffectsRuby]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        mutation_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_ruby.go
+              functions: [sniffEffectsRuby]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
 
   lang.php.framework.laravel:
     capabilities:
@@ -863,6 +895,42 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
+          verified_at: "2026-05-28"
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_php.go
+              functions: [sniffEffectsPHP, appendPHPMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        http_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_php.go
+              functions: [sniffEffectsPHP]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        fs_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_php.go
+              functions: [sniffEffectsPHP]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        mutation_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_php.go
+              functions: [sniffEffectsPHP]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
 
   lang.rust.framework.axum:
@@ -913,6 +981,42 @@ records:
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
           verified_at: "2026-05-28"
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        http_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        fs_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        mutation_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
 
   lang.csharp.framework.aspnet-core:
     capabilities:
@@ -961,6 +1065,42 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
+          verified_at: "2026-05-28"
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp, appendCSharpMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        http_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        fs_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        mutation_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
 
   lang.kotlin.framework.spring-boot:
@@ -1011,6 +1151,42 @@ records:
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
           verified_at: "2026-05-28"
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_kotlin.go
+              functions: [sniffEffectsKotlin, appendKotlinMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        http_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_kotlin.go
+              functions: [sniffEffectsKotlin]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        fs_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_kotlin.go
+              functions: [sniffEffectsKotlin]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        mutation_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_kotlin.go
+              functions: [sniffEffectsKotlin]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
 
   lang.elixir.framework.phoenix:
     capabilities:
@@ -1059,6 +1235,42 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
+          verified_at: "2026-05-28"
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_elixir.go
+              functions: [sniffEffectsElixir, appendElixirMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        http_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_elixir.go
+              functions: [sniffEffectsElixir]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        fs_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_elixir.go
+              functions: [sniffEffectsElixir]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        mutation_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_elixir.go
+              functions: [sniffEffectsElixir]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
 
   lang.scala.framework.play:
@@ -1109,6 +1321,42 @@ records:
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
           verified_at: "2026-05-28"
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_scala.go
+              functions: [sniffEffectsScala, appendScalaMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        http_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_scala.go
+              functions: [sniffEffectsScala]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        fs_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_scala.go
+              functions: [sniffEffectsScala]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        mutation_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_scala.go
+              functions: [sniffEffectsScala]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
 
   lang.c-cpp.framework.crow:
     capabilities:
@@ -1156,4 +1404,40 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
+          verified_at: "2026-05-28"
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_c_cpp.go
+              functions: [sniffEffectsCCPP, appendCCPPMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        http_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_c_cpp.go
+              functions: [sniffEffectsCCPP]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        fs_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_c_cpp.go
+              functions: [sniffEffectsCCPP]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
+        mutation_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_c_cpp.go
+              functions: [sniffEffectsCCPP]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2765"]
           verified_at: "2026-05-28"


### PR DESCRIPTION
Closes #2765. Extends Phase 1A effect classification (#2764) to the T2 language set: **ruby, php, rust, csharp, kotlin, elixir, scala, c-cpp**.

## Summary

- Eight per-language sink-recognition sniffers in `internal/substrate/effect_sinks_<lang>.go` (139-183 LOC each).
- Reuses the generic `runEffectPropagationPass` + `EffectSet` machinery and `archigraph_effects` MCP tool landed in #2764 — no changes to the pipeline.
- 372 registry cells flipped (93 T2 framework records × 4 keys: `db_effect`, `http_effect`, `fs_effect`, `mutation_effect`).
- Cleans up pre-existing main breakage: unresolved YAML conflict markers in `capability-map.yaml` (from #2786 merge) and Go-sniffer misattribution on `lang.c-cpp.framework.crow` (from #2787 merge).
- Adds `db_effect`/`http_effect`/`fs_effect`/`mutation_effect` to the `desktop` subcategory in the capability dictionary (the only subcategory that landed reachability/dead_code in #2767 but missed the effect keys from #2764).

## Sink primitives covered

| Language | DB | HTTP | FS | Mutation |
|---|---|---|---|---|
| ruby   | ActiveRecord (.where/.find/.create/.update/.destroy/.save), raw `connection.execute` SELECT/INSERT/UPDATE/DELETE | `Net::HTTP`, HTTParty, RestClient, Faraday, Excon | `File.read`/`.write`/`.open(mode)`, `FileUtils.*`, `IO.read/write` | `@ivar=`, `Process.spawn`/`Kernel.system` |
| php    | Eloquent (`::all/::find/::create/::update/::delete/::save`), Doctrine (`->persist/->remove/->flush`), PDO/mysqli `->query/->execute` (SQL-keyword disambiguated) | curl, Guzzle (`->get/post`, `new Client`), `wp_remote_*`, Symfony HttpClient | `file_get_contents` (HTTP vs FS disambiguated post-match — RE2 lacks negative lookahead), `fopen` mode-arg, `file_put_contents`/`fwrite`, exec/system/proc_open | `$this->prop=` |
| rust   | `sqlx::query!` SELECT/INSERT/UPDATE/DELETE, Diesel `.load/.insert_into/.update/.delete`, sea-orm | reqwest, hyper, surf, ureq, isahc | `std::fs::*`, `tokio::fs::*`, `File::open/create`, `std::process::Command` | `self.field=` |
| csharp | EF Core DbSet (`.Find/.First/.Add/.Update/.Remove/.SaveChanges/.FromSqlRaw`), Dapper (`Query*/Execute*`), ADO.NET (`ExecuteReader/Scalar/NonQuery`) | `HttpClient.*Async`, WebClient, RestSharp | `File.ReadAll*/WriteAll*`, `Directory.*`, `new FileStream/StreamReader/StreamWriter`, `Process.Start` | `this.field=` |
| kotlin | JPA/Hibernate (`em.find/em.persist/em.remove`), JpaRepository, Exposed (`Table.select/insert/update/deleteWhere`), R2DBC | Ktor `HttpClient`, OkHttp, RestTemplate, Fuel | `File(...).readText/writeText`, `Files.read*/write*`, `ProcessBuilder` | `this.field=` |
| elixir | Ecto `Repo.{all,get,one,insert,update,delete,insert_all,transaction}`, `Ecto.Adapters.SQL.query` | HTTPoison, Tesla, Finch, Req, `:httpc` | `File.read!`/`write!`/`cp`/`rm`/`mkdir_p`, `System.cmd`/`Port.open` | `Agent.update`, `GenServer.cast`, `:ets.insert`, `:persistent_term.put`, `Process.put` (Elixir's immutable bindings mean mutation tracks observable OTP / runtime state) |
| scala  | Slick (`.result/.+=/.delete`), Doobie `sql"..."`, Quill `quote(query[T])`, JPA | sttp basicRequest, akka-http, http4s Client, requests-scala | `Source.fromFile`, `Files.read*/write*`, os-lib | `this.field=` |
| c-cpp  | libpq (`PQexec*` with SQL-keyword disambig), MySQL `mysql_query`, SQLite (`sqlite3_prepare_v2`/`sqlite3_exec`), ODBC | libcurl, cpp-httplib, Boost.Beast, Poco | POSIX `fopen(mode)`/`read`/`write`/`open(O_*)`, `std::ifstream`/`std::ofstream`, `std::filesystem`, `mkdir`/`rmdir`/`unlink`/`rename`, `system`/`exec*`/`posix_spawn` | `this->member=` |

## Test plan

- [x] `go test ./internal/substrate/...` — registry assertions + per-language `TestSniffEffects{Ruby,PHP,Rust,CSharp,Kotlin,Elixir,Scala,CCPP}_PrimitiveCoverage`
- [x] `go test ./internal/links/...` — propagation pass unchanged
- [x] `go test ./tools/coverage/...` — coverage tooling clean
- [x] `go run ./tools/coverage validate` — 0 errors (was 24 errors on main pre-PR — broken `capability-map.yaml` conflict markers and missing T1 registry cells)
- [x] `go run ./tools/coverage gen` — byte-stable
- [x] Self-rebased against latest origin/main; mergeable verified

## Per-language sniffer LOC

| File | LOC |
|---|---|
| effect_sinks_ruby.go | 149 |
| effect_sinks_php.go | 165 |
| effect_sinks_rust.go | 142 |
| effect_sinks_csharp.go | 169 |
| effect_sinks_kotlin.go | 140 |
| effect_sinks_elixir.go | 146 |
| effect_sinks_scala.go | 139 |
| effect_sinks_c_cpp.go | 183 |
| **Total** | **1233** |

implements-capability tags for every flipped cell are recorded in the commit body (372 cells across 93 T2 records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)