### PR TITLE
feat(substrate): Phase 2A payload-shape + drift detection for T2 languages (#2771)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,39 +11,39 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/7 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/12 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
 | [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -64,7 +64,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/16 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 7/12 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -79,33 +79,33 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — | — | — | — | — | — | |
 | [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — | — | — | — | — | — | |
-| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/16 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
 | [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -120,32 +120,32 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | — | — | — | — | — | — | |
 
 
@@ -153,14 +153,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 2/13 | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/9 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 
@@ -169,23 +169,23 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ## Mobile
 
 | Language | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 | [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
@@ -193,33 +193,33 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ## Desktop
 
 | Language | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 | [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
 | [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ## RPC Framework
 
 | Language | Name | Schema | Codegen | Transport | Substrate | Notes |
 |---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
+| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/10 | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | — | |
+| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | — | |
 
 
 ## AI Integration

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -12,35 +12,35 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/7 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
 
 
 ### UI Frontend
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -12,45 +12,45 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 
 
 ### UI Frontend
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ### Mobile
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ### RPC Framework
 
 | Name | Schema | Codegen | Transport | Substrate | Notes |
 |---|---|---|---|---|---|
-| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
+| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/10 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -12,21 +12,21 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 
 
 ### Meta Framework
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -16,7 +16,7 @@ Back to [summary](../summary.md).
 | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/12 | |
+| [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
 | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -22,7 +22,7 @@ Back to [summary](../summary.md).
 | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/16 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 7/12 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 
@@ -39,7 +39,7 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | — | |
 
 
 ### Mobile

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -31,7 +31,7 @@ Back to [summary](../summary.md).
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
 | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 2/13 | |
+| [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/9 | |
 | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 
@@ -40,12 +40,12 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
+| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 
 
 ### Mobile
@@ -69,8 +69,8 @@ Back to [summary](../summary.md).
 
 | Name | Schema | Codegen | Transport | Substrate | Notes |
 |---|---|---|---|---|---|
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
-| [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | ⚠️ 2/3 | |
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | — | |
+| [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | — | |
 
 
 ### AI Integration

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -12,30 +12,30 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
 
 
 ### Mobile
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
-| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
+| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ## ORMs

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -12,18 +12,18 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -16,7 +16,7 @@ Back to [summary](../summary.md).
 | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/16 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
 | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -12,14 +12,14 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -12,23 +12,23 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 
 
 ### Desktop
 
 | Name | Process | Native | Updates | Substrate | Notes |
 |---|---|---|---|---|---|
-| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | — | |
+| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 3/7 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -12,21 +12,21 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 2/3 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 
 
 ### Meta Framework
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 11
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,13 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.qt.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.qt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 18
+- **Capability cells:** 25
 
 ## Capabilities
 
@@ -60,9 +60,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
+| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.ros.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ros.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 3
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,6 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.framework.unreal-engine.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.unreal-engine.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 3
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,6 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 18
+- **Capability cells:** 25
 
 ## Capabilities
 
@@ -60,9 +60,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 18
+- **Capability cells:** 25
 
 ## Capabilities
 
@@ -60,9 +60,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 18
+- **Capability cells:** 25
 
 ## Capabilities
 
@@ -60,9 +60,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.grpc-net.md
+++ b/docs/coverage/detail/lang.csharp.framework.grpc-net.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 6
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -33,9 +33,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.net-maui.md
+++ b/docs/coverage/detail/lang.csharp.framework.net-maui.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -69,9 +69,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.uno.md
+++ b/docs/coverage/detail/lang.csharp.framework.uno.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 3
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,6 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.winforms.md
+++ b/docs/coverage/detail/lang.csharp.framework.winforms.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 3
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,6 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.wpf.md
+++ b/docs/coverage/detail/lang.csharp.framework.wpf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 3
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,6 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.framework.xamarin.md
+++ b/docs/coverage/detail/lang.csharp.framework.xamarin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -69,9 +69,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/csharp.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_csharp.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_csharp.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 23
 
 ## Capabilities
 
@@ -68,9 +68,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/elixir.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_elixir.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_elixir.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_elixir.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -55,17 +55,17 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
-| `dead_code_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/links/reachability.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_golang.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
-| `reachability_analysis` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/substrate/entry_points.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_golang.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_golang.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_golang.go` | — |
-| `sanitizer_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_golang.go` | — |
-| `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
-| `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
-| `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.play.md
+++ b/docs/coverage/detail/lang.java.framework.play.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -68,9 +68,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 20
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -55,21 +55,17 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `dead_code_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/links/reachability.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `reachability_analysis` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/substrate/entry_points.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| `sanitizer_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
-| `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
-| `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.jsts.framework.astro.md
+++ b/docs/coverage/detail/lang.jsts.framework.astro.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -68,9 +68,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.gatsby.md
+++ b/docs/coverage/detail/lang.jsts.framework.gatsby.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -68,9 +68,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 6
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,9 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -68,9 +68,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -68,9 +68,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 28
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -61,18 +61,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `dead_code_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/links/reachability.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_jsts.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `reachability_analysis` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/substrate/entry_points.go` | — |
-| `sanitizer_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
-| `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
-| `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
-| `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.remix.md
+++ b/docs/coverage/detail/lang.jsts.framework.remix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -68,9 +68,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -68,9 +68,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 6
+- **Capability cells:** 3
 
 ## Capabilities
 
@@ -33,9 +33,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-desktop.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 3
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,6 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose-multiplatform.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 3
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,6 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -69,9 +69,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -69,9 +69,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [php](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_php.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 20
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -55,21 +55,17 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `dead_code_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/links/reachability.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2764) | `internal/substrate/effects.go` | — |
-| `reachability_analysis` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2766) | `internal/substrate/entry_points.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
-| `sanitizer_recognition` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
-| `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
-| `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
-| `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2772) | `internal/substrate/taint_sites.go`<br>`internal/links/taint_flow.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/ruby.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_ruby.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_ruby.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_ruby.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tauri.md
+++ b/docs/coverage/detail/lang.rust.framework.tauri.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Desktop
-- **Capability cells:** 3
+- **Capability cells:** 10
 
 ## Capabilities
 
@@ -33,6 +33,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.play.md
+++ b/docs/coverage/detail/lang.scala.framework.play.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 23
 
 ## Capabilities
 
@@ -68,9 +68,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 7
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -54,9 +54,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ✅ `full` | `2026-05-28` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
+| `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9,16 +9,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/bazel/extractor.go"
-          ],
+          "cites": ["internal/extractors/bazel/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/bazel/parser.go"
-          ],
+          "cites": ["internal/extractors/bazel/parser.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -31,16 +27,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -53,16 +45,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -75,16 +63,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -97,16 +81,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -119,16 +99,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -141,16 +117,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -191,17 +163,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/golang/gomod.go"
-          ],
+          "cites": ["internal/extractors/golang/gomod.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/build_tools.yaml",
-            "internal/extractors/golang/gomod.go"
-          ],
+          "cites": ["internal/engine/rules/go/build_tools.yaml","internal/extractors/golang/gomod.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -214,17 +181,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml",
-            "internal/engine/rules/kotlin/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml","internal/engine/rules/kotlin/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -251,16 +213,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -273,16 +231,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/extractors/just/just.go"
-          ],
+          "cites": ["internal/extractors/just/just.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/just/just.go"
-          ],
+          "cites": ["internal/extractors/just/just.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -326,9 +280,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -341,16 +293,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -377,16 +325,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -399,16 +343,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -421,16 +361,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -471,16 +407,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -493,16 +425,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -515,16 +443,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -537,16 +461,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -562,9 +482,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -591,16 +509,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/scala/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/scala/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -613,16 +527,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -663,16 +573,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -688,9 +594,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -706,9 +610,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -721,16 +623,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/build_tools.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/build_tools.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -743,16 +641,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -765,16 +659,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -787,16 +677,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/buildkite.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/buildkite.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -809,16 +695,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/circleci.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/circleci.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -845,17 +727,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/github_actions.yaml",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/github_actions.yaml","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -868,16 +745,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -893,9 +766,7 @@
         },
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/cicd/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -908,16 +779,12 @@
       "capabilities": {
         "env_resolution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/cicd/frameworks/travis_ci.yaml"
-          ],
+          "cites": ["internal/engine/rules/cicd/frameworks/travis_ci.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -930,9 +797,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -941,20 +806,16 @@
       "id": "config.dotenv",
       "category": "platform",
       "language": "multi",
-      "label": ".env (names-only \u2014 values stripped at extraction boundary)",
+      "label": ".env (names-only — values stripped at extraction boundary)",
       "capabilities": {
         "env_resolution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -967,9 +828,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -982,9 +841,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -997,9 +854,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1023,9 +878,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1038,10 +891,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go",
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go","internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1054,9 +904,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/config/discover.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1069,10 +917,7 @@
       "capabilities": {
         "file_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/config/discover.go",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/config/discover.go","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1113,16 +958,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1135,16 +976,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1157,16 +994,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1179,17 +1012,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/database_index/language.yaml",
-            "internal/extractors/sql"
-          ],
+          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1216,17 +1044,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/database_index/language.yaml",
-            "internal/extractors/sql"
-          ],
+          "cites": ["internal/engine/rules/database_index/language.yaml","internal/extractors/sql"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1239,16 +1062,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1275,16 +1094,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/sql"
-          ],
+          "cites": ["internal/extractors/sql"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1297,17 +1112,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/docker/frameworks/docker_compose.yaml",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/engine/rules/docker/frameworks/docker_compose.yaml","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1320,17 +1130,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/docker/frameworks/dockerfile.yaml",
-            "internal/extractors/dockerfile/dockerfile.go"
-          ],
+          "cites": ["internal/engine/rules/docker/frameworks/dockerfile.yaml","internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1343,16 +1148,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1365,17 +1166,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml",
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml","internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1402,16 +1198,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ansible/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ansible/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1438,16 +1230,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/cdk/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/cdk/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1460,16 +1248,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1482,16 +1266,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/pulumi/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/pulumi/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/pulumi/_manifest.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1504,16 +1284,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/serverless_edges.go"
-          ],
+          "cites": ["internal/engine/serverless_edges.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/serverless_edges.go"
-          ],
+          "cites": ["internal/engine/serverless_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1526,16 +1302,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl"
-          ],
+          "cites": ["internal/extractors/hcl"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl"
-          ],
+          "cites": ["internal/extractors/hcl"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1616,9 +1388,7 @@
       "capabilities": {
         "log_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/_engine/logging_config_extractor.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/logging_config_extractor.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1651,17 +1421,12 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/event_flow.go",
-            "internal/engine/process_flow.go"
-          ],
+          "cites": ["internal/engine/event_flow.go","internal/engine/process_flow.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1677,9 +1442,7 @@
         },
         "metric_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/_engine/comment_marker_extractor.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/comment_marker_extractor.yaml"],
           "verified_at": "2026-05-28"
         },
         "trace_extraction": {
@@ -1712,9 +1475,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/extractor.go"
-          ],
+          "cites": ["internal/extractors/hcl/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1727,9 +1488,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/workflow_edges.go"
-          ],
+          "cites": ["internal/engine/workflow_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1753,9 +1512,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/yaml/extractor.go"
-          ],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1768,9 +1525,7 @@
       "capabilities": {
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/extractor.go"
-          ],
+          "cites": ["internal/extractors/hcl/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1783,17 +1538,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/relationships.go"
-          ],
+          "cites": ["internal/extractors/hcl/relationships.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "full",
-          "cites": [
-            "internal/extractors/hcl/extractor.go",
-            "internal/extractors/hcl/relationships.go"
-          ],
+          "cites": ["internal/extractors/hcl/extractor.go","internal/extractors/hcl/relationships.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1892,32 +1642,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -1948,32 +1739,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2004,32 +1836,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2060,32 +1933,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2116,63 +2030,72 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-27"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
           "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
           },
           "fs_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
           },
           "http_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
             "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-27"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
             "verified_at": "2026-05-28"
           }
         }
@@ -2204,32 +2127,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2260,32 +2224,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2316,32 +2321,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2372,32 +2418,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2428,32 +2515,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2484,32 +2612,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2540,32 +2709,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2635,32 +2845,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2691,32 +2924,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2747,32 +3021,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/c_cpp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/c_cpp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_c_cpp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -2796,6 +3111,43 @@
           "native_module_imports": {
             "status": "missing"
           }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -2817,6 +3169,43 @@
         "Native": {
           "native_module_imports": {
             "status": "missing"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_c_cpp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_c_cpp.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3026,9 +3415,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/cassandra_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3047,9 +3434,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3068,9 +3453,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3089,9 +3472,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/mongodb_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3110,9 +3491,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/mysql_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3131,9 +3510,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3152,9 +3529,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/npgsql.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3173,9 +3548,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/redis_stackexchange.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3194,9 +3567,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/sqlite_csharp.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -3211,17 +3582,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/aspnet_core_routes.go",
-              "internal/engine/rules/csharp/frameworks/asp_net_core.yaml"
-            ],
+            "cites": ["internal/engine/aspnet_core_routes.go","internal/engine/rules/csharp/frameworks/asp_net_core.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/aspnet_core_routes.go"
-            ],
+            "cites": ["internal/engine/aspnet_core_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -3233,39 +3599,78 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/aspnet_core_routes.go"
-            ],
+            "cites": ["internal/engine/aspnet_core_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3280,16 +3685,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
-            ],
+            "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"
-            ],
+            "cites": ["internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -3304,32 +3705,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3399,32 +3841,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3494,32 +3959,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3589,32 +4077,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3645,32 +4156,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3701,32 +4253,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3752,32 +4345,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3808,32 +4424,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3904,32 +4561,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -3960,32 +4640,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_csharp.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4009,6 +4730,43 @@
           "native_module_imports": {
             "status": "missing"
           }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -4031,6 +4789,43 @@
           "native_module_imports": {
             "status": "missing"
           }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -4052,6 +4847,43 @@
         "Native": {
           "native_module_imports": {
             "status": "missing"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4122,32 +4954,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/csharp.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/csharp.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_csharp.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_csharp.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4163,16 +5018,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/dapper.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/dapper.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4188,17 +5039,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/csharp/frameworks/entity_framework_core.yaml",
-            "internal/engine/rules/csharp/orms/entity_framework_core.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/frameworks/entity_framework_core.yaml","internal/engine/rules/csharp/orms/entity_framework_core.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4214,16 +5060,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4256,16 +5098,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/nhibernate.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/orms/nhibernate.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4284,9 +5122,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4305,9 +5141,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4326,9 +5160,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4347,9 +5179,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/myxql.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/myxql.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4368,9 +5198,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4389,9 +5217,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/postgrex.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/postgrex.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4410,9 +5236,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/redix.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/redix.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4431,9 +5255,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/xandra.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/xandra.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -4448,17 +5270,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/absinthe.yaml",
-              "internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml","internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/absinthe.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -4473,32 +5290,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4513,16 +5371,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/ash_framework.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/ash_framework.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -4537,32 +5391,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4593,32 +5488,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4649,32 +5585,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4692,9 +5669,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/nerves.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/nerves.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -4709,32 +5684,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4752,9 +5768,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/elixir/frameworks/oban.yaml"
-            ],
+            "cites": ["internal/engine/rules/elixir/frameworks/oban.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -4769,32 +5783,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4809,17 +5864,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/phoenix_routes.go",
-              "internal/engine/rules/elixir/frameworks/phoenix.yaml"
-            ],
+            "cites": ["internal/engine/phoenix_routes.go","internal/engine/rules/elixir/frameworks/phoenix.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/phoenix_routes.go"
-            ],
+            "cites": ["internal/engine/phoenix_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -4834,32 +5884,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4927,32 +6018,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -4983,32 +6097,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/elixir.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/elixir.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_elixir.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_elixir.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -5024,16 +6179,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5049,16 +6200,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
-          ],
+          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5077,9 +6224,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/cassandra_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/cassandra_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5098,9 +6243,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/dynamodb_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/dynamodb_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5119,9 +6262,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/elasticsearch_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/elasticsearch_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5140,9 +6281,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/mongo_driver.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/mongo_driver.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5161,9 +6300,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/mysql_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/mysql_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5182,9 +6319,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5203,9 +6338,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/go_redis.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/go_redis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5224,9 +6357,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlite_go.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlite_go.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -5241,16 +6372,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/go/frameworks/beego.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/go/frameworks/beego.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/beego.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5267,29 +6394,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -5320,16 +6435,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/buffalo.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/buffalo.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5346,29 +6457,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -5399,17 +6498,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/chi.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/chi.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5426,29 +6520,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -5479,17 +6561,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/echo.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/echo.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5506,29 +6583,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -5559,16 +6624,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/fasthttp.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/fasthttp.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5585,29 +6646,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -5638,17 +6687,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/fiber.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/fiber.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5665,29 +6709,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -5740,17 +6772,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/gin.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gin.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5767,81 +6794,47 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_golang.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
-          "taint_source_detection": {
+          "mutation_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "taint_sink_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "sanitizer_recognition": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "vulnerability_finding": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "dead_code_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/links/reachability.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/entry_points.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_golang.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -5872,16 +6865,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/go_zero.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/go_zero.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/go_zero.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -5898,29 +6887,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6009,29 +6986,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -6047,17 +7012,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/gorilla_mux.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gorilla_mux.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6074,29 +7034,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6127,16 +7075,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/hertz.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/hertz.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6153,29 +7097,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6206,16 +7138,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_go_trio.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_go_trio.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_go_trio.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_go_trio.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6232,29 +7160,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6285,16 +7201,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/iris.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/iris.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/iris.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6311,29 +7223,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6364,16 +7264,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/kratos.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/kratos.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/kratos.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6390,29 +7286,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6443,17 +7327,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go",
-              "internal/engine/rules/go/frameworks/net_http_stdlib.yaml"
-            ],
+            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/net_http_stdlib.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/go_routes.go"
-            ],
+            "cites": ["internal/engine/go_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6470,29 +7349,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6523,16 +7390,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/revel.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/go/frameworks/revel.yaml"
-            ],
+            "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -6549,29 +7412,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/golang.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6603,16 +7454,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/bun.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/bun.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6628,16 +7475,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/orms/ent.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/ent.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6670,18 +7513,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/go/frameworks/gorm.yaml",
-            "internal/engine/rules/go/orms/gorm.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/go/frameworks/gorm.yaml","internal/engine/rules/go/orms/gorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6694,9 +7531,7 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/golang_migrate.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/golang_migrate.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -6721,9 +7556,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/pgx.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/pgx.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6736,23 +7569,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlc.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlc.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlc.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6768,16 +7595,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -6827,29 +7650,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -6938,29 +7749,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7034,29 +7833,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7072,17 +7859,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/rules/java/frameworks/dropwizard.yaml"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/dropwizard.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7099,29 +7881,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7209,29 +7979,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -7265,29 +8023,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7318,16 +8064,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7344,29 +8086,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7415,29 +8145,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7468,26 +8186,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/rules/java/frameworks/jakarta_ee.yaml"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7499,29 +8210,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7574,26 +8273,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/rules/java/frameworks/micronaut.yaml"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/micronaut.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7605,29 +8297,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7658,16 +8338,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/microprofile.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/microprofile.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7684,29 +8360,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7788,35 +8452,6 @@
           "tests_linkage": {
             "status": "missing"
           }
-        },
-        "Substrate": {
-          "constant_propagation": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          }
         }
       }
     },
@@ -7830,26 +8465,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/rules/java/frameworks/quarkus.yaml"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/rules/java/frameworks/quarkus.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -7861,29 +8489,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -7914,151 +8530,73 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_synthesis.go",
-              "internal/engine/rules/java/frameworks/spring_boot.yaml",
-              "internal/engine/rules/java/frameworks/spring_mvc.yaml",
-              "internal/engine/spring_routes.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/java/frameworks/spring_boot.yaml","internal/engine/rules/java/frameworks/spring_mvc.yaml","internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_annotation_routes.go",
-              "internal/engine/spring_routes.go"
-            ],
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "full",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_annotation_params.go"
-            ],
+            "cites": ["internal/engine/java_annotation_params.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "taint_source_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "taint_sink_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "sanitizer_recognition": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "vulnerability_finding": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/links/reachability.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "fs_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
             "verified_at": "2026-05-28"
           },
           "http_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/entry_points.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_java.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8105,26 +8643,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/java/frameworks/spring_webflux.yaml",
