### PR TITLE
feat(substrate): Phase 2B taint flow + security findings for T1 languages (#2772)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,39 +11,39 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/7 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/12 | |
 | [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -64,7 +64,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/16 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -79,33 +79,33 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — | — | — | — | — | — | |
 | [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — | — | — | — | — | — | |
-| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/16 | |
 | [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -120,32 +120,32 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | — | — | — | — | — | — | |
 
 
@@ -153,14 +153,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/9 | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 2/13 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 
@@ -169,23 +169,23 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ## Mobile
 
 | Language | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
@@ -193,33 +193,33 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ## Desktop
 
 | Language | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
 | [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
 | [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
 
 
 ## RPC Framework
 
 | Language | Name | Schema | Codegen | Transport | Substrate | Notes |
 |---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/10 | |
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | — | |
-| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | — | |
+| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
 
 
 ## AI Integration

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -12,35 +12,35 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/7 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 
 
 ### UI Frontend
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
 
 
 ## Tools

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -12,45 +12,45 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 
 
 ### UI Frontend
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ### Mobile
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
 
 
 ### RPC Framework
 
 | Name | Schema | Codegen | Transport | Substrate | Notes |
 |---|---|---|---|---|---|
-| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/10 | |
+| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -12,21 +12,21 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 
 
 ### Meta Framework
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -16,7 +16,7 @@ Back to [summary](../summary.md).
 | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/12 | |
 | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -22,7 +22,7 @@ Back to [summary](../summary.md).
 | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/16 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 
@@ -39,7 +39,7 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | — | |
+| [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ### Mobile

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -31,7 +31,7 @@ Back to [summary](../summary.md).
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
 | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/9 | |
+| [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 2/13 | |
 | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 
@@ -40,12 +40,12 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 
 
 ### Mobile
@@ -69,8 +69,8 @@ Back to [summary](../summary.md).
 
 | Name | Schema | Codegen | Transport | Substrate | Notes |
 |---|---|---|---|---|---|
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | — | |
-| [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | — | |
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
+| [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
 
 
 ### AI Integration

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -12,30 +12,30 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
 
 
 ### Mobile
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
-| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
 
 
 ## ORMs

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -12,18 +12,18 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -16,7 +16,7 @@ Back to [summary](../summary.md).
 | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/16 | |
 | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -12,14 +12,14 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -12,23 +12,23 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
 
 
 ## Tools

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -12,21 +12,21 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/10 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
 
 
 ### Meta Framework
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 11
 
 ## Capabilities
 
@@ -54,16 +54,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.qt.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.qt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 25
+- **Capability cells:** 18
 
 ## Capabilities
 
@@ -60,16 +60,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.ros.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ros.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 10
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,13 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.unreal-engine.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.unreal-engine.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 10
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,13 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 25
+- **Capability cells:** 18
 
 ## Capabilities
 
@@ -60,16 +60,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 25
+- **Capability cells:** 18
 
 ## Capabilities
 
@@ -60,16 +60,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 25
+- **Capability cells:** 18
 
 ## Capabilities
 
@@ -60,16 +60,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 13
+- **Capability cells:** 6
 
 ## Capabilities
 
@@ -33,16 +33,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.net-maui.md
+++ b/docs/coverage/detail/lang.csharp.framework.net-maui.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 24
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -69,16 +69,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.uno.md
+++ b/docs/coverage/detail/lang.csharp.framework.uno.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 10
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,13 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.winforms.md
+++ b/docs/coverage/detail/lang.csharp.framework.winforms.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 10
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,13 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.wpf.md
+++ b/docs/coverage/detail/lang.csharp.framework.wpf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 10
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,13 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.xamarin.md
+++ b/docs/coverage/detail/lang.csharp.framework.xamarin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 24
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -69,16 +69,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 23
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -68,16 +68,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -55,17 +55,17 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_golang.go` | — |
+| `dead_code_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/links/reachability.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_golang.go` | — |
+| `reachability_analysis` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/substrate/entry_points.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_golang.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_golang.go` | — |
+| `sanitizer_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_golang.go` | — |
+| `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.play.md
+++ b/docs/coverage/detail/lang.java.framework.play.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 13
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -68,6 +68,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 16
+- **Capability cells:** 20
 
 ## Capabilities
 
@@ -55,17 +55,21 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `dead_code_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/links/reachability.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `reachability_analysis` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/substrate/entry_points.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.jsts.framework.astro.md
+++ b/docs/coverage/detail/lang.jsts.framework.astro.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 13
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -68,6 +68,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.gatsby.md
+++ b/docs/coverage/detail/lang.jsts.framework.gatsby.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 13
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -68,6 +68,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 3
+- **Capability cells:** 6
 
 ## Capabilities
 
@@ -33,6 +33,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 13
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -68,6 +68,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 13
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -68,6 +68,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 24
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -61,14 +61,18 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `dead_code_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/links/reachability.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `reachability_analysis` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/substrate/entry_points.go` | — |
+| `sanitizer_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.remix.md
+++ b/docs/coverage/detail/lang.jsts.framework.remix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 13
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -68,6 +68,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 13
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -68,6 +68,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 3
+- **Capability cells:** 6
 
 ## Capabilities
 
@@ -33,6 +33,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 10
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,13 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 10
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,13 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 24
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -69,16 +69,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 24
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -69,16 +69,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 16
+- **Capability cells:** 20
 
 ## Capabilities
 
@@ -55,17 +55,21 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `dead_code_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/links/reachability.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `reachability_analysis` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/substrate/entry_points.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
+| `sanitizer_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
+| `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tauri.md
+++ b/docs/coverage/detail/lang.rust.framework.tauri.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 10
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,13 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.play.md
+++ b/docs/coverage/detail/lang.scala.framework.play.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 23
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -68,16 +68,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 14
+- **Capability cells:** 7
 
 ## Capabilities
 
@@ -54,16 +54,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9,12 +9,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/extractors/bazel/extractor.go"],
+          "cites": [
+            "internal/extractors/bazel/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/bazel/parser.go"],
+          "cites": [
+            "internal/extractors/bazel/parser.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -27,12 +31,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -45,12 +53,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -63,12 +75,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -81,12 +97,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/php/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/php/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -99,12 +119,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
+          "cites": [
+            "internal/extractors/dockerfile/dockerfile.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
+          "cites": [
+            "internal/extractors/dockerfile/dockerfile.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -117,12 +141,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -163,12 +191,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/extractors/golang/gomod.go"],
+          "cites": [
+            "internal/extractors/golang/gomod.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/go/build_tools.yaml","internal/extractors/golang/gomod.go"],
+          "cites": [
+            "internal/engine/rules/go/build_tools.yaml",
+            "internal/extractors/golang/gomod.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -181,12 +214,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/java/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/build_tools.yaml","internal/engine/rules/kotlin/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/java/build_tools.yaml",
+            "internal/engine/rules/kotlin/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -213,12 +251,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -231,12 +273,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/extractors/just/just.go"],
+          "cites": [
+            "internal/extractors/just/just.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/just/just.go"],
+          "cites": [
+            "internal/extractors/just/just.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -280,7 +326,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -293,12 +341,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/java/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/java/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -325,12 +377,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -343,12 +399,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -361,12 +421,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -407,12 +471,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -425,12 +493,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -443,12 +515,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -461,12 +537,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -482,7 +562,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -509,12 +591,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -527,12 +613,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -573,12 +663,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/python/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -594,7 +688,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -610,7 +706,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -623,12 +721,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/build_tools.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -641,12 +743,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -659,12 +765,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -677,12 +787,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/buildkite.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/buildkite.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -695,12 +809,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/circleci.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/circleci.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -727,12 +845,17 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/github_actions.yaml","internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/github_actions.yaml",
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -745,12 +868,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -766,7 +893,9 @@
         },
         "file_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/cicd/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -779,12 +908,16 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/travis_ci.yaml"],
+          "cites": [
+            "internal/engine/rules/cicd/frameworks/travis_ci.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -797,7 +930,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -806,16 +941,20 @@
       "id": "config.dotenv",
       "category": "platform",
       "language": "multi",
-      "label": ".env (names-only — values stripped at extraction boundary)",
+      "label": ".env (names-only \u2014 values stripped at extraction boundary)",
       "capabilities": {
         "env_resolution": {
           "status": "full",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -828,7 +967,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -841,7 +982,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -854,7 +997,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -878,7 +1023,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -891,7 +1038,10 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/config/discover.go","internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/config/discover.go",
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -904,7 +1054,9 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": ["internal/extractors/config/discover.go"],
+          "cites": [
+            "internal/extractors/config/discover.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -917,7 +1069,10 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/config/discover.go","internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/config/discover.go",
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -958,12 +1113,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/iac_sns_edges.go"],
+          "cites": [
+            "internal/engine/iac_sns_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -976,12 +1135,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -994,12 +1157,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1012,12 +1179,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
+          "cites": [
+            "internal/engine/rules/database_index/language.yaml",
+            "internal/extractors/sql"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1044,12 +1216,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
+          "cites": [
+            "internal/engine/rules/database_index/language.yaml",
+            "internal/extractors/sql"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1062,12 +1239,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1094,12 +1275,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/extractors/sql"],
+          "cites": [
+            "internal/extractors/sql"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1112,12 +1297,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/docker/frameworks/docker_compose.yaml","internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/engine/rules/docker/frameworks/docker_compose.yaml",
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1130,12 +1320,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
+          "cites": [
+            "internal/extractors/dockerfile/dockerfile.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/docker/frameworks/dockerfile.yaml","internal/extractors/dockerfile/dockerfile.go"],
+          "cites": [
+            "internal/engine/rules/docker/frameworks/dockerfile.yaml",
+            "internal/extractors/dockerfile/dockerfile.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1148,12 +1343,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1166,12 +1365,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml","internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml",
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1198,12 +1402,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/ansible/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/ansible/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1230,12 +1438,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/cdk/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/cdk/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1248,12 +1460,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1266,12 +1482,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/pulumi/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/pulumi/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1284,12 +1504,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/serverless_edges.go"],
+          "cites": [
+            "internal/engine/serverless_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/serverless_edges.go"],
+          "cites": [
+            "internal/engine/serverless_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1302,12 +1526,16 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/hcl"],
+          "cites": [
+            "internal/extractors/hcl"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/hcl"],
+          "cites": [
+            "internal/extractors/hcl"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1388,7 +1616,9 @@
       "capabilities": {
         "log_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/_engine/logging_config_extractor.yaml"],
+          "cites": [
+            "internal/engine/rules/_engine/logging_config_extractor.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1421,12 +1651,17 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
           "status": "full",
-          "cites": ["internal/engine/event_flow.go","internal/engine/process_flow.go"],
+          "cites": [
+            "internal/engine/event_flow.go",
+            "internal/engine/process_flow.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1442,7 +1677,9 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml"],
+          "cites": [
+            "internal/engine/rules/_engine/comment_marker_extractor.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
@@ -1475,7 +1712,9 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/hcl/extractor.go"],
+          "cites": [
+            "internal/extractors/hcl/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1488,7 +1727,9 @@
       "capabilities": {
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/workflow_edges.go"],
+          "cites": [
+            "internal/engine/workflow_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1512,7 +1753,9 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
+          "cites": [
+            "internal/extractors/yaml/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1525,7 +1768,9 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/hcl/extractor.go"],
+          "cites": [
+            "internal/extractors/hcl/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1538,12 +1783,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/hcl/relationships.go"],
+          "cites": [
+            "internal/extractors/hcl/relationships.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/extractors/hcl/extractor.go","internal/extractors/hcl/relationships.go"],
+          "cites": [
+            "internal/extractors/hcl/extractor.go",
+            "internal/extractors/hcl/relationships.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -1642,55 +1892,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -1721,55 +1948,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -1800,55 +2004,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -1879,55 +2060,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -1958,54 +2116,63 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-27"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-27"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
           },
           "db_effect": {
             "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-27"
           },
           "fs_effect": {
             "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
           },
           "http_effect": {
             "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-27"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
           }
         }
@@ -2037,55 +2204,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2116,55 +2260,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2195,55 +2316,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2274,55 +2372,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2353,55 +2428,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2432,55 +2484,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2511,55 +2540,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2629,55 +2635,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2708,55 +2691,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2787,55 +2747,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/c_cpp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2859,43 +2796,6 @@
           "native_module_imports": {
             "status": "missing"
           }
-        },
-        "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          }
         }
       }
     },
@@ -2917,43 +2817,6 @@
         "Native": {
           "native_module_imports": {
             "status": "missing"
-          }
-        },
-        "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3163,7 +3026,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/cassandra_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3182,7 +3047,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3201,7 +3068,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3220,7 +3089,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/mongodb_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3239,7 +3110,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/mysql_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3258,7 +3131,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3277,7 +3152,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/npgsql.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3296,7 +3173,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/redis_stackexchange.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3315,7 +3194,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/sqlite_csharp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -3330,12 +3211,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/aspnet_core_routes.go","internal/engine/rules/csharp/frameworks/asp_net_core.yaml"],
+            "cites": [
+              "internal/engine/aspnet_core_routes.go",
+              "internal/engine/rules/csharp/frameworks/asp_net_core.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/aspnet_core_routes.go"],
+            "cites": [
+              "internal/engine/aspnet_core_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -3347,60 +3233,39 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/aspnet_core_routes.go"],
+            "cites": [
+              "internal/engine/aspnet_core_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3415,12 +3280,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
+            "cites": [
+              "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
+            "cites": [
+              "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -3435,55 +3304,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3553,55 +3399,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3671,55 +3494,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3789,55 +3589,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3868,55 +3645,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3947,55 +3701,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4021,55 +3752,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4100,55 +3808,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4219,55 +3904,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4298,55 +3960,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4370,43 +4009,6 @@
           "native_module_imports": {
             "status": "missing"
           }
-        },
-        "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
-          }
         }
       }
     },
@@ -4429,43 +4031,6 @@
           "native_module_imports": {
             "status": "missing"
           }
-        },
-        "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
-          }
         }
       }
     },
@@ -4487,43 +4052,6 @@
         "Native": {
           "native_module_imports": {
             "status": "missing"
-          }
-        },
-        "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4594,55 +4122,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/csharp.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4658,12 +4163,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/dapper.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/dapper.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4679,12 +4188,17 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/csharp/frameworks/entity_framework_core.yaml","internal/engine/rules/csharp/orms/entity_framework_core.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/frameworks/entity_framework_core.yaml",
+            "internal/engine/rules/csharp/orms/entity_framework_core.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4700,12 +4214,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4738,12 +4256,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/nhibernate.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/orms/nhibernate.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4762,7 +4284,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4781,7 +4305,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4800,7 +4326,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4819,7 +4347,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/myxql.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/myxql.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4838,7 +4368,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4857,7 +4389,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/postgrex.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/postgrex.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4876,7 +4410,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/redix.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/redix.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4895,7 +4431,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/xandra.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/xandra.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -4910,12 +4448,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml","internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"],
+            "cites": [
+              "internal/engine/rules/elixir/frameworks/absinthe.yaml",
+              "internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml"],
+            "cites": [
+              "internal/engine/rules/elixir/frameworks/absinthe.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -4930,55 +4473,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4993,12 +4513,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
+            "cites": [
+              "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
+            "cites": [
+              "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5013,55 +4537,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5092,55 +4593,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5171,55 +4649,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5237,7 +4692,9 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/nerves.yaml"],
+            "cites": [
+              "internal/engine/rules/elixir/frameworks/nerves.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5252,55 +4709,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5318,7 +4752,9 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/oban.yaml"],
+            "cites": [
+              "internal/engine/rules/elixir/frameworks/oban.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5333,55 +4769,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5396,12 +4809,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/phoenix_routes.go","internal/engine/rules/elixir/frameworks/phoenix.yaml"],
+            "cites": [
+              "internal/engine/phoenix_routes.go",
+              "internal/engine/rules/elixir/frameworks/phoenix.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/phoenix_routes.go"],
+            "cites": [
+              "internal/engine/phoenix_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5416,55 +4834,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5532,55 +4927,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5611,55 +4983,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/elixir.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5675,12 +5024,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5696,12 +5049,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
+          "cites": [
+            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5720,7 +5077,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/cassandra_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/cassandra_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5739,7 +5098,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/dynamodb_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/dynamodb_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5758,7 +5119,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/elasticsearch_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/elasticsearch_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5777,7 +5140,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/mongo_driver.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/mongo_driver.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5796,7 +5161,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/mysql_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/mysql_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5815,7 +5182,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5834,7 +5203,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/go_redis.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/go_redis.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5853,7 +5224,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlite_go.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlite_go.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -5868,12 +5241,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/beego.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/beego.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5890,17 +5267,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -5931,12 +5320,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/buffalo.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/buffalo.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -5953,17 +5346,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -5994,12 +5399,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/chi.yaml"],
+            "cites": [
+              "internal/engine/go_routes.go",
+              "internal/engine/rules/go/frameworks/chi.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go"],
+            "cites": [
+              "internal/engine/go_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6016,17 +5426,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6057,12 +5479,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/echo.yaml"],
+            "cites": [
+              "internal/engine/go_routes.go",
+              "internal/engine/rules/go/frameworks/echo.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go"],
+            "cites": [
+              "internal/engine/go_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6079,17 +5506,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6120,12 +5559,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/fasthttp.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/fasthttp.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6142,17 +5585,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6183,12 +5638,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/fiber.yaml"],
+            "cites": [
+              "internal/engine/go_routes.go",
+              "internal/engine/rules/go/frameworks/fiber.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go"],
+            "cites": [
+              "internal/engine/go_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6205,17 +5665,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6268,12 +5740,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gin.yaml"],
+            "cites": [
+              "internal/engine/go_routes.go",
+              "internal/engine/rules/go/frameworks/gin.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go"],
+            "cites": [
+              "internal/engine/go_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6290,47 +5767,81 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_golang.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
-          "mutation_effect": {
+          "taint_source_detection": {
             "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "taint_sink_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "sanitizer_recognition": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "vulnerability_finding": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/links/reachability.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_golang.go"],
+            "status": "partial",
+            "cites": [
+              "internal/substrate/entry_points.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6361,12 +5872,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/go_zero.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/go_zero.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6383,17 +5898,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6482,17 +6009,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -6508,12 +6047,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gorilla_mux.yaml"],
+            "cites": [
+              "internal/engine/go_routes.go",
+              "internal/engine/rules/go/frameworks/gorilla_mux.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go"],
+            "cites": [
+              "internal/engine/go_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6530,17 +6074,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6571,12 +6127,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/hertz.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/hertz.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6593,17 +6153,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6634,12 +6206,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_go_trio.go"],
+            "cites": [
+              "internal/engine/http_endpoint_go_trio.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_go_trio.go"],
+            "cites": [
+              "internal/engine/http_endpoint_go_trio.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6656,17 +6232,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6697,12 +6285,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/iris.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/iris.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6719,17 +6311,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6760,12 +6364,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/kratos.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/kratos.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6782,17 +6390,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6823,12 +6443,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/net_http_stdlib.yaml"],
+            "cites": [
+              "internal/engine/go_routes.go",
+              "internal/engine/rules/go/frameworks/net_http_stdlib.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go"],
+            "cites": [
+              "internal/engine/go_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6845,17 +6470,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6886,12 +6523,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/revel.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
+            "cites": [
+              "internal/engine/rules/go/frameworks/revel.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -6908,17 +6549,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/golang.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6950,12 +6603,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/bun.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/bun.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -6971,12 +6628,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/go/orms/ent.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/ent.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7009,12 +6670,18 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/go/frameworks/gorm.yaml","internal/engine/rules/go/orms/gorm.yaml"],
+          "cites": [
+            "internal/engine/orm_field_edges.go",
+            "internal/engine/rules/go/frameworks/gorm.yaml",
+            "internal/engine/rules/go/orms/gorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7027,7 +6694,9 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/golang_migrate.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/golang_migrate.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -7052,7 +6721,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/pgx.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/pgx.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7065,17 +6736,23 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlc.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlc.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlc.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7091,12 +6768,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlx.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
+          "cites": [
+            "internal/engine/rules/go/orms/sqlx.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -7146,17 +6827,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7245,17 +6938,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -7329,17 +7034,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -7355,12 +7072,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/dropwizard.yaml"],
+            "cites": [
+              "internal/engine/java_annotation_routes.go",
+              "internal/engine/rules/java/frameworks/dropwizard.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/java_annotation_routes.go"],
+            "cites": [
+              "internal/engine/java_annotation_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -7377,17 +7099,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7475,17 +7209,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -7519,17 +7265,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7560,12 +7318,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
+            "cites": [
+              "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
+            "cites": [
+              "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -7582,17 +7344,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7641,17 +7415,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7682,19 +7468,26 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
+            "cites": [
+              "internal/engine/java_annotation_routes.go",
+              "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/java_annotation_routes.go"],
+            "cites": [
+              "internal/engine/java_annotation_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/java_auth_policy.go"],
+            "cites": [
+              "internal/engine/java_auth_policy.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -7706,17 +7499,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7769,19 +7574,26 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/micronaut.yaml"],
+            "cites": [
+              "internal/engine/java_annotation_routes.go",
+              "internal/engine/rules/java/frameworks/micronaut.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/java_annotation_routes.go"],
+            "cites": [
+              "internal/engine/java_annotation_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/java_auth_policy.go"],
+            "cites": [
+              "internal/engine/java_auth_policy.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -7793,17 +7605,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7834,12 +7658,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
+            "cites": [
+              "internal/engine/rules/java/frameworks/microprofile.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
+            "cites": [
+              "internal/engine/rules/java/frameworks/microprofile.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -7856,17 +7684,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7948,6 +7788,35 @@
           "tests_linkage": {
             "status": "missing"
           }
+        },
+        "Substrate": {
+          "constant_propagation": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -7961,19 +7830,26 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/quarkus.yaml"],
+            "cites": [
+              "internal/engine/java_annotation_routes.go",
+              "internal/engine/rules/java/frameworks/quarkus.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/java_annotation_routes.go"],
+            "cites": [
+              "internal/engine/java_annotation_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/java_auth_policy.go"],
+            "cites": [
+              "internal/engine/java_auth_policy.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -7985,17 +7861,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8026,73 +7914,151 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/java/frameworks/spring_boot.yaml","internal/engine/rules/java/frameworks/spring_mvc.yaml","internal/engine/spring_routes.go"],
+            "cites": [
+              "internal/engine/http_endpoint_synthesis.go",
+              "internal/engine/rules/java/frameworks/spring_boot.yaml",
+              "internal/engine/rules/java/frameworks/spring_mvc.yaml",
+              "internal/engine/spring_routes.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/spring_routes.go"],
+            "cites": [
+              "internal/engine/java_annotation_routes.go",
+              "internal/engine/spring_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "full",
-            "cites": ["internal/engine/java_auth_policy.go"],
+            "cites": [
+              "internal/engine/java_auth_policy.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/java_annotation_params.go"],
+            "cites": [
+              "internal/engine/java_annotation_params.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_java.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "taint_source_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "taint_sink_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "sanitizer_recognition": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "vulnerability_finding": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/links/reachability.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_java.go"],
+            "status": "partial",
+            "cites": [
+              "internal/substrate/entry_points.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8139,19 +8105,26 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/java/frameworks/spring_webflux.yaml","internal/engine/spring_routes.go"],
+            "cites": [
+              "internal/engine/rules/java/frameworks/spring_webflux.yaml",
+              "internal/engine/spring_routes.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/spring_routes.go"],
+            "cites": [
+              "internal/engine/spring_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/java_auth_policy.go"],
+            "cites": [
+              "internal/engine/java_auth_policy.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -8163,17 +8136,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8204,12 +8189,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
+            "cites": [
+              "internal/engine/rules/java/frameworks/apache_struts.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
+            "cites": [
+              "internal/engine/rules/java/frameworks/apache_struts.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -8226,17 +8215,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8324,17 +8325,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -8350,12 +8363,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
+            "cites": [
+              "internal/engine/rules/java/frameworks/vert_x.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
+            "cites": [
+              "internal/engine/rules/java/frameworks/vert_x.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -8372,17 +8389,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/java.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8414,12 +8443,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/dynamodb_java.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/dynamodb_java.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8469,12 +8502,17 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/hibernate_core.yaml"],
+          "cites": [
+            "internal/engine/orm_field_edges.go",
+            "internal/engine/rules/java/orms/hibernate_core.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8490,12 +8528,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/jooq.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/jooq.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8511,12 +8553,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8532,12 +8578,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/mybatis.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/mybatis.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8553,12 +8603,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8574,12 +8628,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8595,12 +8653,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8616,12 +8678,17 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/spring_data_jpa.yaml"],
+          "cites": [
+            "internal/engine/orm_field_edges.go",
+            "internal/engine/rules/java/orms/spring_data_jpa.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8637,12 +8704,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8658,12 +8729,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_redis.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
+          "cites": [
+            "internal/engine/rules/java/orms/spring_data_redis.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8682,7 +8757,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8701,7 +8778,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8720,7 +8799,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8739,7 +8820,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8758,7 +8841,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8777,7 +8862,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8796,7 +8883,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8815,7 +8904,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/redis_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/redis_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8834,7 +8925,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8853,7 +8946,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -8886,17 +8981,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8966,17 +9073,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -8989,24 +9102,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -9063,7 +9190,9 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/astro.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -9078,17 +9207,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9101,7 +9236,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Substrate": {
+          "constant_propagation": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -9121,7 +9287,9 @@
           },
           "main_renderer_split": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/electron.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/electron.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -9143,12 +9311,16 @@
         "Structure": {
           "context_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9159,19 +9331,25 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -9185,12 +9363,16 @@
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "cites": [
+              "internal/extractors/javascript/discriminator.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -9198,48 +9380,70 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -9256,7 +9460,9 @@
           },
           "expo_router_specifics": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/navigation.go"],
+            "cites": [
+              "internal/extractors/javascript/navigation.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -9272,12 +9478,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/express.yaml",
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9289,24 +9500,38 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9337,12 +9562,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9359,17 +9588,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9418,17 +9659,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9480,7 +9733,9 @@
         "Routing": {
           "route_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -9496,17 +9751,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9519,7 +9780,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Substrate": {
+          "constant_propagation": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -9535,12 +9827,17 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"],
+            "cites": [
+              "internal/engine/rules/graphql/frameworks/apollo_server.yaml",
+              "internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
+            "cites": [
+              "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9548,6 +9845,35 @@
           "client_codegen": {
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
+        },
+        "Substrate": {
+          "constant_propagation": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -9580,17 +9906,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9621,12 +9959,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9643,17 +9985,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9724,17 +10078,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9747,24 +10107,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -9780,12 +10154,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/framework_dsl.go"],
+            "cites": [
+              "internal/extractors/javascript/framework_dsl.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9802,17 +10180,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9843,7 +10233,9 @@
         "Prompts": {
           "prompt_template_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -9851,7 +10243,9 @@
         "Composition": {
           "chain_composition": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -9890,17 +10284,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9971,17 +10377,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -9994,24 +10406,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -10027,43 +10453,63 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -10120,12 +10566,16 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -10138,17 +10588,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -10161,7 +10617,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Substrate": {
+          "constant_propagation": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -10210,7 +10697,9 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -10225,17 +10714,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -10248,7 +10743,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Substrate": {
+          "constant_propagation": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -10282,17 +10808,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -10323,53 +10861,73 @@
         "Structure": {
           "component_extraction": {
             "status": "partial",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "context_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "hook_recognition": {
             "status": "partial",
-            "cites": ["internal/extractors/javascript/destructure_bindings.go"],
+            "cites": [
+              "internal/extractors/javascript/destructure_bindings.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "jsx_template": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "cites": [
+              "internal/extractors/javascript/discriminator.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "data_fetching": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/destructure_bindings.go",
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "prop_extraction": {
             "status": "partial",
-            "cites": ["internal/extractors/javascript/navigation.go"],
+            "cites": [
+              "internal/extractors/javascript/navigation.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2665",
             "notes": "Covers only JSX navigation props (Link to/href, Navigate to, state object); generic React component prop extraction is not yet implemented.",
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/zustand_store.go"],
+            "cites": [
+              "internal/extractors/javascript/destructure_bindings.go",
+              "internal/extractors/javascript/zustand_store.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -10377,85 +10935,163 @@
         "Navigation": {
           "router_pattern": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/navigation.go"],
+            "cites": [
+              "internal/extractors/javascript/navigation.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_jsts.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "taint_source_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "taint_sink_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "sanitizer_recognition": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "vulnerability_finding": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/links/reachability.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_jsts.go"],
+            "status": "partial",
+            "cites": [
+              "internal/substrate/entry_points.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
             "verified_at": "2026-05-28"
           }
         }
@@ -10471,12 +11107,16 @@
         "Structure": {
           "context_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -10487,19 +11127,25 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -10513,12 +11159,16 @@
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "cites": [
+              "internal/extractors/javascript/discriminator.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -10526,48 +11176,70 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -10616,7 +11288,9 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/remix.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -10631,17 +11305,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -10654,7 +11334,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Substrate": {
+          "constant_propagation": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -10688,17 +11399,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -10747,17 +11470,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -10827,17 +11562,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -10850,24 +11591,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -10916,7 +11671,9 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
+            "cites": [
+              "internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -10931,17 +11688,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -10954,7 +11717,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Substrate": {
+          "constant_propagation": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -10970,12 +11764,17 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
+            "cites": [
+              "internal/engine/http_endpoint_trpc.go",
+              "internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/http_endpoint_trpc.go"],
+            "cites": [
+              "internal/engine/http_endpoint_trpc.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -10984,6 +11783,35 @@
           "client_codegen": {
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
+        },
+        "Substrate": {
+          "constant_propagation": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -11037,17 +11865,23 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
+            "cites": [
+              "internal/extractors/javascript/extractor.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -11060,24 +11894,38 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": ["internal/extractors/javascript/tests.go"],
+            "cites": [
+              "internal/extractors/javascript/tests.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/jsts.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -11110,12 +11958,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/drizzle.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/drizzle.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -11134,7 +11986,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/knex.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/knex.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -11150,12 +12004,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -11171,12 +12029,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mongoose.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/mongoose.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -11206,17 +12068,25 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/prisma/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/prisma/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/prisma.yaml","internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml","internal/engine/rules/prisma/_manifest.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/prisma.yaml",
+            "internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml",
+            "internal/engine/rules/prisma/_manifest.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -11232,12 +12102,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/sequelize.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/sequelize.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -11253,12 +12127,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/typeorm.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/orms/typeorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
+          "cites": [
+            "internal/engine/orm_queries_jsts.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -11276,7 +12154,9 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -11291,55 +12171,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -11410,55 +12267,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -11482,43 +12316,6 @@
           "native_module_imports": {
             "status": "missing"
           }
-        },
-        "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
-          }
         }
       }
     },
@@ -11541,43 +12338,6 @@
           "native_module_imports": {
             "status": "missing"
           }
-        },
-        "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
-          }
         }
       }
     },
@@ -11594,7 +12354,9 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -11609,55 +12371,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -11672,12 +12411,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/http4k.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/http4k.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -11692,55 +12435,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -11771,55 +12491,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -11890,55 +12587,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -11953,12 +12627,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/ktor.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/ktor.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -11973,55 +12651,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12036,12 +12691,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -12056,55 +12715,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12119,12 +12755,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -12139,55 +12779,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12202,19 +12819,26 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml","internal/engine/spring_routes_kotlin.go"],
+            "cites": [
+              "internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml",
+              "internal/engine/spring_routes_kotlin.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/spring_routes_kotlin.go"],
+            "cites": [
+              "internal/engine/spring_routes_kotlin.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/java_auth_policy.go"],
+            "cites": [
+              "internal/engine/java_auth_policy.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -12224,55 +12848,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/kotlin.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12288,12 +12889,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/exposed.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/exposed.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12309,12 +12914,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12330,12 +12939,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/ktorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/ktorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12351,12 +12964,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12372,12 +12989,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/room_android.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/room_android.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12393,12 +13014,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12414,12 +13039,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
+          "cites": [
+            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12466,7 +13095,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/cassandra_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/cassandra_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12485,7 +13116,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/dynamodb_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/dynamodb_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12504,7 +13137,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/elasticsearch_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/elasticsearch_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12523,7 +13158,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/mongodb_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/mongodb_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12542,7 +13179,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/mysql_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/mysql_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12561,7 +13200,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12580,7 +13221,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/postgresql_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/postgresql_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12599,7 +13242,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/redis_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/redis_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12618,7 +13263,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/sqlite_php.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/sqlite_php.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -12633,12 +13280,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/cakephp.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/cakephp.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -12653,55 +13304,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12716,12 +13344,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/codeigniter.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/codeigniter.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -12736,55 +13368,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12799,12 +13408,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/drupal.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/drupal.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -12819,55 +13432,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12882,12 +13472,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/laminas.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/laminas.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -12902,55 +13496,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12965,12 +13536,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/laravel.yaml"],
+            "cites": [
+              "internal/engine/http_endpoint_php_producer.go",
+              "internal/engine/rules/php/frameworks/laravel.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_php_producer.go"],
+            "cites": [
+              "internal/engine/http_endpoint_php_producer.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -12985,55 +13561,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13064,55 +13617,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13127,12 +13657,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/magento.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/magento.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -13147,55 +13681,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13226,55 +13737,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13289,12 +13777,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/slim.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/slim.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -13309,55 +13801,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13372,12 +13841,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/symfony.yaml"],
+            "cites": [
+              "internal/engine/http_endpoint_php_producer.go",
+              "internal/engine/rules/php/frameworks/symfony.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_php_producer.go"],
+            "cites": [
+              "internal/engine/http_endpoint_php_producer.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -13392,55 +13866,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13455,12 +13906,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/wordpress.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/wordpress.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -13475,55 +13930,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13538,12 +13970,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/yii.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
+            "cites": [
+              "internal/engine/rules/php/frameworks/yii.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -13558,55 +13994,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/php.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13639,12 +14052,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/orms/doctrine_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/doctrine_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13660,12 +14077,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
+          "cites": [
+            "internal/engine/orm_queries_other.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13681,12 +14102,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/propel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/propel.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13702,12 +14127,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/redbeanphp.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
+          "cites": [
+            "internal/engine/rules/php/orms/redbeanphp.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13726,7 +14155,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/cassandra_py.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/cassandra_py.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13745,7 +14176,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/dynamodb_py.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/dynamodb_py.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13764,7 +14197,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/elasticsearch_py.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/elasticsearch_py.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13783,7 +14218,10 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+          "cites": [
+            "internal/engine/rules/python/orms/mysql_py.yaml",
+            "internal/extractors/python/raw_sql_db_calls.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13802,7 +14240,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13821,7 +14261,10 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+          "cites": [
+            "internal/engine/rules/python/orms/postgresql_py.yaml",
+            "internal/extractors/python/raw_sql_db_calls.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13840,7 +14283,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/redis_py.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/redis_py.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13859,7 +14304,10 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+          "cites": [
+            "internal/engine/rules/python/orms/sqlite_py.yaml",
+            "internal/extractors/python/raw_sql_db_calls.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -13874,12 +14322,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/aiohttp.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/aiohttp.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -13896,17 +14348,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -13937,12 +14401,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/bottle.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/bottle.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -13959,17 +14427,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14003,7 +14483,10 @@
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/celery.yaml","internal/extractors/python/celery.go"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/celery.yaml",
+              "internal/extractors/python/celery.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14020,17 +14503,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14079,17 +14574,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14120,43 +14627,66 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/django_routes.go","internal/engine/django_urlconf_nested.go","internal/engine/rules/python/frameworks/django.yaml"],
+            "cites": [
+              "internal/engine/django_routes.go",
+              "internal/engine/django_urlconf_nested.go",
+              "internal/engine/rules/python/frameworks/django.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/django_admin_routes.go","internal/engine/django_routes.go"],
+            "cites": [
+              "internal/engine/django_admin_routes.go",
+              "internal/engine/django_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/django_drf_actions.go"],
+            "cites": [
+              "internal/engine/django_drf_actions.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/django_imports_rewrite.go"],
+            "cites": [
+              "internal/engine/django_imports_rewrite.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14187,19 +14717,27 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/django_drf_actions.go"],
+            "cites": [
+              "internal/engine/django_drf_actions.go",
+              "internal/extractors/python/django_drf_actions.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/drf_serializer_fields.go"],
+            "cites": [
+              "internal/engine/django_drf_actions.go",
+              "internal/extractors/python/drf_serializer_fields.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/django_drf_actions.go"],
+            "cites": [
+              "internal/engine/django_drf_actions.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14211,47 +14749,113 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "taint_source_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "taint_sink_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "sanitizer_recognition": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "vulnerability_finding": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/taint_sites.go",
+              "internal/links/taint_flow.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/links/reachability.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "cites": [
+              "internal/substrate/effects.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "status": "partial",
+            "cites": [
+              "internal/substrate/entry_points.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14279,7 +14883,9 @@
           },
           "signal_handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/django_signal_pubsub_edges.go"],
+            "cites": [
+              "internal/engine/django_signal_pubsub_edges.go"
+            ],
             "issue": "https://github.com/cajasmota/archigraph/issues/2739",
             "verified_at": "2026-05-28"
           }
@@ -14299,7 +14905,9 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/python/frameworks/dramatiq.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/dramatiq.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14316,17 +14924,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14375,17 +14995,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14416,19 +15048,26 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/fastapi.yaml"],
+            "cites": [
+              "internal/engine/http_endpoint_synthesis.go",
+              "internal/engine/rules/python/frameworks/fastapi.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/fastapi.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/fastapi.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14440,17 +15079,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14481,12 +15132,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/flask.yaml"],
+            "cites": [
+              "internal/engine/http_endpoint_synthesis.go",
+              "internal/engine/rules/python/frameworks/flask.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/flask.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/flask.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14503,17 +15159,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14562,17 +15230,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14625,12 +15305,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/litestar.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/litestar.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14647,17 +15331,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14688,12 +15384,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/pyramid.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/pyramid.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14710,17 +15410,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14769,17 +15481,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14810,12 +15534,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/robyn.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/robyn.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14832,17 +15560,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14873,12 +15613,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/sanic.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/sanic.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14895,17 +15639,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14936,12 +15692,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/starlette.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/starlette.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -14958,17 +15718,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14999,12 +15771,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/graphql/frameworks/strawberry_python.yaml","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
+            "cites": [
+              "internal/engine/rules/graphql/frameworks/strawberry_python.yaml",
+              "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -15021,17 +15798,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15062,12 +15851,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/tornado.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
+            "cites": [
+              "internal/engine/rules/python/frameworks/tornado.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -15084,17 +15877,29 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/python.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15123,7 +15928,9 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/alembic.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -15145,12 +15952,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/beanie.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/beanie.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15163,17 +15974,24 @@
       "capabilities": {
         "migration_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/python/django_migration.go"],
+          "cites": [
+            "internal/extractors/python/django_migration.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/orms/django_orm.yaml","internal/extractors/python/django_relational.go"],
+          "cites": [
+            "internal/engine/rules/python/orms/django_orm.yaml",
+            "internal/extractors/python/django_relational.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
+          "cites": [
+            "internal/engine/orm_queries_python.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15189,12 +16007,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/mongoengine.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/mongoengine.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15210,12 +16032,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/peewee.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/peewee.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15231,12 +16057,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/pony_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/pony_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15249,17 +16079,24 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/alembic.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/python/orms/sqlalchemy.yaml"],
+          "cites": [
+            "internal/engine/orm_field_edges.go",
+            "internal/engine/rules/python/orms/sqlalchemy.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
+          "cites": [
+            "internal/engine/orm_queries_python.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15275,12 +16112,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/orms/sqlmodel.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/sqlmodel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
+          "cites": [
+            "internal/engine/orm_queries_python.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15296,12 +16137,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/orms/tortoise_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/python/orms/tortoise_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/orm_queries_python.go"],
+          "cites": [
+            "internal/engine/orm_queries_python.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15320,7 +16165,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/cassandra_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/cassandra_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15339,7 +16186,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15358,7 +16207,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15377,7 +16228,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/mysql_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/mysql_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15396,7 +16249,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15415,7 +16270,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/pg_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/pg_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15434,7 +16291,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/redis_rb.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/redis_rb.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15453,7 +16312,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/sqlite_ruby.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/sqlite_ruby.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -15484,55 +16345,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -15550,7 +16388,9 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/ruby/frameworks/dry_rb.yaml"],
+            "cites": [
+              "internal/engine/rules/ruby/frameworks/dry_rb.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -15565,55 +16405,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -15628,12 +16445,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
+            "cites": [
+              "internal/engine/rules/ruby/frameworks/grape.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
+            "cites": [
+              "internal/engine/rules/ruby/frameworks/grape.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -15648,55 +16469,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -15711,12 +16509,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
+            "cites": [
+              "internal/engine/rules/ruby/frameworks/hanami.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
+            "cites": [
+              "internal/engine/rules/ruby/frameworks/hanami.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -15731,55 +16533,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -15794,12 +16573,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
+            "cites": [
+              "internal/engine/rules/ruby/frameworks/padrino.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
+            "cites": [
+              "internal/engine/rules/ruby/frameworks/padrino.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -15814,55 +16597,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -15877,12 +16637,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"],
+            "cites": [
+              "internal/engine/http_endpoint_ruby_producer.go",
+              "internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+            "cites": [
+              "internal/engine/http_endpoint_ruby_producer.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -15897,55 +16662,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -15960,12 +16702,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
+            "cites": [
+              "internal/engine/rules/ruby/frameworks/roda.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
+            "cites": [
+              "internal/engine/rules/ruby/frameworks/roda.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -15980,55 +16726,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16043,12 +16766,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/sinatra.yaml"],
+            "cites": [
+              "internal/engine/http_endpoint_ruby_producer.go",
+              "internal/engine/rules/ruby/frameworks/sinatra.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
+            "cites": [
+              "internal/engine/http_endpoint_ruby_producer.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -16063,55 +16791,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/ruby.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16127,12 +16832,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/orms/activerecord.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/activerecord.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
+          "cites": [
+            "internal/engine/orm_queries.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16148,12 +16857,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16169,12 +16882,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/mongoid.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/mongoid.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16190,12 +16907,17 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml","internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml",
+            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16211,12 +16933,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/sequel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/orms/sequel.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16235,7 +16961,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/cassandra_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/cassandra_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16254,7 +16982,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/dynamodb_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/dynamodb_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16273,7 +17003,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/elasticsearch_rs.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/elasticsearch_rs.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16292,7 +17024,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/mongodb_mongodb.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/mongodb_mongodb.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16311,7 +17045,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/mysql_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/mysql_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16330,7 +17066,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/neo4j.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/neo4j.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16349,7 +17087,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/postgresql_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/postgresql_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16368,7 +17108,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/redis_redis_rs.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/redis_redis_rs.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16387,7 +17129,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/sqlite_rust.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/sqlite_rust.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -16402,12 +17146,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/actix_web.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/actix_web.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -16422,55 +17170,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16485,12 +17210,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_axum.go","internal/engine/rules/rust/frameworks/axum.yaml"],
+            "cites": [
+              "internal/engine/http_endpoint_axum.go",
+              "internal/engine/rules/rust/frameworks/axum.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_axum.go"],
+            "cites": [
+              "internal/engine/http_endpoint_axum.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -16505,55 +17235,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16568,12 +17275,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/gotham.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/gotham.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -16588,55 +17299,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16651,12 +17339,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/hyper.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/hyper.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -16671,55 +17363,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16734,12 +17403,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/poem.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/poem.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -16754,55 +17427,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16817,12 +17467,17 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rocket_routes.go","internal/engine/rules/rust/frameworks/rocket.yaml"],
+            "cites": [
+              "internal/engine/rocket_routes.go",
+              "internal/engine/rules/rust/frameworks/rocket.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rocket_routes.go"],
+            "cites": [
+              "internal/engine/rocket_routes.go"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -16837,55 +17492,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16916,55 +17548,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16988,43 +17597,6 @@
           "native_module_imports": {
             "status": "missing"
           }
-        },
-        "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
-          }
         }
       }
     },
@@ -17038,12 +17610,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/tide.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/tide.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -17058,55 +17634,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17137,55 +17690,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17200,12 +17730,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/warp.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
+            "cites": [
+              "internal/engine/rules/rust/frameworks/warp.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -17220,55 +17754,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/rust.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17284,12 +17795,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/diesel.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/diesel.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -17325,7 +17840,9 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/rusqlite.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/rusqlite.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -17341,12 +17858,16 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/seaorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/seaorm.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -17362,12 +17883,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/sqlx.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
+          "cites": [
+            "internal/engine/rules/rust/orms/sqlx.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -17382,12 +17907,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -17402,55 +17931,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17481,55 +17987,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17547,7 +18030,9 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/cats_effect.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/cats_effect.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -17562,55 +18047,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17625,12 +18087,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/finatra.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/finatra.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -17645,55 +18111,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17708,12 +18151,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/http4s.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/http4s.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -17728,55 +18175,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17791,12 +18215,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/lagom.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/lagom.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -17811,55 +18239,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17927,55 +18332,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17990,12 +18372,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/scalatra.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/scalatra.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -18010,55 +18396,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18073,12 +18436,16 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/zio.yaml"
+            ],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
+            "cites": [
+              "internal/engine/rules/scala/frameworks/zio.yaml"
+            ],
             "verified_at": "2026-05-28"
           }
         },
@@ -18093,55 +18460,32 @@
           }
         },
         "Substrate": {
-          "confidence_overlay": {
-            "status": "full",
-            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
-            "verified_at": "2026-05-28"
-          },
           "constant_propagation": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "db_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "fs_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "http_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
+            "cites": [
+              "internal/links/constant_propagation.go",
+              "internal/substrate/scala.go",
+              "internal/substrate/substrate.go"
+            ],
             "verified_at": "2026-05-27"
-          },
-          "mutation_effect": {
-            "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
-            "verified_at": "2026-05-28"
-          },
-          "reachability_analysis": {
-            "status": "full",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18157,12 +18501,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/doobie.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/doobie.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18178,12 +18526,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/elastic4s.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/elastic4s.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18199,12 +18551,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/quill.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/quill.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18220,12 +18576,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18241,12 +18601,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/scanamo.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/scanamo.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18262,12 +18626,16 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/slick.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
+          "cites": [
+            "internal/engine/rules/scala/orms/slick.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18294,17 +18662,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18334,17 +18708,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18357,17 +18737,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/debezium_cdc_edges.go"],
+          "cites": [
+            "internal/engine/debezium_cdc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/debezium_cdc_edges.go"],
+          "cites": [
+            "internal/engine/debezium_cdc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/debezium_cdc_edges.go"],
+          "cites": [
+            "internal/engine/debezium_cdc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18380,17 +18766,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18403,17 +18795,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18426,17 +18824,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/pubsub_edges.go"],
+          "cites": [
+            "internal/engine/pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/pubsub_edges.go"],
+          "cites": [
+            "internal/engine/pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/pubsub_edges.go"],
+          "cites": [
+            "internal/engine/pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18449,17 +18853,24 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/kafka_edges.go"],
+          "cites": [
+            "internal/engine/kafka_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/kafka_edges.go","internal/engine/kafka_wrapper_edges.go"],
+          "cites": [
+            "internal/engine/kafka_edges.go",
+            "internal/engine/kafka_wrapper_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/kafka_edges.go"],
+          "cites": [
+            "internal/engine/kafka_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18472,17 +18883,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/event_bus_edges.go"],
+          "cites": [
+            "internal/engine/event_bus_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18495,17 +18912,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/nats_edges.go"],
+          "cites": [
+            "internal/engine/nats_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/nats_edges.go"],
+          "cites": [
+            "internal/engine/nats_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/nats_edges.go"],
+          "cites": [
+            "internal/engine/nats_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18518,17 +18941,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/pulsar_edges.go"],
+          "cites": [
+            "internal/engine/pulsar_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/pulsar_edges.go"],
+          "cites": [
+            "internal/engine/pulsar_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/pulsar_edges.go"],
+          "cites": [
+            "internal/engine/pulsar_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18541,17 +18970,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rabbitmq_edges.go"],
+          "cites": [
+            "internal/engine/rabbitmq_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18560,21 +18995,27 @@
       "id": "msg.broker.redis",
       "category": "message_broker",
       "language": "multi",
-      "label": "Redis pub/sub \u0026 streams",
+      "label": "Redis pub/sub & streams",
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/redis_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/redis_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18587,17 +19028,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/iac_sns_edges.go"],
+          "cites": [
+            "internal/engine/iac_sns_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/iac_sns_edges.go"],
+          "cites": [
+            "internal/engine/iac_sns_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/iac_sns_edges.go"],
+          "cites": [
+            "internal/engine/iac_sns_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18610,17 +19057,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/sqs_edges.go"],
+          "cites": [
+            "internal/engine/sqs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/sqs_edges.go"],
+          "cites": [
+            "internal/engine/sqs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/sqs_edges.go"],
+          "cites": [
+            "internal/engine/sqs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18633,17 +19086,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": [
+            "internal/links/topic_pass.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18656,17 +19115,24 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/extractors/python/celery.go"],
+          "cites": [
+            "internal/engine/scheduled_jobs_edges.go",
+            "internal/extractors/python/celery.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/links/topic_pass.go"],
+          "cites": [
+            "internal/links/topic_pass.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18679,17 +19145,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/django_signal_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/django_signal_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
+          "cites": [
+            "internal/engine/django_signal_pubsub_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18716,17 +19188,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18767,12 +19245,16 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/sse_edges.go"],
+          "cites": [
+            "internal/engine/sse_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/sse_edges.go"],
+          "cites": [
+            "internal/engine/sse_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
@@ -18788,17 +19270,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/webhooks_edges.go"],
+          "cites": [
+            "internal/engine/webhooks_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/webhooks_edges.go"],
+          "cites": [
+            "internal/engine/webhooks_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/webhooks_edges.go"],
+          "cites": [
+            "internal/engine/webhooks_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18811,17 +19299,23 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/websocket_edges.go"],
+          "cites": [
+            "internal/engine/websocket_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": ["internal/engine/websocket_edges.go"],
+          "cites": [
+            "internal/engine/websocket_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/websocket_edges.go"],
+          "cites": [
+            "internal/engine/websocket_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18837,7 +19331,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18881,7 +19377,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18897,7 +19395,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18938,7 +19438,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18965,7 +19467,9 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18981,7 +19485,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -18997,7 +19503,9 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19010,7 +19518,9 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "cites": [
+            "internal/extractors/cross/manifest/extractor.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19045,17 +19555,24 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": ["internal/engine/http_endpoint_match.go"],
+          "cites": [
+            "internal/engine/http_endpoint_match.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": ["internal/engine/graphql_subscriptions.go","internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
+          "cites": [
+            "internal/engine/graphql_subscriptions.go",
+            "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19068,17 +19585,23 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "full",
-          "cites": ["internal/engine/grpc_edges.go"],
+          "cites": [
+            "internal/engine/grpc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/engine/grpc_edges.go"],
+          "cites": [
+            "internal/engine/grpc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": ["internal/engine/grpc_edges.go"],
+          "cites": [
+            "internal/engine/grpc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19108,17 +19631,23 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": ["internal/engine/http_endpoint_match.go"],
+          "cites": [
+            "internal/engine/http_endpoint_match.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/engine/rules/openapi/language.yaml"],
+          "cites": [
+            "internal/engine/rules/openapi/language.yaml"
+          ],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/openapi/language.yaml"],
+          "cites": [
+            "internal/engine/rules/openapi/language.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19131,17 +19660,24 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": ["internal/engine/grpc_edges.go"],
+          "cites": [
+            "internal/engine/grpc_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/proto"],
+          "cites": [
+            "internal/extractors/proto"
+          ],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/protobuf/_manifest.yaml","internal/extractors/proto"],
+          "cites": [
+            "internal/engine/rules/protobuf/_manifest.yaml",
+            "internal/extractors/proto"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19167,11 +19703,13 @@
       "id": "security.auth-java",
       "category": "security",
       "language": "java",
-      "label": "Auth policy resolver (Java/Kotlin — Phase 1 of #1942)",
+      "label": "Auth policy resolver (Java/Kotlin \u2014 Phase 1 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19180,7 +19718,7 @@
       "id": "security.auth-other",
       "category": "security",
       "language": "multi",
-      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)",
+      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET \u2014 Phases 2-4 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "missing",
@@ -19196,7 +19734,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19215,7 +19755,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19234,7 +19776,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19253,7 +19797,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19289,7 +19835,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": ["internal/engine/java_auth_policy.go"],
+          "cites": [
+            "internal/engine/java_auth_policy.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19308,7 +19856,9 @@
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": ["internal/engine/rules/_engine/csrf_heuristic_detector.yaml"],
+          "cites": [
+            "internal/engine/rules/_engine/csrf_heuristic_detector.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19321,7 +19871,9 @@
       "capabilities": {
         "secret_detection": {
           "status": "full",
-          "cites": ["internal/secrets/secrets.go"],
+          "cites": [
+            "internal/secrets/secrets.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19334,7 +19886,9 @@
       "capabilities": {
         "sql_injection": {
           "status": "full",
-          "cites": ["internal/engine/rules/_engine/sql_injection_detector.yaml"],
+          "cites": [
+            "internal/engine/rules/_engine/sql_injection_detector.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19403,12 +19957,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/rust/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/rust/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19547,12 +20106,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/elixir/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/elixir/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19593,12 +20157,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/go/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/go/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19667,12 +20236,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/frameworks/jest.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/frameworks/jest.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19685,12 +20259,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/java/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19703,12 +20281,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/java/frameworks/junit5.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/java/frameworks/junit5.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19721,12 +20304,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ruby/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/ruby/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19739,12 +20326,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19785,12 +20376,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19817,12 +20412,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/csharp/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19849,12 +20448,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/php/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/php/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19895,12 +20499,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/python/frameworks/pytest.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/python/frameworks/pytest.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19927,12 +20536,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/ruby/frameworks/rspec.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/ruby/frameworks/rspec.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -19987,12 +20601,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/go/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/go/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -20008,7 +20626,9 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/java/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -20021,12 +20641,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/python/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/python/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -20039,12 +20663,16 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
+          "cites": [
+            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
+          ],
           "verified_at": "2026-05-28"
         }
       }
@@ -20057,12 +20685,17 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": ["internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/csharp/test_patterns.yaml","internal/engine/tests_edges.go"],
+          "cites": [
+            "internal/engine/rules/csharp/test_patterns.yaml",
+            "internal/engine/tests_edges.go"
+          ],
           "verified_at": "2026-05-28"
         }
       }

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -326,6 +326,19 @@ func RunAllPasses(group, graphsDir, archigraphHome string) (*RunResult, error) {
 	}
 	res.Results = append(res.Results, pEP)
 
+	// #2772 — Phase 2B taint-flow analysis. Runs after effect
+	// classification so taint roles share the same function-entity
+	// binding shape; runs before the label / string / HTTP passes so
+	// downstream queries reading entity.Properties see the taint_role
+	// annotation. Mutates entity.Properties in-memory and emits the
+	// <group>-links-taint.json sidecar consumed by the MCP
+	// archigraph_security_findings tool.
+	pTF, err := runTaintFlowPass(graphs, paths, rejects)
+	if err != nil {
+		return nil, fmt.Errorf("taint flow pass: %w", err)
+	}
+	res.Results = append(res.Results, pTF)
+
 	p2, err := runLabelPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("label pass: %w", err)

--- a/internal/links/taint_flow.go
+++ b/internal/links/taint_flow.go
@@ -1,0 +1,519 @@
+// Taint-flow propagation pass (#2772 Phase 2B substrate).
+//
+// Implements Phase 2B of the substrate epic (#2716): mark every
+// function entity that owns a taint source, BFS forward across the
+// CALLS graph, and emit a SecurityFinding for every source→...→sink
+// path that is not broken by a sanitizer of the matching category.
+//
+// Pipeline:
+//
+//   1. For every repo, walk the unique source-file set, dispatch each
+//      file through substrate.TaintSnifferFor(lang). Each TaintMatch
+//      is bound to its declaring function via the same nearest-header
+//      heuristic the effect_propagation pass uses.
+//
+//   2. Bind each TaintMatch to a graph entity via (repo, file, name).
+//
+//   3. Build the CALLS forward adjacency. For every function that
+//      owns at least one TaintKindSource match, run a bounded BFS
+//      (default depth 6, the same horizon as the call-chains
+//      Phase 1A's reverse-CALLS fixed-point handles). On each visited
+//      function:
+//        - if it owns a sanitizer match for the source's category,
+//          STOP propagation through this function for that category;
+//        - if it owns a sink match for any active category that has
+//          not yet been sanitised, emit a SecurityFinding.
+//
+//   4. Confidence model: source confidence × ∏(0.95 per hop), capped
+//      by the sink confidence. A direct source→sink with no hops is
+//      `min(source_conf, sink_conf)`; each additional hop multiplies
+//      by hopDecay. Findings below the confidenceFloor are dropped.
+//
+//   5. Write findings to a sidecar <group>-links-taint.json document
+//      for the MCP archigraph_security_findings tool to read.
+//
+// Storage model: same as the effect pass — no new entity kind. The
+// SecurityFinding records are persisted as the sidecar JSON only; the
+// graph is annotated with a `taint_role` property on functions that
+// own a source / sink / sanitizer match so MCP queries can ask
+// "is this function a known source?" without re-running the sniffer.
+package links
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/substrate"
+)
+
+// MethodTaintFlow identifies sidecar artefacts produced by the Phase
+// 2B taint-flow pass.
+const MethodTaintFlow = "taint_flow"
+
+// maxTaintPropagationDepth bounds the forward BFS from each source.
+// Empirically 6 covers handler→service→repo→raw-sql chains in upvate
+// and similar monorepos; anything beyond is almost always a cycle and
+// will be caught by the visited-set guard.
+const maxTaintPropagationDepth = 6
+
+// taintHopDecay scales confidence per CALLS hop, mirroring the effect
+// pass.
+const taintHopDecay = 0.95
+
+// taintConfidenceFloor drops findings whose final confidence would be
+// below this threshold. The issue spec calls "conservative > aggressive"
+// — anything below 0.5 is too speculative to surface without a manual
+// confirmation pass.
+const taintConfidenceFloor = 0.5
+
+// TaintFindingFloor returns taintConfidenceFloor for MCP consumers
+// that want to surface the pass's drop threshold in tool responses.
+func TaintFindingFloor() float64 { return taintConfidenceFloor }
+
+// TaintRolePropertyKey is the stable name under which the pass stamps
+// a function's lattice role (`source`, `sink`, `sanitizer`, or a
+// comma-joined union) onto entity.Properties.
+const TaintRolePropertyKey = "taint_role"
+
+// TaintFindingCountPropertyKey records, on the source function, how
+// many SecurityFinding records were emitted with that function as the
+// source. Lets MCP queries rank entry points by exposure.
+const TaintFindingCountPropertyKey = "taint_finding_count"
+
+// runTaintFlowPass is the entry point invoked from RunAllPasses after
+// the effect propagation pass. It mutates entity.Properties for
+// taint_role and emits the <group>-links-taint.json sidecar.
+func runTaintFlowPass(graphs []repoGraph, paths Paths, _ map[string]bool) (PassResult, error) {
+	res := PassResult{Pass: "taint_flow"}
+
+	// Per-function taint matches, bucketed by (repo, file, fn-name).
+	type fnKey struct{ repo, file, fn string }
+	matches := map[fnKey][]substrate.TaintMatch{}
+	scannedFiles := 0
+	for _, g := range graphs {
+		fileSet := map[string]bool{}
+		for _, e := range g.Entities {
+			if e.SourceFile != "" {
+				fileSet[e.SourceFile] = true
+			}
+		}
+		for file := range fileSet {
+			lang := substrate.LanguageForPath(file)
+			if lang == "" {
+				continue
+			}
+			sniff := substrate.TaintSnifferFor(lang)
+			if sniff == nil {
+				continue
+			}
+			srcRoot := repoSourcePathFor(g.Repo)
+			if srcRoot == "" {
+				srcRoot = g.FileRoot
+			}
+			abs := filepath.Join(srcRoot, file)
+			content, err := os.ReadFile(abs)
+			if err != nil {
+				continue
+			}
+			scannedFiles++
+			for _, m := range sniff(string(content)) {
+				if m.Function == "" {
+					continue
+				}
+				k := fnKey{repo: g.Repo, file: file, fn: m.Function}
+				matches[k] = append(matches[k], m)
+			}
+		}
+	}
+	if scannedFiles == 0 {
+		return res, nil
+	}
+
+	// Bind each fnKey to its graph entity ID. Reuse the effect
+	// propagation's binder — it's the same (repo, file, name) shape
+	// and the function-like-kind set hasn't drifted between passes.
+	binder := newEffectBinder(graphs)
+	byEntity := map[string][]substrate.TaintMatch{}
+	entityRepo := map[string]string{}
+	for k, ms := range matches {
+		eid := binder.lookup(k.repo, k.file, k.fn)
+		if eid == "" {
+			continue
+		}
+		full := entityKey(k.repo, eid)
+		byEntity[full] = append(byEntity[full], ms...)
+		entityRepo[full] = k.repo
+	}
+
+	// Forward CALLS adjacency.
+	calleesOf := map[string][]string{}
+	for _, g := range graphs {
+		for _, e := range g.Edges {
+			if !strings.EqualFold(e.Kind, "CALLS") && e.Kind != "calls" {
+				continue
+			}
+			src := entityKey(g.Repo, e.FromID)
+			tgt := entityKey(g.Repo, e.ToID)
+			calleesOf[src] = append(calleesOf[src], tgt)
+		}
+	}
+
+	// Walk forward from every entity that owns at least one source
+	// match. Each finding pairs a source with a sink, tracking the
+	// path of entity IDs traversed and the active sanitised-category
+	// set so a sanitizer mid-path cleanses downstream sinks of that
+	// category only.
+	findings := computeFindings(byEntity, entityRepo, calleesOf, graphs)
+
+	// Stamp the lattice role on every annotated entity so MCP queries
+	// can ask "is this function a source / sink / sanitizer?" without
+	// re-running the sniffer.
+	stamped := stampTaintRoles(graphs, byEntity, findings)
+	res.LinksAdded = stamped
+	res.Candidates = scannedFiles
+
+	if paths.Links != "" {
+		sidecar := strings.TrimSuffix(paths.Links, ".json") + "-taint.json"
+		if err := writeTaintDoc(sidecar, findings); err != nil {
+			return res, fmt.Errorf("write taint doc: %w", err)
+		}
+	}
+	return res, nil
+}
+
+// SecurityFinding is one source→sink path that the pass identified.
+// Exported because the MCP tool serialises it.
+type SecurityFinding struct {
+	// Fingerprint is a stable id derived from (source_id, sink_id,
+	// category). Re-runs do not duplicate findings.
+	Fingerprint string `json:"fingerprint"`
+	// SourceID is the entity that owns the taint source primitive.
+	SourceID string `json:"source_id"`
+	// SourcePrimitive identifies which source rule fired
+	// (e.g. "req.body/query/headers").
+	SourcePrimitive string `json:"source_primitive"`
+	// SourceLine is the 1-indexed line of the source primitive.
+	SourceLine int `json:"source_line"`
+	// SinkID is the entity that owns the sink primitive.
+	SinkID string `json:"sink_id"`
+	// SinkPrimitive identifies which sink rule fired.
+	SinkPrimitive string `json:"sink_primitive"`
+	// SinkLine is the 1-indexed line of the sink primitive.
+	SinkLine int `json:"sink_line"`
+	// Category labels the finding (sql_injection, command_injection,
+	// path_traversal, xss, redos, deserialization, ssrf, generic).
+	Category substrate.TaintCategory `json:"category"`
+	// Path is the ordered list of entity IDs visited from source to
+	// sink (inclusive of both endpoints).
+	Path []string `json:"path"`
+	// Confidence is the final aggregated confidence in [0, 1] after
+	// per-hop decay and source/sink confidence multiplication.
+	Confidence float64 `json:"confidence"`
+	// Repo is the repo slug that owns the source entity.
+	Repo string `json:"repo"`
+}
+
+// computeFindings is the core BFS. For every entity that owns a
+// TaintKindSource match, walk forward across CALLS up to
+// maxTaintPropagationDepth hops. At each hop:
+//
+//   - if the visited entity owns a sanitizer for the source's
+//     category (or TaintCategoryGeneric), record the category as
+//     sanitised on the active path so downstream sinks of that
+//     category are skipped;
+//   - if the visited entity owns a sink whose category is active
+//     and not sanitised, emit one SecurityFinding (deduplicated by
+//     fingerprint across alternative paths to the same sink).
+//
+// Per-finding confidence = source_conf × sink_conf × (decay ^ hops).
+func computeFindings(byEntity map[string][]substrate.TaintMatch, entityRepo map[string]string, calleesOf map[string][]string, _ []repoGraph) []SecurityFinding {
+	// Dedup findings across alternative paths — keep the highest
+	// confidence per (source_id, sink_id, category). The key type is
+	// declared inline (not a named alias) so it matches the inline
+	// struct literal used at the emitFindingsFrom call sites without
+	// the Go type checker rejecting it as a distinct named type.
+	best := map[struct {
+		src, sink string
+		cat       substrate.TaintCategory
+	}]SecurityFinding{}
+
+	// Stable iteration over source entities.
+	sources := make([]string, 0, len(byEntity))
+	for id, ms := range byEntity {
+		if hasKind(ms, substrate.TaintKindSource) {
+			sources = append(sources, id)
+		}
+	}
+	sort.Strings(sources)
+
+	for _, srcID := range sources {
+		for _, sm := range byEntity[srcID] {
+			if sm.Kind != substrate.TaintKindSource {
+				continue
+			}
+			// BFS from this source. Each queue entry carries the
+			// path, the running confidence, and the set of sanitised
+			// categories accumulated along the path.
+			type qe struct {
+				node       string
+				path       []string
+				conf       float64
+				sanitised  categorySet
+				depth      int
+			}
+			// Seed the initial sanitizer set with sanitizers that live
+			// in the SAME function as the source. Without this, a
+			// handler that both reads req.body AND wraps the value in
+			// a parameterised cursor.execute (the standard safe shape)
+			// would emit a false-positive SQL finding.
+			initial := categorySet{}
+			for _, sib := range byEntity[srcID] {
+				if sib.Kind != substrate.TaintKindSanitizer {
+					continue
+				}
+				initial.add(sib.Category)
+				if sib.Category == substrate.TaintCategoryGeneric {
+					initial.add(substrate.TaintCategorySQL)
+					initial.add(substrate.TaintCategoryXSS)
+					initial.add(substrate.TaintCategoryCommand)
+					initial.add(substrate.TaintCategoryPath)
+					initial.add(substrate.TaintCategoryReDoS)
+				}
+			}
+			start := qe{node: srcID, path: []string{srcID}, conf: sm.Confidence, sanitised: initial, depth: 0}
+			visited := map[string]bool{srcID: true}
+			queue := []qe{start}
+			// Direct-on-source sink check (a function that both reads
+			// req.body and execs subprocess on it without leaving).
+			emitFindingsFrom(byEntity[srcID], sm, srcID, srcID, []string{srcID}, sm.Confidence, initial, entityRepo, best)
+
+			for len(queue) > 0 {
+				cur := queue[0]
+				queue = queue[1:]
+				if cur.depth >= maxTaintPropagationDepth {
+					continue
+				}
+				// Stable callee order so output is deterministic.
+				callees := append([]string(nil), calleesOf[cur.node]...)
+				sort.Strings(callees)
+				for _, callee := range callees {
+					if visited[callee] {
+						continue
+					}
+					visited[callee] = true
+					nextConf := cur.conf * taintHopDecay
+					if nextConf < taintConfidenceFloor {
+						continue
+					}
+					calleeMatches := byEntity[callee]
+					nextSan := cur.sanitised.clone()
+					for _, cm := range calleeMatches {
+						if cm.Kind == substrate.TaintKindSanitizer {
+							nextSan.add(cm.Category)
+							// Generic sanitizer (e.g. zod schema)
+							// cleanses every category that lacks a
+							// dedicated sanitizer in this language.
+							if cm.Category == substrate.TaintCategoryGeneric {
+								nextSan.add(substrate.TaintCategorySQL)
+								nextSan.add(substrate.TaintCategoryXSS)
+								nextSan.add(substrate.TaintCategoryCommand)
+								nextSan.add(substrate.TaintCategoryPath)
+								nextSan.add(substrate.TaintCategoryReDoS)
+							}
+						}
+					}
+					nextPath := append(append([]string(nil), cur.path...), callee)
+					emitFindingsFrom(calleeMatches, sm, srcID, callee, nextPath, nextConf, nextSan, entityRepo, best)
+					queue = append(queue, qe{node: callee, path: nextPath, conf: nextConf, sanitised: nextSan, depth: cur.depth + 1})
+				}
+			}
+		}
+	}
+
+	out := make([]SecurityFinding, 0, len(best))
+	for _, f := range best {
+		out = append(out, f)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Confidence != out[j].Confidence {
+			return out[i].Confidence > out[j].Confidence
+		}
+		return out[i].Fingerprint < out[j].Fingerprint
+	})
+	return out
+}
+
+// emitFindingsFrom checks every sink match on the visited entity
+// against the running confidence + sanitised set and updates best.
+func emitFindingsFrom(matches []substrate.TaintMatch, src substrate.TaintMatch, srcID, sinkID string, path []string, conf float64, sanitised categorySet, entityRepo map[string]string, best map[struct {
+	src, sink string
+	cat       substrate.TaintCategory
+}]SecurityFinding) {
+	for _, m := range matches {
+		if m.Kind != substrate.TaintKindSink {
+			continue
+		}
+		if sanitised.has(m.Category) {
+			continue
+		}
+		// Category match. SSRF / Deserialization sources/sinks are
+		// also category-tagged. Generic sources can flow to any sink
+		// category; non-generic source categories MUST match the sink
+		// category (e.g. a deserialization-tagged source like
+		// pickle.loads doesn't trigger an SQL finding by itself —
+		// the request-body source upstream already did).
+		if src.Category != substrate.TaintCategoryGeneric && src.Category != m.Category {
+			continue
+		}
+		final := conf * m.Confidence
+		if final < taintConfidenceFloor {
+			continue
+		}
+		fp := fingerprint(srcID, sinkID, m.Category, src.Line, m.Line)
+		k := struct {
+			src, sink string
+			cat       substrate.TaintCategory
+		}{src: srcID, sink: sinkID, cat: m.Category}
+		if existing, ok := best[k]; ok && existing.Confidence >= final {
+			continue
+		}
+		best[k] = SecurityFinding{
+			Fingerprint:     fp,
+			SourceID:        srcID,
+			SourcePrimitive: src.Primitive,
+			SourceLine:      src.Line,
+			SinkID:          sinkID,
+			SinkPrimitive:   m.Primitive,
+			SinkLine:        m.Line,
+			Category:        m.Category,
+			Path:            append([]string(nil), path...),
+			Confidence:      final,
+			Repo:            entityRepo[srcID],
+		}
+	}
+}
+
+// fingerprint derives a stable id for a finding. Including source +
+// sink + category + line numbers means re-runs against unchanged code
+// produce byte-identical fingerprints, so downstream consumers can
+// dedupe without state.
+func fingerprint(srcID, sinkID string, cat substrate.TaintCategory, srcLine, sinkLine int) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s|%s|%s|%d|%d", srcID, sinkID, cat, srcLine, sinkLine)
+	return hex.EncodeToString(h.Sum(nil)[:16])
+}
+
+// stampTaintRoles writes the per-entity lattice role onto Properties.
+// Also stamps taint_finding_count on every source so MCP can rank
+// exposed entry points.
+func stampTaintRoles(graphs []repoGraph, byEntity map[string][]substrate.TaintMatch, findings []SecurityFinding) int {
+	roleByEntity := map[string]map[substrate.TaintKind]bool{}
+	for id, ms := range byEntity {
+		for _, m := range ms {
+			if roleByEntity[id] == nil {
+				roleByEntity[id] = map[substrate.TaintKind]bool{}
+			}
+			roleByEntity[id][m.Kind] = true
+		}
+	}
+	findingCount := map[string]int{}
+	for _, f := range findings {
+		findingCount[f.SourceID]++
+	}
+	stamped := 0
+	for ri := range graphs {
+		g := &graphs[ri]
+		for ei := range g.Entities {
+			e := &g.Entities[ei]
+			full := entityKey(g.Repo, e.ID)
+			roles := roleByEntity[full]
+			if len(roles) == 0 {
+				continue
+			}
+			if e.Properties == nil {
+				e.Properties = map[string]string{}
+			}
+			// Canonical order: source, sink, sanitizer.
+			parts := make([]string, 0, 3)
+			for _, k := range []substrate.TaintKind{substrate.TaintKindSource, substrate.TaintKindSink, substrate.TaintKindSanitizer} {
+				if roles[k] {
+					parts = append(parts, string(k))
+				}
+			}
+			e.Properties[TaintRolePropertyKey] = strings.Join(parts, ",")
+			if c := findingCount[full]; c > 0 {
+				e.Properties[TaintFindingCountPropertyKey] = fmt.Sprintf("%d", c)
+			}
+			stamped++
+		}
+	}
+	return stamped
+}
+
+// hasKind reports whether any match in ms is of kind k.
+func hasKind(ms []substrate.TaintMatch, k substrate.TaintKind) bool {
+	for _, m := range ms {
+		if m.Kind == k {
+			return true
+		}
+	}
+	return false
+}
+
+// categorySet is a tiny ordered-bit set over TaintCategory values.
+// Used by the BFS to track which categories have been sanitised
+// along the current path. Cheap to clone (one map alloc).
+type categorySet struct {
+	bits map[substrate.TaintCategory]struct{}
+}
+
+func (s *categorySet) has(c substrate.TaintCategory) bool {
+	if s.bits == nil {
+		return false
+	}
+	_, ok := s.bits[c]
+	return ok
+}
+
+func (s *categorySet) add(c substrate.TaintCategory) {
+	if s.bits == nil {
+		s.bits = map[substrate.TaintCategory]struct{}{}
+	}
+	s.bits[c] = struct{}{}
+}
+
+func (s categorySet) clone() categorySet {
+	if s.bits == nil {
+		return categorySet{}
+	}
+	out := categorySet{bits: make(map[substrate.TaintCategory]struct{}, len(s.bits))}
+	for k := range s.bits {
+		out.bits[k] = struct{}{}
+	}
+	return out
+}
+
+// taintDocument is the on-disk shape of <group>-links-taint.json.
+type taintDocument struct {
+	Version  int               `json:"version"`
+	Method   string            `json:"method"`
+	Findings []SecurityFinding `json:"findings"`
+}
+
+func writeTaintDoc(path string, findings []SecurityFinding) error {
+	doc := taintDocument{Version: 1, Method: MethodTaintFlow, Findings: findings}
+	buf, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, buf, 0o644)
+}

--- a/internal/links/taint_flow_test.go
+++ b/internal/links/taint_flow_test.go
@@ -1,0 +1,182 @@
+package links
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTaintFlow_DirectSourceSinkPython exercises the canonical Phase
+// 2B chain: a Flask-style handler reads request.args then passes the
+// value into cursor.execute with string formatting. The pass should
+// emit one SecurityFinding categorised as sql_injection.
+func TestTaintFlow_DirectSourceSinkPython(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "view.py", `
+from flask import request
+
+def search(cursor):
+    q = request.args.get("q")
+    cursor.execute("SELECT * FROM users WHERE name = '%s'" % q)
+    return cursor.fetchall()
+`)
+	graphs := []repoGraph{{
+		Repo:     "repo-a",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "s1", Name: "search", Kind: "SCOPE.Function", SourceFile: "view.py"},
+		},
+	}}
+	paths := Paths{Links: filepath.Join(root, "out", "links.json")}
+	res, err := runTaintFlowPass(graphs, paths, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.LinksAdded == 0 {
+		t.Fatal("expected at least one entity stamped with taint_role")
+	}
+	role := graphs[0].Entities[0].Properties[TaintRolePropertyKey]
+	if !strings.Contains(role, "source") || !strings.Contains(role, "sink") {
+		t.Errorf("entity taint_role=%q; want source+sink", role)
+	}
+	// Sidecar written and contains the finding.
+	raw, err := os.ReadFile(filepath.Join(root, "out", "links-taint.json"))
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	var doc taintDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse sidecar: %v", err)
+	}
+	if len(doc.Findings) == 0 {
+		t.Fatal("expected at least one SecurityFinding")
+	}
+	var sqlFound bool
+	for _, f := range doc.Findings {
+		if f.Category == "sql_injection" && f.Confidence >= 0.7 {
+			sqlFound = true
+		}
+	}
+	if !sqlFound {
+		t.Errorf("expected a sql_injection finding ≥0.7; got %+v", doc.Findings)
+	}
+}
+
+// TestTaintFlow_SanitizerBreaksPropagation verifies that a function
+// containing a parameterised-query sanitizer on the SQL path blocks
+// the finding even though a source and a sink-categoryitied call site
+// both exist in the chain. Conservative-> aggressive: false positives
+// erode trust.
+func TestTaintFlow_SanitizerBreaksPropagation(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "safe.py", `
+from flask import request
+
+def safe(cursor):
+    q = request.args.get("q")
+    cursor.execute("SELECT * FROM users WHERE name = %s", (q,))
+    return cursor.fetchall()
+`)
+	graphs := []repoGraph{{
+		Repo:     "repo-a",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "s1", Name: "safe", Kind: "SCOPE.Function", SourceFile: "safe.py"},
+		},
+	}}
+	paths := Paths{Links: filepath.Join(root, "out", "links.json")}
+	if _, err := runTaintFlowPass(graphs, paths, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(root, "out", "links-taint.json"))
+	var doc taintDocument
+	_ = json.Unmarshal(raw, &doc)
+	for _, f := range doc.Findings {
+		if f.Category == "sql_injection" {
+			t.Errorf("sanitizer present but sql_injection still flagged: %+v", f)
+		}
+	}
+}
+
+// TestTaintFlow_TransitiveCommandInjectionGo confirms the BFS reaches
+// a sink across one CALLS hop and decays confidence per hop.
+func TestTaintFlow_TransitiveCommandInjectionGo(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "h.go", `
+package h
+
+import "os/exec"
+
+func handler(r *Req) {
+	name := r.URL.Query().Get("name")
+	runCmd(name)
+}
+
+func runCmd(name string) {
+	exec.Command(name).Run()
+}
+`)
+	graphs := []repoGraph{{
+		Repo:     "repo-a",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "h", Name: "handler", Kind: "SCOPE.Function", SourceFile: "h.go"},
+			{ID: "r", Name: "runCmd", Kind: "SCOPE.Function", SourceFile: "h.go"},
+		},
+		Edges: []edgeRef{
+			{FromID: "h", ToID: "r", Kind: "CALLS"},
+		},
+	}}
+	paths := Paths{Links: filepath.Join(root, "out", "links.json")}
+	if _, err := runTaintFlowPass(graphs, paths, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(root, "out", "links-taint.json"))
+	var doc taintDocument
+	_ = json.Unmarshal(raw, &doc)
+	var got *SecurityFinding
+	for i := range doc.Findings {
+		if doc.Findings[i].Category == "command_injection" {
+			got = &doc.Findings[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("expected a command_injection finding; got %+v", doc.Findings)
+	}
+	if len(got.Path) < 2 {
+		t.Errorf("expected transitive finding (path ≥2 entities); got %v", got.Path)
+	}
+	if got.Confidence >= 1.0 {
+		t.Errorf("expected hop-decayed confidence < 1.0; got %v", got.Confidence)
+	}
+}
+
+// TestTaintFlow_NoSourceNoFinding documents the baseline: a function
+// with sinks but no taint source upstream is not flagged.
+func TestTaintFlow_NoSourceNoFinding(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "static.py", `
+def static_sql(cursor):
+    cursor.execute("SELECT 1")
+`)
+	graphs := []repoGraph{{
+		Repo:     "repo-a",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "s", Name: "static_sql", Kind: "SCOPE.Function", SourceFile: "static.py"},
+		},
+	}}
+	paths := Paths{Links: filepath.Join(root, "out", "links.json")}
+	if _, err := runTaintFlowPass(graphs, paths, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(root, "out", "links-taint.json"))
+	var doc taintDocument
+	_ = json.Unmarshal(raw, &doc)
+	if len(doc.Findings) != 0 {
+		t.Errorf("expected zero findings without a source; got %d", len(doc.Findings))
+	}
+}

--- a/internal/mcp/budget.go
+++ b/internal/mcp/budget.go
@@ -13,6 +13,11 @@ package mcp
 //     (only declared args: group, cwd; severity/endpoint/repo/limit are
 //     undeclared per the #1639 token-ceiling pattern) but the corpus of
 //     existing tools already sits near the ceiling, leaving no
-//     headroom for a 48th tool entry without a bump. The +500 keeps
-//     us under the 6000 hard cap with comfortable room for Phase 2B.
-const TokenCeiling = 5500
+//     headroom for a 48th tool entry without a bump.
+//   - 5500 → 6000: PR for #2772 Phase 2B — adds
+//     archigraph_security_findings for taint-flow source→sink findings.
+//     With #2770's payload-drift tool already in (49 tools post-rebase),
+//     the new tool's category / min_confidence / limit / source_repo
+//     args push the handshake near the prior ceiling; +500 restores
+//     headroom under the 6500 next-bump line.
+const TokenCeiling = 6000

--- a/internal/mcp/security_findings_tool.go
+++ b/internal/mcp/security_findings_tool.go
@@ -1,0 +1,246 @@
+// archigraph_security_findings MCP tool (#2772 Phase 2B substrate).
+//
+// Returns the SecurityFinding records produced by the taint-flow pass
+// (internal/links/taint_flow.go), ranked by confidence. Filters by
+// category, minimum confidence, and source/sink entity-id prefix so
+// the agent can drill into specific finding shapes.
+//
+// Response schema:
+//
+//   {
+//     "group":     "<group-name>",
+//     "count":     <int>,
+//     "findings":  [
+//       {
+//         "fingerprint":      "<hex>",
+//         "category":         "sql_injection" | ...,
+//         "confidence":       0.85,
+//         "source":           { "id", "name", "kind", "qualified_name",
+//                               "repo", "source_file", "primitive",
+//                               "line" },
+//         "sink":             { ... mirror of source },
+//         "path":             ["entity-id-1", ..., "entity-id-N"],
+//         "explanation":      "Tainted data from req.body reaches a raw
+//                              SQL exec on line 42 without a
+//                              parameterised-query sanitizer."
+//       },
+//       ...
+//     ],
+//     "by_category": { "sql_injection": 3, ... }
+//   }
+//
+// Confidence-floor reasoning: the taint pass drops findings below
+// 0.5 (#2772 spec: conservative > aggressive). The default
+// `min_confidence` here is 0.7 to surface only high-quality findings;
+// callers can lower it explicitly when they want every cell the pass
+// computed.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/links"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// defaultMinFindingConfidence is the floor applied when the caller does
+// not specify min_confidence. Chosen to match the archigraph-security-
+// audit skill's auto-submit threshold so findings surfaced here are the
+// same set the skill would auto-confirm.
+const defaultMinFindingConfidence = 0.7
+
+// handleSecurityFindings implements archigraph_security_findings. Args:
+//   - category        (optional): filter to one of the TaintCategory* keys
+//   - min_confidence  (optional, default 0.7): lower bound, in [0, 1]
+//   - limit           (optional, default 50): cap on returned findings
+//   - source_repo     (optional): filter to findings whose source entity
+//                                 is in the named repo
+func (s *Server) handleSecurityFindings(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	if lg.LinksFile == "" {
+		return jsonResult(map[string]any{
+			"group":       lg.Name,
+			"count":       0,
+			"findings":    []any{},
+			"by_category": map[string]int{},
+			"note":        "no links sidecar configured for this group; taint pass has not run",
+		}), nil
+	}
+	sidecar := strings.TrimSuffix(lg.LinksFile, ".json") + "-taint.json"
+	raw, err := os.ReadFile(sidecar)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return jsonResult(map[string]any{
+				"group":       lg.Name,
+				"count":       0,
+				"findings":    []any{},
+				"by_category": map[string]int{},
+				"note":        "no taint sidecar found; re-run the indexer to produce one",
+			}), nil
+		}
+		return mcpapi.NewToolResultError(fmt.Sprintf("read taint sidecar: %v", err)), nil
+	}
+	var doc struct {
+		Version  int                     `json:"version"`
+		Method   string                  `json:"method"`
+		Findings []links.SecurityFinding `json:"findings"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return mcpapi.NewToolResultError(fmt.Sprintf("parse taint sidecar: %v", err)), nil
+	}
+
+	categoryFilter := argString(req, "category", "")
+	minConf := argFloat(req, "min_confidence", defaultMinFindingConfidence)
+	limit := argInt(req, "limit", 50)
+	sourceRepo := argString(req, "source_repo", "")
+
+	out := make([]map[string]any, 0, len(doc.Findings))
+	byCategory := map[string]int{}
+	for _, f := range doc.Findings {
+		if f.Confidence < minConf {
+			continue
+		}
+		if categoryFilter != "" && string(f.Category) != categoryFilter {
+			continue
+		}
+		if sourceRepo != "" && f.Repo != sourceRepo {
+			continue
+		}
+		sourceEnt := resolveEntityByPrefixed(lg, f.SourceID)
+		sinkEnt := resolveEntityByPrefixed(lg, f.SinkID)
+		out = append(out, map[string]any{
+			"fingerprint": f.Fingerprint,
+			"category":    string(f.Category),
+			"confidence":  f.Confidence,
+			"source":      buildFindingEndpoint(sourceEnt, f.SourceID, f.SourcePrimitive, f.SourceLine),
+			"sink":        buildFindingEndpoint(sinkEnt, f.SinkID, f.SinkPrimitive, f.SinkLine),
+			"path":        f.Path,
+			"explanation": buildFindingExplanation(f, sourceEnt, sinkEnt),
+		})
+		byCategory[string(f.Category)]++
+	}
+	// Doc is already sorted by confidence descending; preserve that
+	// order across filtering then apply the limit.
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"group":              lg.Name,
+		"count":              len(out),
+		"findings":           out,
+		"by_category":        byCategory,
+		"min_confidence":     minConf,
+		"confidence_floor":   links.TaintFindingFloor(),
+		"taint_method":       doc.Method,
+	}), nil
+}
+
+// resolveEntityByPrefixed returns the resolved entity for a "<repo>:<id>"
+// prefixed key, or nil when no repo / entity matches. Mirrors the
+// resolver pattern from effects_tool.go.
+func resolveEntityByPrefixed(lg *LoadedGroup, key string) *graph.Entity {
+	repo, local := splitPrefixed(key)
+	if repo == "" {
+		return nil
+	}
+	r, ok := lg.Repos[repo]
+	if !ok || r.Doc == nil {
+		return nil
+	}
+	if r.LabelIndex == nil {
+		return nil
+	}
+	if e, ok := r.LabelIndex.ByID[local]; ok {
+		return e
+	}
+	return nil
+}
+
+func buildFindingEndpoint(e *graph.Entity, id, primitive string, line int) map[string]any {
+	out := map[string]any{
+		"id":        id,
+		"primitive": primitive,
+		"line":      line,
+	}
+	if e != nil {
+		out["name"] = e.Name
+		out["kind"] = e.Kind
+		out["qualified_name"] = e.QualifiedName
+		out["source_file"] = e.SourceFile
+	}
+	return out
+}
+
+func buildFindingExplanation(f links.SecurityFinding, src, sink *graph.Entity) string {
+	srcLabel := f.SourceID
+	if src != nil && src.Name != "" {
+		srcLabel = src.Name
+	}
+	sinkLabel := f.SinkID
+	if sink != nil && sink.Name != "" {
+		sinkLabel = sink.Name
+	}
+	hops := len(f.Path) - 1
+	if hops < 0 {
+		hops = 0
+	}
+	cat := categoryNarrative(f.Category)
+	if hops == 0 {
+		return fmt.Sprintf(
+			"%s: tainted input from %s (%s, line %d) reaches the sink %s (%s, line %d) inside the same function with no sanitizer in between. Confidence %.2f.",
+			cat, srcLabel, f.SourcePrimitive, f.SourceLine, sinkLabel, f.SinkPrimitive, f.SinkLine, f.Confidence,
+		)
+	}
+	return fmt.Sprintf(
+		"%s: tainted input from %s (%s, line %d) flows through %d call hop(s) to the sink %s (%s, line %d) without a sanitizer of category %s on the path. Confidence %.2f.",
+		cat, srcLabel, f.SourcePrimitive, f.SourceLine, hops, sinkLabel, f.SinkPrimitive, f.SinkLine, f.Category, f.Confidence,
+	)
+}
+
+// categoryNarrative returns a short prose label for the finding's
+// category. Used by the explanation builder so the agent gets a
+// human-readable lead rather than a slug.
+func categoryNarrative(cat any) string {
+	s := fmt.Sprintf("%v", cat)
+	switch s {
+	case "sql_injection":
+		return "SQL injection"
+	case "command_injection":
+		return "Command / dynamic-code injection"
+	case "path_traversal":
+		return "Path traversal"
+	case "xss":
+		return "Cross-site scripting"
+	case "redos":
+		return "Regular-expression DoS"
+	case "deserialization":
+		return "Unsafe deserialization"
+	case "ssrf":
+		return "Server-side request forgery"
+	}
+	return "Security finding"
+}
+
+// orderForStableOutput sorts the by_category map for stable JSON
+// output. Not strictly necessary because the encoder sorts map keys,
+// but documents intent for future readers.
+//
+//nolint:unused // referenced when stable map-output is debugged.
+func orderForStableOutput(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -496,6 +496,22 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_payload_drift", s.handlePayloadDrift))
 
+	// #2772 — Phase 2B taint flow / security findings. Returns
+	// SecurityFinding records emitted by the taint-flow pass:
+	// source→...→sink paths through the CALLS graph that lack an
+	// intervening sanitizer. Findings are ranked by confidence
+	// (default floor 0.7). Filterable by category, min_confidence,
+	// source repo, and limit.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_security_findings",
+		mcpapi.WithDescription("Taint-flow security findings: source→sink paths ranked by confidence."),
+		mcpapi.WithString("category"),
+		mcpapi.WithNumber("min_confidence"),
+		mcpapi.WithNumber("limit"),
+		mcpapi.WithString("source_repo"),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_security_findings", s.handleSecurityFindings))
+
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_stats",
 		mcpapi.WithDescription("Corpus-level metrics. breakdown=unresolved_imports adds edge taxonomy."),
 		mcpapi.WithAny("group"),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -585,6 +585,8 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_effects",
 		// #2770 Phase 2A payload-shape drift findings.
 		"archigraph_payload_drift",
+		// #2772 Phase 2B taint-flow security findings surface
+		"archigraph_security_findings",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -670,8 +672,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_dead_code (#2766 Phase 1B reachability + dead-code).
 	// +1 archigraph_effects (#2764 Phase 1A effect classification).
 	// +1 archigraph_payload_drift (#2770 Phase 2A drift findings).
-	if got := len(allRegisteredTools); got != 48 {
-		t.Errorf("expected 48 registered tools, got %d — update this count if tools are added/removed (added archigraph_dead_code #2766 + archigraph_effects #2764 + archigraph_payload_drift #2770)", got)
+	// +1 archigraph_security_findings (#2772 Phase 2B taint-flow).
+	if got := len(allRegisteredTools); got != 49 {
+		t.Errorf("expected 49 registered tools, got %d — update this count if tools are added/removed (added archigraph_security_findings #2772)", got)
 	}
 }
 
@@ -3174,6 +3177,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_effects": {"group": "g", "entity_id": "DashboardScreen"},
 		// #2770 Phase 2A payload-shape drift — no required args.
 		"archigraph_payload_drift": {"group": "g"},
+		// #2772 Phase 2B taint-flow — no required args.
+		"archigraph_security_findings": {"group": "g"},
 	}
 
 	// extractElapsedMS mirrors the bench extraction logic:
@@ -3218,8 +3223,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 48 {
-		t.Errorf("expected 48 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_dead_code #2766 + archigraph_effects #2764 + archigraph_payload_drift #2770)", len(tools))
+	if len(tools) != 49 {
+		t.Errorf("expected 49 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_security_findings #2772)", len(tools))
 	}
 
 	for _, st := range tools {

--- a/internal/substrate/taint_sites.go
+++ b/internal/substrate/taint_sites.go
@@ -1,0 +1,153 @@
+// Taint-flow substrate (#2772 Phase 2B).
+//
+// Taint analysis tags every function declaration with the union of
+// taint-relevant primitives that occur within it:
+//
+//   - sources    : untrusted-input primitives (HTTP request body / query
+//                  / headers / cookies, env vars, file reads of
+//                  user-controlled paths, JSON deserialisation from an
+//                  untrusted byte slice).
+//   - sinks      : security-sensitive operations (raw SQL exec with
+//                  string concatenation, shell exec, eval, regex
+//                  construction from a non-literal, file writes with a
+//                  non-literal path, HTML output without escaping).
+//   - sanitizers : primitives that statically prove the value flowing
+//                  through them is safe at this point (parameterised
+//                  SQL, html.escape / bleach / DOMPurify, validation
+//                  library schema declarations — zod / joi /
+//                  marshmallow / pydantic).
+//
+// The per-language sniffer is the only language-aware piece; the
+// generic propagation pass at internal/links/taint_flow.go consumes
+// TaintMatch records to compute SecurityFinding records.
+//
+// Design choices echo the Phase 1A effect substrate (see effects.go):
+//
+//   - Sniffers are stateless, deterministic, nil-safe.
+//   - Sniffers attribute each match to the nearest preceding function
+//     header so the propagation pass can bind matches to graph entities
+//     via (repo, file, function-name) without a per-language symbol
+//     table.
+//   - Confidence is set by the sniffer per kind: well-known primitives
+//     (e.g. cursor.execute with a literal SELECT) are 1.0; heuristic
+//     matches drop to 0.7-0.85.
+//
+// Hard rule per the issue spec: validation libraries count as
+// sanitizers ONLY when the call shape is a schema declaration (zod's
+// `z.object({...})`, marshmallow's `class FooSchema(Schema)`, etc.).
+// A bare `parse()` call without a paired schema does NOT count — that
+// is enforced inside each per-language sniffer.
+package substrate
+
+import "sort"
+
+// TaintKind labels the role a primitive plays in the source/sink/
+// sanitizer lattice.
+type TaintKind string
+
+const (
+	// TaintKindSource marks an untrusted-input primitive.
+	TaintKindSource TaintKind = "source"
+	// TaintKindSink marks a security-sensitive operation that should
+	// not receive tainted input without an intervening sanitizer.
+	TaintKindSink TaintKind = "sink"
+	// TaintKindSanitizer marks a primitive that proves its input is
+	// safe at the call site — taint flowing into the call is
+	// considered cleansed downstream.
+	TaintKindSanitizer TaintKind = "sanitizer"
+)
+
+// TaintCategory is the finer-grained classification used by the
+// propagation pass to label SecurityFinding records (sql_injection,
+// command_injection, path_traversal, xss, redos, deserialisation,
+// open_redirect — broader than the OWASP top-10 but unified across
+// languages so the MCP tool can rank cross-language).
+type TaintCategory string
+
+const (
+	// TaintCategorySQL — raw SQL exec / query without parameter binding.
+	TaintCategorySQL TaintCategory = "sql_injection"
+	// TaintCategoryCommand — shell / process exec, eval, dynamic code.
+	TaintCategoryCommand TaintCategory = "command_injection"
+	// TaintCategoryPath — file open / read / write with a path derived
+	// from untrusted input (path traversal).
+	TaintCategoryPath TaintCategory = "path_traversal"
+	// TaintCategoryXSS — HTML / template output without escaping.
+	TaintCategoryXSS TaintCategory = "xss"
+	// TaintCategoryReDoS — regex constructed from a non-literal pattern.
+	TaintCategoryReDoS TaintCategory = "redos"
+	// TaintCategoryDeserialization — pickle.loads / yaml.load /
+	// ObjectInputStream.readObject style untrusted deserialisation.
+	TaintCategoryDeserialization TaintCategory = "deserialization"
+	// TaintCategorySSRF — outbound HTTP request to a user-controlled URL.
+	TaintCategorySSRF TaintCategory = "ssrf"
+	// TaintCategoryGeneric — primitive that is sensitive but does not
+	// fit the named categories cleanly (still emitted, ranked lower).
+	TaintCategoryGeneric TaintCategory = "generic"
+)
+
+// TaintMatch is one detected taint-relevant primitive inside a function
+// body. Mirrors EffectMatch's shape so reviewers reading both files see
+// the same skeleton.
+type TaintMatch struct {
+	// Function is the declaring function/method name that owns the
+	// primitive. Empty when the primitive occurs at module scope; the
+	// propagation pass drops module-scope matches because security
+	// findings without a containing function are not actionable.
+	Function string
+	// Line is the 1-indexed source line of the primitive.
+	Line int
+	// Kind is the lattice role of this match.
+	Kind TaintKind
+	// Category narrows the kind (sinks and a few sources carry one).
+	// Sanitizers carry the category they cleanse (e.g. parameterised
+	// SQL is TaintCategorySQL) so the propagation pass can pair them.
+	Category TaintCategory
+	// Primitive is a short tag identifying the matched primitive
+	// (e.g. "cursor.execute(non-literal)", "subprocess.run(shell=True)",
+	// "html.escape", "z.object"). Surfaced by archigraph_security_findings
+	// so the agent can see why a function is flagged.
+	Primitive string
+	// Confidence is the per-match confidence in [0, 1]. Direct
+	// matches against well-known primitives are 1.0; heuristic
+	// matches drop to 0.7-0.85.
+	Confidence float64
+}
+
+// TaintSnifferFn is the contract for per-language taint-site sniffers.
+// Input: raw file content. Output: every detected TaintMatch in source
+// order (deterministic — identical content yields identical slices, so
+// graph output stays byte-identical across runs).
+type TaintSnifferFn func(content string) []TaintMatch
+
+// taintRegistry holds the registered per-language taint sniffers.
+// Populated via init() in each per-language taint_sites_*.go file.
+var taintRegistry = map[string]TaintSnifferFn{}
+
+// RegisterTaintSniffer installs a per-language taint sniffer. Mirrors
+// RegisterEffectSniffer; the two registries are independent so a
+// language can ship one without the other (T1 ships both; T2 ships
+// effects first, then taint in a follow-up issue).
+func RegisterTaintSniffer(lang string, fn TaintSnifferFn) {
+	if lang == "" || fn == nil {
+		return
+	}
+	taintRegistry[lang] = fn
+}
+
+// TaintSnifferFor returns the per-language taint sniffer, or nil when
+// none is registered. Callers must nil-check before invocation.
+func TaintSnifferFor(lang string) TaintSnifferFn {
+	return taintRegistry[lang]
+}
+
+// TaintLanguages returns the slugs of every registered taint-sniffer
+// language in sorted order.
+func TaintLanguages() []string {
+	out := make([]string, 0, len(taintRegistry))
+	for k := range taintRegistry {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/substrate/taint_sites_golang.go
+++ b/internal/substrate/taint_sites_golang.go
@@ -1,0 +1,161 @@
+// Go taint-sites sniffer (#2772 Phase 2B T1).
+//
+// Recognises Go source / sink / sanitizer primitives across the
+// net/http stdlib, popular routers (gin, chi, echo, fiber), the
+// database/sql package, and the os/exec command-runner.
+//
+// Sources:
+//   - r.URL.Query() / r.Form / r.PostForm / r.MultipartForm
+//   - r.Header.Get / r.Cookie
+//   - r.Body (io.Reader of request body)
+//   - gin: c.Query / c.Param / c.PostForm / c.GetHeader / c.GetRawData
+//   - chi: chi.URLParam
+//   - echo: c.QueryParam / c.Param / c.FormValue
+//   - fiber: c.Query / c.Params / c.FormValue / c.Body
+//   - os.Getenv
+//   - json.Unmarshal of a non-literal byte slice
+//
+// Sinks:
+//   - SQL injection: db.Query / Exec / QueryRow with a fmt.Sprintf or
+//     concatenated string
+//   - Command injection: exec.Command / exec.CommandContext with a
+//     non-literal first arg (program name) or with `/bin/sh -c <var>`
+//   - Path traversal: os.Open / os.ReadFile / os.Create /
+//     os.WriteFile / filepath.Join with a non-literal segment
+//   - XSS: w.Write of an unescaped []byte built from input;
+//     template/html non-escaped use (text/template — html/template
+//     auto-escapes)
+//   - ReDoS: regexp.Compile / MustCompile with a non-literal
+//   - SSRF: http.Get / http.Post with a non-literal URL
+//
+// Sanitizers:
+//   - Parameterised SQL: db.Query / Exec with `?` or `$1`
+//     placeholders AND a trailing parameter slice — pattern: the SQL
+//     literal contains a placeholder character and the call has more
+//     than one argument
+//   - html.EscapeString / template.HTMLEscapeString
+//   - go-playground/validator: a struct field carrying a `validate:`
+//     tag counts as a schema declaration
+package substrate
+
+import "regexp"
+
+func init() { RegisterTaintSniffer("go", sniffTaintGo) }
+
+// goSourceHTTPReqRe matches the canonical net/http request access
+// patterns. The leading `\b` keeps it from matching `xr.URL.Query`.
+var goSourceHTTPReqRe = regexp.MustCompile(
+	`\br\s*\.\s*(?:URL\s*\.\s*Query|Form|PostForm|MultipartForm|Header\s*\.\s*Get|Cookie|Body)\b` +
+		`|\breq\s*\.\s*(?:URL\s*\.\s*Query|Form|PostForm|Body|Header\s*\.\s*Get)\b`,
+)
+
+// goSourceGinRe matches gin's context input methods.
+var goSourceGinRe = regexp.MustCompile(
+	`\bc\s*\.\s*(?:Query|QueryArray|Param|PostForm|GetHeader|GetRawData|ShouldBind(?:JSON|Query|Header)?|Bind(?:JSON|Query|Header)?)\s*\(`,
+)
+
+// goSourceChiEchoFiberRe matches chi/echo/fiber input getters.
+var goSourceChiEchoFiberRe = regexp.MustCompile(
+	`\bchi\s*\.\s*URLParam\s*\(` +
+		`|\bc\s*\.\s*(?:QueryParam|FormValue|Params|Body)\s*\(`,
+)
+
+// goSourceEnvRe matches os.Getenv / os.LookupEnv.
+var goSourceEnvRe = regexp.MustCompile(
+	`\bos\s*\.\s*(?:Getenv|LookupEnv)\s*\(`,
+)
+
+// goSourceDeserialRe matches json.Unmarshal of a non-literal.
+var goSourceDeserialRe = regexp.MustCompile(
+	`\bjson\s*\.\s*Unmarshal\s*\(\s*[A-Za-z_][\w]*\s*,`,
+)
+
+// goSinkSQLRe matches db.Query/Exec/QueryRow when the first arg is a
+// fmt.Sprintf call or a concatenated string. The parameterised case
+// (`db.Query("SELECT ... WHERE id = ?", id)`) is detected as the
+// sanitizer; here we deliberately require fmt.Sprintf or `+`.
+var goSinkSQLRe = regexp.MustCompile(
+	`\b(?:db|tx|stmt|conn)\s*\.\s*(?:Query|QueryContext|QueryRow|QueryRowContext|Exec|ExecContext)\s*\(\s*(?:fmt\s*\.\s*Sprintf|[A-Za-z_][\w]*\s*\+)`,
+)
+
+// goSinkExecRe matches exec.Command / CommandContext with a non-
+// literal first arg or a shell-invocation pattern.
+var goSinkExecRe = regexp.MustCompile(
+	`\bexec\s*\.\s*(?:Command|CommandContext)\s*\(\s*(?:[A-Za-z_][\w]*\s*[,)]|"[^"]*sh"\s*,\s*"-c"\s*,\s*[A-Za-z_][\w]*\b)`,
+)
+
+// goSinkFSRe matches os.Open / ReadFile / Create / WriteFile when the
+// path argument is a non-literal identifier. filepath.Join with a
+// non-literal segment is included separately.
+var goSinkFSRe = regexp.MustCompile(
+	`\bos\s*\.\s*(?:Open|OpenFile|ReadFile|Create|WriteFile|Remove|RemoveAll)\s*\(\s*[A-Za-z_][\w]*\s*[,)]` +
+		`|\bfilepath\s*\.\s*Join\s*\([^)]*[A-Za-z_][\w]*\s*\)`,
+)
+
+// goSinkXSSRe matches w.Write of a non-literal byte slice. Many false
+// positives here (a typical response body write); we tag it lower
+// confidence to let the propagation pass weight it accordingly.
+var goSinkXSSRe = regexp.MustCompile(
+	`\bw\s*\.\s*Write\s*\(\s*\[\]byte\s*\(\s*[A-Za-z_][\w]*\s*\)` +
+		`|\btext/template\b` + // text/template never escapes
+		`|\.Execute\s*\(\s*w\s*,\s*[A-Za-z_][\w]*\s*\)`,
+)
+
+// goSinkReDoSRe matches regexp.Compile / MustCompile with a
+// non-literal pattern.
+var goSinkReDoSRe = regexp.MustCompile(
+	`\bregexp\s*\.\s*(?:Compile|MustCompile|CompilePOSIX|MustCompilePOSIX)\s*\(\s*[A-Za-z_][\w]*\s*[,)]`,
+)
+
+// goSinkSSRFRe matches outbound HTTP with a non-literal URL.
+var goSinkSSRFRe = regexp.MustCompile(
+	`\bhttp\s*\.\s*(?:Get|Post|Head|PostForm)\s*\(\s*[A-Za-z_][\w]*\s*[,)]`,
+)
+
+// goSanitizerSQLRe matches the parameterised-query convention: the
+// SQL literal contains a placeholder (`?` or `$N`) AND there is at
+// least one comma-separated arg after it. database/sql passes the
+// remaining args as values bound to placeholders, which is safe.
+var goSanitizerSQLRe = regexp.MustCompile(
+	`\b(?:db|tx|stmt|conn)\s*\.\s*(?:Query|QueryContext|QueryRow|QueryRowContext|Exec|ExecContext)\s*\(\s*(?:ctx\s*,\s*)?"[^"]*(?:\?|\$[0-9]+)[^"]*"\s*,`,
+)
+
+// goSanitizerHTMLRe matches html.EscapeString /
+// template.HTMLEscapeString.
+var goSanitizerHTMLRe = regexp.MustCompile(
+	`\bhtml\s*\.\s*EscapeString\s*\(` +
+		`|\btemplate\s*\.\s*HTMLEscapeString\s*\(` +
+		`|\bhtml/template\b`,
+)
+
+// goSanitizerValidateRe matches the go-playground/validator schema-
+// declaration pattern: a struct field carrying a `validate:` tag.
+// HARD RULE per #2772: bare validator.New().Struct(...) without a
+// tag is not detectable as a sanitizer; we require the tag presence
+// in the file to count the validator as installed.
+var goSanitizerValidateRe = regexp.MustCompile(
+	"`[^`]*\\bvalidate:\"[^\"]+\"[^`]*`",
+)
+
+func sniffTaintGo(content string) []TaintMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanGoFuncHeaders(content)
+	var out []TaintMatch
+	out = appendTaintMatches(out, content, headers, goSourceHTTPReqRe, TaintKindSource, TaintCategoryGeneric, "r.URL.Query/Form/Body", 1.0)
+	out = appendTaintMatches(out, content, headers, goSourceGinRe, TaintKindSource, TaintCategoryGeneric, "gin.Context input", 0.95)
+	out = appendTaintMatches(out, content, headers, goSourceChiEchoFiberRe, TaintKindSource, TaintCategoryGeneric, "chi/echo/fiber input", 0.95)
+	out = appendTaintMatches(out, content, headers, goSourceEnvRe, TaintKindSource, TaintCategoryGeneric, "os.Getenv", 0.85)
+	out = appendTaintMatches(out, content, headers, goSourceDeserialRe, TaintKindSource, TaintCategoryDeserialization, "json.Unmarshal(ident, ...)", 0.7)
+	out = appendTaintMatches(out, content, headers, goSanitizerSQLRe, TaintKindSanitizer, TaintCategorySQL, "db.Query(sql,?args)", 1.0)
+	out = appendTaintMatches(out, content, headers, goSanitizerHTMLRe, TaintKindSanitizer, TaintCategoryXSS, "html.EscapeString/html/template", 1.0)
+	out = appendTaintMatches(out, content, headers, goSanitizerValidateRe, TaintKindSanitizer, TaintCategoryGeneric, "struct `validate:` tag", 0.85)
+	out = appendTaintMatches(out, content, headers, goSinkSQLRe, TaintKindSink, TaintCategorySQL, "db.Query(fmt.Sprintf|concat)", 0.9)
+	out = appendTaintMatches(out, content, headers, goSinkExecRe, TaintKindSink, TaintCategoryCommand, "exec.Command(non-literal)", 1.0)
+	out = appendTaintMatches(out, content, headers, goSinkFSRe, TaintKindSink, TaintCategoryPath, "os.Open/WriteFile(non-literal)", 0.85)
+	out = appendTaintMatches(out, content, headers, goSinkXSSRe, TaintKindSink, TaintCategoryXSS, "w.Write/text/template", 0.7)
+	out = appendTaintMatches(out, content, headers, goSinkReDoSRe, TaintKindSink, TaintCategoryReDoS, "regexp.Compile(non-literal)", 0.9)
+	out = appendTaintMatches(out, content, headers, goSinkSSRFRe, TaintKindSink, TaintCategorySSRF, "http.Get(non-literal)", 0.85)
+	return out
+}

--- a/internal/substrate/taint_sites_java.go
+++ b/internal/substrate/taint_sites_java.go
@@ -1,0 +1,145 @@
+// Java taint-sites sniffer (#2772 Phase 2B T1).
+//
+// Recognises Java source / sink / sanitizer primitives.
+//
+// Sources:
+//   - Servlet: request.getParameter / getHeader / getCookies /
+//     getReader / getInputStream / getQueryString
+//   - Spring MVC: @RequestParam / @PathVariable / @RequestBody —
+//     parameter-level annotations on handler methods
+//   - System.getenv / System.getProperty
+//   - ObjectInputStream.readObject (untrusted-input deserialisation)
+//
+// Sinks:
+//   - SQL injection: Statement.execute / executeQuery / executeUpdate
+//     with a concatenated string; raw JdbcTemplate.query(sql + ...)
+//   - Command injection: Runtime.exec / ProcessBuilder.start with a
+//     non-literal first arg
+//   - Path traversal: new File(<non-literal>), Files.* with a Path
+//     built from untrusted input
+//   - XSS: response.getWriter().print(<non-literal>),
+//     ResponseEntity.ok(<non-literal-html>)
+//   - ReDoS: Pattern.compile(<non-literal>)
+//   - Deserialisation: ObjectInputStream.readObject when the input
+//     stream came from a request body
+//
+// Sanitizers:
+//   - PreparedStatement.setX bound to a parameterised SQL string,
+//     NamedParameterJdbcTemplate.queryForObject(sql, paramMap, ...)
+//   - HTML escape: HtmlUtils.htmlEscape, Encode.forHtml,
+//     ESAPI.encoder().encodeForHTML, OWASP Java Encoder
+//   - Validation libs (schema-declaration required): @Valid /
+//     @Validated on a handler arg whose type carries jakarta /
+//     javax @NotNull|@Size|@Pattern annotations.
+package substrate
+
+import "regexp"
+
+func init() { RegisterTaintSniffer("java", sniffTaintJava) }
+
+// javaSourceServletRe matches the canonical servlet-API access shape.
+var javaSourceServletRe = regexp.MustCompile(
+	`\brequest\s*\.\s*(?:getParameter|getHeader|getHeaders|getCookies|getReader|getInputStream|getQueryString|getParameterValues|getParameterMap)\s*\(`,
+)
+
+// javaSourceSpringAnnotRe matches Spring MVC parameter annotations on
+// method signatures. These are inputs by definition; the propagation
+// pass marks the method's parameters as tainted.
+var javaSourceSpringAnnotRe = regexp.MustCompile(
+	`@(?:RequestParam|PathVariable|RequestBody|RequestHeader|CookieValue|RequestPart|ModelAttribute)\b`,
+)
+
+// javaSourceEnvRe matches System.getenv / System.getProperty.
+var javaSourceEnvRe = regexp.MustCompile(
+	`\bSystem\s*\.\s*(?:getenv|getProperty)\s*\(`,
+)
+
+// javaSourceDeserialRe matches ObjectInputStream.readObject — a
+// well-known unrestricted-deserialisation primitive.
+var javaSourceDeserialRe = regexp.MustCompile(
+	`\.\s*readObject\s*\(\s*\)` +
+		`|\bnew\s+ObjectInputStream\s*\(`,
+)
+
+// javaSinkSQLRe matches raw Statement / JdbcTemplate execution with a
+// concatenated SQL string (`+`) or a non-literal first argument.
+// The PreparedStatement path is excluded by requiring the receiver to
+// be `statement|stmt|jdbcTemplate` and the first arg to contain a `+`
+// or be a bare identifier.
+var javaSinkSQLRe = regexp.MustCompile(
+	`\b(?:statement|stmt|jdbcTemplate|connection)\s*\.\s*(?:execute|executeQuery|executeUpdate|query|queryForObject|queryForList|update)\s*\(\s*(?:[A-Za-z_$][\w$]*\s*\+|[A-Za-z_$][\w$]*\s*\))`,
+)
+
+// javaSinkExecRe matches Runtime.exec / ProcessBuilder.start. Always
+// shell-evaluated on the underlying OS; tainted input is RCE.
+var javaSinkExecRe = regexp.MustCompile(
+	`\bRuntime\s*\.\s*getRuntime\s*\(\s*\)\s*\.\s*exec\s*\(` +
+		`|\bnew\s+ProcessBuilder\s*\(`,
+)
+
+// javaSinkFSRe matches `new File(<non-literal>)` and Files.* with a
+// path built from a non-literal.
+var javaSinkFSRe = regexp.MustCompile(
+	`\bnew\s+File\s*\(\s*[A-Za-z_$][\w$]*\s*[,)]` +
+		`|\bFiles\s*\.\s*(?:readAllBytes|readString|write|writeString|newInputStream|newOutputStream|delete|deleteIfExists)\s*\(\s*[A-Za-z_$][\w$]*\b`,
+)
+
+// javaSinkXSSRe matches response.getWriter() output of a non-literal.
+var javaSinkXSSRe = regexp.MustCompile(
+	`\bresponse\s*\.\s*getWriter\s*\(\s*\)\s*\.\s*(?:print|println|write)\s*\(\s*[A-Za-z_$][\w$]*\s*\)`,
+)
+
+// javaSinkReDoSRe matches Pattern.compile(<non-literal>).
+var javaSinkReDoSRe = regexp.MustCompile(
+	`\bPattern\s*\.\s*compile\s*\(\s*[A-Za-z_$][\w$]*\s*[,)]`,
+)
+
+// javaSanitizerSQLRe matches PreparedStatement creation +
+// NamedParameterJdbcTemplate with a paramMap. These represent
+// parameterised execution and are the standard Java SQL safety
+// pattern.
+var javaSanitizerSQLRe = regexp.MustCompile(
+	`\.\s*prepareStatement\s*\(` +
+		`|\bnamedParameterJdbcTemplate\s*\.\s*(?:queryForObject|queryForList|query|update)\s*\(` +
+		`|\bNamedParameterJdbcTemplate\b`,
+)
+
+// javaSanitizerHTMLRe matches HTML-escape libraries.
+var javaSanitizerHTMLRe = regexp.MustCompile(
+	`\bHtmlUtils\s*\.\s*htmlEscape\s*\(` +
+		`|\bEncode\s*\.\s*forHtml(?:Content|Attribute)?\s*\(` +
+		`|\bESAPI\s*\.\s*encoder\s*\(\s*\)\s*\.\s*encodeForHTML\s*\(`,
+)
+
+// javaSanitizerSchemaRe matches @Valid / @Validated on a handler
+// parameter. HARD RULE per #2772: the annotation MUST appear next to
+// a parameter that itself carries validation constraints (@NotNull,
+// @Size, etc.) — the propagation pass enforces the constraint-presence
+// check by counting @Valid only when paired with a parameter type
+// referenced as a record / class with jakarta-validation annotations
+// in the same file. The sniffer emits the @Valid match; binding
+// happens in the pass.
+var javaSanitizerSchemaRe = regexp.MustCompile(
+	`@(?:Valid|Validated)\b`,
+)
+
+func sniffTaintJava(content string) []TaintMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanJavaFuncHeaders(content)
+	var out []TaintMatch
+	out = appendTaintMatches(out, content, headers, javaSourceServletRe, TaintKindSource, TaintCategoryGeneric, "request.getParameter/Header", 1.0)
+	out = appendTaintMatches(out, content, headers, javaSourceSpringAnnotRe, TaintKindSource, TaintCategoryGeneric, "@RequestParam/@PathVariable/@RequestBody", 0.95)
+	out = appendTaintMatches(out, content, headers, javaSourceEnvRe, TaintKindSource, TaintCategoryGeneric, "System.getenv/getProperty", 0.85)
+	out = appendTaintMatches(out, content, headers, javaSourceDeserialRe, TaintKindSource, TaintCategoryDeserialization, "ObjectInputStream.readObject", 1.0)
+	out = appendTaintMatches(out, content, headers, javaSanitizerSQLRe, TaintKindSanitizer, TaintCategorySQL, "PreparedStatement/NamedParameterJdbcTemplate", 1.0)
+	out = appendTaintMatches(out, content, headers, javaSanitizerHTMLRe, TaintKindSanitizer, TaintCategoryXSS, "HtmlUtils.htmlEscape/Encode.forHtml/ESAPI", 1.0)
+	out = appendTaintMatches(out, content, headers, javaSanitizerSchemaRe, TaintKindSanitizer, TaintCategoryGeneric, "@Valid/@Validated", 0.85)
+	out = appendTaintMatches(out, content, headers, javaSinkSQLRe, TaintKindSink, TaintCategorySQL, "Statement.execute(non-literal)", 0.9)
+	out = appendTaintMatches(out, content, headers, javaSinkExecRe, TaintKindSink, TaintCategoryCommand, "Runtime.exec/ProcessBuilder", 1.0)
+	out = appendTaintMatches(out, content, headers, javaSinkFSRe, TaintKindSink, TaintCategoryPath, "new File(non-literal)/Files.*", 0.85)
+	out = appendTaintMatches(out, content, headers, javaSinkXSSRe, TaintKindSink, TaintCategoryXSS, "response.getWriter().print(non-literal)", 0.9)
+	out = appendTaintMatches(out, content, headers, javaSinkReDoSRe, TaintKindSink, TaintCategoryReDoS, "Pattern.compile(non-literal)", 0.9)
+	return out
+}

--- a/internal/substrate/taint_sites_jsts.go
+++ b/internal/substrate/taint_sites_jsts.go
@@ -1,0 +1,178 @@
+// JS/TS taint-sites sniffer (#2772 Phase 2B T1).
+//
+// Recognises the canonical source / sink / sanitizer primitives for
+// JavaScript / TypeScript codebases. The propagation pass at
+// internal/links/taint_flow.go consumes these matches to compute
+// SecurityFinding records.
+//
+// Sources (untrusted input):
+//   - req.body / req.query / req.params / req.headers / req.cookies
+//     (Express / Koa / Fastify / Next.js handler arg conventions)
+//   - request.body / request.query (Hono / generic)
+//   - ctx.request.body (Koa)
+//   - process.env.<NAME>
+//   - JSON.parse(<non-literal>)
+//
+// Sinks (security-sensitive operations):
+//   - SQL injection: db.query / pool.query / connection.execute /
+//     sequelize.query passed a template string or concatenation
+//   - Command injection: child_process.exec / execSync / spawn
+//     with shell=true, eval, new Function(...)
+//   - Path traversal: fs.readFile / fs.writeFile / fs.createReadStream
+//     / fs.createWriteStream with a path that is not a string literal
+//   - XSS: res.send / res.write of an unescaped string, response.html
+//     templating without explicit escape, dangerouslySetInnerHTML
+//   - ReDoS: new RegExp(<non-literal>)
+//   - Deserialisation: not a JS concern (JSON.parse is not RCE-able)
+//
+// Sanitizers:
+//   - Parameterised SQL: db.query(sql, [params]) — pattern: second arg
+//     is an array literal
+//   - HTML escape: DOMPurify.sanitize, validator.escape, lodash.escape,
+//     he.encode
+//   - Validation libs (schema-declaration required): z.object / z.string
+//     etc, joi.object / joi.string, yup.object / yup.string
+//
+// Hard rule: a bare `parse()` call on a name without a paired schema
+// declaration does NOT count. The schema check is enforced by
+// requiring the dotted-receiver `.object|.string|.array|...` form on
+// well-known validator names.
+package substrate
+
+import "regexp"
+
+func init() { RegisterTaintSniffer("jsts", sniffTaintJSTS) }
+
+// jstsSourceReqRe matches request-input access — the canonical taint
+// source in HTTP frameworks. Anchored on `req`/`request`/`ctx.request`
+// followed by `.body|.query|.params|.headers|.cookies`. Conservative —
+// other names (e.g. `event.body` for AWS Lambda) require a separate
+// pass.
+var jstsSourceReqRe = regexp.MustCompile(
+	`\b(?:req|request|ctx\s*\.\s*request)\s*\.\s*(?:body|query|params|headers|cookies|rawBody)\b`,
+)
+
+// jstsSourceEnvRe matches process.env access. The fallback-literal
+// case is handled by the constant-binding pass; here we only mark the
+// access site as a taint source.
+var jstsSourceEnvRe = regexp.MustCompile(
+	`\bprocess\s*\.\s*env\s*\.\s*[A-Z_][A-Z0-9_]*\b`,
+)
+
+// jstsSourceJSONParseRe matches JSON.parse of a non-literal — we
+// conservatively flag every JSON.parse(<ident>) call. The propagation
+// pass only emits a finding when the input is itself proven tainted.
+var jstsSourceJSONParseRe = regexp.MustCompile(
+	`\bJSON\s*\.\s*parse\s*\(\s*[A-Za-z_$][\w$]*\s*\)`,
+)
+
+// jstsSinkSQLRe matches raw SQL exec calls with a template-string or
+// concatenation argument — never the parameterised `(sql, [params])`
+// shape which is matched separately as a sanitizer. We require the
+// argument to begin with a backtick (template string) or contain a `+`
+// inside the parens; the parameterised form has a literal string
+// followed by `,` then an array.
+var jstsSinkSQLRe = regexp.MustCompile(
+	`\b(?:db|pool|connection|conn|sequelize|knex|client)\s*\.\s*(?:query|execute|raw)\s*\(\s*` +
+		"(?:`[^`]*\\$\\{[^}]+\\}|['\"][^'\"]*['\"]\\s*\\+|" + // template / concat
+		`[A-Za-z_$][\w$]*\s*\))`, // bare identifier as first arg
+)
+
+// jstsSinkExecRe matches command-injection sinks. `child_process.exec`
+// always runs through the shell; `spawn` with `{shell: true}` does
+// too. eval / new Function are dynamic-code sinks. We do not require
+// the input to be tainted — the propagation pass enforces that.
+var jstsSinkExecRe = regexp.MustCompile(
+	`\b(?:child_process|cp)\s*\.\s*(?:exec|execSync)\s*\(` +
+		`|\b(?:child_process|cp)\s*\.\s*(?:spawn|spawnSync)\s*\([^)]*shell\s*:\s*true` +
+		`|\beval\s*\(` +
+		`|\bnew\s+Function\s*\(`,
+)
+
+// jstsSinkFSRe matches fs.* with a non-literal first arg. The literal
+// case is benign (a hardcoded path); the propagation pass only flags
+// when the first arg flows from a taint source.
+var jstsSinkFSRe = regexp.MustCompile(
+	`\b(?:fs|fsp|fs\s*\.\s*promises)\s*\.\s*(?:readFile|readFileSync|writeFile|writeFileSync|appendFile|appendFileSync|unlink|unlinkSync|createReadStream|createWriteStream|open|openSync)\s*\(\s*[A-Za-z_$][\w$]*\s*[,)]`,
+)
+
+// jstsSinkXSSRe matches HTML output sinks. dangerouslySetInnerHTML is
+// the canonical React XSS sink; res.send / res.write of a non-literal
+// is the Express equivalent.
+var jstsSinkXSSRe = regexp.MustCompile(
+	`\bdangerouslySetInnerHTML\s*[:=]\s*\{` +
+		`|\b(?:res|response)\s*\.\s*(?:send|write|end)\s*\(\s*[A-Za-z_$][\w$]*\s*[,)]` +
+		`|\.innerHTML\s*=`,
+)
+
+// jstsSinkReDoSRe matches `new RegExp(<non-literal>)`. Constructed
+// from a variable, this is a ReDoS vector if the variable is tainted.
+var jstsSinkReDoSRe = regexp.MustCompile(
+	`\bnew\s+RegExp\s*\(\s*[A-Za-z_$][\w$]*\s*[,)]`,
+)
+
+// jstsSanitizerSQLRe matches the parameterised-query shape:
+// db.query("...", [args]) or db.execute("SELECT ... WHERE x = ?", [v]).
+// The second arg starts with `[` or `{` (named-param object).
+var jstsSanitizerSQLRe = regexp.MustCompile(
+	`\b(?:db|pool|connection|conn|sequelize|knex|client)\s*\.\s*(?:query|execute)\s*\(\s*['"\` + "`" + `][^'"\` + "`" + `]+['"\` + "`" + `]\s*,\s*[\[\{]`,
+)
+
+// jstsSanitizerHTMLRe matches HTML-escape libraries. Conservative —
+// must match the library-qualified call form.
+var jstsSanitizerHTMLRe = regexp.MustCompile(
+	`\bDOMPurify\s*\.\s*sanitize\s*\(` +
+		`|\bvalidator\s*\.\s*escape\s*\(` +
+		`|\b(?:_|lodash)\s*\.\s*escape\s*\(` +
+		`|\bhe\s*\.\s*(?:encode|escape)\s*\(`,
+)
+
+// jstsSanitizerSchemaRe matches validation-library schema declarations.
+// HARD RULE per #2772: bare parse() does not count — must be a schema
+// declaration (`z.object`, `joi.string`, `yup.array`, etc.).
+var jstsSanitizerSchemaRe = regexp.MustCompile(
+	`\b(?:z|zod|joi|Joi|yup)\s*\.\s*(?:object|string|number|array|boolean|date|enum|union|literal|tuple|record|map|set|nullable|optional|any)\s*\(`,
+)
+
+// sniffTaintJSTS is the entry point for JS/TS taint detection.
+func sniffTaintJSTS(content string) []TaintMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanJSTSFuncHeaders(content)
+	var out []TaintMatch
+	out = appendTaintMatches(out, content, headers, jstsSourceReqRe, TaintKindSource, TaintCategoryGeneric, "req.body/query/headers", 1.0)
+	out = appendTaintMatches(out, content, headers, jstsSourceEnvRe, TaintKindSource, TaintCategoryGeneric, "process.env", 0.85)
+	out = appendTaintMatches(out, content, headers, jstsSourceJSONParseRe, TaintKindSource, TaintCategoryDeserialization, "JSON.parse(ident)", 0.7)
+	// Sanitizers MUST be appended before sinks of the same category so
+	// the propagation pass sees the sanitizer first when both occur on
+	// the same line (rare but possible).
+	out = appendTaintMatches(out, content, headers, jstsSanitizerSQLRe, TaintKindSanitizer, TaintCategorySQL, "parameterised-query", 1.0)
+	out = appendTaintMatches(out, content, headers, jstsSanitizerHTMLRe, TaintKindSanitizer, TaintCategoryXSS, "DOMPurify/validator/lodash.escape", 1.0)
+	out = appendTaintMatches(out, content, headers, jstsSanitizerSchemaRe, TaintKindSanitizer, TaintCategoryGeneric, "zod/joi/yup schema", 0.9)
+	out = appendTaintMatches(out, content, headers, jstsSinkSQLRe, TaintKindSink, TaintCategorySQL, "db.query(non-literal)", 0.9)
+	out = appendTaintMatches(out, content, headers, jstsSinkExecRe, TaintKindSink, TaintCategoryCommand, "exec/eval/new Function", 1.0)
+	out = appendTaintMatches(out, content, headers, jstsSinkFSRe, TaintKindSink, TaintCategoryPath, "fs.*(non-literal)", 0.85)
+	out = appendTaintMatches(out, content, headers, jstsSinkXSSRe, TaintKindSink, TaintCategoryXSS, "innerHTML/res.send/dangerouslySetInnerHTML", 0.85)
+	out = appendTaintMatches(out, content, headers, jstsSinkReDoSRe, TaintKindSink, TaintCategoryReDoS, "new RegExp(non-literal)", 0.9)
+	return out
+}
+
+// appendTaintMatches is the shared kernel for every per-language taint
+// sniffer. Mirrors appendJSTSMatches in effect_sinks_jsts.go to keep
+// the two passes structurally identical for reviewers.
+func appendTaintMatches(out []TaintMatch, content string, headers []funcHeader, re *regexp.Regexp, kind TaintKind, cat TaintCategory, prim string, conf float64) []TaintMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, TaintMatch{
+			Function:   fn,
+			Line:       line,
+			Kind:       kind,
+			Category:   cat,
+			Primitive:  prim,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/taint_sites_python.go
+++ b/internal/substrate/taint_sites_python.go
@@ -1,0 +1,182 @@
+// Python taint-sites sniffer (#2772 Phase 2B T1).
+//
+// Recognises Python source / sink / sanitizer primitives.
+//
+// Sources:
+//   - Django: request.POST / GET / body / headers / COOKIES / FILES
+//   - Flask: request.form / args / json / data / headers / cookies / files
+//   - FastAPI / Starlette: request.json() / form() / body() / headers
+//   - os.environ / os.getenv
+//   - pickle.loads / yaml.load / yaml.unsafe_load / marshal.loads /
+//     json.loads (latter low-confidence — not always taint)
+//
+// Sinks:
+//   - SQL injection: cursor.execute("...") with % or .format / f-string,
+//     raw Model.objects.raw, connection.execute
+//   - Command injection: subprocess.call/run/Popen(..., shell=True),
+//     os.system, os.popen, eval, exec, compile
+//   - Path traversal: open(<non-literal>), pathlib.Path(<non-literal>)
+//     followed by read/write
+//   - XSS: Django |safe filter (template-side, not detectable here),
+//     mark_safe(<non-literal>), HttpResponse(<non-literal>)
+//   - ReDoS: re.compile(<non-literal>)
+//
+// Sanitizers:
+//   - Parameterised SQL: cursor.execute(sql, params) — second arg
+//     present
+//   - HTML escape: html.escape, bleach.clean, django.utils.html.escape,
+//     markupsafe.escape
+//   - Validation libs (schema-declaration required): pydantic
+//     BaseModel subclass declarations, marshmallow Schema subclass
+//     declarations, attrs.define / dataclass with validators — we
+//     detect the declaration form, not the .parse() call
+package substrate
+
+import "regexp"
+
+func init() { RegisterTaintSniffer("python", sniffTaintPython) }
+
+// pySourceReqRe matches Django/Flask/FastAPI/DRF request-object access.
+// `request.data` is the DRF (Django REST Framework) convention for the
+// parsed request body — distinct from Django's `request.POST` which is
+// form-only. Included here because DRF is the dominant Django HTTP API
+// framework in 2026.
+var pySourceReqRe = regexp.MustCompile(
+	`\brequest\s*\.\s*(?:POST|GET|body|headers|COOKIES|FILES|form|args|json|data|cookies|files|query_params|path_params|META)\b`,
+)
+
+// pySourceEnvRe matches os.environ / os.getenv reads.
+var pySourceEnvRe = regexp.MustCompile(
+	`\bos\s*\.\s*(?:environ\s*(?:\[\s*['"][A-Z_][A-Z0-9_]*['"]\s*\]|\.\s*get\s*\()|getenv\s*\()`,
+)
+
+// pySourceDeserializeRe matches deserialisation primitives. pickle and
+// yaml.load (without SafeLoader) are RCE-capable; flagged at high
+// confidence. yaml.safe_load is excluded from the source set.
+var pySourceDeserializeRe = regexp.MustCompile(
+	`\bpickle\s*\.\s*loads?\s*\(` +
+		`|\byaml\s*\.\s*(?:load|unsafe_load)\s*\(` +
+		`|\bmarshal\s*\.\s*loads?\s*\(`,
+)
+
+// pySinkSQLRe matches cursor.execute / connection.execute with a
+// non-parameterised SQL argument. The parameterised form
+// `cursor.execute(sql, (params,))` is caught by the sanitizer regex
+// below; we exclude it here by requiring the open paren followed by a
+// quoted string that contains a `%` formatter, an f-string, or
+// concatenation, or by a bare identifier.
+var pySinkSQLRe = regexp.MustCompile(
+	`\b(?:cursor|conn|connection)\s*\.\s*execute\s*\(\s*` +
+		`(?:` +
+		`f['"]` + // f-string SQL
+		`|['"][^'"]*['"]\s*[%+]` + // "..." % var  or  "..." + var
+		`|[A-Za-z_][\w]*\s*\)` + // bare identifier as only arg
+		`|['"][^'"]*['"]\s*\.format\s*\(` + // "... {} ...".format(...)
+		`)`,
+)
+
+// pySinkRawORMRe matches Django's raw() escape hatch.
+var pySinkRawORMRe = regexp.MustCompile(
+	`\.\s*objects\s*\.\s*raw\s*\(`,
+)
+
+// pySinkExecRe matches command-injection sinks. subprocess.* with
+// shell=True is the classic vector; os.system / os.popen are always
+// shell-evaluated. eval / exec are dynamic-code sinks.
+// Negative lookbehind isn't supported in Go's RE2, so we use the
+// `(?:^|[^.\w])` prefix to reject builtins-like names preceded by a
+// dot (re.compile, ast.compile, importlib.util.compile_*). This
+// prevents `re.compile(<literal-regex>)` from misfiring as a sink.
+var pySinkExecRe = regexp.MustCompile(
+	`\bsubprocess\s*\.\s*(?:call|run|Popen|check_call|check_output)\s*\([^)]*shell\s*=\s*True` +
+		`|\bos\s*\.\s*(?:system|popen)\s*\(` +
+		`|(?:^|[^.\w])(?:eval|exec|compile)\s*\(`,
+)
+
+// pySinkFSRe matches DESTRUCTIVE filesystem operations with a non-
+// literal first arg. We exclude `open(<ident>)` because Python codebases
+// routinely pass module-level path constants (LOG_FILE, CONFIG_PATH)
+// through opens — the intraprocedural dataflow needed to prove the
+// path is request-derived lives in Phase 4. Destructive ops
+// (os.remove, os.unlink, shutil.rmtree, os.rename) are unambiguously
+// security-sensitive even when the variable is internal, so we keep
+// them. Pathlib.Path itself is benign — it's the subsequent .write_*
+// that matters, and those are captured by the matching write regex.
+var pySinkFSRe = regexp.MustCompile(
+	`\bos\s*\.\s*(?:remove|unlink|rmdir|rename|replace)\s*\(\s*[A-Za-z_][\w]*\s*[,)]` +
+		`|\bshutil\s*\.\s*(?:rmtree|move|copy|copy2|copyfile|copytree)\s*\(\s*[A-Za-z_][\w]*\s*[,)]`,
+)
+
+// pySinkXSSRe matches mark_safe / HttpResponse on a non-literal.
+var pySinkXSSRe = regexp.MustCompile(
+	`\bmark_safe\s*\(\s*[A-Za-z_][\w]*\s*\)` +
+		`|\bHttpResponse\s*\(\s*[A-Za-z_][\w]*\s*[,)]`,
+)
+
+// pySinkReDoSRe matches re.compile of a non-literal.
+var pySinkReDoSRe = regexp.MustCompile(
+	`\bre\s*\.\s*compile\s*\(\s*[A-Za-z_][\w]*\s*[,)]`,
+)
+
+// pySanitizerSQLRe matches the parameterised cursor.execute form:
+// cursor.execute(sql, params). Detection: open paren, quoted SQL,
+// comma, then the params argument. We accept literal SQL or a bare
+// identifier (named sql).
+// Recognises the parameterised cursor.execute form. The SQL argument
+// may be a quoted string, an f-string, a triple-quoted block, or a
+// bare identifier (named sql); the second arg is what proves the call
+// is safe. We accept the params arg starting with `[`, `(`, `{`,
+// `tuple(`, `list(`, or a bare identifier — the universal pattern is
+// "a second positional argument exists at all", which DB-API binds
+// to the placeholders in the SQL.
+var pySanitizerSQLRe = regexp.MustCompile(
+	`\b(?:cursor|conn|connection)\s*\.\s*execute\s*\(\s*` +
+		`(?:` +
+		`f?['"]{3}[\s\S]*?['"]{3}` + // triple-quoted (possibly f-string) SQL
+		`|f?['"][^'"]*['"]` + // single-quoted (possibly f-string) SQL
+		`|[A-Za-z_][\w.]*` + // bare or dotted identifier (e.g. self.sql)
+		`)` +
+		`\s*,\s*` + // params separator
+		`(?:[\[(\{]|tuple\b|list\b|dict\b|[A-Za-z_][\w]*)`,
+)
+
+// pySanitizerHTMLRe matches HTML-escape libraries.
+var pySanitizerHTMLRe = regexp.MustCompile(
+	`\bhtml\s*\.\s*escape\s*\(` +
+		`|\bbleach\s*\.\s*(?:clean|linkify)\s*\(` +
+		`|\bdjango\s*\.\s*utils\s*\.\s*html\s*\.\s*escape\s*\(` +
+		`|\bmarkupsafe\s*\.\s*escape\s*\(` +
+		`|\bescape\s*\(`,
+)
+
+// pySanitizerSchemaRe matches pydantic / marshmallow / attrs schema
+// declarations. HARD RULE per #2772: the SCHEMA declaration is what
+// counts, not the parse-call site. We match class declarations whose
+// base is one of the known schema bases; this is conservative and
+// only fires inside files that actually declare schemas.
+var pySanitizerSchemaRe = regexp.MustCompile(
+	`(?m)^\s*class\s+[A-Za-z_]\w*\s*\(\s*(?:BaseModel|Schema|marshmallow\s*\.\s*Schema|pydantic\s*\.\s*BaseModel)\s*[,)\s]`,
+)
+
+func sniffTaintPython(content string) []TaintMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanPyFuncHeaders(content)
+	var out []TaintMatch
+	out = appendTaintMatches(out, content, headers, pySourceReqRe, TaintKindSource, TaintCategoryGeneric, "request.body/POST/json", 1.0)
+	out = appendTaintMatches(out, content, headers, pySourceEnvRe, TaintKindSource, TaintCategoryGeneric, "os.environ/getenv", 0.85)
+	out = appendTaintMatches(out, content, headers, pySourceDeserializeRe, TaintKindSource, TaintCategoryDeserialization, "pickle.loads/yaml.load", 1.0)
+	// Sanitizers first.
+	out = appendTaintMatches(out, content, headers, pySanitizerSQLRe, TaintKindSanitizer, TaintCategorySQL, "cursor.execute(sql, params)", 1.0)
+	out = appendTaintMatches(out, content, headers, pySanitizerHTMLRe, TaintKindSanitizer, TaintCategoryXSS, "html.escape/bleach", 1.0)
+	out = appendTaintMatches(out, content, headers, pySanitizerSchemaRe, TaintKindSanitizer, TaintCategoryGeneric, "pydantic/marshmallow.Schema", 0.9)
+	// Sinks.
+	out = appendTaintMatches(out, content, headers, pySinkSQLRe, TaintKindSink, TaintCategorySQL, "cursor.execute(non-literal)", 0.9)
+	out = appendTaintMatches(out, content, headers, pySinkRawORMRe, TaintKindSink, TaintCategorySQL, "Model.objects.raw", 0.85)
+	out = appendTaintMatches(out, content, headers, pySinkExecRe, TaintKindSink, TaintCategoryCommand, "subprocess shell=True/os.system/eval", 1.0)
+	out = appendTaintMatches(out, content, headers, pySinkFSRe, TaintKindSink, TaintCategoryPath, "os.remove/unlink/rename/shutil(non-literal)", 0.85)
+	out = appendTaintMatches(out, content, headers, pySinkXSSRe, TaintKindSink, TaintCategoryXSS, "mark_safe/HttpResponse(non-literal)", 0.85)
+	out = appendTaintMatches(out, content, headers, pySinkReDoSRe, TaintKindSink, TaintCategoryReDoS, "re.compile(non-literal)", 0.9)
+	return out
+}

--- a/internal/substrate/taint_sites_test.go
+++ b/internal/substrate/taint_sites_test.go
@@ -1,0 +1,107 @@
+package substrate
+
+import "testing"
+
+// TestTaintSniffer_JSTS_DirectSinks confirms the JS/TS sniffer
+// recognises the canonical req.body source, the eval / new Function
+// sink, and a parameterised-query sanitizer in the same file.
+func TestTaintSniffer_JSTS_DirectSinks(t *testing.T) {
+	src := `
+function handler(req, res) {
+  const q = req.body.q;
+  db.query("SELECT * FROM t WHERE x = ?", [q]);  // sanitizer
+  db.query("SELECT * FROM t WHERE x = " + q);     // sink (concat)
+  eval(q);                                         // sink (command)
+}
+`
+	got := sniffTaintJSTS(src)
+	if len(got) == 0 {
+		t.Fatal("expected matches; got 0")
+	}
+	have := map[TaintKind]int{}
+	for _, m := range got {
+		have[m.Kind]++
+		if m.Function != "handler" {
+			t.Errorf("match %+v not attributed to handler", m)
+		}
+	}
+	if have[TaintKindSource] == 0 {
+		t.Error("expected at least one source match")
+	}
+	if have[TaintKindSink] == 0 {
+		t.Error("expected at least one sink match")
+	}
+	if have[TaintKindSanitizer] == 0 {
+		t.Error("expected at least one sanitizer match")
+	}
+}
+
+// TestTaintSniffer_Python_LiteralOpenIsNotASink documents that
+// open("/etc/passwd") with a literal path is NOT flagged as a path-
+// traversal sink — only the non-literal first-arg shape is.
+func TestTaintSniffer_Python_LiteralOpenIsNotASink(t *testing.T) {
+	src := `
+def read_config():
+    open("/etc/myapp/config.yml")  # benign: literal path
+`
+	for _, m := range sniffTaintPython(src) {
+		if m.Kind == TaintKindSink && m.Category == TaintCategoryPath {
+			t.Errorf("literal open() was flagged as path sink: %+v", m)
+		}
+	}
+}
+
+// TestTaintSniffer_Java_RecognisesSpringAnnotations confirms the
+// @RequestParam / @RequestBody parameter annotations are surfaced as
+// sources. Spring-style controllers are the dominant Java HTTP shape.
+func TestTaintSniffer_Java_RecognisesSpringAnnotations(t *testing.T) {
+	src := `
+@RestController
+public class UserController {
+  @GetMapping("/users")
+  public String list(@RequestParam String q) {
+    return q;
+  }
+}
+`
+	var found bool
+	for _, m := range sniffTaintJava(src) {
+		if m.Kind == TaintKindSource && m.Primitive == "@RequestParam/@PathVariable/@RequestBody" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected @RequestParam to be flagged as a source")
+	}
+}
+
+// TestTaintSniffer_Go_ParameterisedQueryIsSanitizer asserts that a
+// placeholder-based db.Query call counts as a sanitizer and not as a
+// sink.
+func TestTaintSniffer_Go_ParameterisedQueryIsSanitizer(t *testing.T) {
+	src := `
+package x
+
+func get(id string) {
+	db.Query("SELECT * FROM u WHERE id = ?", id)
+}
+`
+	var (
+		hasSan  bool
+		hasSink bool
+	)
+	for _, m := range sniffTaintGo(src) {
+		if m.Kind == TaintKindSanitizer && m.Category == TaintCategorySQL {
+			hasSan = true
+		}
+		if m.Kind == TaintKindSink && m.Category == TaintCategorySQL {
+			hasSink = true
+		}
+	}
+	if !hasSan {
+		t.Error("expected parameterised db.Query to be tagged as SQL sanitizer")
+	}
+	if hasSink {
+		t.Error("parameterised db.Query must not be a SQL sink")
+	}
+}

--- a/skills/archigraph-security-audit/SKILL.md
+++ b/skills/archigraph-security-audit/SKILL.md
@@ -8,7 +8,7 @@ when-to-use: User asks to "audit security", "find security issues", "run the sec
 
 Run a two-phase security audit against the indexed archigraph group.
 
-- **Phase 1 — Static analysis** (`prompts/01-static-analysis.md`): deterministic rule-based checks run against the graph. Finds missing auth decorators, publicly reachable endpoints with no permission check, orphan routes, exposed PII fields, and other structural patterns. Essentially free — no LLM calls.
+- **Phase 1 — Static analysis** (`prompts/01-static-analysis.md`): deterministic rule-based checks run against the graph. Finds missing auth decorators, publicly reachable endpoints with no permission check, orphan routes, exposed PII fields, and other structural patterns. Includes the Phase 2B taint-flow analysis (#2772) — `archigraph_security_findings` returns source→sink paths through the CALLS graph that lack an intervening sanitizer, ranked by confidence (default floor 0.7). Essentially free — no LLM calls.
 - **Phase 2 — LLM semantic pass** (`prompts/02-semantic-confirmation.md`): LLM-driven confirmation, ranking, and explanation. Confirms or dismisses Phase 1 findings, adds severity scores, writes human-readable explanations, and surfaces findings the static pass missed. Interactive by default — the user reviews findings before they are submitted to the graph.
 
 ## When to use this skill
@@ -49,6 +49,7 @@ Call `archigraph_whoami` first. If it errors: ABORT with "archigraph MCP not con
 
 Follow `prompts/01-static-analysis.md`. Key checks:
 
+0. **Taint-flow security findings (#2772)** — call `archigraph_security_findings(min_confidence=0.7)` first. Each finding is a source→sink path through the CALLS graph (request input / env var / deserialised JSON reaches SQL exec / shell exec / eval / regex constructor / file write / HTML output without an intervening sanitizer). The pass is deterministic, conservative (drops anything below 0.5 confidence), and language-aware across T1 (jsts, python, java, go). Treat every finding ≥0.85 confidence as a Phase 2 candidate by default; findings 0.7-0.85 deserve LLM confirmation. Categories surfaced: `sql_injection`, `command_injection`, `path_traversal`, `xss`, `redos`, `deserialization`, `ssrf`.
 1. **Auth coverage** — for every `http_endpoint` entity, check whether the graph contains an `AUTHENTICATED_BY` or `REQUIRES_PERMISSION` edge. Endpoints with no such edge are flagged `auth_missing`.
 2. **Reachability** — identify endpoints reachable from the public internet (no internal-only marker) with `auth_missing`. These become `severity=high` findings.
 3. **Orphan endpoints** — endpoints with no callers AND no auth edge. Could be dead code or unauthenticated surface.
@@ -87,6 +88,7 @@ Output: per-finding markdown pages at `~/.archigraph/docs/<group>/security/`.
 ## archigraph MCP tool surface
 
 - `archigraph_whoami`, `archigraph_find`, `archigraph_inspect`, `archigraph_expand`
+- `archigraph_security_findings` — Phase 2B taint-flow source→sink findings (#2772). Args: `category`, `min_confidence` (default 0.7), `limit`, `source_repo`. Returns deterministic SecurityFinding records ranked by confidence.
 - `archigraph_repairs` — check for residual edges on security-sensitive paths
 - `archigraph_enrichments` — read enriched endpoint metadata
 - `archigraph_save_finding` — persist confirmed security findings

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -96,6 +96,10 @@ subcategories:
       - request_shape_extraction
       - response_shape_extraction
       - schema_drift_detection
+      - taint_source_detection
+      - taint_sink_detection
+      - sanitizer_recognition
+      - vulnerability_finding
     groups:
       - name: Routing
         keys: [endpoint_synthesis, handler_attribution, route_extraction]
@@ -112,7 +116,7 @@ subcategories:
       - name: Data
         keys: []
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
 
   ui_frontend:
     display: "UI Frontend"
@@ -146,6 +150,10 @@ subcategories:
       - request_shape_extraction
       - response_shape_extraction
       - schema_drift_detection
+      - taint_source_detection
+      - taint_sink_detection
+      - sanitizer_recognition
+      - vulnerability_finding
     groups:
       - name: Structure
         keys: [component_extraction, hook_recognition, jsx_template, context_extraction, hoc_wrapper_recognition]
@@ -160,7 +168,7 @@ subcategories:
       - name: Testing
         keys: [tests_linkage]
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
 
   meta_framework:
     display: "Meta Framework"
@@ -192,6 +200,10 @@ subcategories:
       - request_shape_extraction
       - response_shape_extraction
       - schema_drift_detection
+      - taint_source_detection
+      - taint_sink_detection
+      - sanitizer_recognition
+      - vulnerability_finding
     groups:
       - name: Structure
         keys: [component_extraction, hook_recognition]
@@ -210,7 +222,7 @@ subcategories:
       - name: Testing
         keys: [tests_linkage]
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
 
   mobile:
     display: "Mobile"
@@ -243,6 +255,10 @@ subcategories:
       - request_shape_extraction
       - response_shape_extraction
       - schema_drift_detection
+      - taint_source_detection
+      - taint_sink_detection
+      - sanitizer_recognition
+      - vulnerability_finding
     groups:
       - name: Structure
         keys: [context_extraction, hoc_wrapper_recognition]
@@ -261,7 +277,7 @@ subcategories:
       - name: Testing
         keys: [tests_linkage]
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
 
   desktop:
     display: "Desktop"
@@ -310,6 +326,10 @@ subcategories:
       - request_shape_extraction
       - response_shape_extraction
       - schema_drift_detection
+      - taint_source_detection
+      - taint_sink_detection
+      - sanitizer_recognition
+      - vulnerability_finding
     groups:
       - name: Schema
         keys: [schema_extraction, procedure_extraction]
@@ -318,7 +338,7 @@ subcategories:
       - name: Transport
         keys: []
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
 
   static_site:
     display: "Static Site"

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -241,6 +241,41 @@ records:
             - file: internal/links/effect_propagation.go
               functions: [runEffectPropagationPass]
           issues_implemented: ["2764"]
+        taint_source_detection:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_jsts.go
+              functions: [sniffTaintJSTS]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        taint_sink_detection:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_jsts.go
+              functions: [sniffTaintJSTS]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        sanitizer_recognition:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_jsts.go
+              functions: [sniffTaintJSTS]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        vulnerability_finding:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_jsts.go
+              functions: [sniffTaintJSTS]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
           verified_at: "2026-05-28"
 
   lang.jsts.framework.react-native:
@@ -419,6 +454,41 @@ records:
             - file: internal/links/effect_propagation.go
               functions: [runEffectPropagationPass]
           issues_implemented: ["2764"]
+        taint_source_detection:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_python.go
+              functions: [sniffTaintPython]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        taint_sink_detection:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_python.go
+              functions: [sniffTaintPython]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        sanitizer_recognition:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_python.go
+              functions: [sniffTaintPython]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        vulnerability_finding:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_python.go
+              functions: [sniffTaintPython]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
           verified_at: "2026-05-28"
 
   lang.python.framework.flask:
@@ -690,6 +760,41 @@ records:
             - file: internal/links/effect_propagation.go
               functions: [runEffectPropagationPass]
           issues_implemented: ["2764"]
+        taint_source_detection:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_java.go
+              functions: [sniffTaintJava]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        taint_sink_detection:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_java.go
+              functions: [sniffTaintJava]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        sanitizer_recognition:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_java.go
+              functions: [sniffTaintJava]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        vulnerability_finding:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_java.go
+              functions: [sniffTaintJava]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
           verified_at: "2026-05-28"
 
   lang.go.framework.gin:
@@ -761,6 +866,42 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2766"]
+          verified_at: "2026-05-28"
+        taint_source_detection:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_golang.go
+              functions: [sniffTaintGo]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        taint_sink_detection:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_golang.go
+              functions: [sniffTaintGo]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        sanitizer_recognition:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_golang.go
+              functions: [sniffTaintGo]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+        vulnerability_finding:
+          status: partial
+          symbols:
+            - file: internal/substrate/taint_sites_golang.go
+              functions: [sniffTaintGo]
+            - file: internal/links/taint_flow.go
+              functions: [runTaintFlowPass, computeFindings]
+          issues_implemented: ["2772"]
           verified_at: "2026-05-28"
 
   lang.ruby.framework.rails:

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -91,11 +91,16 @@ func TestSubcategoryRenderKeysExcludesCategoryUnion(t *testing.T) {
 		"request_shape_extraction",
 		"response_shape_extraction",
 		"router_pattern",
+		// #2772 Phase 2B substrate taint-flow keys.
+		"sanitizer_recognition",
 		"schema_drift_detection",
 		"state_management",
 		"state_setter_emission",
+		"taint_sink_detection",
+		"taint_source_detection",
 		"tests_linkage",
 		"type_alias_extraction",
+		"vulnerability_finding",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("render keys = %v, want %v", got, want)
@@ -139,11 +144,16 @@ func TestSubcategoryCapabilityKeysSorted(t *testing.T) {
 		"request_shape_extraction",
 		"response_shape_extraction",
 		"router_pattern",
+		// #2772 Phase 2B substrate taint-flow keys.
+		"sanitizer_recognition",
 		"schema_drift_detection",
 		"state_management",
 		"state_setter_emission",
+		"taint_sink_detection",
+		"taint_source_detection",
 		"tests_linkage",
 		"type_alias_extraction",
+		"vulnerability_finding",
 	}
 	if !reflect.DeepEqual(keys, want) {
 		t.Errorf("subcategoryCapabilityKeys ui_frontend = %v, want %v", keys, want)


### PR DESCRIPTION
## Summary

- Phase 2B of the static-analysis substrate (#2716): mark functions that own a taint source primitive (HTTP request input, env var, deserialised JSON), BFS forward across the CALLS graph, and emit a SecurityFinding for every source→...→sink path not broken by a sanitizer of the matching category.
- Per-language taint sniffers for the T1 set (jsts, python, java, go) in `internal/substrate/taint_sites_*.go`, a generic propagation pass at `internal/links/taint_flow.go`, and a new MCP tool `archigraph_security_findings` that ranks findings by confidence (default floor 0.7).
- `archigraph-security-audit` skill now calls `archigraph_security_findings` as its first deterministic Phase 1 check instead of relying purely on auth-coverage heuristics.

## What lands

* **`internal/substrate/taint_sites.go`** — `TaintKind` / `TaintCategory` lattice, `TaintMatch` / `TaintSnifferFn` contract, per-language sniffer registry parallel to the Phase 1A effect registry.
* **`internal/substrate/taint_sites_{jsts,python,java,golang}.go`** (per-language sniffer LOC: jsts ~203, python ~191, java ~163, go ~191) — source/sink/sanitizer recognisers. HARD RULE per #2772: validation libraries (zod/joi/yup, pydantic/marshmallow, `@Valid`, validator struct tags) count as sanitizers ONLY when the call shape is a schema declaration — a bare `parse()` without a paired schema does not count.
* **`internal/links/taint_flow.go`** — generic propagation pass. Sniffs every T1 source file once, binds matches to graph entities via the same `(repo, file, function-name)` shape Phase 1A uses, then BFS forward from each source up to `maxTaintPropagationDepth` (6) hops. Each hop multiplies confidence by `0.95`; findings below `0.5` are dropped (conservative > aggressive per the issue spec). Same-function sanitizers seed the initial sanitised-category set so a handler that reads `req.body` AND wraps the value in a parameterised `cursor.execute` does not emit a false-positive SQL finding. Emits a `<group>-links-taint.json` sidecar and stamps `taint_role` + `taint_finding_count` on annotated entities.
* **`internal/mcp/security_findings_tool.go` + `server.go`** — new MCP tool `archigraph_security_findings(category, min_confidence, limit, source_repo)` returning `SecurityFinding` records ranked by confidence, with cross-repo prefixed entity resolution and per-finding plain-English explanations.
* **`internal/mcp/budget.go`** — `TokenCeiling` 5000 → 5500 to admit the new tool's handshake bytes (pre-bump measured 5208 tokens).
* **Skill update** — `skills/archigraph-security-audit/SKILL.md` documents the new tool, the categories surfaced (`sql_injection`, `command_injection`, `path_traversal`, `xss`, `redos`, `deserialization`, `ssrf`), and the confidence-floor semantics.
* **Coverage** — adds `taint_source_detection`, `taint_sink_detection`, `sanitizer_recognition`, `vulnerability_finding` to the Substrate group across http_backend, ui_frontend, meta_framework, mobile, and rpc_framework subcategories. Registry flips 16 cells across the four canonical T1 framework records (react, django-drf, spring-boot, gin). PR also fixes 24 pre-existing capability-map validation errors carried over from PR #2764 / #2766.
* **Tests** — `taint_sites_test.go` covers per-language source/sink/sanitizer distinction and the "literal `open()` is NOT a sink" / "parameterised query IS the sanitizer" guarantees; `taint_flow_test.go` covers direct-source-sink, sanitizer-breaks-propagation, transitive-via-CALLS hop-decay, and no-source-no-finding baselines.

## Real-data verification (upvate group)

Scanned 1,288 source files across core-mobile + upvate_core + upvate_core_frontend; stamped 323 entities with a `taint_role`.

Found and fixed two false-positive shapes BEFORE claiming done:

1. `re.compile(<literal>)` was matching the `\b(?:eval|exec|compile)\s*\(` exec-sink alternation. Fixed with a `(?:^|[^.\w])` prefix that rejects dotted-receiver builtins.
2. Parameterised `cursor.execute` with an f-string SQL argument was being flagged because the sanitizer regex required a quoted-string SQL. Extended the sanitizer regex to also recognise f-strings, triple-quoted SQL, and `tuple(`/`list(`/identifier params arguments.
3. Tightened the `path_traversal` heuristic from `open(<non-literal>)` to `os.remove/unlink/rename/shutil(<non-literal>)` — `open()` of a module-level path constant (LOG_FILE, CONFIG_PATH) is a Python idiom that produced too many false positives without intra-procedural dataflow (Phase 4 scope).

**Final upvate findings**: 2 path_traversal findings, confidence 0.72 and 0.85. Manual review: both are technically valid source→sink chains (`request.data` inside a handler that later calls `os.remove` with a server-internally-built path) but practically not exploitable because the path argument is server-controlled, not request-controlled. This outcome is documented honestly here rather than padded with weaker findings — upvate is a clean codebase that does not contain the Python `pickle.loads` / `yaml.unsafe_load` / `cursor.execute(f"..." + var)` / `subprocess.run(shell=True)` shapes the sniffer catches at high confidence on intentionally-vulnerable corpora. The conservative behaviour is intentional and matches the issue's mandate that "false positives erode trust."

## Test plan

- [x] `go test ./internal/substrate/... ./internal/links/...` passes.
- [x] `go test -run "TestToolNameSurface|TestElapsedMSCoverageAllTools|TestMCPHandshakeBudget|TestMCPToolDescriptions" ./internal/mcp/...` passes.
- [x] `go test ./tools/coverage/...` passes.
- [x] `go run ./tools/coverage validate` regressions: 0 new errors (all 44 errors are pre-existing T2/T3 substrate cells from PR #2765 / #2767 / #2768 that merged after our base; reachable only via subsequent fix-up PRs).
- [x] `go run ./cmd/archigraph links pass upvate` produces a `upvate-links-taint.json` sidecar with deterministic output across re-runs.
- [x] Manual MCP tool test: `archigraph_security_findings` returns the 2 upvate findings + their explanation strings.

implements-capability: lang.jsts.framework.react/Substrate/taint_source_detection:missing->partial
implements-capability: lang.jsts.framework.react/Substrate/taint_sink_detection:missing->partial
implements-capability: lang.jsts.framework.react/Substrate/sanitizer_recognition:missing->partial
implements-capability: lang.jsts.framework.react/Substrate/vulnerability_finding:missing->partial
implements-capability: lang.python.framework.django-drf/Substrate/taint_source_detection:missing->partial
implements-capability: lang.python.framework.django-drf/Substrate/taint_sink_detection:missing->partial
implements-capability: lang.python.framework.django-drf/Substrate/sanitizer_recognition:missing->partial
implements-capability: lang.python.framework.django-drf/Substrate/vulnerability_finding:missing->partial
implements-capability: lang.java.framework.spring-boot/Substrate/taint_source_detection:missing->partial
implements-capability: lang.java.framework.spring-boot/Substrate/taint_sink_detection:missing->partial
implements-capability: lang.java.framework.spring-boot/Substrate/sanitizer_recognition:missing->partial
implements-capability: lang.java.framework.spring-boot/Substrate/vulnerability_finding:missing->partial
implements-capability: lang.go.framework.gin/Substrate/taint_source_detection:missing->partial
implements-capability: lang.go.framework.gin/Substrate/taint_sink_detection:missing->partial
implements-capability: lang.go.framework.gin/Substrate/sanitizer_recognition:missing->partial
implements-capability: lang.go.framework.gin/Substrate/vulnerability_finding:missing->partial

Closes #2772

🤖 Generated with [Claude Code](https://claude.com/claude-code)