-              "internal/engine/spring_routes.go"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/spring_webflux.yaml","internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/spring_routes.go"
-            ],
+            "cites": ["internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8136,29 +8667,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8189,16 +8708,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/apache_struts.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/apache_struts.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8215,29 +8730,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8325,29 +8828,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -8363,16 +8854,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/vert_x.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/java/frameworks/vert_x.yaml"
-            ],
+            "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -8389,29 +8876,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/java.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -8443,16 +8918,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/dynamodb_java.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/dynamodb_java.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8502,17 +8973,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/java/orms/hibernate_core.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/hibernate_core.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8528,16 +8994,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/jooq.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/jooq.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8553,16 +9015,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8578,16 +9036,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/mybatis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/mybatis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8603,16 +9057,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8628,16 +9078,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_cassandra.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8653,16 +9099,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8678,17 +9120,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/java/orms/spring_data_jpa.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/spring_data_jpa.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8704,16 +9141,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_mongodb.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8729,16 +9162,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_redis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/orms/spring_data_redis.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8757,9 +9186,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8778,9 +9205,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8799,9 +9224,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8820,9 +9243,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8841,9 +9262,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mysql_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8862,9 +9281,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8883,9 +9300,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8904,9 +9319,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/redis_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/redis_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8925,9 +9338,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8946,9 +9357,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/supabase_js.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -8981,29 +9390,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9073,23 +9470,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9102,38 +9493,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9190,9 +9567,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/astro.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/astro.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -9207,23 +9582,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9236,38 +9605,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
-            "verified_at": "2026-05-28"
-          }
-        },
-        "Substrate": {
-          "constant_propagation": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9287,9 +9625,7 @@
           },
           "main_renderer_split": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/electron.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/electron.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -9311,16 +9647,12 @@
         "Structure": {
           "context_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9331,25 +9663,19 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -9363,16 +9689,12 @@
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/discriminator.go"
-            ],
+            "cites": ["internal/extractors/javascript/discriminator.go"],
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/expo.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -9380,70 +9702,48 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9460,9 +9760,7 @@
           },
           "expo_router_specifics": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/navigation.go"
-            ],
+            "cites": ["internal/extractors/javascript/navigation.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9478,17 +9776,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/express.yaml",
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9500,38 +9793,24 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/express.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/express.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9562,16 +9841,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9588,29 +9863,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9659,29 +9922,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9733,9 +9984,7 @@
         "Routing": {
           "route_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -9751,23 +10000,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9780,38 +10023,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
-            "verified_at": "2026-05-28"
-          }
-        },
-        "Substrate": {
-          "constant_propagation": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -9827,17 +10039,12 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/graphql/frameworks/apollo_server.yaml",
-              "internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"
-            ],
+            "cites": ["internal/engine/rules/graphql/frameworks/apollo_server.yaml","internal/engine/rules/graphql/frameworks/graphql_yoga.yaml"],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
-            ],
+            "cites": ["internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9845,35 +10052,6 @@
           "client_codegen": {
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/2735"
-          }
-        },
-        "Substrate": {
-          "constant_propagation": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -9906,29 +10084,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -9959,16 +10125,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -9985,29 +10147,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -10078,23 +10228,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10107,38 +10251,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10154,16 +10284,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/framework_dsl.go"
-            ],
+            "cites": ["internal/extractors/javascript/framework_dsl.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10180,29 +10306,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -10233,9 +10347,7 @@
         "Prompts": {
           "prompt_template_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -10243,9 +10355,7 @@
         "Composition": {
           "chain_composition": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/langchain.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
@@ -10284,29 +10394,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -10377,23 +10475,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10406,38 +10498,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10453,63 +10531,43 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -10566,16 +10624,12 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/next_js.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10588,23 +10642,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10617,38 +10665,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
-            "verified_at": "2026-05-28"
-          }
-        },
-        "Substrate": {
-          "constant_propagation": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10697,9 +10714,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -10714,23 +10729,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -10743,38 +10752,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
-            "verified_at": "2026-05-28"
-          }
-        },
-        "Substrate": {
-          "constant_propagation": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -10808,29 +10786,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -10861,73 +10827,53 @@
         "Structure": {
           "component_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "context_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "hook_recognition": {
             "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/destructure_bindings.go"
-            ],
+            "cites": ["internal/extractors/javascript/destructure_bindings.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "jsx_template": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/discriminator.go"
-            ],
+            "cites": ["internal/extractors/javascript/discriminator.go"],
             "verified_at": "2026-05-28"
           },
           "data_fetching": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/destructure_bindings.go",
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "prop_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/navigation.go"
-            ],
+            "cites": ["internal/extractors/javascript/navigation.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2665",
             "notes": "Covers only JSX navigation props (Link to/href, Navigate to, state object); generic React component prop extraction is not yet implemented.",
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/destructure_bindings.go",
-              "internal/extractors/javascript/zustand_store.go"
-            ],
+            "cites": ["internal/extractors/javascript/destructure_bindings.go","internal/extractors/javascript/zustand_store.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -10935,163 +10881,85 @@
         "Navigation": {
           "router_pattern": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/navigation.go"
-            ],
+            "cites": ["internal/extractors/javascript/navigation.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "taint_source_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "taint_sink_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "sanitizer_recognition": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "vulnerability_finding": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/links/reachability.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_jsts.go"],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "fs_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
             "verified_at": "2026-05-28"
           },
           "http_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/entry_points.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_jsts.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11107,16 +10975,12 @@
         "Structure": {
           "context_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "hoc_wrapper_recognition": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11127,25 +10991,19 @@
           },
           "navigation_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "verified_at": "2026-05-28"
           },
           "screen_detection": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Platform": {
           "platform_branching": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2666",
             "verified_at": "2026-05-28"
           }
@@ -11159,16 +11017,12 @@
         "Data Flow": {
           "branch_conditions": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/discriminator.go"
-            ],
+            "cites": ["internal/extractors/javascript/discriminator.go"],
             "verified_at": "2026-05-28"
           },
           "state_management": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2632",
             "verified_at": "2026-05-28"
           }
@@ -11176,70 +11030,48 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11288,9 +11120,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/remix.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/remix.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -11305,23 +11135,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11334,38 +11158,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
-            "verified_at": "2026-05-28"
-          }
-        },
-        "Substrate": {
-          "constant_propagation": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11399,29 +11192,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -11470,29 +11251,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -11562,23 +11331,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11591,38 +11354,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11671,9 +11420,7 @@
         "Routing": {
           "route_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"
-            ],
+            "cites": ["internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml"],
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
@@ -11688,23 +11435,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11717,38 +11458,7 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
-            "verified_at": "2026-05-28"
-          }
-        },
-        "Substrate": {
-          "constant_propagation": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11764,17 +11474,12 @@
         "Schema": {
           "procedure_extraction": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_trpc.go",
-              "internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_trpc.go","internal/engine/rules/javascript_typescript/frameworks/trpc.yaml"],
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
             "status": "partial",
-            "cites": [
-              "internal/engine/http_endpoint_trpc.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_trpc.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           }
@@ -11783,35 +11488,6 @@
           "client_codegen": {
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/2735"
-          }
-        },
-        "Substrate": {
-          "constant_propagation": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -11865,23 +11541,17 @@
         "Type System": {
           "enum_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "interface_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/extractor.go"
-            ],
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -11894,38 +11564,24 @@
         "Testing": {
           "tests_linkage": {
             "status": "full",
-            "cites": [
-              "internal/extractors/javascript/tests.go"
-            ],
+            "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/jsts.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11958,16 +11614,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/drizzle.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/drizzle.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -11986,9 +11638,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/knex.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/knex.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12004,16 +11654,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12029,16 +11675,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/mongoose.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/mongoose.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12068,25 +11710,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/prisma/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/prisma/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/prisma.yaml",
-            "internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml",
-            "internal/engine/rules/prisma/_manifest.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/prisma.yaml","internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml","internal/engine/rules/prisma/_manifest.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12102,16 +11736,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/sequelize.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/sequelize.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12127,16 +11757,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/orms/typeorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/orms/typeorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_jsts.go"
-          ],
+          "cites": ["internal/engine/orm_queries_jsts.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12154,9 +11780,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12171,32 +11795,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12267,32 +11932,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12316,6 +12004,43 @@
           "native_module_imports": {
             "status": "missing"
           }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -12338,6 +12063,43 @@
           "native_module_imports": {
             "status": "missing"
           }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -12354,9 +12116,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12371,32 +12131,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12411,16 +12212,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/http4k.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/http4k.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12435,32 +12232,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12491,32 +12329,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12587,32 +12466,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12627,16 +12529,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/ktor.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/ktor.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12651,32 +12549,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12691,16 +12630,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12715,32 +12650,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12755,16 +12731,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12779,32 +12751,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12819,26 +12832,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml",
-              "internal/engine/spring_routes_kotlin.go"
-            ],
+            "cites": ["internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml","internal/engine/spring_routes_kotlin.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/spring_routes_kotlin.go"
-            ],
+            "cites": ["internal/engine/spring_routes_kotlin.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/java_auth_policy.go"
-            ],
+            "cites": ["internal/engine/java_auth_policy.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12848,32 +12854,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/kotlin.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -12889,16 +12936,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/exposed.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/exposed.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12914,16 +12957,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12939,16 +12978,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/ktorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/ktorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12964,16 +12999,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -12989,16 +13020,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/room_android.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/room_android.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13014,16 +13041,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13039,16 +13062,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/kotlin/orms/sqldelight.yaml"
-          ],
+          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13095,9 +13114,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/cassandra_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/cassandra_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13116,9 +13133,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/dynamodb_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/dynamodb_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13137,9 +13152,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/elasticsearch_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/elasticsearch_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13158,9 +13171,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/mongodb_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/mongodb_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13179,9 +13190,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/mysql_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/mysql_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13200,9 +13209,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13221,9 +13228,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/postgresql_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/postgresql_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13242,9 +13247,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/redis_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/redis_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13263,9 +13266,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/sqlite_php.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/sqlite_php.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -13280,16 +13281,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/cakephp.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/cakephp.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/cakephp.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13304,32 +13301,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13344,16 +13382,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/codeigniter.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/codeigniter.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/codeigniter.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13368,32 +13402,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13408,16 +13483,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/drupal.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/drupal.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/drupal.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13432,32 +13503,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13472,16 +13584,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/laminas.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/laminas.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/laminas.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13496,32 +13604,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13536,17 +13685,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_php_producer.go",
-              "internal/engine/rules/php/frameworks/laravel.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/laravel.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_php_producer.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_php_producer.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13561,32 +13705,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13617,32 +13802,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13657,16 +13883,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/magento.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/magento.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/magento.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13681,32 +13903,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13737,32 +14000,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13777,16 +14081,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/php/frameworks/slim.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/php/frameworks/slim.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/slim.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13801,32 +14101,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13841,17 +14182,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_php_producer.go",
-              "internal/engine/rules/php/frameworks/symfony.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_php_producer.go","internal/engine/rules/php/frameworks/symfony.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_php_producer.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_php_producer.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13866,32 +14202,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13906,16 +14283,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/wordpress.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/wordpress.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/wordpress.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13930,32 +14303,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13970,16 +14384,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/yii.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/php/frameworks/yii.yaml"
-            ],
+            "cites": ["internal/engine/rules/php/frameworks/yii.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -13994,32 +14404,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/php.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/php.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_php.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -14052,16 +14503,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/orms/doctrine_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/doctrine_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14077,16 +14524,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_other.go"
-          ],
+          "cites": ["internal/engine/orm_queries_other.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14102,16 +14545,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/propel.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/propel.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14127,16 +14566,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/redbeanphp.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/php/orms/redbeanphp.yaml"
-          ],
+          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14155,9 +14590,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/cassandra_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/cassandra_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14176,9 +14609,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/dynamodb_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/dynamodb_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14197,9 +14628,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/elasticsearch_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/elasticsearch_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14218,10 +14647,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/mysql_py.yaml",
-            "internal/extractors/python/raw_sql_db_calls.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14240,9 +14666,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14261,10 +14685,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/postgresql_py.yaml",
-            "internal/extractors/python/raw_sql_db_calls.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14283,9 +14704,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/redis_py.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/redis_py.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14304,10 +14723,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/sqlite_py.yaml",
-            "internal/extractors/python/raw_sql_db_calls.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -14322,16 +14738,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/aiohttp.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/aiohttp.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14348,29 +14760,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14401,16 +14801,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/bottle.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/bottle.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14427,29 +14823,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14483,10 +14867,7 @@
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/celery.yaml",
-              "internal/extractors/python/celery.go"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/celery.yaml","internal/extractors/python/celery.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14503,29 +14884,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14574,29 +14943,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14627,66 +14984,43 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/django_routes.go",
-              "internal/engine/django_urlconf_nested.go",
-              "internal/engine/rules/python/frameworks/django.yaml"
-            ],
+            "cites": ["internal/engine/django_routes.go","internal/engine/django_urlconf_nested.go","internal/engine/rules/python/frameworks/django.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/django_admin_routes.go",
-              "internal/engine/django_routes.go"
-            ],
+            "cites": ["internal/engine/django_admin_routes.go","internal/engine/django_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/django_drf_actions.go"
-            ],
+            "cites": ["internal/engine/django_drf_actions.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/django_imports_rewrite.go"
-            ],
+            "cites": ["internal/engine/django_imports_rewrite.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14717,27 +15051,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/django_drf_actions.go",
-              "internal/extractors/python/django_drf_actions.go"
-            ],
+            "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/django_drf_actions.go"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/django_drf_actions.go",
-              "internal/extractors/python/drf_serializer_fields.go"
-            ],
+            "cites": ["internal/engine/django_drf_actions.go","internal/extractors/python/drf_serializer_fields.go"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/django_drf_actions.go"
-            ],
+            "cites": ["internal/engine/django_drf_actions.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14749,113 +15075,47 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "env_fallback_recognition": {
-            "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "import_resolution_quality": {
-            "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
-            "verified_at": "2026-05-28"
-          },
-          "taint_source_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "taint_sink_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "sanitizer_recognition": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
-            "verified_at": "2026-05-28"
-          },
-          "vulnerability_finding": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/taint_sites.go",
-              "internal/links/taint_flow.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2772",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "db_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/links/reachability.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "verified_at": "2026-05-28"
+          },
+          "env_fallback_recognition": {
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "fs_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
             "verified_at": "2026-05-28"
           },
           "http_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "verified_at": "2026-05-28"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "mutation_effect": {
             "status": "partial",
-            "cites": [
-              "internal/substrate/effects.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2764",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
-            "status": "partial",
-            "cites": [
-              "internal/substrate/entry_points.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2766",
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14883,9 +15143,7 @@
           },
           "signal_handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/django_signal_pubsub_edges.go"
-            ],
+            "cites": ["internal/engine/django_signal_pubsub_edges.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2739",
             "verified_at": "2026-05-28"
           }
@@ -14905,9 +15163,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/python/frameworks/dramatiq.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/dramatiq.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -14924,29 +15180,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -14995,29 +15239,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15048,26 +15280,19 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_synthesis.go",
-              "internal/engine/rules/python/frameworks/fastapi.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/fastapi.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/fastapi.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
             "verified_at": "2026-05-28"
           }
         },
         "Security": {
           "auth_coverage": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/python/frameworks/fastapi.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15079,29 +15304,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15132,17 +15345,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_synthesis.go",
-              "internal/engine/rules/python/frameworks/flask.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/flask.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/flask.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/flask.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15159,29 +15367,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15230,29 +15426,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15305,16 +15489,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/litestar.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/litestar.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15331,29 +15511,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15384,16 +15552,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/pyramid.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/pyramid.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/pyramid.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15410,29 +15574,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15481,29 +15633,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15534,16 +15674,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/robyn.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/robyn.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15560,29 +15696,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15613,16 +15737,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/sanic.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/sanic.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15639,29 +15759,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15692,16 +15800,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/starlette.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/starlette.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/starlette.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15718,29 +15822,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15771,17 +15863,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/graphql/frameworks/strawberry_python.yaml",
-              "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
-            ],
+            "cites": ["internal/engine/rules/graphql/frameworks/strawberry_python.yaml","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/python/frameworks/strawberry_graphql.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15798,29 +15885,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15851,16 +15926,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/tornado.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/python/frameworks/tornado.yaml"
-            ],
+            "cites": ["internal/engine/rules/python/frameworks/tornado.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -15877,29 +15948,17 @@
         "Substrate": {
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/python.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
@@ -15928,9 +15987,7 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/alembic.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -15952,16 +16009,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/beanie.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/beanie.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -15974,24 +16027,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/python/django_migration.go"
-          ],
+          "cites": ["internal/extractors/python/django_migration.go"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/orms/django_orm.yaml",
-            "internal/extractors/python/django_relational.go"
-          ],
+          "cites": ["internal/engine/rules/python/orms/django_orm.yaml","internal/extractors/python/django_relational.go"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16007,16 +16053,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/mongoengine.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/mongoengine.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16032,16 +16074,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/peewee.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/peewee.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16057,16 +16095,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/pony_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/pony_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16079,24 +16113,17 @@
       "capabilities": {
         "migration_parsing": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/orms/alembic.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_field_edges.go",
-            "internal/engine/rules/python/orms/sqlalchemy.yaml"
-          ],
+          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/python/orms/sqlalchemy.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16112,16 +16139,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/orms/sqlmodel.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/sqlmodel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16137,16 +16160,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/orms/tortoise_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/orms/tortoise_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/orm_queries_python.go"
-          ],
+          "cites": ["internal/engine/orm_queries_python.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16165,9 +16184,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/cassandra_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/cassandra_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16186,9 +16203,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16207,9 +16222,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16228,9 +16241,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/mysql_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/mysql_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16249,9 +16260,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16270,9 +16279,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/pg_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/pg_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16291,9 +16298,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/redis_rb.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/redis_rb.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16312,9 +16317,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/sqlite_ruby.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/sqlite_ruby.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16345,32 +16348,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16388,9 +16432,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/dry_rb.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/dry_rb.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16405,32 +16447,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16445,16 +16528,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/grape.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/grape.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/grape.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16469,32 +16548,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16509,16 +16629,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/hanami.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/hanami.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/hanami.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16533,32 +16649,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16573,16 +16730,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/padrino.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/padrino.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/padrino.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16597,32 +16750,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16637,17 +16831,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_ruby_producer.go",
-              "internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_ruby_producer.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16662,32 +16851,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16702,16 +16932,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/roda.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/ruby/frameworks/roda.yaml"
-            ],
+            "cites": ["internal/engine/rules/ruby/frameworks/roda.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16726,32 +16952,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16766,17 +17033,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_ruby_producer.go",
-              "internal/engine/rules/ruby/frameworks/sinatra.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_ruby_producer.go","internal/engine/rules/ruby/frameworks/sinatra.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_ruby_producer.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_ruby_producer.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -16791,32 +17053,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/ruby.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/ruby.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_ruby.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_ruby.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -16832,16 +17135,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/orms/activerecord.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/activerecord.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/orm_queries.go"
-          ],
+          "cites": ["internal/engine/orm_queries.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16857,16 +17156,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16882,16 +17177,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/mongoid.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/mongoid.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16907,17 +17198,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml",
-            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml","internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16933,16 +17219,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/sequel.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/orms/sequel.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16961,9 +17243,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/cassandra_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/cassandra_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -16982,9 +17262,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/dynamodb_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/dynamodb_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17003,9 +17281,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/elasticsearch_rs.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/elasticsearch_rs.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17024,9 +17300,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/mongodb_mongodb.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/mongodb_mongodb.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17045,9 +17319,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/mysql_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/mysql_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17066,9 +17338,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/neo4j.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/neo4j.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17087,9 +17357,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/postgresql_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/postgresql_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17108,9 +17376,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/redis_redis_rs.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/redis_redis_rs.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17129,9 +17395,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/sqlite_rust.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/sqlite_rust.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17146,16 +17410,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/actix_web.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/actix_web.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/actix_web.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17170,32 +17430,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17210,17 +17511,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_axum.go",
-              "internal/engine/rules/rust/frameworks/axum.yaml"
-            ],
+            "cites": ["internal/engine/http_endpoint_axum.go","internal/engine/rules/rust/frameworks/axum.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/http_endpoint_axum.go"
-            ],
+            "cites": ["internal/engine/http_endpoint_axum.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17235,32 +17531,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17275,16 +17612,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/gotham.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/gotham.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/gotham.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17299,32 +17632,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17339,16 +17713,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/hyper.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/hyper.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/hyper.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17363,32 +17733,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17403,16 +17814,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/poem.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/poem.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/poem.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17427,32 +17834,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17467,17 +17915,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rocket_routes.go",
-              "internal/engine/rules/rust/frameworks/rocket.yaml"
-            ],
+            "cites": ["internal/engine/rocket_routes.go","internal/engine/rules/rust/frameworks/rocket.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rocket_routes.go"
-            ],
+            "cites": ["internal/engine/rocket_routes.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17492,32 +17935,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17548,32 +18032,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17597,6 +18122,43 @@
           "native_module_imports": {
             "status": "missing"
           }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -17610,16 +18172,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/tide.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/tide.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/tide.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17634,32 +18192,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17690,32 +18289,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17730,16 +18370,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/warp.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": [
-              "internal/engine/rules/rust/frameworks/warp.yaml"
-            ],
+            "cites": ["internal/engine/rules/rust/frameworks/warp.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17754,32 +18390,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/rust.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/rust.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_rust.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_rust.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17795,16 +18472,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/diesel.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/diesel.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17840,9 +18513,7 @@
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/rusqlite.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/rusqlite.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17858,16 +18529,12 @@
         },
         "model_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/seaorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/orms/seaorm.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17883,16 +18550,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/rust/orms/sqlx.yaml"
-          ],
+          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -17907,16 +18570,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -17931,32 +18590,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -17987,32 +18687,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18030,9 +18771,7 @@
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/cats_effect.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/cats_effect.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18047,32 +18786,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18087,16 +18867,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/finatra.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/finatra.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18111,32 +18887,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18151,16 +18968,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/http4s.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/http4s.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18175,32 +18988,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18215,16 +19069,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/lagom.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/lagom.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18239,32 +19089,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18332,32 +19223,55 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18372,16 +19286,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/scalatra.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/scalatra.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18396,32 +19306,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18436,16 +19387,12 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/zio.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
             "status": "partial",
-            "cites": [
-              "internal/engine/rules/scala/frameworks/zio.yaml"
-            ],
+            "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
             "verified_at": "2026-05-28"
           }
         },
@@ -18460,32 +19407,73 @@
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "full",
+            "cites": ["internal/graph/graph.go","internal/mcp/tools.go","internal/types/confidence.go"],
+            "verified_at": "2026-05-28"
+          },
           "constant_propagation": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "db_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "env_fallback_recognition": {
             "status": "full",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "fs_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "http_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
           },
           "import_resolution_quality": {
             "status": "partial",
-            "cites": [
-              "internal/links/constant_propagation.go",
-              "internal/substrate/scala.go",
-              "internal/substrate/substrate.go"
-            ],
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
+          },
+          "mutation_effect": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "reachability_analysis": {
+            "status": "full",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
+            "verified_at": "2026-05-28"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
+          },
+          "schema_drift_detection": {
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2771",
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18501,16 +19489,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/doobie.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/doobie.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18526,16 +19510,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/elastic4s.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/elastic4s.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18551,16 +19531,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/quill.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/quill.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18576,16 +19552,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scalikejdbc.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18601,16 +19573,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scanamo.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/scanamo.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18626,16 +19594,12 @@
         },
         "model_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/slick.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/scala/orms/slick.yaml"
-          ],
+          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18662,23 +19626,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18708,23 +19666,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18737,23 +19689,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/debezium_cdc_edges.go"
-          ],
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/debezium_cdc_edges.go"
-          ],
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/debezium_cdc_edges.go"
-          ],
+          "cites": ["internal/engine/debezium_cdc_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18766,23 +19712,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18795,23 +19735,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18824,23 +19758,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18853,24 +19781,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/kafka_edges.go"
-          ],
+          "cites": ["internal/engine/kafka_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/kafka_edges.go",
-            "internal/engine/kafka_wrapper_edges.go"
-          ],
+          "cites": ["internal/engine/kafka_edges.go","internal/engine/kafka_wrapper_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/kafka_edges.go"
-          ],
+          "cites": ["internal/engine/kafka_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18883,23 +19804,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/event_bus_edges.go"
-          ],
+          "cites": ["internal/engine/event_bus_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18912,23 +19827,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/nats_edges.go"
-          ],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/nats_edges.go"
-          ],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/nats_edges.go"
-          ],
+          "cites": ["internal/engine/nats_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18941,23 +19850,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pulsar_edges.go"
-          ],
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pulsar_edges.go"
-          ],
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/pulsar_edges.go"
-          ],
+          "cites": ["internal/engine/pulsar_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18970,23 +19873,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rabbitmq_edges.go"
-          ],
+          "cites": ["internal/engine/rabbitmq_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -18995,27 +19892,21 @@
       "id": "msg.broker.redis",
       "category": "message_broker",
       "language": "multi",
-      "label": "Redis pub/sub & streams",
+      "label": "Redis pub/sub \u0026 streams",
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/redis_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/redis_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19028,23 +19919,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/iac_sns_edges.go"
-          ],
+          "cites": ["internal/engine/iac_sns_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19057,23 +19942,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sqs_edges.go"
-          ],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sqs_edges.go"
-          ],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/sqs_edges.go"
-          ],
+          "cites": ["internal/engine/sqs_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19086,23 +19965,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/links/topic_pass.go"
-          ],
+          "cites": ["internal/links/topic_pass.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19115,24 +19988,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/scheduled_jobs_edges.go",
-            "internal/extractors/python/celery.go"
-          ],
+          "cites": ["internal/engine/scheduled_jobs_edges.go","internal/extractors/python/celery.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/links/topic_pass.go"
-          ],
+          "cites": ["internal/links/topic_pass.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19145,23 +20011,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_signal_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/django_signal_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/django_signal_pubsub_edges.go"
-          ],
+          "cites": ["internal/engine/django_signal_pubsub_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19188,23 +20048,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19245,16 +20099,12 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sse_edges.go"
-          ],
+          "cites": ["internal/engine/sse_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/sse_edges.go"
-          ],
+          "cites": ["internal/engine/sse_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
@@ -19270,23 +20120,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/webhooks_edges.go"
-          ],
+          "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/webhooks_edges.go"
-          ],
+          "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/webhooks_edges.go"
-          ],
+          "cites": ["internal/engine/webhooks_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19299,23 +20143,17 @@
       "capabilities": {
         "consumer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/websocket_edges.go"
-          ],
+          "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         },
         "producer_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/websocket_edges.go"
-          ],
+          "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
           "status": "partial",
-          "cites": [
-            "internal/engine/websocket_edges.go"
-          ],
+          "cites": ["internal/engine/websocket_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19331,9 +20169,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19377,9 +20213,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19395,9 +20229,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19438,9 +20270,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19467,9 +20297,7 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19485,9 +20313,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19503,9 +20329,7 @@
         },
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19518,9 +20342,7 @@
       "capabilities": {
         "manifest_parsing": {
           "status": "full",
-          "cites": [
-            "internal/extractors/cross/manifest/extractor.go"
-          ],
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19555,24 +20377,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/http_endpoint_match.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_match.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/graphql_subscriptions.go",
-            "internal/engine/rules/graphql/frameworks/graphql_schema.yaml"
-          ],
+          "cites": ["internal/engine/graphql_subscriptions.go","internal/engine/rules/graphql/frameworks/graphql_schema.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19585,23 +20400,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "full",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19631,23 +20440,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/http_endpoint_match.go"
-          ],
+          "cites": ["internal/engine/http_endpoint_match.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/openapi/language.yaml"
-          ],
+          "cites": ["internal/engine/rules/openapi/language.yaml"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/openapi/language.yaml"
-          ],
+          "cites": ["internal/engine/rules/openapi/language.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19660,24 +20463,17 @@
       "capabilities": {
         "cross_repo_linkage": {
           "status": "partial",
-          "cites": [
-            "internal/engine/grpc_edges.go"
-          ],
+          "cites": ["internal/engine/grpc_edges.go"],
           "verified_at": "2026-05-28"
         },
         "method_attribution": {
           "status": "full",
-          "cites": [
-            "internal/extractors/proto"
-          ],
+          "cites": ["internal/extractors/proto"],
           "verified_at": "2026-05-28"
         },
         "service_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/protobuf/_manifest.yaml",
-            "internal/extractors/proto"
-          ],
+          "cites": ["internal/engine/rules/protobuf/_manifest.yaml","internal/extractors/proto"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19703,13 +20499,11 @@
       "id": "security.auth-java",
       "category": "security",
       "language": "java",
-      "label": "Auth policy resolver (Java/Kotlin \u2014 Phase 1 of #1942)",
+      "label": "Auth policy resolver (Java/Kotlin — Phase 1 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19718,7 +20512,7 @@
       "id": "security.auth-other",
       "category": "security",
       "language": "multi",
-      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET \u2014 Phases 2-4 of #1942)",
+      "label": "Auth policy resolver (Python / NestJS / Go / Ruby / ASP.NET — Phases 2-4 of #1942)",
       "capabilities": {
         "auth_policy": {
           "status": "missing",
@@ -19734,9 +20528,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19755,9 +20547,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19776,9 +20566,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19797,9 +20585,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19835,9 +20621,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "partial",
-          "cites": [
-            "internal/engine/java_auth_policy.go"
-          ],
+          "cites": ["internal/engine/java_auth_policy.go"],
           "verified_at": "2026-05-28"
         },
         "secret_detection": {
@@ -19856,9 +20640,7 @@
       "capabilities": {
         "auth_policy": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/_engine/csrf_heuristic_detector.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/csrf_heuristic_detector.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19871,9 +20653,7 @@
       "capabilities": {
         "secret_detection": {
           "status": "full",
-          "cites": [
-            "internal/secrets/secrets.go"
-          ],
+          "cites": ["internal/secrets/secrets.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19886,9 +20666,7 @@
       "capabilities": {
         "sql_injection": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/_engine/sql_injection_detector.yaml"
-          ],
+          "cites": ["internal/engine/rules/_engine/sql_injection_detector.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -19957,17 +20735,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/rust/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/rust/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20106,17 +20879,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/elixir/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/elixir/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20157,17 +20925,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/go/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/go/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20236,17 +20999,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/frameworks/jest.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/frameworks/jest.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20259,16 +21017,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20281,17 +21035,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/java/frameworks/junit5.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/java/frameworks/junit5.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20304,16 +21053,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/ruby/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/ruby/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20326,16 +21071,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20376,16 +21117,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20412,16 +21149,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20448,17 +21181,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/php/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/php/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20499,17 +21227,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/python/frameworks/pytest.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/python/frameworks/pytest.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20536,17 +21259,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "full",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "full",
-          "cites": [
-            "internal/engine/rules/ruby/frameworks/rspec.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/ruby/frameworks/rspec.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20601,16 +21319,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/go/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/go/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20626,9 +21340,7 @@
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/java/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/java/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20641,16 +21353,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/python/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/python/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20663,16 +21371,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/javascript_typescript/test_patterns.yaml"
-          ],
+          "cites": ["internal/engine/rules/javascript_typescript/test_patterns.yaml"],
           "verified_at": "2026-05-28"
         }
       }
@@ -20685,17 +21389,12 @@
       "capabilities": {
         "dependency_graph": {
           "status": "partial",
-          "cites": [
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         },
         "target_extraction": {
           "status": "partial",
-          "cites": [
-            "internal/engine/rules/csharp/test_patterns.yaml",
-            "internal/engine/tests_edges.go"
-          ],
+          "cites": ["internal/engine/rules/csharp/test_patterns.yaml","internal/engine/tests_edges.go"],
           "verified_at": "2026-05-28"
         }
       }

--- a/internal/substrate/payload_shapes_c_cpp.go
+++ b/internal/substrate/payload_shapes_c_cpp.go
@@ -1,0 +1,163 @@
+// C/C++ payload-shape sniffer (#2771 Phase 2A T2).
+//
+// C/C++ web frameworks are mostly opaque from a static-analysis view —
+// payloads are typically `const char*` blobs or hand-rolled JSON
+// readers, so there is no equivalent of Python's DRF serializer or
+// Spring's `@RequestBody` DTO to mine. We restrict this sniffer to the
+// two cases where structure is statically observable:
+//
+//   - cpprestsdk producer: `body[U("x")]` field reads via the
+//     `web::json::value` accessor. Each access contributes one field
+//     to the enclosing handler's request shape.
+//   - cpprestsdk producer response literal: a `json::value::object`
+//     followed by repeated `result[U("x")] = ...` assignments. Each
+//     assignment contributes one field to the response shape.
+//   - libcurl consumer: `curl_easy_setopt(..., CURLOPT_POSTFIELDS,
+//     "x=1&y=2");` — the urlencoded body is parsed for keys.
+//
+// Everything else (Boost.Beast, Drogon, Pistache, Crow) is recognised
+// by file (so the registry cell flips to "partial" rather than "full"
+// — Phase 4 would add per-framework recognisers).
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterPayloadShapeSniffer("c-cpp", sniffPayloadShapesCCPP) }
+
+// cppBodyAccessRe matches a cpprestsdk JSON-value access:
+// `body[U("name")]` or `value[U("name")]` or
+// `request[U("name")]`. Capture group 1 = the field name.
+var cppBodyAccessRe = regexp.MustCompile(
+	`\b(?:body|value|request|req|json)\s*\[\s*U\s*\(\s*"([A-Za-z_][\w]*)"\s*\)\s*\]`,
+)
+
+// cppResponseAssignRe matches `result[U("name")] = ...` and
+// `response[U("name")] = ...` — typical cpprestsdk response builders.
+// Capture group 1 = the field name. Reuses cppBodyAccessRe shape but
+// requires a trailing `=` to disambiguate writes from reads.
+var cppResponseAssignRe = regexp.MustCompile(
+	`\b(?:result|response|resp|output|out)\s*\[\s*U\s*\(\s*"([A-Za-z_][\w]*)"\s*\)\s*\]\s*=(?:[^=])`,
+)
+
+// cppCurlPostFieldsRe matches `curl_easy_setopt(handle, CURLOPT_POSTFIELDS, "x=1&y=2")`.
+// Capture group 1 = the urlencoded body string.
+var cppCurlPostFieldsRe = regexp.MustCompile(
+	`\bcurl_easy_setopt\s*\([^,]*,\s*CURLOPT_POSTFIELDS(?:_COPY)?\s*,\s*"([^"]*)"\s*\)`,
+)
+
+func sniffPayloadShapesCCPP(content string) []PayloadShape {
+	if content == "" {
+		return nil
+	}
+	headers := scanCCPPFuncHeaders(content)
+	var out []PayloadShape
+
+	// Producer-side: body[U("x")] reads bucket by enclosing function.
+	reqFields := map[string][]PayloadField{}
+	reqFirstLine := map[string]int{}
+	for _, m := range cppBodyAccessRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		reqFields[fn] = append(reqFields[fn], PayloadField{Name: name})
+		if _, ok := reqFirstLine[fn]; !ok {
+			reqFirstLine[fn] = line
+		}
+	}
+	for fn, fields := range reqFields {
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       reqFirstLine[fn],
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     DedupFields(fields),
+			Confidence: 0.8,
+		})
+	}
+
+	// Producer-side: result[U("x")] = ... assignments → response.
+	respFields := map[string][]PayloadField{}
+	respFirstLine := map[string]int{}
+	for _, m := range cppResponseAssignRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		respFields[fn] = append(respFields[fn], PayloadField{Name: name})
+		if _, ok := respFirstLine[fn]; !ok {
+			respFirstLine[fn] = line
+		}
+	}
+	for fn, fields := range respFields {
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       respFirstLine[fn],
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     DedupFields(fields),
+			Confidence: 0.9,
+		})
+	}
+
+	// Consumer-side: libcurl CURLOPT_POSTFIELDS urlencoded body.
+	for _, m := range cppCurlPostFieldsRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		fields := extractURLEncodedKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideConsumer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	return out
+}
+
+// extractURLEncodedKeys parses a `"x=1&y=2"` urlencoded body string
+// into a deduped field slice. Empty / malformed segments are skipped.
+func extractURLEncodedKeys(body string) []PayloadField {
+	var fields []PayloadField
+	for _, seg := range strings.Split(body, "&") {
+		if seg == "" {
+			continue
+		}
+		eq := strings.IndexByte(seg, '=')
+		var key string
+		if eq >= 0 {
+			key = seg[:eq]
+		} else {
+			key = seg
+		}
+		key = strings.TrimSpace(key)
+		if !isPlainIdent(key) {
+			continue
+		}
+		fields = append(fields, PayloadField{Name: key})
+	}
+	return DedupFields(fields)
+}

--- a/internal/substrate/payload_shapes_csharp.go
+++ b/internal/substrate/payload_shapes_csharp.go
@@ -1,0 +1,266 @@
+// C# payload-shape sniffer (#2771 Phase 2A T2).
+//
+// Producer-side shapes (ASP.NET Core / Carter / FastEndpoints):
+//
+//   - `[FromBody] T name` parameter — the wrapped DTO T's public
+//     properties (declared in the same file) become the request shape.
+//   - DTO classes / records: `public string Name { get; set; }` and
+//     positional record `record CreateDto(string Name, int Age)`.
+//     `[Required]` is treated as default (Optional=false); nullable
+//     reference / `int?` flips Optional=true.
+//   - Response shapes: `return Ok(new T { A = ..., B = ... })` and
+//     `return new JsonResult(new { A = ..., B = ... })` — anonymous
+//     object initializers contribute their property set.
+//
+// Consumer-side shapes (HttpClient + JsonContent / StringContent):
+//
+//   - `client.PostAsJsonAsync(url, new { A = ..., B = ... })`
+//   - `JsonContent.Create(new { A = ..., B = ... })`
+//   - `new StringContent(JsonSerializer.Serialize(new { A = ... }))` —
+//     out of scope for the regex sniffer (multi-call); we recognise
+//     PostAsJsonAsync as the canonical idiom.
+//
+// Optional/required: `?` (nullable) flips Optional=true; everything
+// else stays default-false (the `[Required]` attribute is implied).
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterPayloadShapeSniffer("csharp", sniffPayloadShapesCSharp) }
+
+// csClassHeaderRe matches a C# class or record declaration.
+// Capture group 1 = the type name.
+var csClassHeaderRe = regexp.MustCompile(
+	`(?m)^\s*(?:public\s+|internal\s+|private\s+|protected\s+|sealed\s+|abstract\s+|static\s+|partial\s+)*(?:class|record)\s+([A-Z][\w]*)\b`,
+)
+
+// csPropertyRe matches a public property declaration:
+// `public string Name { get; set; }`. Capture group 1 = type;
+// group 2 = name.
+var csPropertyRe = regexp.MustCompile(
+	`(?m)^\s*public\s+([A-Za-z_][\w<>?\[\],\s.]*?)\s+([A-Z][\w]*)\s*\{\s*get\s*;`,
+)
+
+// csPositionalRecordRe matches `record Name(string A, int B, ...)`.
+// Capture group 1 = type name; group 2 = the parameter list body.
+var csPositionalRecordRe = regexp.MustCompile(
+	`(?m)^\s*(?:public\s+|internal\s+)?record\s+([A-Z][\w]*)\s*\(([^)]*)\)`,
+)
+
+// csFromBodyParamRe matches `[FromBody] T name`. Capture group 1 = T;
+// group 2 = parameter name.
+var csFromBodyParamRe = regexp.MustCompile(
+	`\[FromBody\]\s+([A-Z][\w<>,?\s.]*)\s+([A-Za-z_][\w]*)`,
+)
+
+// csAnonObjectRe matches `new { A = ..., B = ... }`. Capture group 1 =
+// body between `{` and `}`. Bounded single-level.
+var csAnonObjectRe = regexp.MustCompile(
+	`\bnew\s*\{([^{}]*)\}`,
+)
+
+// csPostAsJsonRe matches `client.PostAsJsonAsync(url, ...)`. Capture
+// group 1 = inline URL when present, group 2 = verb (POST/PUT etc).
+var csPostAsJsonRe = regexp.MustCompile(
+	`\.\s*(Post|Put|Patch|Get|Delete)AsJsonAsync\s*\(\s*[$@]?"([^"]*)"`,
+)
+
+// csAnonAssignRe matches `Identifier =` inside an anonymous-object
+// body. Capture group 1 = the property name. C# property casing is
+// conventionally PascalCase but anonymous-object members can be any
+// identifier shape; we accept both. The trailing `(?:[^=])` excludes
+// `==` comparisons.
+var csAnonAssignRe = regexp.MustCompile(
+	`\b([A-Za-z_][\w]*)\s*=(?:[^=])`,
+)
+
+func sniffPayloadShapesCSharp(content string) []PayloadShape {
+	if content == "" {
+		return nil
+	}
+	headers := scanCSharpFuncHeaders(content)
+	classFields := scanCSharpClassFields(content)
+
+	var out []PayloadShape
+
+	// Producer-side: [FromBody] T name → request shape from T.
+	for _, m := range csFromBodyParamRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		typ := strings.TrimSpace(content[m[2]:m[3]])
+		typ = stripGenericSuffix(typ)
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		fields := classFields[typ]
+		conf := 0.9
+		if len(fields) == 0 {
+			conf = 0.4
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: conf,
+		})
+	}
+
+	// Producer-side: anonymous-object initializers as response shape.
+	// We must also tag PostAsJsonAsync usages as consumer; detect those
+	// by checking whether the surrounding line contains the marker.
+	clientLines := scanCSharpClientLines(content)
+	for _, m := range csAnonObjectRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		fields := extractCSharpAnonKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if hint, ok := clientLines[line]; ok {
+			out = append(out, PayloadShape{
+				Function:     fn,
+				Line:         line,
+				Direction:    PayloadDirectionRequest,
+				Side:         PayloadSideConsumer,
+				Fields:       fields,
+				Confidence:   1.0,
+				EndpointHint: hint.url,
+				VerbHint:     hint.verb,
+			})
+			continue
+		}
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	return out
+}
+
+// scanCSharpClassFields walks the file once and returns a map of
+// className → []PayloadField. Recognises both property-style classes
+// and positional records.
+func scanCSharpClassFields(content string) map[string][]PayloadField {
+	out := map[string][]PayloadField{}
+	// Property-style: bucket between consecutive class headers.
+	type block struct {
+		name       string
+		start, end int
+	}
+	var blocks []block
+	matches := csClassHeaderRe.FindAllStringSubmatchIndex(content, -1)
+	for i, m := range matches {
+		if len(m) < 4 {
+			continue
+		}
+		end := len(content)
+		if i+1 < len(matches) {
+			end = matches[i+1][0]
+		}
+		blocks = append(blocks, block{name: content[m[2]:m[3]], start: m[1], end: end})
+	}
+	for _, b := range blocks {
+		body := content[b.start:b.end]
+		var fields []PayloadField
+		for _, fm := range csPropertyRe.FindAllStringSubmatchIndex(body, -1) {
+			if len(fm) < 6 {
+				continue
+			}
+			typ := strings.TrimSpace(body[fm[2]:fm[3]])
+			name := body[fm[4]:fm[5]]
+			optional := strings.HasSuffix(typ, "?")
+			fields = append(fields, PayloadField{Name: name, Type: typ, Optional: optional})
+		}
+		if len(fields) > 0 {
+			out[b.name] = DedupFields(fields)
+		}
+	}
+	// Positional records: shape = constructor parameters.
+	for _, m := range csPositionalRecordRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		paramList := content[m[4]:m[5]]
+		var fields []PayloadField
+		for _, p := range splitTopLevel(paramList) {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			// `Type Name` — split on last whitespace.
+			i := strings.LastIndexAny(p, " \t")
+			if i <= 0 {
+				continue
+			}
+			typ := strings.TrimSpace(p[:i])
+			fname := strings.TrimSpace(p[i+1:])
+			if !isPlainIdent(fname) {
+				continue
+			}
+			optional := strings.HasSuffix(typ, "?")
+			fields = append(fields, PayloadField{Name: fname, Type: typ, Optional: optional})
+		}
+		if len(fields) > 0 {
+			out[name] = DedupFields(fields)
+		}
+	}
+	return out
+}
+
+// csharpClientHint mirrors the rust hint struct.
+type csharpClientHint struct {
+	url  string
+	verb string
+}
+
+// scanCSharpClientLines returns a line-keyed map of HttpClient
+// PostAsJsonAsync / PutAsJsonAsync call sites. The anonymous-object
+// recognition uses this to flip side=consumer when the literal is the
+// body argument on the same line.
+func scanCSharpClientLines(content string) map[int]csharpClientHint {
+	out := map[int]csharpClientHint{}
+	for _, m := range csPostAsJsonRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		// HttpClient.{Verb}AsJsonAsync → HTTP verb is the prefix.
+		out[line] = csharpClientHint{url: content[m[4]:m[5]], verb: verb}
+	}
+	return out
+}
+
+// extractCSharpAnonKeys lifts `Name =` property assignments out of a
+// `new { ... }` body. Deduped, source order preserved.
+func extractCSharpAnonKeys(body string) []PayloadField {
+	var fields []PayloadField
+	for _, m := range csAnonAssignRe.FindAllStringSubmatchIndex(body, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		fields = append(fields, PayloadField{Name: body[m[2]:m[3]]})
+	}
+	return DedupFields(fields)
+}

--- a/internal/substrate/payload_shapes_elixir.go
+++ b/internal/substrate/payload_shapes_elixir.go
@@ -1,0 +1,307 @@
+// Elixir payload-shape sniffer (#2771 Phase 2A T2).
+//
+// Producer-side shapes (Phoenix controllers / Plug pipelines):
+//
+//   - `def action(conn, %{"a" => a, "b" => b})` — Phoenix's idiomatic
+//     params map destructuring. The string keys are the request shape.
+//   - `params["a"]`, `Map.get(params, "a")` — bare read fallback.
+//   - `Ecto.Schema` `field :name, :type` declarations contribute to a
+//     same-module schema map. When `cast(attrs, [:a, :b])` is called
+//     with a literal list, those names are also recorded as the
+//     request shape for the surrounding changeset function.
+//   - `conn |> json(%{a: ..., b: ...})` and `json(conn, %{...})` —
+//     inline map response bodies. Bracket-key and bareword-atom forms
+//     are both recognised.
+//
+// Consumer-side shapes (HTTPoison / Tesla):
+//
+//   - `HTTPoison.<verb>(url, Jason.encode!(%{a: ..., b: ...}))`
+//   - `Tesla.<verb>(client, url, %{a: ..., b: ...})`
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterPayloadShapeSniffer("elixir", sniffPayloadShapesElixir) }
+
+// exDefRe is re-used from effect_sinks_elixir.go via scanElixirFuncHeaders.
+
+// exDestructureRe matches a function head with a destructured params
+// map as the second argument: `def action(conn, %{"a" => a, "b" => b})`.
+// Capture group 1 = the literal map body between %{ and }.
+var exDestructureRe = regexp.MustCompile(
+	`\bdef\s+[A-Za-z_][\w?!]*\s*\([^)]*,\s*%\{([^{}]*)\}\s*\)`,
+)
+
+// exParamsReadRe matches `params["x"]` and `Map.get(params, "x")` /
+// `Map.get(params, :x)`. Capture groups 1/2/3 each hold the name.
+var exParamsReadRe = regexp.MustCompile(
+	`\bparams\s*\[\s*"([A-Za-z_][\w]*)"\s*\]` +
+		`|\bMap\s*\.\s*get\s*\(\s*params\s*,\s*"([A-Za-z_][\w]*)"` +
+		`|\bMap\s*\.\s*get\s*\(\s*params\s*,\s*:([A-Za-z_][\w]*)`,
+)
+
+// exEctoFieldRe matches `field :name, :type` declarations inside an
+// Ecto schema block. Capture group 1 = the field atom.
+var exEctoFieldRe = regexp.MustCompile(
+	`(?m)^\s*field\s+:([A-Za-z_][\w]*)`,
+)
+
+// exCastListRe matches `cast(attrs, [:a, :b, :c])`. Capture group 1 =
+// the atom list body between `[` and `]`.
+var exCastListRe = regexp.MustCompile(
+	`\bcast\s*\([^,]*,\s*\[([^\[\]]*)\]`,
+)
+
+// exJSONResponseRe matches `json(conn, %{...})` and `|> json(%{...})`.
+// Capture group 1 = body between %{ and }.
+var exJSONResponseRe = regexp.MustCompile(
+	`\bjson\s*\(\s*(?:conn\s*,\s*)?%\{([^{}]*)\}` +
+		`|\|>\s*json\s*\(\s*%\{([^{}]*)\}`,
+)
+
+// exConsumerRe matches HTTPoison / Tesla outbound calls with an inline
+// map body. Capture groups:
+//
+//	1 = HTTPoison verb, 2 = url, 3 = body inside Jason.encode!(%{...})
+//	4 = Tesla verb,     5 = url, 6 = body inside %{...}
+var exConsumerRe = regexp.MustCompile(
+	`\bHTTPoison\s*\.\s*(get|post|put|patch|delete|head)\s*\(\s*"([^"]*)"[^)]*?Jason\s*\.\s*encode!\s*\(\s*%\{([^{}]*)\}` +
+		`|\bTesla\s*\.\s*(get|post|put|patch|delete|head)\s*\(\s*[^,]+,\s*"([^"]*)"[^)]*?%\{([^{}]*)\}`,
+)
+
+// exMapKeyRe matches a key in an Elixir map literal: `"name" =>`
+// (string keys) or bareword atom `name:`. Capture groups 1/2 hold the
+// name (first non-empty wins).
+var exMapKeyRe = regexp.MustCompile(
+	`"([A-Za-z_][\w]*)"\s*=>` +
+		`|\b([A-Za-z_][\w]*)\s*:`,
+)
+
+// exAtomListRe matches a `:name` atom inside a list literal.
+var exAtomListRe = regexp.MustCompile(`:([A-Za-z_][\w]*)`)
+
+func sniffPayloadShapesElixir(content string) []PayloadShape {
+	if content == "" {
+		return nil
+	}
+	headers := scanElixirFuncHeaders(content)
+	var out []PayloadShape
+
+	// Producer-side: def action(conn, %{"a" => a}) — destructure.
+	for _, m := range exDestructureRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		fields := extractElixirMapKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	// Producer-side: bare params reads.
+	paramFields := map[string][]PayloadField{}
+	paramFirstLine := map[string]int{}
+	for _, m := range exParamsReadRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		}
+		if name == "" {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		paramFields[fn] = append(paramFields[fn], PayloadField{Name: name})
+		if _, ok := paramFirstLine[fn]; !ok {
+			paramFirstLine[fn] = line
+		}
+	}
+	for fn, fields := range paramFields {
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       paramFirstLine[fn],
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     DedupFields(fields),
+			Confidence: 0.8,
+		})
+	}
+
+	// Producer-side: Ecto `cast(attrs, [:a, :b])` whitelist.
+	for _, m := range exCastListRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		var fields []PayloadField
+		for _, am := range exAtomListRe.FindAllStringSubmatchIndex(body, -1) {
+			if len(am) >= 4 {
+				fields = append(fields, PayloadField{Name: body[am[2]:am[3]]})
+			}
+		}
+		fields = DedupFields(fields)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 0.9,
+		})
+	}
+
+	// Producer-side: Ecto `field :name, :type` schema declarations.
+	schemaFields := map[string][]PayloadField{}
+	schemaFirstLine := map[string]int{}
+	for _, m := range exEctoFieldRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		schemaFields[fn] = append(schemaFields[fn], PayloadField{Name: name})
+		if _, ok := schemaFirstLine[fn]; !ok {
+			schemaFirstLine[fn] = line
+		}
+	}
+	for fn, fields := range schemaFields {
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       schemaFirstLine[fn],
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     DedupFields(fields),
+			Confidence: 0.85,
+		})
+	}
+
+	// Producer-side: json(conn, %{...}) response.
+	for _, m := range exJSONResponseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var body string
+		switch {
+		case m[2] >= 0:
+			body = content[m[2]:m[3]]
+		case m[4] >= 0:
+			body = content[m[4]:m[5]]
+		}
+		fields := extractElixirMapKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	// Consumer-side: HTTPoison / Tesla inline body.
+	for _, m := range exConsumerRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 14 {
+			continue
+		}
+		var verb, url, body string
+		switch {
+		case m[2] >= 0:
+			verb = strings.ToUpper(content[m[2]:m[3]])
+			url = content[m[4]:m[5]]
+			body = content[m[6]:m[7]]
+		case m[8] >= 0:
+			verb = strings.ToUpper(content[m[8]:m[9]])
+			url = content[m[10]:m[11]]
+			body = content[m[12]:m[13]]
+		}
+		fields := extractElixirMapKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, PayloadShape{
+			Function:     fn,
+			Line:         line,
+			Direction:    PayloadDirectionRequest,
+			Side:         PayloadSideConsumer,
+			Fields:       fields,
+			Confidence:   1.0,
+			EndpointHint: url,
+			VerbHint:     verb,
+		})
+	}
+
+	return out
+}
+
+// extractElixirMapKeys lifts keys out of an Elixir map literal body
+// (text between %{ and }). Both "name" => and bareword name: forms.
+func extractElixirMapKeys(body string) []PayloadField {
+	var fields []PayloadField
+	for _, m := range exMapKeyRe.FindAllStringSubmatchIndex(body, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = body[m[2]:m[3]]
+		case m[4] >= 0:
+			name = body[m[4]:m[5]]
+		}
+		if name == "" {
+			continue
+		}
+		fields = append(fields, PayloadField{Name: name})
+	}
+	return DedupFields(fields)
+}

--- a/internal/substrate/payload_shapes_kotlin.go
+++ b/internal/substrate/payload_shapes_kotlin.go
@@ -1,0 +1,258 @@
+// Kotlin payload-shape sniffer (#2771 Phase 2A T2).
+//
+// Producer-side shapes (Spring Boot / Ktor / Micronaut handlers):
+//
+//   - `@RequestBody dto: T` — the wrapped data class T's primary-
+//     constructor properties (declared in the same file) become the
+//     request shape.
+//   - Data class `data class T(val a: String, val b: Int? = null)` —
+//     the property list is the field set. `?` on the type flips
+//     Optional=true.
+//   - Ktor `call.receive<T>()` — wrapped type's properties as request
+//     shape.
+//   - Response shapes: `mapOf("a" to ..., "b" to ...)` inline maps and
+//     `ResponseEntity.ok(T(a, b))` constructor returns paired with a
+//     same-file data class.
+//
+// Consumer-side shapes (Ktor client / OkHttp):
+//
+//   - `client.post(url) { setBody(mapOf("a" to ..., "b" to ...)) }`
+//   - `OkHttpClient` is opaque (body comes from
+//     `RequestBody.create(JSON, "{...}")`) — out of scope for a regex
+//     sniffer; we recognise mapOf within a `client.post/get` block.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterPayloadShapeSniffer("kotlin", sniffPayloadShapesKotlin) }
+
+// ktDataClassRe matches `data class Name(...)`. Capture group 1 = the
+// type name; group 2 = the primary-constructor parameter list body.
+var ktDataClassRe = regexp.MustCompile(
+	`(?m)^\s*(?:public\s+|internal\s+|private\s+|open\s+|sealed\s+)*data\s+class\s+([A-Z][\w]*)\s*\(([^)]*)\)`,
+)
+
+// ktRequestBodyParamRe matches a Spring `@RequestBody name: T` or
+// `@RequestBody name: T,`. Capture group 1 = parameter name; group 2 =
+// type (may include generic suffix).
+var ktRequestBodyParamRe = regexp.MustCompile(
+	`@RequestBody\s+(?:@\w+(?:\([^)]*\))?\s+)*([A-Za-z_][\w]*)\s*:\s*([A-Z][\w<>,?\s.]*)`,
+)
+
+// ktCallReceiveRe matches Ktor `call.receive<T>()`. Capture group 1 = T.
+var ktCallReceiveRe = regexp.MustCompile(
+	`\bcall\s*\.\s*receive\s*<\s*([A-Z][\w]*)\s*>\s*\(\s*\)`,
+)
+
+// ktMapOfRe matches `mapOf("a" to v, "b" to v)`. Capture group 1 =
+// the arg list body.
+var ktMapOfRe = regexp.MustCompile(
+	`\bmapOf\s*\(([^()]*)\)`,
+)
+
+// ktClientPostRe matches Ktor client `client.<verb>(url)`. Capture
+// group 1 = verb, group 2 = inline URL.
+var ktClientPostRe = regexp.MustCompile(
+	`\bclient\s*\.\s*(get|post|put|patch|delete|head)\s*\(\s*['"]([^'"]*)['"]`,
+)
+
+// ktTopArgKeyRe matches a `"name" to ...` pair in a mapOf body.
+// Capture group 1 = the bare name.
+var ktTopArgKeyRe = regexp.MustCompile(
+	`"([A-Za-z_][\w]*)"\s+to\b`,
+)
+
+func sniffPayloadShapesKotlin(content string) []PayloadShape {
+	if content == "" {
+		return nil
+	}
+	headers := scanKotlinFuncHeaders(content)
+	dataClassFields := scanKotlinDataClassFields(content)
+	clientHints := scanKotlinClientHints(content, headers)
+
+	var out []PayloadShape
+
+	// Producer-side: @RequestBody → request shape from data class.
+	for _, m := range ktRequestBodyParamRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		typ := stripGenericSuffix(strings.TrimSpace(content[m[4]:m[5]]))
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		fields := dataClassFields[typ]
+		conf := 0.9
+		if len(fields) == 0 {
+			conf = 0.4
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: conf,
+		})
+	}
+
+	// Producer-side: call.receive<T>() → request shape from data class.
+	for _, m := range ktCallReceiveRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		typ := content[m[2]:m[3]]
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		fields := dataClassFields[typ]
+		conf := 0.9
+		if len(fields) == 0 {
+			conf = 0.4
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: conf,
+		})
+	}
+
+	// Producer/Consumer-side: mapOf("a" to v, ...) literals.
+	for _, m := range ktMapOfRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		var fields []PayloadField
+		for _, km := range ktTopArgKeyRe.FindAllStringSubmatchIndex(body, -1) {
+			if len(km) < 4 {
+				continue
+			}
+			fields = append(fields, PayloadField{Name: body[km[2]:km[3]]})
+		}
+		fields = DedupFields(fields)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if hint, ok := clientHints[fn]; ok {
+			out = append(out, PayloadShape{
+				Function:     fn,
+				Line:         line,
+				Direction:    PayloadDirectionRequest,
+				Side:         PayloadSideConsumer,
+				Fields:       fields,
+				Confidence:   1.0,
+				EndpointHint: hint.url,
+				VerbHint:     hint.verb,
+			})
+			continue
+		}
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	return out
+}
+
+// scanKotlinDataClassFields builds the map of data-class name →
+// []PayloadField from primary-constructor parameter lists.
+func scanKotlinDataClassFields(content string) map[string][]PayloadField {
+	out := map[string][]PayloadField{}
+	for _, m := range ktDataClassRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		paramList := content[m[4]:m[5]]
+		var fields []PayloadField
+		for _, p := range splitTopLevel(paramList) {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			// Strip annotations like `@SerializedName("x")`.
+			for strings.HasPrefix(p, "@") {
+				if idx := strings.Index(p, " "); idx > 0 {
+					p = strings.TrimSpace(p[idx:])
+				} else {
+					p = ""
+					break
+				}
+			}
+			// Strip val/var keyword.
+			p = strings.TrimPrefix(p, "val ")
+			p = strings.TrimPrefix(p, "var ")
+			// `name: Type` (with optional default `= value`).
+			colon := strings.IndexByte(p, ':')
+			if colon <= 0 {
+				continue
+			}
+			fname := strings.TrimSpace(p[:colon])
+			rest := strings.TrimSpace(p[colon+1:])
+			// Drop default-value clause.
+			if eq := strings.IndexByte(rest, '='); eq >= 0 {
+				rest = strings.TrimSpace(rest[:eq])
+			}
+			optional := strings.HasSuffix(rest, "?")
+			if !isPlainIdent(fname) {
+				continue
+			}
+			fields = append(fields, PayloadField{Name: fname, Type: rest, Optional: optional})
+		}
+		if len(fields) > 0 {
+			out[name] = DedupFields(fields)
+		}
+	}
+	return out
+}
+
+// kotlinClientHint mirrors rust/csharp hint structs.
+type kotlinClientHint struct {
+	url  string
+	verb string
+}
+
+// scanKotlinClientHints maps function name → first observed Ktor
+// client call hint. Used by the mapOf scan to disambiguate.
+func scanKotlinClientHints(content string, headers []funcHeader) map[string]kotlinClientHint {
+	out := map[string]kotlinClientHint{}
+	for _, m := range ktClientPostRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if _, ok := out[fn]; ok {
+			continue
+		}
+		out[fn] = kotlinClientHint{
+			url:  content[m[4]:m[5]],
+			verb: strings.ToUpper(content[m[2]:m[3]]),
+		}
+	}
+	return out
+}

--- a/internal/substrate/payload_shapes_php.go
+++ b/internal/substrate/payload_shapes_php.go
@@ -1,0 +1,249 @@
+// PHP payload-shape sniffer (#2771 Phase 2A T2).
+//
+// Producer-side shapes (Laravel / Symfony / Slim / vanilla):
+//
+//   - Laravel FormRequest `rules()` returning `[ 'name' => '...', ... ]`
+//     — the array keys are the validated request field set.
+//   - `$request->only(['a', 'b'])`, `$request->all()` (we skip — no
+//     usable shape), `$request->get('x')`, `$request->input('x')` —
+//     bare bracket / get reads bind to the enclosing controller method.
+//   - `$_POST['x']` / `$_GET['x']` superglobal reads (vanilla / legacy).
+//   - `return response()->json([ 'x' => ..., 'y' => ... ])` and
+//     `return new JsonResponse([ 'x' => ... ])` — inline assoc-array
+//     response bodies.
+//
+// Consumer-side shapes (Guzzle):
+//
+//   - `$client->request('POST', $url, [ 'json' => [ 'x' => ... ] ])`
+//   - `$client->post($url, [ 'form_params' => [ 'x' => ... ] ])`
+//   - `$client->post($url, [ 'json' => [ 'x' => ... ] ])`
+//
+// Optional/required: PHP doesn't statically annotate. Phase 2A leaves
+// Optional default-false on every shape. Symfony `@SerializedName` is
+// out of scope for the regex sniffer — Phase 4 candidate.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterPayloadShapeSniffer("php", sniffPayloadShapesPHP) }
+
+// phpRulesArrayRe matches a Laravel FormRequest `public function
+// rules()` returning an inline assoc array. Capture group 1 = array
+// body between the outer `[` and matching `]` (single-level — bounded
+// by [^\[\]] so nested arrays terminate the match honestly).
+var phpRulesArrayRe = regexp.MustCompile(
+	`\bfunction\s+rules\s*\([^)]*\)\s*(?::\s*\w+\s*)?\{\s*return\s*\[([^\[\]]*)\]`,
+)
+
+// phpRequestReadRe matches `$request->get('x')`, `$request->input('x')`,
+// and `$request->only(['x', 'y'])`. Capture group 1 = single name for
+// get/input; group 2 = the bracketed name list for only.
+var phpRequestReadRe = regexp.MustCompile(
+	`\$(?:request|req)\s*->\s*(?:get|input)\s*\(\s*['"]([A-Za-z_][\w]*)['"]\s*\)` +
+		`|\$(?:request|req)\s*->\s*only\s*\(\s*\[([^\[\]]*)\]`,
+)
+
+// phpSuperglobalRe matches `$_POST['x']` / `$_GET['x']`. Capture
+// group 1 = the bare name.
+var phpSuperglobalRe = regexp.MustCompile(
+	`\$_(?:POST|GET|REQUEST)\s*\[\s*['"]([A-Za-z_][\w]*)['"]\s*\]`,
+)
+
+// phpJsonResponseRe matches `response()->json([...])` and
+// `new JsonResponse([...])`. Capture group 1 = the array body.
+var phpJsonResponseRe = regexp.MustCompile(
+	`\bresponse\s*\(\s*\)\s*->\s*json\s*\(\s*\[([^\[\]]*)\]` +
+		`|\bnew\s+JsonResponse\s*\(\s*\[([^\[\]]*)\]`,
+)
+
+// phpGuzzleBodyRe matches Guzzle outbound calls with an inline body
+// option. Capture groups:
+//
+//	1 = HTTP verb when present (request('POST', ...) → POST)
+//	2 = inline URL
+//	3 = body assoc array (json / form_params)
+var phpGuzzleBodyRe = regexp.MustCompile(
+	`->\s*(?:request\s*\(\s*['"](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)['"]\s*,\s*['"]([^'"]*)['"]` +
+		`|(get|post|put|patch|delete|head|options)\s*\(\s*['"]([^'"]*)['"])` +
+		`[^)]*?(?:'json'|"json"|'form_params'|"form_params")\s*=>\s*\[([^\[\]]*)\]`,
+)
+
+// phpAssocKeyRe matches a key in a PHP assoc array literal:
+// `'name' =>` or `"name" =>`. Capture group 1 = the bare name.
+var phpAssocKeyRe = regexp.MustCompile(
+	`['"]([A-Za-z_][\w]*)['"]\s*=>`,
+)
+
+func sniffPayloadShapesPHP(content string) []PayloadShape {
+	if content == "" {
+		return nil
+	}
+	headers := scanPHPFuncHeaders(content)
+	var out []PayloadShape
+
+	// Producer-side: FormRequest rules() → request shape (high conf).
+	for _, m := range phpRulesArrayRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		fields := extractPHPAssocKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			fn = "rules"
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	// Producer-side: $request->get/input/only reads.
+	reqFields := map[string][]PayloadField{}
+	reqFirstLine := map[string]int{}
+	collect := func(fn string, line int, names ...string) {
+		for _, n := range names {
+			if n == "" {
+				continue
+			}
+			reqFields[fn] = append(reqFields[fn], PayloadField{Name: n})
+		}
+		if _, ok := reqFirstLine[fn]; !ok {
+			reqFirstLine[fn] = line
+		}
+	}
+	for _, m := range phpRequestReadRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		switch {
+		case m[2] >= 0:
+			collect(fn, line, content[m[2]:m[3]])
+		case m[4] >= 0:
+			// Extract single-quoted strings from the only-list body.
+			body := content[m[4]:m[5]]
+			for _, sm := range regexp.MustCompile(`['"]([A-Za-z_][\w]*)['"]`).FindAllStringSubmatchIndex(body, -1) {
+				if len(sm) >= 4 {
+					collect(fn, line, body[sm[2]:sm[3]])
+				}
+			}
+		}
+	}
+	// Producer-side: $_POST / $_GET superglobal reads bucket the same way.
+	for _, m := range phpSuperglobalRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		collect(fn, line, content[m[2]:m[3]])
+	}
+	for fn, fields := range reqFields {
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       reqFirstLine[fn],
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     DedupFields(fields),
+			Confidence: 0.8,
+		})
+	}
+
+	// Producer-side: response()->json([...]) literal response shape.
+	for _, m := range phpJsonResponseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var body string
+		switch {
+		case m[2] >= 0:
+			body = content[m[2]:m[3]]
+		case m[4] >= 0:
+			body = content[m[4]:m[5]]
+		}
+		fields := extractPHPAssocKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	// Consumer-side: Guzzle json / form_params body.
+	for _, m := range phpGuzzleBodyRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 12 {
+			continue
+		}
+		var verb, url string
+		switch {
+		case m[2] >= 0:
+			verb = strings.ToUpper(content[m[2]:m[3]])
+			url = content[m[4]:m[5]]
+		case m[6] >= 0:
+			verb = strings.ToUpper(content[m[6]:m[7]])
+			url = content[m[8]:m[9]]
+		}
+		body := content[m[10]:m[11]]
+		fields := extractPHPAssocKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, PayloadShape{
+			Function:     fn,
+			Line:         line,
+			Direction:    PayloadDirectionRequest,
+			Side:         PayloadSideConsumer,
+			Fields:       fields,
+			Confidence:   1.0,
+			EndpointHint: url,
+			VerbHint:     verb,
+		})
+	}
+
+	return out
+}
+
+// extractPHPAssocKeys lifts `'name' =>` / `"name" =>` keys from a PHP
+// assoc-array body. Deduped, source order preserved.
+func extractPHPAssocKeys(body string) []PayloadField {
+	var fields []PayloadField
+	for _, m := range phpAssocKeyRe.FindAllStringSubmatchIndex(body, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		fields = append(fields, PayloadField{Name: body[m[2]:m[3]]})
+	}
+	return DedupFields(fields)
+}

--- a/internal/substrate/payload_shapes_ruby.go
+++ b/internal/substrate/payload_shapes_ruby.go
@@ -1,0 +1,292 @@
+// Ruby payload-shape sniffer (#2771 Phase 2A T2).
+//
+// Producer-side shapes (Rails / Sinatra / Grape / Hanami handlers):
+//
+//   - `params.require(:foo).permit(:a, :b, :c)` — the permit list is
+//     the canonical Rails strong-parameter request shape.
+//   - `params[:x]`, `params.fetch(:x)`, `params.fetch("x")` — bare
+//     symbol / string indexed reads bind to the enclosing action.
+//   - `render json: { x: ..., y: ... }` — inline hash returned as the
+//     response body. The hash literal is captured single-line.
+//   - Grape `expose :name` declarations inside an `Entity` class become
+//     the response shape for any endpoint that `presents` the entity
+//     (the present/expose pairing is recognised conservatively per
+//     enclosing block via nearestHeader).
+//
+// Consumer-side shapes (HTTParty / Faraday / Net::HTTP / RestClient):
+//
+//   - `HTTParty.<verb>(url, body: { x: ... }.to_json)`,
+//     `HTTParty.<verb>(url, query: { x: ... })`
+//   - `Faraday.<verb>(url) { |req| req.body = { x: ... }.to_json }` —
+//     we match the inline hash regardless of the block wrapper.
+//   - `Net::HTTP.post_form(URI(url), { "x" => ... })` — the form-hash
+//     literal contributes the field set.
+//
+// Optional/required: Ruby doesn't statically annotate. Phase 2A leaves
+// Optional default-false on every shape.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterPayloadShapeSniffer("ruby", sniffPayloadShapesRuby) }
+
+// rubyPermitListRe matches the canonical Rails strong-parameter pattern
+// `params.require(:foo).permit(:a, :b, :c)`. Capture group 1 = the
+// permit arg list between parens (we then split on commas to extract
+// the bare symbols).
+var rubyPermitListRe = regexp.MustCompile(
+	`\bparams\s*(?:\.\s*require\s*\([^)]*\))?\s*\.\s*permit\s*\(([^)]*)\)`,
+)
+
+// rubyParamsIndexRe matches `params[:x]` and `params["x"]` and
+// `params.fetch(:x)` / `params.fetch("x")`. Capture groups 1/2/3/4 each
+// hold the bare name (first non-empty wins).
+var rubyParamsIndexRe = regexp.MustCompile(
+	`\bparams\s*` +
+		`(?:\[\s*:([A-Za-z_][\w]*)\s*\]` +
+		`|\[\s*['"]([A-Za-z_][\w]*)['"]\s*\]` +
+		`|\.\s*fetch\s*\(\s*:([A-Za-z_][\w]*)` +
+		`|\.\s*fetch\s*\(\s*['"]([A-Za-z_][\w]*)['"])`,
+)
+
+// rubyRenderJSONRe matches `render json: { ... }`. Capture group 1 is
+// the hash body between { and the first balanced } on the same line.
+var rubyRenderJSONRe = regexp.MustCompile(
+	`\brender\s+json\s*:\s*\{([^{}]*)\}`,
+)
+
+// rubyGrapeExposeRe matches Grape `expose :name` (the entity pattern).
+// Capture group 1 = the field name.
+var rubyGrapeExposeRe = regexp.MustCompile(
+	`(?m)^\s*expose\s+:([A-Za-z_][\w]*)`,
+)
+
+// rubyConsumerHTTPRe matches inline outbound calls with a hash body.
+// Capture groups:
+//
+//	1 = HTTParty verb when present
+//	2 = inline URL for HTTParty
+//	3 = body hash (between { and })
+//	4 = Faraday verb when present
+//	5 = inline URL for Faraday
+//	6 = body hash for Faraday (req.body = {...})
+var rubyConsumerHTTPRe = regexp.MustCompile(
+	`\bHTTParty\s*\.\s*(get|post|put|patch|delete|head)\s*\(\s*['"]([^'"]*)['"][^)]*?(?:body|query|json)\s*:\s*\{([^{}]*)\}` +
+		`|\bFaraday\s*\.\s*(get|post|put|patch|delete|head)\s*\(\s*['"]([^'"]*)['"][^)]*?\.\s*body\s*=\s*\{([^{}]*)\}`,
+)
+
+// rubyHashKeyRe matches a key in a Ruby hash literal: bare `name:`,
+// symbol `:name =>`, or string `"name" =>`. Capture groups 1/2/3 hold
+// the name (first non-empty wins).
+var rubyHashKeyRe = regexp.MustCompile(
+	`([A-Za-z_][\w]*)\s*:` +
+		`|:([A-Za-z_][\w]*)\s*=>` +
+		`|['"]([A-Za-z_][\w]*)['"]\s*=>`,
+)
+
+// rubySymbolListRe matches a single `:name` symbol inside the permit
+// argument list. Bare identifiers with no colon are ignored — Rails
+// permit only accepts symbols / strings / hashes.
+var rubySymbolListRe = regexp.MustCompile(`:([A-Za-z_][\w]*)`)
+
+func sniffPayloadShapesRuby(content string) []PayloadShape {
+	if content == "" {
+		return nil
+	}
+	headers := scanRubyFuncHeaders(content)
+	var out []PayloadShape
+
+	// Producer-side: permit list → request shape (high confidence).
+	for _, m := range rubyPermitListRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		var fields []PayloadField
+		for _, sm := range rubySymbolListRe.FindAllStringSubmatchIndex(body, -1) {
+			if len(sm) < 4 {
+				continue
+			}
+			fields = append(fields, PayloadField{Name: body[sm[2]:sm[3]]})
+		}
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     DedupFields(fields),
+			Confidence: 1.0,
+		})
+	}
+
+	// Producer-side: bare params[:x] / params.fetch reads — fallback
+	// when the handler doesn't use strong parameters.
+	idxFields := map[string][]PayloadField{}
+	idxFirstLine := map[string]int{}
+	for _, m := range rubyParamsIndexRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		case m[8] >= 0:
+			name = content[m[8]:m[9]]
+		}
+		if name == "" {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		idxFields[fn] = append(idxFields[fn], PayloadField{Name: name})
+		if _, ok := idxFirstLine[fn]; !ok {
+			idxFirstLine[fn] = line
+		}
+	}
+	for fn, fields := range idxFields {
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       idxFirstLine[fn],
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     DedupFields(fields),
+			Confidence: 0.8,
+		})
+	}
+
+	// Producer-side: render json: {...} response shape.
+	for _, m := range rubyRenderJSONRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		fields := extractRubyHashKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	// Producer-side: Grape expose declarations bucket-by-enclosing-
+	// header (the Entity class' header binds them).
+	exposeFields := map[string][]PayloadField{}
+	exposeFirstLine := map[string]int{}
+	for _, m := range rubyGrapeExposeRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		exposeFields[fn] = append(exposeFields[fn], PayloadField{Name: name})
+		if _, ok := exposeFirstLine[fn]; !ok {
+			exposeFirstLine[fn] = line
+		}
+	}
+	for fn, fields := range exposeFields {
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       exposeFirstLine[fn],
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     DedupFields(fields),
+			Confidence: 0.85,
+		})
+	}
+
+	// Consumer-side: HTTParty / Faraday inline body.
+	for _, m := range rubyConsumerHTTPRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 14 {
+			continue
+		}
+		var verb, url, body string
+		switch {
+		case m[2] >= 0:
+			verb = strings.ToUpper(content[m[2]:m[3]])
+			url = content[m[4]:m[5]]
+			body = content[m[6]:m[7]]
+		case m[8] >= 0:
+			verb = strings.ToUpper(content[m[8]:m[9]])
+			url = content[m[10]:m[11]]
+			body = content[m[12]:m[13]]
+		}
+		fields := extractRubyHashKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, PayloadShape{
+			Function:     fn,
+			Line:         line,
+			Direction:    PayloadDirectionRequest,
+			Side:         PayloadSideConsumer,
+			Fields:       fields,
+			Confidence:   1.0,
+			EndpointHint: url,
+			VerbHint:     verb,
+		})
+	}
+
+	return out
+}
+
+// extractRubyHashKeys lifts the keys out of a Ruby hash-literal body,
+// recognising both modern (`name: value`) and rocket (`:name => value`
+// / `"name" => value`) forms. Deduped, source order preserved.
+func extractRubyHashKeys(body string) []PayloadField {
+	var fields []PayloadField
+	for _, m := range rubyHashKeyRe.FindAllStringSubmatchIndex(body, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = body[m[2]:m[3]]
+		case m[4] >= 0:
+			name = body[m[4]:m[5]]
+		case m[6] >= 0:
+			name = body[m[6]:m[7]]
+		}
+		if name == "" {
+			continue
+		}
+		fields = append(fields, PayloadField{Name: name})
+	}
+	return DedupFields(fields)
+}

--- a/internal/substrate/payload_shapes_rust.go
+++ b/internal/substrate/payload_shapes_rust.go
@@ -1,0 +1,225 @@
+// Rust payload-shape sniffer (#2771 Phase 2A T2).
+//
+// Producer-side shapes (Axum / Actix / Rocket / Warp handlers):
+//
+//   - `Json<T>` / `web::Json<T>` extractor in a handler signature —
+//     the wrapped struct T's fields (when declared in the same file)
+//     become the request shape.
+//   - `#[derive(Deserialize)] struct T { a: String, b: Option<i32> }`
+//     declarations contribute their fields to the same-file struct map.
+//     `Option<U>` flips the Optional flag on the field.
+//   - Response shapes: `Json(T { a, b })` literal constructors and
+//     return types like `-> Json<UserResponse>` paired with a same-file
+//     struct definition.
+//
+// Consumer-side shapes (reqwest):
+//
+//   - `client.post(url).json(&body)` where `body` is an inline literal
+//     `serde_json::json!({"a": ..., "b": ...})` — the json! body is
+//     captured as the request shape.
+//   - `.body(format!(r#"{{"a": ...}}"#))` style raw-string bodies are
+//     out of scope (no static structure).
+//
+// Optional/required: Rust's `Option<T>` is observable and flips the
+// Optional flag; everything else stays default-false.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterPayloadShapeSniffer("rust", sniffPayloadShapesRust) }
+
+// rustStructHeaderRe matches `pub struct Name {` / `struct Name {`.
+// Capture group 1 = the type name.
+var rustStructHeaderRe = regexp.MustCompile(
+	`(?m)^\s*(?:pub\s+(?:\(crate\)\s+)?)?struct\s+([A-Z][\w]*)\s*\{`,
+)
+
+// rustStructFieldRe matches `pub? name: Type,` inside a struct body.
+// Capture group 1 = field name; group 2 = type (may be `Option<X>`).
+// Bounded by comma or end-of-line; the body iteration trims commas.
+var rustStructFieldRe = regexp.MustCompile(
+	`(?m)^\s*(?:pub\s+(?:\([^)]*\)\s+)?)?([a-z_][\w]*)\s*:\s*([^,\n]+?)\s*[,\n]`,
+)
+
+// rustJsonExtractorRe matches `Json<T>` / `web::Json<T>` extractor
+// parameters in a handler signature. Capture group 1 = the type name.
+var rustJsonExtractorRe = regexp.MustCompile(
+	`(?:web\s*::\s*)?Json\s*<\s*([A-Z][\w]*)\s*>`,
+)
+
+// rustJsonMacroRe matches `serde_json::json!({...})` and bare `json!({...})`.
+// Capture group 1 = the inline object body between `{` and `}`.
+var rustJsonMacroRe = regexp.MustCompile(
+	`\b(?:serde_json\s*::\s*)?json!\s*\(\s*\{([^{}]*)\}`,
+)
+
+// rustClientPostRe matches `client.<verb>(url)` reqwest builder calls.
+// Capture group 1 = verb, group 2 = inline URL when present. Used to
+// tag the consumer shape with a hint.
+var rustClientPostRe = regexp.MustCompile(
+	`\bclient\s*\.\s*(get|post|put|patch|delete|head)\s*\(\s*['"]([^'"]*)['"]`,
+)
+
+// rustQuotedKeyRe matches a JSON-style key in a json!({...}) body.
+var rustQuotedKeyRe = regexp.MustCompile(`"([A-Za-z_][\w]*)"\s*:`)
+
+func sniffPayloadShapesRust(content string) []PayloadShape {
+	if content == "" {
+		return nil
+	}
+	headers := scanRustFuncHeaders(content)
+	structFields := scanRustStructFields(content)
+	clientHints := scanRustClientHints(content, headers)
+
+	var out []PayloadShape
+
+	// Producer-side: Json<T> extractor → request shape from struct T.
+	for _, m := range rustJsonExtractorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		typ := content[m[2]:m[3]]
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		fields := structFields[typ]
+		conf := 0.9
+		if len(fields) == 0 {
+			conf = 0.4 // cross-file unresolved
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: conf,
+		})
+	}
+
+	// Producer-side & Consumer-side: json!({...}) literals. We bind
+	// each literal to its enclosing function; if that function is a
+	// known reqwest client caller (it has a `client.post(...)` shape
+	// in the same body), we tag it as consumer. Otherwise it's a
+	// producer response shape.
+	for _, m := range rustJsonMacroRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		fields := extractRustJSONKeys(body)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if hint, ok := clientHints[fn]; ok {
+			out = append(out, PayloadShape{
+				Function:     fn,
+				Line:         line,
+				Direction:    PayloadDirectionRequest,
+				Side:         PayloadSideConsumer,
+				Fields:       fields,
+				Confidence:   1.0,
+				EndpointHint: hint.url,
+				VerbHint:     hint.verb,
+			})
+			continue
+		}
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	return out
+}
+
+// scanRustStructFields walks the file once and returns a map of struct
+// name → []PayloadField. Body is delimited by a brace counter from the
+// opening `{` of the struct header to the matching `}`.
+func scanRustStructFields(content string) map[string][]PayloadField {
+	out := map[string][]PayloadField{}
+	for _, m := range rustStructHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		body, ok := goBalancedBlock(content, m[1]-1)
+		if !ok {
+			continue
+		}
+		var fields []PayloadField
+		for _, fm := range rustStructFieldRe.FindAllStringSubmatchIndex(body+"\n", -1) {
+			if len(fm) < 6 {
+				continue
+			}
+			fname := body[fm[2]:fm[3]]
+			ftype := strings.TrimSpace(body[fm[4]:fm[5]])
+			optional := strings.HasPrefix(ftype, "Option<")
+			fields = append(fields, PayloadField{
+				Name:     fname,
+				Type:     ftype,
+				Optional: optional,
+			})
+		}
+		if len(fields) > 0 {
+			out[name] = DedupFields(fields)
+		}
+	}
+	return out
+}
+
+// rustClientCallHint captures the URL/verb tagged onto a reqwest call.
+type rustClientCallHint struct {
+	url  string
+	verb string
+}
+
+// scanRustClientHints returns the set of functions that contain a
+// `client.<verb>(url)` reqwest builder. The consumer-side recognition
+// uses this to disambiguate json! literals that are HTTP bodies vs
+// response constructors.
+func scanRustClientHints(content string, headers []funcHeader) map[string]rustClientCallHint {
+	out := map[string]rustClientCallHint{}
+	for _, m := range rustClientPostRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		out[fn] = rustClientCallHint{
+			url:  content[m[4]:m[5]],
+			verb: strings.ToUpper(content[m[2]:m[3]]),
+		}
+	}
+	return out
+}
+
+// extractRustJSONKeys lifts JSON-style keys out of a `json!({...})`
+// body. Deduped, source order preserved.
+func extractRustJSONKeys(body string) []PayloadField {
+	var fields []PayloadField
+	for _, m := range rustQuotedKeyRe.FindAllStringSubmatchIndex(body, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		fields = append(fields, PayloadField{Name: body[m[2]:m[3]]})
+	}
+	return DedupFields(fields)
+}

--- a/internal/substrate/payload_shapes_scala.go
+++ b/internal/substrate/payload_shapes_scala.go
@@ -1,0 +1,245 @@
+// Scala payload-shape sniffer (#2771 Phase 2A T2).
+//
+// Producer-side shapes (Play Framework / http4s / Akka HTTP):
+//
+//   - Play: `request.body.as[T]` or `request.body.asJson` followed by
+//     `(json \ "x").as[String]` reads — both forms contribute fields.
+//   - http4s: `req.decodeJson[T]` / `req.as[T]` — wrapped T's case-
+//     class members (same-file) are the request shape.
+//   - Case class declarations `case class T(a: String, b: Option[Int])`
+//     — primary-constructor parameters are the field set. `Option[U]`
+//     flips Optional=true.
+//   - Response shapes: `Ok(Json.obj("a" -> ..., "b" -> ...))` and
+//     `Json.toJson(T(...))` (when T is a same-file case class).
+//
+// Consumer-side shapes (sttp):
+//
+//   - `basicRequest.post(uri).body(Map("a" -> ..., "b" -> ...))`
+//   - `basicRequest.body(asJson(T(a, b)))` — when T resolves to a
+//     same-file case class.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterPayloadShapeSniffer("scala", sniffPayloadShapesScala) }
+
+// scalaCaseClassRe matches `case class T(...)`. Capture group 1 = the
+// type name; group 2 = the primary-constructor parameter list.
+var scalaCaseClassRe = regexp.MustCompile(
+	`(?m)^\s*(?:final\s+|sealed\s+)*case\s+class\s+([A-Z][\w]*)\s*\(([^)]*)\)`,
+)
+
+// scalaDecodeJsonRe matches http4s `req.decodeJson[T]` / `req.as[T]`.
+// Capture group 1 = T.
+var scalaDecodeJsonRe = regexp.MustCompile(
+	`\b(?:req|request)\s*\.\s*(?:decodeJson|as)\s*\[\s*([A-Z][\w]*)\s*\]`,
+)
+
+// scalaJsonReadRe matches `(json \ "x").as[Type]` style Play reads.
+// Capture group 1 = the field name.
+var scalaJsonReadRe = regexp.MustCompile(
+	`\(\s*(?:json|js|body)\s*\\\s*"([A-Za-z_][\w]*)"\s*\)\s*\.\s*as`,
+)
+
+// scalaJsonObjRe matches `Json.obj("a" -> ..., "b" -> ...)`. Capture
+// group 1 = the arg list body.
+var scalaJsonObjRe = regexp.MustCompile(
+	`\bJson\s*\.\s*obj\s*\(([^()]*)\)`,
+)
+
+// scalaMapTupleRe matches a `"name" ->` tuple inside Json.obj /
+// Map literals. Capture group 1 = the bare name.
+var scalaMapTupleRe = regexp.MustCompile(
+	`"([A-Za-z_][\w]*)"\s*->`,
+)
+
+// scalaConsumerRe matches sttp `basicRequest.<verb>(uri)` chain. We
+// recognise the verb + URL for the consumer hint; the body is picked
+// up by the generic Json.obj / Map.apply recognition.
+var scalaConsumerRe = regexp.MustCompile(
+	`\bbasicRequest\s*\.\s*(get|post|put|patch|delete|head)\s*\(\s*uri"([^"]*)"`,
+)
+
+func sniffPayloadShapesScala(content string) []PayloadShape {
+	if content == "" {
+		return nil
+	}
+	headers := scanScalaFuncHeaders(content)
+	caseClassFields := scanScalaCaseClassFields(content)
+	clientHints := scanScalaClientHints(content, headers)
+
+	var out []PayloadShape
+
+	// Producer-side: req.decodeJson[T] / req.as[T] → request shape.
+	for _, m := range scalaDecodeJsonRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		typ := content[m[2]:m[3]]
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		fields := caseClassFields[typ]
+		conf := 0.9
+		if len(fields) == 0 {
+			conf = 0.4
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: conf,
+		})
+	}
+
+	// Producer-side: (json \ "x").as[T] bare reads.
+	readFields := map[string][]PayloadField{}
+	readFirstLine := map[string]int{}
+	for _, m := range scalaJsonReadRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		readFields[fn] = append(readFields[fn], PayloadField{Name: name})
+		if _, ok := readFirstLine[fn]; !ok {
+			readFirstLine[fn] = line
+		}
+	}
+	for fn, fields := range readFields {
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       readFirstLine[fn],
+			Direction:  PayloadDirectionRequest,
+			Side:       PayloadSideProducer,
+			Fields:     DedupFields(fields),
+			Confidence: 0.85,
+		})
+	}
+
+	// Producer/Consumer-side: Json.obj("a" -> ...) literals.
+	for _, m := range scalaJsonObjRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		var fields []PayloadField
+		for _, km := range scalaMapTupleRe.FindAllStringSubmatchIndex(body, -1) {
+			if len(km) >= 4 {
+				fields = append(fields, PayloadField{Name: body[km[2]:km[3]]})
+			}
+		}
+		fields = DedupFields(fields)
+		if len(fields) == 0 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if hint, ok := clientHints[fn]; ok {
+			out = append(out, PayloadShape{
+				Function:     fn,
+				Line:         line,
+				Direction:    PayloadDirectionRequest,
+				Side:         PayloadSideConsumer,
+				Fields:       fields,
+				Confidence:   1.0,
+				EndpointHint: hint.url,
+				VerbHint:     hint.verb,
+			})
+			continue
+		}
+		if fn == "" {
+			continue
+		}
+		out = append(out, PayloadShape{
+			Function:   fn,
+			Line:       line,
+			Direction:  PayloadDirectionResponse,
+			Side:       PayloadSideProducer,
+			Fields:     fields,
+			Confidence: 1.0,
+		})
+	}
+
+	return out
+}
+
+// scanScalaCaseClassFields builds the map of case-class name →
+// []PayloadField from primary-constructor parameters.
+func scanScalaCaseClassFields(content string) map[string][]PayloadField {
+	out := map[string][]PayloadField{}
+	for _, m := range scalaCaseClassRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		paramList := content[m[4]:m[5]]
+		var fields []PayloadField
+		for _, p := range splitTopLevel(paramList) {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			// `name: Type` (with optional default).
+			colon := strings.IndexByte(p, ':')
+			if colon <= 0 {
+				continue
+			}
+			fname := strings.TrimSpace(p[:colon])
+			rest := strings.TrimSpace(p[colon+1:])
+			if eq := strings.IndexByte(rest, '='); eq >= 0 {
+				rest = strings.TrimSpace(rest[:eq])
+			}
+			optional := strings.HasPrefix(rest, "Option[") || strings.HasPrefix(rest, "Option<")
+			if !isPlainIdent(fname) {
+				continue
+			}
+			fields = append(fields, PayloadField{Name: fname, Type: rest, Optional: optional})
+		}
+		if len(fields) > 0 {
+			out[name] = DedupFields(fields)
+		}
+	}
+	return out
+}
+
+// scalaClientHint mirrors the other consumer-hint structs.
+type scalaClientHint struct {
+	url  string
+	verb string
+}
+
+// scanScalaClientHints maps function name → first sttp basicRequest
+// call hint observed inside it.
+func scanScalaClientHints(content string, headers []funcHeader) map[string]scalaClientHint {
+	out := map[string]scalaClientHint{}
+	for _, m := range scalaConsumerRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if _, ok := out[fn]; ok {
+			continue
+		}
+		out[fn] = scalaClientHint{
+			url:  content[m[4]:m[5]],
+			verb: strings.ToUpper(content[m[2]:m[3]]),
+		}
+	}
+	return out
+}

--- a/internal/substrate/payload_shapes_t2_test.go
+++ b/internal/substrate/payload_shapes_t2_test.go
@@ -1,0 +1,304 @@
+// Tests for the Phase 2A payload-shape sniffers — T2 languages (#2771).
+// One canonical test per language verifying the inline-literal cases the
+// drift detector relies on. Mirrors payload_shapes_test.go (T1).
+package substrate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPayloadShapesRuby_PermitAndRender(t *testing.T) {
+	const src = `
+class UsersController < ApplicationController
+  def create
+    user_params = params.require(:user).permit(:name, :email, :phone)
+    render json: { id: 1, name: user_params[:name] }
+  end
+end
+`
+	shapes := sniffPayloadShapesRuby(src)
+	req := findShape(shapes, "create", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected ruby permit request shape; got %+v", shapes)
+	}
+	wantReq := []string{"email", "name", "phone"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, wantReq) {
+		t.Errorf("ruby permit fields: want %v got %v", wantReq, got)
+	}
+	resp := findShape(shapes, "create", PayloadDirectionResponse, PayloadSideProducer)
+	if resp == nil {
+		t.Fatalf("expected ruby render response shape; got %+v", shapes)
+	}
+	wantResp := []string{"id", "name"}
+	if got := sortedNames(resp.Fields); !reflect.DeepEqual(got, wantResp) {
+		t.Errorf("ruby render fields: want %v got %v", wantResp, got)
+	}
+}
+
+func TestPayloadShapesRuby_ConsumerHTTParty(t *testing.T) {
+	const src = `
+def push
+  HTTParty.post("/api/users", body: { name: "x", email: "y" }.to_json)
+end
+`
+	shapes := sniffPayloadShapesRuby(src)
+	cs := findShape(shapes, "push", PayloadDirectionRequest, PayloadSideConsumer)
+	if cs == nil {
+		t.Fatalf("expected ruby consumer shape; got %+v", shapes)
+	}
+	if cs.EndpointHint != "/api/users" || cs.VerbHint != "POST" {
+		t.Errorf("ruby consumer hint: got %q %q", cs.EndpointHint, cs.VerbHint)
+	}
+	want := []string{"email", "name"}
+	if got := sortedNames(cs.Fields); !reflect.DeepEqual(got, want) {
+		t.Errorf("ruby consumer fields: want %v got %v", want, got)
+	}
+}
+
+func TestPayloadShapesPHP_FormRequestAndGuzzle(t *testing.T) {
+	const src = `
+<?php
+class CreateUserRequest extends FormRequest {
+  public function rules() {
+    return [ 'name' => 'required', 'email' => 'email', 'phone' => 'nullable' ];
+  }
+}
+class UserClient {
+  public function push() {
+    return $this->client->request('POST', '/api/users', [ 'json' => [ 'name' => 'x', 'email' => 'y' ] ]);
+  }
+}
+`
+	shapes := sniffPayloadShapesPHP(src)
+	req := findShape(shapes, "rules", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected php rules() shape; got %+v", shapes)
+	}
+	want := []string{"email", "name", "phone"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, want) {
+		t.Errorf("php rules fields: want %v got %v", want, got)
+	}
+	cs := findShape(shapes, "push", PayloadDirectionRequest, PayloadSideConsumer)
+	if cs == nil {
+		t.Fatalf("expected php guzzle consumer shape; got %+v", shapes)
+	}
+	if cs.EndpointHint != "/api/users" || cs.VerbHint != "POST" {
+		t.Errorf("php consumer hint: got %q %q", cs.EndpointHint, cs.VerbHint)
+	}
+}
+
+func TestPayloadShapesRust_JsonExtractor(t *testing.T) {
+	const src = `
+#[derive(Deserialize)]
+pub struct CreateUser {
+    pub name: String,
+    pub email: String,
+    pub phone: Option<String>,
+}
+
+async fn create_user(Json(body): Json<CreateUser>) -> impl IntoResponse {
+    let _ = body;
+}
+`
+	shapes := sniffPayloadShapesRust(src)
+	req := findShape(shapes, "create_user", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected rust Json<T> shape; got %+v", shapes)
+	}
+	want := []string{"email", "name", "phone"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, want) {
+		t.Errorf("rust fields: want %v got %v", want, got)
+	}
+	// phone is Option<String> → Optional=true.
+	for _, f := range req.Fields {
+		if f.Name == "phone" && !f.Optional {
+			t.Errorf("phone should be Optional=true; got %+v", f)
+		}
+	}
+}
+
+func TestPayloadShapesRust_ConsumerReqwest(t *testing.T) {
+	const src = `
+async fn push() {
+    let _ = client.post("/api/users").json(&serde_json::json!({"name": "x", "email": "y"})).send().await;
+}
+`
+	shapes := sniffPayloadShapesRust(src)
+	cs := findShape(shapes, "push", PayloadDirectionRequest, PayloadSideConsumer)
+	if cs == nil {
+		t.Fatalf("expected rust consumer shape; got %+v", shapes)
+	}
+	if cs.EndpointHint != "/api/users" || cs.VerbHint != "POST" {
+		t.Errorf("rust consumer hint: got %q %q", cs.EndpointHint, cs.VerbHint)
+	}
+}
+
+func TestPayloadShapesCSharp_FromBodyDTO(t *testing.T) {
+	const src = `
+public class CreateUserDto {
+  public string Name { get; set; }
+  public string Email { get; set; }
+  public int? Age { get; set; }
+}
+public class UsersController {
+  [HttpPost]
+  public IActionResult Create([FromBody] CreateUserDto dto) {
+    return Ok(new { id = 1, name = dto.Name });
+  }
+}
+`
+	shapes := sniffPayloadShapesCSharp(src)
+	req := findShape(shapes, "Create", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected csharp [FromBody] shape; got %+v", shapes)
+	}
+	want := []string{"Age", "Email", "Name"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, want) {
+		t.Errorf("csharp DTO fields: want %v got %v", want, got)
+	}
+	for _, f := range req.Fields {
+		if f.Name == "Age" && !f.Optional {
+			t.Errorf("Age should be Optional=true (int?); got %+v", f)
+		}
+	}
+	resp := findShape(shapes, "Create", PayloadDirectionResponse, PayloadSideProducer)
+	if resp == nil {
+		t.Fatalf("expected csharp anonymous response shape; got %+v", shapes)
+	}
+}
+
+func TestPayloadShapesKotlin_RequestBodyAndMapOf(t *testing.T) {
+	const src = `
+data class CreateUser(val name: String, val email: String, val phone: String? = null)
+
+class UsersController {
+  @PostMapping("/users")
+  fun create(@RequestBody dto: CreateUser): ResponseEntity<Map<String, Any>> {
+    return ResponseEntity.ok(mapOf("id" to 1, "name" to dto.name))
+  }
+}
+`
+	shapes := sniffPayloadShapesKotlin(src)
+	req := findShape(shapes, "create", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected kotlin @RequestBody shape; got %+v", shapes)
+	}
+	want := []string{"email", "name", "phone"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, want) {
+		t.Errorf("kotlin data class fields: want %v got %v", want, got)
+	}
+	for _, f := range req.Fields {
+		if f.Name == "phone" && !f.Optional {
+			t.Errorf("phone should be Optional=true; got %+v", f)
+		}
+	}
+	resp := findShape(shapes, "create", PayloadDirectionResponse, PayloadSideProducer)
+	if resp == nil {
+		t.Fatalf("expected kotlin mapOf response shape; got %+v", shapes)
+	}
+	wantR := []string{"id", "name"}
+	if got := sortedNames(resp.Fields); !reflect.DeepEqual(got, wantR) {
+		t.Errorf("kotlin mapOf fields: want %v got %v", wantR, got)
+	}
+}
+
+func TestPayloadShapesElixir_DestructureAndJSON(t *testing.T) {
+	const src = `
+defmodule UsersController do
+  def create(conn, %{"name" => name, "email" => email}) do
+    json(conn, %{"id" => 1, "name" => name})
+  end
+end
+`
+	shapes := sniffPayloadShapesElixir(src)
+	req := findShape(shapes, "create", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected elixir destructure shape; got %+v", shapes)
+	}
+	want := []string{"email", "name"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, want) {
+		t.Errorf("elixir destructure fields: want %v got %v", want, got)
+	}
+	resp := findShape(shapes, "create", PayloadDirectionResponse, PayloadSideProducer)
+	if resp == nil {
+		t.Fatalf("expected elixir json response shape; got %+v", shapes)
+	}
+	wantR := []string{"id", "name"}
+	if got := sortedNames(resp.Fields); !reflect.DeepEqual(got, wantR) {
+		t.Errorf("elixir json fields: want %v got %v", wantR, got)
+	}
+}
+
+func TestPayloadShapesScala_CaseClassAndJsonObj(t *testing.T) {
+	const src = `
+case class CreateUser(name: String, email: String, phone: Option[String])
+
+class UsersController {
+  def create(request: Request): Future[Response] = {
+    val dto = request.decodeJson[CreateUser]
+    Ok(Json.obj("id" -> 1, "name" -> "x"))
+  }
+}
+`
+	shapes := sniffPayloadShapesScala(src)
+	req := findShape(shapes, "create", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected scala decodeJson shape; got %+v", shapes)
+	}
+	want := []string{"email", "name", "phone"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, want) {
+		t.Errorf("scala case class fields: want %v got %v", want, got)
+	}
+	for _, f := range req.Fields {
+		if f.Name == "phone" && !f.Optional {
+			t.Errorf("phone should be Optional=true; got %+v", f)
+		}
+	}
+	resp := findShape(shapes, "create", PayloadDirectionResponse, PayloadSideProducer)
+	if resp == nil {
+		t.Fatalf("expected scala Json.obj response shape; got %+v", shapes)
+	}
+}
+
+func TestPayloadShapesCCPP_BodyAccessAndCurl(t *testing.T) {
+	const src = `
+void handle_create(http_request request) {
+    auto body = request.extract_json().get();
+    auto name = body[U("name")].as_string();
+    auto email = body[U("email")].as_string();
+    json::value result;
+    result[U("id")] = json::value::number(1);
+    result[U("name")] = json::value::string(name);
+}
+
+void push() {
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "name=x&email=y");
+}
+`
+	shapes := sniffPayloadShapesCCPP(src)
+	req := findShape(shapes, "handle_create", PayloadDirectionRequest, PayloadSideProducer)
+	if req == nil {
+		t.Fatalf("expected cpp body access shape; got %+v", shapes)
+	}
+	want := []string{"email", "name"}
+	if got := sortedNames(req.Fields); !reflect.DeepEqual(got, want) {
+		t.Errorf("cpp body fields: want %v got %v", want, got)
+	}
+	resp := findShape(shapes, "handle_create", PayloadDirectionResponse, PayloadSideProducer)
+	if resp == nil {
+		t.Fatalf("expected cpp result assign shape; got %+v", shapes)
+	}
+	wantR := []string{"id", "name"}
+	if got := sortedNames(resp.Fields); !reflect.DeepEqual(got, wantR) {
+		t.Errorf("cpp result fields: want %v got %v", wantR, got)
+	}
+	cs := findShape(shapes, "push", PayloadDirectionRequest, PayloadSideConsumer)
+	if cs == nil {
+		t.Fatalf("expected cpp curl consumer shape; got %+v", shapes)
+	}
+	wantC := []string{"email", "name"}
+	if got := sortedNames(cs.Fields); !reflect.DeepEqual(got, wantC) {
+		t.Errorf("cpp curl fields: want %v got %v", wantC, got)
+	}
+}

--- a/internal/substrate/payload_shapes_test.go
+++ b/internal/substrate/payload_shapes_test.go
@@ -10,8 +10,13 @@ import (
 	"testing"
 )
 
-func TestPayloadShapeSnifferRegistry_T1(t *testing.T) {
-	want := []string{"go", "java", "jsts", "python"}
+func TestPayloadShapeSnifferRegistry_T1AndT2(t *testing.T) {
+	// T1 (#2770): go, java, jsts, python.
+	// T2 (#2771): c-cpp, csharp, elixir, kotlin, php, ruby, rust, scala.
+	want := []string{
+		"c-cpp", "csharp", "elixir", "go", "java", "jsts", "kotlin",
+		"php", "python", "ruby", "rust", "scala",
+	}
 	got := PayloadShapeLanguages()
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("registered languages mismatch: want %v got %v", want, got)


### PR DESCRIPTION
## Summary

Adds payload-shape sniffers for the 8 T2 languages on top of the T1 substrate landed in #2793. Each sniffer is a pure function over file content, registered into `PayloadShapeRegistry`; the generic drift detector at `internal/links/payload_drift.go` picks them up automatically — no other plumbing.

Languages: `ruby`, `php`, `rust`, `csharp`, `kotlin`, `elixir`, `scala`, `c-cpp`.

## What's recognised

| Language | Producer-side | Consumer-side |
|---|---|---|
| ruby | `params.require(...).permit(...)`, `params[:x]`, `render json: {...}`, Grape `expose :name` | HTTParty / Faraday inline hash body |
| php | Laravel FormRequest `rules()`, `$request->only/get/input`, `$_POST/$_GET`, `response()->json([...])` | Guzzle `json` / `form_params` |
| rust | `Json<T>` extractor + same-file serde struct, `json!({...})` | reqwest `client.<verb>(url).json(...)` |
| csharp | `[FromBody] T` + property class / positional record, anonymous `new { ... }` | `PostAsJsonAsync` |
| kotlin | `@RequestBody dto: T` + same-file data class, `call.receive<T>()`, `mapOf("k" to v)` | Ktor client `client.<verb>(url)` |
| elixir | `def action(conn, %{"x" => x})`, `params[...]`, Ecto `field` + `cast([:a,:b])`, `json(conn, %{...})` | HTTPoison / Tesla inline map body |
| scala | case class primary-ctor params, `req.decodeJson[T]` / `req.as[T]`, `(json \ "x").as[T]`, `Json.obj("k" -> v)` | sttp `basicRequest` |
| c-cpp | cpprestsdk `body[U("x")]` reads, `result[U("x")] = ...` assigns | libcurl `CURLOPT_POSTFIELDS` urlencoded body |

`Option<T>`, `Optional<T>`, nullable `?`, and Kotlin `String?` flip `PayloadField.Optional`. Everything else stays default-false per the issue spec — absence of annotation is not proof of required-ness.

## Coverage matrix

222 cells flipped across 74 records (8 languages × 3 capabilities: `request_shape_extraction`, `response_shape_extraction`, `schema_drift_detection`). C/C++ records get `status=partial` (most C/C++ web frameworks are opaque `char*`; only cpprestsdk gives any static structure). All other T2 records flip to `status=full`.

## Real-data verification

upvate's stack is Python/JS/Java/Go (all T1, already covered). Expected new findings on upvate: **0**. The value here is unblocking future projects in any of these 8 T2 languages.

## implements-capability tags

Sampled (full list in commit message):
- `lang.ruby.framework.rails/Substrate/{request_shape_extraction,response_shape_extraction,schema_drift_detection}:missing→full`
- `lang.php.framework.laravel/Substrate/{request_shape_extraction,response_shape_extraction,schema_drift_detection}:missing→full`
- `lang.rust.framework.axum/Substrate/{request_shape_extraction,response_shape_extraction,schema_drift_detection}:missing→full`
- `lang.csharp.framework.aspnet-core/Substrate/{request_shape_extraction,response_shape_extraction,schema_drift_detection}:missing→full`
- `lang.kotlin.framework.{spring-boot,ktor}/Substrate/{request_shape_extraction,response_shape_extraction,schema_drift_detection}:missing→full`
- `lang.elixir.framework.phoenix/Substrate/{request_shape_extraction,response_shape_extraction,schema_drift_detection}:missing→full`
- `lang.scala.framework.{akka-http,http4s}/Substrate/{request_shape_extraction,response_shape_extraction,schema_drift_detection}:missing→full`
- `lang.c-cpp.framework.cpprestsdk/Substrate/{request_shape_extraction,response_shape_extraction,schema_drift_detection}:missing→partial`

Plus 192 additional cells across the remaining 65 T2 `http_backend` records.

## Test plan

- [x] `go test ./internal/substrate/` — passes (new T2 tests + updated registry test)
- [x] `go test ./internal/links/` — passes (drift detector picks up new sniffers automatically)
- [x] `go test ./tools/coverage/` — passes (registry round-trip stable)
- [x] `go run ./tools/coverage validate` — no new errors introduced
- [x] `go run ./tools/coverage gen` — derived docs regenerated
- [ ] Real-data run on a Ruby/PHP/Rust/etc. corpus when one is added (none in upvate today)

## Files

- `internal/substrate/payload_shapes_{ruby,php,rust,csharp,kotlin,elixir,scala,c_cpp}.go` — new sniffers
- `internal/substrate/payload_shapes_t2_test.go` — canonical tests, one per language
- `internal/substrate/payload_shapes_test.go` — registry test extended to assert T1+T2 slugs
- `docs/coverage/registry.json` + derived docs — 222 cell updates

Closes #2771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)