### PR TITLE
feat(substrate): Phase 3 misc for T2 languages (#2775)

### DIFF
--- a/internal/links/def_use_pass.go
+++ b/internal/links/def_use_pass.go
@@ -1,0 +1,245 @@
+// Phase 3C reaching-definitions / def-use chain pass (#2774).
+//
+// For every (function, use) the pass finds the last preceding def of
+// the same variable in the same function and emits a DefUseChain
+// record. "Last write wins" — we deliberately skip SSA-phi precision
+// per the issue spec; that lives in Phase 4.
+//
+// Intra-procedural ONLY. Cross-function chains require alias analysis
+// and are out of Phase 3C scope.
+//
+// Per-language sniffing happens once per file via the registered
+// substrate.DefUseSnifferFor sniffer. The pass binds each (file, fn)
+// pair to its graph entity via the same (repo, file, name) lookup the
+// effect propagation pass uses, then stamps a compact summary on the
+// entity properties:
+//
+//   def_use_chains    "<var>@<defLine>->-<useLine>,..." (bounded length)
+//   def_use_count     "<n>"
+//
+// The full chain list is also persisted in <group>-links-def-use.json
+// for archigraph_def_use to surface unbounded.
+package links
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/substrate"
+)
+
+// MethodDefUse identifies sidecar artefacts from this pass.
+const MethodDefUse = "def_use"
+
+// DefUsePropertyKey* are the stable property keys.
+const (
+	DefUsePropertyKeyChains = "def_use_chains"
+	DefUsePropertyKeyCount  = "def_use_count"
+)
+
+// maxPropertyChains bounds the compact summary stamped onto entity
+// properties (the full set is in the sidecar JSON). Keeps the per-entity
+// property surface small — entities with hundreds of def-use pairs would
+// otherwise blow up the graph file size.
+const maxPropertyChains = 24
+
+// defUseChain is one resolved (def, use) pair for a single variable.
+type defUseChain struct {
+	Var     string `json:"var"`
+	DefLine int    `json:"def_line"`
+	UseLine int    `json:"use_line"`
+}
+
+// defUseEntry is one persistent (function, [chain...]) record for the
+// sidecar JSON surface.
+type defUseEntry struct {
+	Repo       string        `json:"repo"`
+	EntityID   string        `json:"entity_id"`
+	Name       string        `json:"name"`
+	SourceFile string        `json:"source_file,omitempty"`
+	Chains     []defUseChain `json:"chains"`
+}
+
+type defUseDocument struct {
+	Version int           `json:"version"`
+	Method  string        `json:"method"`
+	Total   int           `json:"total_chains"`
+	Entries []defUseEntry `json:"entries"`
+}
+
+// runDefUsePass walks every T1 source file and computes intra-procedural
+// reaching definitions per the substrate.DefUseSnifferFor contract.
+func runDefUsePass(graphs []repoGraph, paths Paths) (PassResult, error) {
+	res := PassResult{Pass: "def_use"}
+	binder := newEffectBinder(graphs) // re-uses the (repo, file, name) index.
+
+	var allEntries []defUseEntry
+	totalChains := 0
+	scanned := 0
+
+	for ri := range graphs {
+		g := &graphs[ri]
+		fileSet := map[string]bool{}
+		for _, e := range g.Entities {
+			if e.SourceFile != "" {
+				fileSet[e.SourceFile] = true
+			}
+		}
+		for file := range fileSet {
+			lang := substrate.LanguageForPath(file)
+			if lang == "" {
+				continue
+			}
+			sniff := substrate.DefUseSnifferFor(lang)
+			if sniff == nil {
+				continue
+			}
+			srcRoot := repoSourcePathFor(g.Repo)
+			if srcRoot == "" {
+				srcRoot = g.FileRoot
+			}
+			abs := filepath.Join(srcRoot, file)
+			content, err := os.ReadFile(abs)
+			if err != nil {
+				continue
+			}
+			scanned++
+			defs, uses := sniff(string(content))
+			if len(uses) == 0 || len(defs) == 0 {
+				continue
+			}
+			// Per-function reaching-defs: group defs by (fn, var) sorted
+			// by line, then for each use binary-search the greatest def
+			// line strictly ≤ use line.
+			defsByFnVar := map[string][]int{}
+			for _, d := range defs {
+				if d.Function == "" {
+					continue
+				}
+				key := d.Function + "::" + d.Var
+				defsByFnVar[key] = append(defsByFnVar[key], d.Line)
+			}
+			for k := range defsByFnVar {
+				sort.Ints(defsByFnVar[k])
+			}
+
+			perFn := map[string][]defUseChain{}
+			for _, u := range uses {
+				if u.Function == "" {
+					continue
+				}
+				key := u.Function + "::" + u.Var
+				lines, ok := defsByFnVar[key]
+				if !ok {
+					continue
+				}
+				idx := sort.SearchInts(lines, u.Line)
+				// idx is the first def-line >= use line; we want strictly
+				// less, so step back by one.
+				if idx == 0 {
+					continue
+				}
+				defLine := lines[idx-1]
+				if defLine >= u.Line {
+					continue
+				}
+				perFn[u.Function] = append(perFn[u.Function], defUseChain{
+					Var:     u.Var,
+					DefLine: defLine,
+					UseLine: u.Line,
+				})
+			}
+
+			for fn, chains := range perFn {
+				if len(chains) == 0 {
+					continue
+				}
+				totalChains += len(chains)
+				eid := binder.lookup(g.Repo, file, fn)
+				if eid == "" {
+					continue
+				}
+				// Stamp the compact summary onto the entity properties.
+				for ei := range g.Entities {
+					if g.Entities[ei].ID != eid {
+						continue
+					}
+					e := &g.Entities[ei]
+					if e.Properties == nil {
+						e.Properties = map[string]string{}
+					}
+					summary := formatDefUseSummary(chains, maxPropertyChains)
+					e.Properties[DefUsePropertyKeyChains] = summary
+					e.Properties[DefUsePropertyKeyCount] = fmt.Sprintf("%d", len(chains))
+					allEntries = append(allEntries, defUseEntry{
+						Repo:       g.Repo,
+						EntityID:   eid,
+						Name:       e.Name,
+						SourceFile: file,
+						Chains:     chains,
+					})
+					break
+				}
+			}
+		}
+	}
+
+	res.LinksAdded = totalChains
+	res.Candidates = scanned
+
+	if paths.Links == "" {
+		return res, nil
+	}
+	sort.Slice(allEntries, func(i, j int) bool {
+		if allEntries[i].Repo != allEntries[j].Repo {
+			return allEntries[i].Repo < allEntries[j].Repo
+		}
+		return allEntries[i].EntityID < allEntries[j].EntityID
+	})
+	sidecar := trimSuffix(paths.Links, ".json") + "-def-use.json"
+	doc := defUseDocument{
+		Version: 1,
+		Method:  MethodDefUse,
+		Total:   totalChains,
+		Entries: allEntries,
+	}
+	buf, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return res, err
+	}
+	if err := os.MkdirAll(filepath.Dir(sidecar), 0o755); err != nil {
+		return res, err
+	}
+	if err := os.WriteFile(sidecar, buf, 0o644); err != nil {
+		return res, fmt.Errorf("write def-use doc: %w", err)
+	}
+	return res, nil
+}
+
+// formatDefUseSummary renders up to max chains as
+// "<var>@<defLine>->-<useLine>" comma-joined. Stable iteration so
+// graph output is byte-identical across runs.
+func formatDefUseSummary(chains []defUseChain, max int) string {
+	cp := append([]defUseChain(nil), chains...)
+	sort.Slice(cp, func(i, j int) bool {
+		if cp[i].UseLine != cp[j].UseLine {
+			return cp[i].UseLine < cp[j].UseLine
+		}
+		if cp[i].DefLine != cp[j].DefLine {
+			return cp[i].DefLine < cp[j].DefLine
+		}
+		return cp[i].Var < cp[j].Var
+	})
+	if len(cp) > max {
+		cp = cp[:max]
+	}
+	parts := make([]string, len(cp))
+	for i, c := range cp {
+		parts[i] = fmt.Sprintf("%s@%d->%d", c.Var, c.DefLine, c.UseLine)
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -421,6 +421,48 @@ func RunAllPasses(group, graphsDir, archigraphHome string) (*RunResult, error) {
 	}
 	res.Results = append(res.Results, pDrift)
 
+	// #2774 / #2775 — Phase 3A pure-function tagging. Derivative of
+	// Phase 1A: every function-like entity without an effect set is
+	// marked pure=true with a low confidence floor. Runs after the
+	// effect propagation pass so it observes the in-memory effect
+	// annotations stamped on entity Properties.
+	pPure, err := runPureFunctionPass(graphs, paths)
+	if err != nil {
+		return nil, fmt.Errorf("pure-function pass: %w", err)
+	}
+	res.Results = append(res.Results, pPure)
+
+	// #2774 / #2775 — Phase 3B module-cycle detection via Tarjan SCC
+	// over IMPORTS edges. Language-agnostic; stamps `module_cycle_id`
+	// on every cycle participant and emits a sidecar with full SCC
+	// membership for the archigraph_import_cycles MCP tool.
+	pCycle, err := runModuleCyclePass(graphs, paths)
+	if err != nil {
+		return nil, fmt.Errorf("module-cycle pass: %w", err)
+	}
+	res.Results = append(res.Results, pCycle)
+
+	// #2774 / #2775 — Phase 3C intra-procedural def-use chains. Per-
+	// language sniffer lifts defs and uses, the pass composes reaching-
+	// definitions (last-write-wins), stamps a compact summary on the
+	// owning function entity, and persists the full chain set in a
+	// sidecar for the archigraph_def_use MCP tool.
+	pDU, err := runDefUsePass(graphs, paths)
+	if err != nil {
+		return nil, fmt.Errorf("def-use pass: %w", err)
+	}
+	res.Results = append(res.Results, pDU)
+
+	// #2774 / #2775 — Phase 3D template-pattern catalog (i18n / log-
+	// format / SQL templates). Per-language sniffer lifts every recog-
+	// nised template literal; the pass persists them in a sidecar for
+	// the archigraph_template_patterns MCP tool.
+	pTP, err := runTemplatePatternPass(graphs, paths)
+	if err != nil {
+		return nil, fmt.Errorf("template-pattern pass: %w", err)
+	}
+	res.Results = append(res.Results, pTP)
+
 	for _, r := range res.Results {
 		res.TotalLinks += r.LinksAdded
 		res.TotalCandid += r.Candidates

--- a/internal/links/module_cycle_pass.go
+++ b/internal/links/module_cycle_pass.go
@@ -1,0 +1,244 @@
+// Phase 3B module-cycle detection pass (#2774).
+//
+// Tarjan strongly-connected-components over IMPORTS edges. Surfaces
+// every non-trivial cycle (SCC of size >= 2) as a ModuleCycle record.
+// Language-agnostic — the IMPORTS edge graph is the same shape across
+// every T1 language because the per-language extractors emit a common
+// edge kind.
+//
+// Storage model: in-memory annotation of every entity that participates
+// in a cycle with the property `module_cycle_id` (the index of the
+// cycle in the sidecar). The persistent <group>-links-module-cycles.json
+// sidecar surfaces the full cycle members + size for the MCP
+// archigraph_module_cycles tool.
+package links
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// MethodModuleCycles identifies sidecar artefacts from this pass.
+const MethodModuleCycles = "module_cycles"
+
+// ModuleCyclePropertyKey is the stable name under which the pass stamps
+// the cycle membership tag onto entity properties.
+const ModuleCyclePropertyKey = "module_cycle_id"
+
+// moduleCycle is one strongly-connected component of size >= 2 over the
+// IMPORTS edge graph. The Members list is sorted (repo, id) for stable
+// output across runs.
+type moduleCycle struct {
+	ID      int                 `json:"id"`
+	Size    int                 `json:"size"`
+	Members []moduleCycleMember `json:"members"`
+}
+
+type moduleCycleMember struct {
+	Repo       string `json:"repo"`
+	EntityID   string `json:"entity_id"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	SourceFile string `json:"source_file,omitempty"`
+}
+
+// moduleCycleDocument is the on-disk shape of <group>-links-module-cycles.json.
+type moduleCycleDocument struct {
+	Version    int           `json:"version"`
+	Method     string        `json:"method"`
+	TotalNodes int           `json:"total_nodes"`
+	TotalEdges int           `json:"total_edges"`
+	Cycles     []moduleCycle `json:"cycles"`
+}
+
+// runModuleCyclePass enumerates SCCs over the IMPORTS edges aggregated
+// across every repo in the group. The cross-repo IMPORTS edges emitted
+// by the link pipeline are honoured by reading both per-repo edges
+// (FromID/ToID local) and any persisted cross-repo links of relation
+// `imports` from the same RunAllPasses invocation — for Phase 3B we
+// keep the analysis intra-repo only (per-repo SCCs), which matches the
+// classical Tarjan-on-imports use-case ("circular dependency cluster
+// inside this repo's module tree").
+//
+// Future cross-repo cycles can be lifted by feeding the cross-repo
+// links.json entries with relation=imports into the same algorithm;
+// out of Phase 3B scope.
+func runModuleCyclePass(graphs []repoGraph, paths Paths) (PassResult, error) {
+	res := PassResult{Pass: "module_cycles"}
+
+	var cycles []moduleCycle
+	totalNodes := 0
+	totalEdges := 0
+	cycleID := 0
+
+	for ri := range graphs {
+		g := &graphs[ri]
+
+		// Build the adjacency: nodeID -> sorted set of nodeIDs reachable
+		// via an IMPORTS edge. We use entity IDs as nodes since the
+		// extractor emits a stable per-file/per-module entity that owns
+		// the IMPORTS outbound edges.
+		nodeSet := map[string]bool{}
+		adj := map[string][]string{}
+		for _, e := range g.Edges {
+			if !strings.EqualFold(e.Kind, "IMPORTS") && e.Kind != "imports" {
+				continue
+			}
+			adj[e.FromID] = append(adj[e.FromID], e.ToID)
+			nodeSet[e.FromID] = true
+			nodeSet[e.ToID] = true
+			totalEdges++
+		}
+		totalNodes += len(nodeSet)
+		if len(nodeSet) == 0 {
+			continue
+		}
+
+		nodes := make([]string, 0, len(nodeSet))
+		for n := range nodeSet {
+			nodes = append(nodes, n)
+		}
+		sort.Strings(nodes)
+
+		// Tarjan's algorithm. Indexed iterative-friendly form — but a
+		// recursive form is cleaner and the call depth is bounded by
+		// the per-repo IMPORTS graph diameter (well under Go's stack).
+		state := newTarjanState(adj)
+		for _, n := range nodes {
+			if _, ok := state.index[n]; !ok {
+				state.strongConnect(n)
+			}
+		}
+
+		// Surface non-trivial SCCs (size >= 2) only. Single-node SCCs
+		// without a self-edge are not cycles; single-node SCCs with a
+		// self-edge are technically cycles but almost always recursion
+		// noise (Phase 3B targets module-graph cycles, not function-
+		// recursion analysis).
+		byID := make(map[string]*entityNode, len(g.Entities))
+		for ei := range g.Entities {
+			byID[g.Entities[ei].ID] = &g.Entities[ei]
+		}
+		for _, scc := range state.sccs {
+			if len(scc) < 2 {
+				continue
+			}
+			cycleID++
+			tag := fmt.Sprintf("%s/%d", g.Repo, cycleID)
+			mem := make([]moduleCycleMember, 0, len(scc))
+			ids := append([]string(nil), scc...)
+			sort.Strings(ids)
+			for _, id := range ids {
+				e := byID[id]
+				if e == nil {
+					continue
+				}
+				if e.Properties == nil {
+					e.Properties = map[string]string{}
+				}
+				e.Properties[ModuleCyclePropertyKey] = tag
+				mem = append(mem, moduleCycleMember{
+					Repo:       g.Repo,
+					EntityID:   id,
+					Name:       e.Name,
+					Kind:       e.Kind,
+					SourceFile: e.SourceFile,
+				})
+			}
+			cycles = append(cycles, moduleCycle{
+				ID:      cycleID,
+				Size:    len(mem),
+				Members: mem,
+			})
+		}
+	}
+
+	res.LinksAdded = len(cycles)
+	res.Candidates = totalNodes
+	res.Skipped = totalEdges
+
+	if paths.Links == "" {
+		return res, nil
+	}
+	sidecar := trimSuffix(paths.Links, ".json") + "-module-cycles.json"
+	doc := moduleCycleDocument{
+		Version:    1,
+		Method:     MethodModuleCycles,
+		TotalNodes: totalNodes,
+		TotalEdges: totalEdges,
+		Cycles:     cycles,
+	}
+	buf, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return res, err
+	}
+	if err := os.MkdirAll(filepath.Dir(sidecar), 0o755); err != nil {
+		return res, err
+	}
+	if err := os.WriteFile(sidecar, buf, 0o644); err != nil {
+		return res, fmt.Errorf("write module-cycles doc: %w", err)
+	}
+	return res, nil
+}
+
+// tarjanState is the per-graph book-keeping for Tarjan's algorithm. The
+// recursive strongConnect closure operates on the receiver, populating
+// `sccs` with every component on its way back up the DFS stack.
+type tarjanState struct {
+	adj      map[string][]string
+	index    map[string]int
+	lowlink  map[string]int
+	onStack  map[string]bool
+	stack    []string
+	counter  int
+	sccs     [][]string
+}
+
+func newTarjanState(adj map[string][]string) *tarjanState {
+	return &tarjanState{
+		adj:     adj,
+		index:   map[string]int{},
+		lowlink: map[string]int{},
+		onStack: map[string]bool{},
+	}
+}
+
+func (t *tarjanState) strongConnect(v string) {
+	t.index[v] = t.counter
+	t.lowlink[v] = t.counter
+	t.counter++
+	t.stack = append(t.stack, v)
+	t.onStack[v] = true
+
+	for _, w := range t.adj[v] {
+		if _, ok := t.index[w]; !ok {
+			t.strongConnect(w)
+			if t.lowlink[w] < t.lowlink[v] {
+				t.lowlink[v] = t.lowlink[w]
+			}
+		} else if t.onStack[w] {
+			if t.index[w] < t.lowlink[v] {
+				t.lowlink[v] = t.index[w]
+			}
+		}
+	}
+
+	if t.lowlink[v] == t.index[v] {
+		var scc []string
+		for {
+			n := len(t.stack) - 1
+			w := t.stack[n]
+			t.stack = t.stack[:n]
+			t.onStack[w] = false
+			scc = append(scc, w)
+			if w == v {
+				break
+			}
+		}
+		t.sccs = append(t.sccs, scc)
+	}
+}

--- a/internal/links/pure_function_pass.go
+++ b/internal/links/pure_function_pass.go
@@ -1,0 +1,145 @@
+// Phase 3A pure-function tagging pass (#2774).
+//
+// Derivative of Phase 1A: any function-like entity that the effect
+// propagation pass did NOT stamp with an effect set is marked as a
+// pure-function candidate. The stamping uses two new property keys:
+//
+//   pure              "true" | "false"
+//   pure_confidence   "0.30"   (matches Phase 1A's "pure" confidence floor;
+//                                absence-of-detection does not prove absence)
+//
+// Why a separate pass instead of inlining into effect_propagation.go?
+//   - Effect propagation runs in-memory and stamps only entities with a
+//     non-empty effect set. The pure tagging needs to walk every
+//     function-like entity (positive AND negative).
+//   - Surfacing the tagged set on its own MCP tool keeps the contract
+//     small: "list me memoization candidates".
+//   - The pass has zero per-language code (it reads effect properties
+//     that Phase 1A has already stamped).
+//
+// The sidecar <group>-links-pure-functions.json is written for the MCP
+// archigraph_pure_functions tool.
+package links
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// MethodPureFunctions identifies sidecar artefacts produced by this pass.
+const MethodPureFunctions = "pure_functions"
+
+// Pure-tagging confidence floor — mirrors Phase 1A's pure baseline so
+// downstream consumers see one consistent number for "pure" judgements.
+const purityConfidence = 0.30
+
+// PurePropertyKey* are the stable property keys this pass stamps onto
+// function-like entities. Tests assert their exact spelling.
+const (
+	PurePropertyKeyPure       = "pure"
+	PurePropertyKeyConfidence = "pure_confidence"
+)
+
+// pureEntry is one persistent pure-function fact for the sidecar.
+type pureEntry struct {
+	Repo       string  `json:"repo"`
+	EntityID   string  `json:"entity_id"`
+	Name       string  `json:"name"`
+	Kind       string  `json:"kind"`
+	SourceFile string  `json:"source_file,omitempty"`
+	Confidence float64 `json:"confidence"`
+}
+
+// pureDocument is the on-disk shape of <group>-links-pure-functions.json.
+type pureDocument struct {
+	Version int         `json:"version"`
+	Method  string      `json:"method"`
+	Total   int         `json:"total"`
+	Entries []pureEntry `json:"entries"`
+}
+
+// runPureFunctionPass walks every function-like entity in every repo
+// and stamps the pure/pure_confidence properties. Entities the effect
+// pass already marked with non-empty effects are explicitly stamped
+// pure="false" so a downstream reader can distinguish "checked-pure"
+// from "never checked" entities.
+//
+// Stamping happens in-memory on the graphs slice; a sidecar JSON is
+// written to <paths.Links>-pure-functions.json for MCP consumption.
+func runPureFunctionPass(graphs []repoGraph, paths Paths) (PassResult, error) {
+	res := PassResult{Pass: "pure_functions"}
+	var entries []pureEntry
+	totalPure := 0
+
+	for ri := range graphs {
+		g := &graphs[ri]
+		for ei := range g.Entities {
+			e := &g.Entities[ei]
+			if !isFunctionLikeKind(e.Kind) {
+				continue
+			}
+			if e.Properties == nil {
+				e.Properties = map[string]string{}
+			}
+			// If Phase 1A stamped effects, this entity is not pure.
+			if eff := e.Properties[EffectPropertyKeyList]; eff != "" {
+				e.Properties[PurePropertyKeyPure] = "false"
+				continue
+			}
+			e.Properties[PurePropertyKeyPure] = "true"
+			e.Properties[PurePropertyKeyConfidence] = fmt.Sprintf("%.2f", purityConfidence)
+			totalPure++
+			entries = append(entries, pureEntry{
+				Repo:       g.Repo,
+				EntityID:   e.ID,
+				Name:       e.Name,
+				Kind:       e.Kind,
+				SourceFile: e.SourceFile,
+				Confidence: purityConfidence,
+			})
+		}
+	}
+
+	res.LinksAdded = totalPure
+
+	if paths.Links == "" {
+		return res, nil
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Repo != entries[j].Repo {
+			return entries[i].Repo < entries[j].Repo
+		}
+		return entries[i].EntityID < entries[j].EntityID
+	})
+	sidecar := trimSuffix(paths.Links, ".json") + "-pure-functions.json"
+	doc := pureDocument{
+		Version: 1,
+		Method:  MethodPureFunctions,
+		Total:   totalPure,
+		Entries: entries,
+	}
+	buf, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return res, err
+	}
+	if err := os.MkdirAll(filepath.Dir(sidecar), 0o755); err != nil {
+		return res, err
+	}
+	if err := os.WriteFile(sidecar, buf, 0o644); err != nil {
+		return res, fmt.Errorf("write pure-functions doc: %w", err)
+	}
+	return res, nil
+}
+
+// trimSuffix removes the trailing suf from s when present. Local helper
+// to avoid importing strings just for this; mirrors the inline
+// strings.TrimSuffix used by sibling passes.
+func trimSuffix(s, suf string) string {
+	if len(s) >= len(suf) && s[len(s)-len(suf):] == suf {
+		return s[:len(s)-len(suf)]
+	}
+	return s
+}

--- a/internal/links/template_pattern_pass.go
+++ b/internal/links/template_pattern_pass.go
@@ -1,0 +1,135 @@
+// Phase 3D template-pattern catalog pass (#2774).
+//
+// Walks every T1 source file once, dispatches to the registered
+// substrate.TemplatePatternSnifferFor sniffer, and persists every
+// match in <group>-links-template-patterns.json. Powers:
+//   - i18n key extraction
+//   - log-format inconsistency surveys
+//   - SQL-injection literal cataloguing (overlaps Phase 2B at the
+//     literal level — Phase 2B tracks taint flow into the literal;
+//     this pass catalogues the literal itself).
+//
+// In-memory: no entity property is stamped (the template literal is a
+// per-call-site fact, not a per-entity fact). The MCP tool reads the
+// sidecar directly.
+package links
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/substrate"
+)
+
+// MethodTemplatePatterns identifies sidecar artefacts from this pass.
+const MethodTemplatePatterns = "template_patterns"
+
+// templatePatternEntry is one persistent template-pattern fact.
+type templatePatternEntry struct {
+	Repo       string `json:"repo"`
+	SourceFile string `json:"source_file"`
+	Function   string `json:"function,omitempty"`
+	Line       int    `json:"line"`
+	Kind       string `json:"kind"`
+	Tag        string `json:"tag"`
+	Literal    string `json:"literal"`
+}
+
+type templatePatternDocument struct {
+	Version int                    `json:"version"`
+	Method  string                 `json:"method"`
+	Total   int                    `json:"total"`
+	ByKind  map[string]int         `json:"by_kind"`
+	Entries []templatePatternEntry `json:"entries"`
+}
+
+// runTemplatePatternPass enumerates every template-pattern match in
+// every T1 source file across every repo.
+func runTemplatePatternPass(graphs []repoGraph, paths Paths) (PassResult, error) {
+	res := PassResult{Pass: "template_patterns"}
+	var entries []templatePatternEntry
+	byKind := map[string]int{}
+	scanned := 0
+
+	for _, g := range graphs {
+		fileSet := map[string]bool{}
+		for _, e := range g.Entities {
+			if e.SourceFile != "" {
+				fileSet[e.SourceFile] = true
+			}
+		}
+		for file := range fileSet {
+			lang := substrate.LanguageForPath(file)
+			if lang == "" {
+				continue
+			}
+			sniff := substrate.TemplatePatternSnifferFor(lang)
+			if sniff == nil {
+				continue
+			}
+			srcRoot := repoSourcePathFor(g.Repo)
+			if srcRoot == "" {
+				srcRoot = g.FileRoot
+			}
+			abs := filepath.Join(srcRoot, file)
+			content, err := os.ReadFile(abs)
+			if err != nil {
+				continue
+			}
+			scanned++
+			for _, tp := range sniff(string(content)) {
+				entries = append(entries, templatePatternEntry{
+					Repo:       g.Repo,
+					SourceFile: file,
+					Function:   tp.Function,
+					Line:       tp.Line,
+					Kind:       string(tp.Kind),
+					Tag:        tp.Tag,
+					Literal:    tp.Literal,
+				})
+				byKind[string(tp.Kind)]++
+			}
+		}
+	}
+
+	res.LinksAdded = len(entries)
+	res.Candidates = scanned
+
+	if paths.Links == "" {
+		return res, nil
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Repo != entries[j].Repo {
+			return entries[i].Repo < entries[j].Repo
+		}
+		if entries[i].SourceFile != entries[j].SourceFile {
+			return entries[i].SourceFile < entries[j].SourceFile
+		}
+		if entries[i].Line != entries[j].Line {
+			return entries[i].Line < entries[j].Line
+		}
+		return entries[i].Kind < entries[j].Kind
+	})
+	sidecar := trimSuffix(paths.Links, ".json") + "-template-patterns.json"
+	doc := templatePatternDocument{
+		Version: 1,
+		Method:  MethodTemplatePatterns,
+		Total:   len(entries),
+		ByKind:  byKind,
+		Entries: entries,
+	}
+	buf, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return res, err
+	}
+	if err := os.MkdirAll(filepath.Dir(sidecar), 0o755); err != nil {
+		return res, err
+	}
+	if err := os.WriteFile(sidecar, buf, 0o644); err != nil {
+		return res, fmt.Errorf("write template-patterns doc: %w", err)
+	}
+	return res, nil
+}

--- a/internal/mcp/budget.go
+++ b/internal/mcp/budget.go
@@ -20,4 +20,13 @@ package mcp
 //     the new tool's category / min_confidence / limit / source_repo
 //     args push the handshake near the prior ceiling; +500 restores
 //     headroom under the 6500 next-bump line.
-const TokenCeiling = 6000
+//   - 6000 → 6500: PR for #2774 / #2775 Phase 3 misc — adds four
+//     sidecar-reader tools (archigraph_pure_functions, archigraph_
+//     import_cycles, archigraph_def_use, archigraph_template_patterns)
+//     for the pure-function / module-cycle / def-use / template-pattern
+//     analyses. Each is a thin reader of its corresponding link-pass
+//     sidecar with a handful of optional filters; per-tool footprint
+//     is small but four entries push us past the 6000 ceiling. After
+//     this bump further additions must fold into an existing action-
+//     dispatch bundle rather than add a new top-level tool.
+const TokenCeiling = 6500

--- a/internal/mcp/phase3_tools.go
+++ b/internal/mcp/phase3_tools.go
@@ -1,0 +1,412 @@
+// Phase 3 MCP tools (#2774).
+//
+// Four new tools, each reading the sidecar JSON written by the
+// corresponding link pass in internal/links/:
+//
+//   - archigraph_pure_functions      ← <group>-links-pure-functions.json
+//   - archigraph_module_cycles       ← <group>-links-module-cycles.json
+//   - archigraph_def_use             ← <group>-links-def-use.json
+//   - archigraph_template_patterns   ← <group>-links-template-patterns.json
+//
+// All four handlers share the same shape: load the sidecar for the
+// resolved group, project into the wire format, apply optional filters,
+// cap to a limit. When the sidecar is missing the handler returns an
+// empty result with `source="missing"` and a note explaining the user
+// must re-run the link passes (mirrors the dead-code tool's contract
+// when reachability has never been computed).
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// sidecarPath returns the canonical on-disk path for a Phase 3 sidecar
+// of the given suffix (e.g. "pure-functions"). Mirrors
+// reachabilitySidecarPath in dead_code.go.
+func sidecarPath(group, suffix string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".archigraph", "groups", group+"-links-"+suffix+".json")
+}
+
+// loadSidecar reads + json-decodes the sidecar at path into v; ok=false
+// on any I/O or decode error (missing file is the common case).
+func loadSidecar(path string, v any) bool {
+	if path == "" {
+		return false
+	}
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return json.Unmarshal(buf, v) == nil
+}
+
+// ---------------------------------------------------------------------
+// 3A — archigraph_pure_functions
+// ---------------------------------------------------------------------
+
+type pureSidecarEntry struct {
+	Repo       string  `json:"repo"`
+	EntityID   string  `json:"entity_id"`
+	Name       string  `json:"name"`
+	Kind       string  `json:"kind"`
+	SourceFile string  `json:"source_file,omitempty"`
+	Confidence float64 `json:"confidence"`
+}
+
+type pureSidecarDoc struct {
+	Version int                `json:"version"`
+	Method  string             `json:"method"`
+	Total   int                `json:"total"`
+	Entries []pureSidecarEntry `json:"entries"`
+}
+
+func (s *Server) handlePureFunctions(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	groupName, _, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repoFilter := map[string]bool{}
+	for _, r := range argStringSlice(req, "repo_filter") {
+		repoFilter[r] = true
+	}
+	limit := argInt(req, "limit", 200)
+
+	var doc pureSidecarDoc
+	path := sidecarPath(groupName, "pure-functions")
+	if !loadSidecar(path, &doc) {
+		return jsonResult(map[string]any{
+			"pure_functions": []any{},
+			"count":          0,
+			"total":          0,
+			"source":         "missing",
+			"note":           "Pure-function sidecar absent — run the link passes to generate it (#2774 Phase 3A).",
+		}), nil
+	}
+	out := make([]map[string]any, 0, len(doc.Entries))
+	for _, e := range doc.Entries {
+		if len(repoFilter) > 0 && !repoFilter[e.Repo] {
+			continue
+		}
+		out = append(out, map[string]any{
+			"entity_id":   prefixedID(e.Repo, e.EntityID),
+			"name":        e.Name,
+			"kind":        e.Kind,
+			"repo":        e.Repo,
+			"source_file": e.SourceFile,
+			"confidence":  e.Confidence,
+		})
+	}
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"pure_functions": out,
+		"count":          len(out),
+		"total":          total,
+		"truncated":      total > len(out),
+		"source":         "sidecar",
+		"note": "Function-like entities with no detected sinks per Phase 1A effect classification. " +
+			"Confidence is low (0.30) — absence of detection does not prove absence of effect (#2774 Phase 3A).",
+	}), nil
+}
+
+// ---------------------------------------------------------------------
+// 3B — archigraph_module_cycles
+// ---------------------------------------------------------------------
+
+type moduleCycleSidecarMember struct {
+	Repo       string `json:"repo"`
+	EntityID   string `json:"entity_id"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	SourceFile string `json:"source_file,omitempty"`
+}
+
+type moduleCycleSidecar struct {
+	ID      int                       `json:"id"`
+	Size    int                       `json:"size"`
+	Members []moduleCycleSidecarMember `json:"members"`
+}
+
+type moduleCycleSidecarDoc struct {
+	Version    int                  `json:"version"`
+	Method     string               `json:"method"`
+	TotalNodes int                  `json:"total_nodes"`
+	TotalEdges int                  `json:"total_edges"`
+	Cycles     []moduleCycleSidecar `json:"cycles"`
+}
+
+// handleModuleCyclesSidecar is the Phase 3B SCC reader. The pre-existing
+// handleModuleCycles in module_gds_tools.go computes SCCs on demand from
+// the in-memory graph and is bundled under archigraph_module_analysis;
+// this handler reads the persistent sidecar emitted by the new Phase 3B
+// link pass, so callers get the same SCC view without paying the
+// recompute cost on each call and entities carry a stamped
+// `module_cycle_id` property usable from any other query.
+func (s *Server) handleModuleCyclesSidecar(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	groupName, _, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repoFilter := map[string]bool{}
+	for _, r := range argStringSlice(req, "repo_filter") {
+		repoFilter[r] = true
+	}
+	minSize := argInt(req, "min_size", 2)
+	limit := argInt(req, "limit", 100)
+
+	var doc moduleCycleSidecarDoc
+	path := sidecarPath(groupName, "module-cycles")
+	if !loadSidecar(path, &doc) {
+		return jsonResult(map[string]any{
+			"cycles": []any{},
+			"count":  0,
+			"source": "missing",
+			"note":   "Module-cycle sidecar absent — run the link passes to generate it (#2774 Phase 3B).",
+		}), nil
+	}
+	out := make([]map[string]any, 0, len(doc.Cycles))
+	for _, c := range doc.Cycles {
+		if c.Size < minSize {
+			continue
+		}
+		members := make([]map[string]any, 0, len(c.Members))
+		keep := false
+		for _, m := range c.Members {
+			if len(repoFilter) == 0 || repoFilter[m.Repo] {
+				keep = true
+			}
+			members = append(members, map[string]any{
+				"entity_id":   prefixedID(m.Repo, m.EntityID),
+				"name":        m.Name,
+				"kind":        m.Kind,
+				"repo":        m.Repo,
+				"source_file": m.SourceFile,
+			})
+		}
+		if !keep {
+			continue
+		}
+		out = append(out, map[string]any{
+			"id":      c.ID,
+			"size":    c.Size,
+			"members": members,
+		})
+	}
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"cycles":      out,
+		"count":       len(out),
+		"total":       total,
+		"truncated":   total > len(out),
+		"total_nodes": doc.TotalNodes,
+		"total_edges": doc.TotalEdges,
+		"source":      "sidecar",
+		"note": "Strongly-connected components over IMPORTS edges (Tarjan SCC, size >= min_size). " +
+			"Per-repo only in Phase 3B; cross-repo IMPORTS cycles are out of scope (#2774).",
+	}), nil
+}
+
+// ---------------------------------------------------------------------
+// 3C — archigraph_def_use
+// ---------------------------------------------------------------------
+
+type defUseChainSidecar struct {
+	Var     string `json:"var"`
+	DefLine int    `json:"def_line"`
+	UseLine int    `json:"use_line"`
+}
+
+type defUseSidecarEntry struct {
+	Repo       string               `json:"repo"`
+	EntityID   string               `json:"entity_id"`
+	Name       string               `json:"name"`
+	SourceFile string               `json:"source_file,omitempty"`
+	Chains     []defUseChainSidecar `json:"chains"`
+}
+
+type defUseSidecarDoc struct {
+	Version int                  `json:"version"`
+	Method  string               `json:"method"`
+	Total   int                  `json:"total_chains"`
+	Entries []defUseSidecarEntry `json:"entries"`
+}
+
+func (s *Server) handleDefUse(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	groupName, _, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repoFilter := map[string]bool{}
+	for _, r := range argStringSlice(req, "repo_filter") {
+		repoFilter[r] = true
+	}
+	entityFilter := strings.TrimSpace(argString(req, "entity_id", ""))
+	limit := argInt(req, "limit", 50)
+
+	var doc defUseSidecarDoc
+	path := sidecarPath(groupName, "def-use")
+	if !loadSidecar(path, &doc) {
+		return jsonResult(map[string]any{
+			"entries": []any{},
+			"count":   0,
+			"total":   0,
+			"source":  "missing",
+			"note":    "Def-use sidecar absent — run the link passes to generate it (#2774 Phase 3C).",
+		}), nil
+	}
+
+	out := make([]map[string]any, 0, len(doc.Entries))
+	for _, e := range doc.Entries {
+		if len(repoFilter) > 0 && !repoFilter[e.Repo] {
+			continue
+		}
+		if entityFilter != "" {
+			eid := prefixedID(e.Repo, e.EntityID)
+			if eid != entityFilter && e.EntityID != entityFilter {
+				continue
+			}
+		}
+		chains := make([]map[string]any, len(e.Chains))
+		for i, c := range e.Chains {
+			chains[i] = map[string]any{
+				"var":      c.Var,
+				"def_line": c.DefLine,
+				"use_line": c.UseLine,
+			}
+		}
+		out = append(out, map[string]any{
+			"entity_id":   prefixedID(e.Repo, e.EntityID),
+			"name":        e.Name,
+			"repo":        e.Repo,
+			"source_file": e.SourceFile,
+			"chain_count": len(e.Chains),
+			"chains":      chains,
+		})
+	}
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"entries":      out,
+		"count":        len(out),
+		"total":        total,
+		"truncated":    total > len(out),
+		"total_chains": doc.Total,
+		"source":       "sidecar",
+		"note": "Intra-procedural reaching-definitions (last-write-wins). " +
+			"Inter-procedural / SSA-phi precision is out of Phase 3C scope (#2774).",
+	}), nil
+}
+
+// ---------------------------------------------------------------------
+// 3D — archigraph_template_patterns
+// ---------------------------------------------------------------------
+
+type templatePatternSidecarEntry struct {
+	Repo       string `json:"repo"`
+	SourceFile string `json:"source_file"`
+	Function   string `json:"function,omitempty"`
+	Line       int    `json:"line"`
+	Kind       string `json:"kind"`
+	Tag        string `json:"tag"`
+	Literal    string `json:"literal"`
+}
+
+type templatePatternSidecarDoc struct {
+	Version int                           `json:"version"`
+	Method  string                        `json:"method"`
+	Total   int                           `json:"total"`
+	ByKind  map[string]int                `json:"by_kind"`
+	Entries []templatePatternSidecarEntry `json:"entries"`
+}
+
+func (s *Server) handleTemplatePatterns(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	groupName, _, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repoFilter := map[string]bool{}
+	for _, r := range argStringSlice(req, "repo_filter") {
+		repoFilter[r] = true
+	}
+	kindFilter := strings.ToLower(argString(req, "kind", ""))
+	limit := argInt(req, "limit", 200)
+
+	var doc templatePatternSidecarDoc
+	path := sidecarPath(groupName, "template-patterns")
+	if !loadSidecar(path, &doc) {
+		return jsonResult(map[string]any{
+			"patterns": []any{},
+			"count":    0,
+			"total":    0,
+			"by_kind":  map[string]int{},
+			"source":   "missing",
+			"note":     "Template-pattern sidecar absent — run the link passes to generate it (#2774 Phase 3D).",
+		}), nil
+	}
+	out := make([]map[string]any, 0, len(doc.Entries))
+	for _, e := range doc.Entries {
+		if len(repoFilter) > 0 && !repoFilter[e.Repo] {
+			continue
+		}
+		if kindFilter != "" && strings.ToLower(e.Kind) != kindFilter {
+			continue
+		}
+		out = append(out, map[string]any{
+			"repo":        e.Repo,
+			"source_file": e.SourceFile,
+			"function":    e.Function,
+			"line":        e.Line,
+			"kind":        e.Kind,
+			"tag":         e.Tag,
+			"literal":     e.Literal,
+		})
+	}
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	// Stable order: byRepo, byFile, byLine.
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, rj := fmt.Sprint(out[i]["repo"]), fmt.Sprint(out[j]["repo"])
+		if ri != rj {
+			return ri < rj
+		}
+		fi, fj := fmt.Sprint(out[i]["source_file"]), fmt.Sprint(out[j]["source_file"])
+		if fi != fj {
+			return fi < fj
+		}
+		li, _ := out[i]["line"].(int)
+		lj, _ := out[j]["line"].(int)
+		return li < lj
+	})
+	return jsonResult(map[string]any{
+		"patterns":  out,
+		"count":     len(out),
+		"total":     total,
+		"truncated": total > len(out),
+		"by_kind":   doc.ByKind,
+		"source":    "sidecar",
+		"note": "i18n / log_format / sql template literals lifted by per-language sniffers. " +
+			"Overlap with Phase 2B SQL-injection is intentional: 2B tracks taint flow into the literal, " +
+			"3D catalogues the literal itself (#2774).",
+	}), nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -512,6 +512,56 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_security_findings", s.handleSecurityFindings))
 
+
+	// #2774 / #2775 — Phase 3A pure-function tagging. Lists function-
+	// like entities with no detected effects per the Phase 1A propag-
+	// ation pass. Confidence floor is 0.30 (absence of detection is
+	// not proof of purity).
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_pure_functions",
+		mcpapi.WithDescription("Functions with no detected effects (Phase 1A) — memoization candidates."),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_pure_functions", s.handlePureFunctions))
+
+	// #2774 / #2775 — Phase 3B module-cycle detection. Surfaces
+	// strongly-connected components over IMPORTS edges (Tarjan SCC) of
+	// size >= min_size. Reads the persistent sidecar written by the
+	// Phase 3B link pass.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_import_cycles",
+		mcpapi.WithDescription("IMPORTS cycle clusters per repo (Tarjan SCC, default min_size=2)."),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithNumber("min_size", mcpapi.DefaultNumber(2)),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_import_cycles", s.handleModuleCyclesSidecar))
+
+	// #2774 / #2775 — Phase 3C intra-procedural reaching-definitions /
+	// def-use chains. Per-function "where does <var> at line N come
+	// from?" answers using last-write-wins.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_def_use",
+		mcpapi.WithDescription("Intra-procedural def-use chains (last-write-wins) per function."),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithString("entity_id", mcpapi.Description("Optional: restrict to one function entity id.")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(50)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_def_use", s.handleDefUse))
+
+	// #2774 / #2775 — Phase 3D template-pattern catalog. Surfaces
+	// every i18n key, log-format string, and SQL template literal
+	// across the group's source files.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_template_patterns",
+		mcpapi.WithDescription("i18n / log_format / sql template literals lifted per file."),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithString("kind", mcpapi.Description("Filter by template kind: i18n | log_format | sql.")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_template_patterns", s.handleTemplatePatterns))
+
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_stats",
 		mcpapi.WithDescription("Corpus-level metrics. breakdown=unresolved_imports adds edge taxonomy."),
 		mcpapi.WithAny("group"),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -587,6 +587,12 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_payload_drift",
 		// #2772 Phase 2B taint-flow security findings surface
 		"archigraph_security_findings",
+		// #2774 / #2775 Phase 3 misc — pure functions, module cycles,
+		// def-use chains, template-pattern catalog.
+		"archigraph_pure_functions",
+		"archigraph_import_cycles",
+		"archigraph_def_use",
+		"archigraph_template_patterns",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -673,8 +679,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_effects (#2764 Phase 1A effect classification).
 	// +1 archigraph_payload_drift (#2770 Phase 2A drift findings).
 	// +1 archigraph_security_findings (#2772 Phase 2B taint-flow).
-	if got := len(allRegisteredTools); got != 49 {
-		t.Errorf("expected 49 registered tools, got %d — update this count if tools are added/removed (added archigraph_security_findings #2772)", got)
+	// +4 archigraph_pure_functions/_import_cycles/_def_use/_template_patterns (#2774/#2775 Phase 3 misc).
+	if got := len(allRegisteredTools); got != 53 {
+		t.Errorf("expected 53 registered tools, got %d — update this count if tools are added/removed (added archigraph_security_findings #2772 + Phase 3 misc #2774/#2775: pure_functions, import_cycles, def_use, template_patterns)", got)
 	}
 }
 
@@ -3179,6 +3186,11 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_payload_drift": {"group": "g"},
 		// #2772 Phase 2B taint-flow — no required args.
 		"archigraph_security_findings": {"group": "g"},
+		// #2774 / #2775 Phase 3 misc — sidecar readers, no required args.
+		"archigraph_pure_functions":    {"group": "g"},
+		"archigraph_import_cycles":     {"group": "g"},
+		"archigraph_def_use":           {"group": "g"},
+		"archigraph_template_patterns": {"group": "g"},
 	}
 
 	// extractElapsedMS mirrors the bench extraction logic:
@@ -3223,8 +3235,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 49 {
-		t.Errorf("expected 49 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_security_findings #2772)", len(tools))
+	if len(tools) != 53 {
+		t.Errorf("expected 53 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_security_findings #2772 + Phase 3 misc #2774/#2775: pure_functions, import_cycles, def_use, template_patterns)", len(tools))
 	}
 
 	for _, st := range tools {

--- a/internal/substrate/def_use.go
+++ b/internal/substrate/def_use.go
@@ -1,0 +1,79 @@
+// Reaching-definitions / def-use chain substrate (#2774 Phase 3C).
+//
+// Per-language sniffers lift two facts per source file:
+//
+//   - VarDef:  a write to a local identifier (assignment, declaration).
+//   - VarUse:  a read of a local identifier.
+//
+// Each fact is pinned to (function, line). The generic pass in
+// internal/links/def_use_pass.go composes intra-procedural reaching-
+// definitions: for every (function, use) it finds the set of (function,
+// def) records whose Line ≤ use.Line and Var == use.Var with no
+// intervening def of the same name (last-write-wins). The result is a
+// list of DefUseChain edges stamped onto the function entity's
+// Properties as a compact "uses=<n>;defs=<n>;chains=v@def_line→use_line,..."
+// string and surfaced via the archigraph_def_use MCP tool.
+//
+// Out of scope (intentionally) per the issue body:
+//   - Inter-procedural def-use (requires alias analysis — Phase 4).
+//   - Object-field / attribute chains (use plain identifiers only).
+//   - Loop-back / SSA-phi precision (last-write-wins is sufficient for
+//     the "where does this value come from at this point" query).
+//
+// Design mirrors Phase 0/1A: per-language sniffers are pure functions
+// over file content, stateless and deterministic.
+package substrate
+
+import "sort"
+
+// VarDef is one identifier write (definition site).
+type VarDef struct {
+	// Function is the declaring function/method name the def occurs in.
+	// Empty when the def is at module/file scope; the pass skips those.
+	Function string
+	// Line is the 1-indexed source line of the def site.
+	Line int
+	// Var is the bare identifier name being defined.
+	Var string
+}
+
+// VarUse is one identifier read (use site).
+type VarUse struct {
+	// Function is the declaring function/method name the use occurs in.
+	// Empty when the use is at module scope; the pass skips those.
+	Function string
+	// Line is the 1-indexed source line of the use site.
+	Line int
+	// Var is the bare identifier name being read.
+	Var string
+}
+
+// DefUseSnifferFn is the contract for per-language def-use sniffers.
+// Returns every def and use site in the file in source order. Must be
+// deterministic so the pass's output is byte-stable across runs.
+type DefUseSnifferFn func(content string) (defs []VarDef, uses []VarUse)
+
+var defUseRegistry = map[string]DefUseSnifferFn{}
+
+// RegisterDefUseSniffer installs a per-language def-use sniffer.
+func RegisterDefUseSniffer(lang string, fn DefUseSnifferFn) {
+	if lang == "" || fn == nil {
+		return
+	}
+	defUseRegistry[lang] = fn
+}
+
+// DefUseSnifferFor returns the registered sniffer for lang, or nil.
+func DefUseSnifferFor(lang string) DefUseSnifferFn {
+	return defUseRegistry[lang]
+}
+
+// DefUseLanguages returns the slugs of every registered def-use sniffer.
+func DefUseLanguages() []string {
+	out := make([]string, 0, len(defUseRegistry))
+	for k := range defUseRegistry {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/substrate/def_use_c_cpp.go
+++ b/internal/substrate/def_use_c_cpp.go
@@ -1,0 +1,115 @@
+// C / C++ def-use sniffer (#2775 Phase 3C T2).
+//
+// Recognises:
+//   - Defs : `<Type> <name> = ...`, `auto <name> = ...`, bare
+//            reassignments `<name> = ...`, `for (<Type> <name> = ...; ...)`
+//            and range-for `for (<Type> <name> : ...)`.
+//   - Uses : bare identifiers `\b<name>\b` filtered against C/C++
+//            keywords and standard-library type names and not on the LHS
+//            of a def we already captured.
+//
+// Function attribution: nearest preceding C/C++ function header via the
+// scanCCPPFuncHeaders helper from effect_sinks_c_cpp.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("c-cpp", sniffDefUseCCPP) }
+
+// cppDefRe matches typed declarations, auto-decls, bare assignments,
+// and range-for.
+//   Group 1 (typed)    : `<Type|auto> <name> =`.
+//   Group 2 (bare)     : `<name> = ` (not `==`, not `.x =`, not `->x =`).
+//   Group 3 (range-for): `for (<Type|auto> <name> :`.
+var cppDefRe = regexp.MustCompile(
+	`\b(?:auto|int|long|short|char|float|double|bool|void|size_t|std::[A-Za-z_][\w:<>,\s]*|[A-Z][\w<>,:\s\*\&]*)\s+\*?\s*([A-Za-z_][\w]*)\s*=` +
+		`|(?m)^\s*([A-Za-z_][\w]*)\s*=(?:[^=])` +
+		`|\bfor\s*\(\s*(?:auto|const\s+auto|[A-Z][\w<>:\s\*\&]*)\s+\*?\s*([A-Za-z_][\w]*)\s*:`,
+)
+
+var cppIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func cppReservedDefUse(s string) bool {
+	switch s {
+	case "auto", "break", "case", "char", "const", "continue", "default",
+		"do", "double", "else", "enum", "extern", "float", "for", "goto",
+		"if", "inline", "int", "long", "register", "restrict", "return",
+		"short", "signed", "sizeof", "static", "struct", "switch",
+		"typedef", "union", "unsigned", "void", "volatile", "while",
+		"bool", "true", "false", "nullptr", "class", "namespace", "using",
+		"public", "private", "protected", "virtual", "override", "final",
+		"new", "delete", "this", "throw", "try", "catch", "template",
+		"typename", "operator", "friend", "explicit", "mutable", "constexpr",
+		"noexcept", "decltype", "static_cast", "dynamic_cast", "reinterpret_cast",
+		"const_cast", "size_t", "ptrdiff_t", "nullptr_t", "std", "string",
+		"vector", "map", "set", "list", "array", "unordered_map", "unordered_set",
+		"pair", "tuple", "shared_ptr", "unique_ptr", "weak_ptr", "make_shared",
+		"make_unique", "cout", "cerr", "cin", "endl", "printf", "scanf",
+		"malloc", "free", "memcpy", "memset", "strlen", "strcpy", "NULL":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseCCPP(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanCCPPFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range cppDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		}
+		if name == "" || cppReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range cppIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if cppReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_csharp.go
+++ b/internal/substrate/def_use_csharp.go
@@ -1,0 +1,108 @@
+// C# def-use sniffer (#2775 Phase 3C T2).
+//
+// Recognises:
+//   - Defs : `<Type> <name> = ...`, `var <name> = ...`, bare reassignments
+//            `<name> = ...`, `foreach (<Type> <name> in ...)`.
+//   - Uses : bare identifiers `\b<name>\b` filtered against C# keywords
+//            and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding C# method header via the
+// scanCSharpFuncHeaders helper from effect_sinks_csharp.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("csharp", sniffDefUseCSharp) }
+
+// csharpDefRe matches typed declarations, var-decls, bare assignments,
+// and foreach.
+//   Group 1 (typed/var) : `<Type|var> <name> =`.
+//   Group 2 (bare)      : `<name> = ` (not `==`, not `.X =`).
+//   Group 3 (foreach)   : `foreach (<Type|var> <name> in`.
+var csharpDefRe = regexp.MustCompile(
+	`\b(?:[A-Z][\w<>,\s\[\]?]*|int|long|short|byte|char|bool|float|double|decimal|string|object|var)\s+([A-Za-z_][\w]*)\s*=` +
+		`|(?m)^\s*([A-Za-z_][\w]*)\s*=(?:[^=])` +
+		`|\bforeach\s*\(\s*(?:[A-Z][\w<>,\s\[\]?]*|var)\s+([A-Za-z_][\w]*)\s+in\b`,
+)
+
+var csharpIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func csharpReservedDefUse(s string) bool {
+	switch s {
+	case "if", "else", "for", "foreach", "while", "do", "switch", "case",
+		"default", "break", "continue", "return", "throw", "try", "catch",
+		"finally", "new", "is", "as", "in", "out", "ref", "true", "false",
+		"null", "this", "base", "void", "public", "private", "protected",
+		"internal", "static", "readonly", "const", "sealed", "abstract",
+		"virtual", "override", "async", "await", "yield", "using", "namespace",
+		"class", "struct", "interface", "enum", "record", "var", "int",
+		"long", "short", "byte", "char", "bool", "float", "double", "decimal",
+		"string", "object", "String", "Int32", "Int64", "Boolean", "Object",
+		"List", "Dictionary", "Task", "IEnumerable", "Console":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseCSharp(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanCSharpFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range csharpDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		}
+		if name == "" || csharpReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range csharpIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if csharpReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_elixir.go
+++ b/internal/substrate/def_use_elixir.go
@@ -1,0 +1,93 @@
+// Elixir def-use sniffer (#2775 Phase 3C T2).
+//
+// Recognises:
+//   - Defs : `<name> = ...` pattern-match binding (Elixir's primary form),
+//            function-head params `def f(<name>, ...)`.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Elixir
+//            keywords / atoms and not on the LHS of a def we already
+//            captured on the same line.
+//
+// Function attribution: nearest preceding `def` / `defp` / `defmacro`
+// header via the scanElixirFuncHeaders helper from effect_sinks_elixir.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("elixir", sniffDefUseElixir) }
+
+// elixirDefUseRe matches simple bindings.
+//   Group 1 (assign)  : `<name> = ` (not `==`, not match-op `<-`).
+var elixirDefUseRe = regexp.MustCompile(
+	`(?m)^\s*([a-z_][\w]*[?!]?)\s*=(?:[^=])`,
+)
+
+var elixirIdentUseRe = regexp.MustCompile(`\b([a-z_][\w]*[?!]?)\b`)
+
+func elixirReservedDefUse(s string) bool {
+	switch s {
+	case "def", "defp", "defmacro", "defmacrop", "defmodule", "defstruct",
+		"defprotocol", "defimpl", "defexception", "do", "end", "if",
+		"unless", "else", "case", "cond", "when", "with", "for", "fn",
+		"true", "false", "nil", "and", "or", "not", "in", "import",
+		"alias", "require", "use", "raise", "rescue", "catch", "throw",
+		"after", "receive", "try", "quote", "unquote", "super", "__MODULE__",
+		"__DIR__", "__ENV__", "__CALLER__":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseElixir(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanElixirFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range elixirDefUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if name == "" || elixirReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range elixirIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if elixirReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_kotlin.go
+++ b/internal/substrate/def_use_kotlin.go
@@ -1,0 +1,112 @@
+// Kotlin def-use sniffer (#2775 Phase 3C T2).
+//
+// Recognises:
+//   - Defs : `val <name> = ...`, `var <name> = ...`, optional type
+//            ascription `: T`, bare reassignments `<name> = ...`,
+//            `for (<name> in ...)`.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Kotlin
+//            keywords and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `fun` header via the
+// scanKotlinFuncHeaders helper from effect_sinks_kotlin.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("kotlin", sniffDefUseKotlin) }
+
+// kotlinDefRe matches val/var-decls, bare assignments, and for-loops.
+//   Group 1 (val/var)  : `(val|var) <name>[: T]`.
+//   Group 2 (bare)     : `<name> =`.
+//   Group 3 (for-in)   : `for (<name> in`.
+var kotlinDefRe = regexp.MustCompile(
+	`\b(?:val|var)\s+([A-Za-z_][\w]*)\b` +
+		`|(?m)^\s*([A-Za-z_][\w]*)\s*=(?:[^=])` +
+		`|\bfor\s*\(\s*([A-Za-z_][\w]*)\s+in\b`,
+)
+
+var kotlinIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func kotlinReservedDefUse(s string) bool {
+	switch s {
+	case "as", "break", "class", "continue", "do", "else", "false", "for",
+		"fun", "if", "in", "interface", "is", "null", "object", "package",
+		"return", "super", "this", "throw", "true", "try", "typealias",
+		"typeof", "val", "var", "when", "while", "by", "catch", "constructor",
+		"delegate", "dynamic", "field", "file", "finally", "get", "import",
+		"init", "param", "property", "receiver", "set", "setparam", "value",
+		"where", "actual", "abstract", "annotation", "companion", "const",
+		"crossinline", "data", "enum", "expect", "external", "final",
+		"infix", "inline", "inner", "internal", "lateinit", "noinline",
+		"open", "operator", "out", "override", "private", "protected",
+		"public", "reified", "sealed", "suspend", "tailrec", "vararg",
+		"String", "Int", "Long", "Short", "Byte", "Char", "Boolean",
+		"Float", "Double", "List", "Map", "Set", "Array", "Unit", "Any",
+		"Nothing", "println", "print":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseKotlin(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanKotlinFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range kotlinDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		}
+		if name == "" || kotlinReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range kotlinIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if kotlinReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_php.go
+++ b/internal/substrate/def_use_php.go
@@ -1,0 +1,95 @@
+// PHP def-use sniffer (#2775 Phase 3C T2).
+//
+// Recognises:
+//   - Defs : `$<name> = ...`, augmented `$<name> += ...`, `foreach (... as
+//            $<name>)`, function parameters `function f($<name>, ...)`.
+//   - Uses : `$<name>` reads (PHP variables always carry the sigil), not
+//            on the LHS of a def already captured on the same line.
+//
+// Function attribution: nearest preceding `function` header via the
+// scanPHPFuncHeaders helper from effect_sinks_php.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("php", sniffDefUsePHP) }
+
+// phpDefRe matches assignment + foreach + function-param defs.
+//   Group 1 (assign)   : `$<name> = ` (not `==`, not array-key `=>`).
+//   Group 2 (foreach)  : `as $<name>` / `as $<key> => $<name>`.
+var phpDefRe = regexp.MustCompile(
+	`\$([A-Za-z_][\w]*)\s*(?:\+|-|\*|/|%|\.|\*\*|&|\||\^|<<|>>)?=(?:[^=])` +
+		`|\bas\s+\$([A-Za-z_][\w]*)\b`,
+)
+
+// phpIdentUseRe matches a `$<name>` read.
+var phpIdentUseRe = regexp.MustCompile(`\$([A-Za-z_][\w]*)\b`)
+
+func phpReservedDefUse(s string) bool {
+	switch s {
+	case "this", "self", "static", "parent":
+		return true
+	}
+	return false
+}
+
+func sniffDefUsePHP(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanPHPFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range phpDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		}
+		if name == "" || phpReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range phpIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if phpReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_ruby.go
+++ b/internal/substrate/def_use_ruby.go
@@ -1,0 +1,100 @@
+// Ruby def-use sniffer (#2775 Phase 3C T2).
+//
+// Recognises:
+//   - Defs : `<name> = ...`, augmented `<name> += ...`, block params
+//            `|<name>, ...|`, method parameters `def m(<name>, ...)`.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Ruby keywords
+//            and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `def` header (uses
+// scanRubyFuncHeaders from effect_sinks_ruby.go).
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("ruby", sniffDefUseRuby) }
+
+// rubyDefRe matches simple assignments, block params, and method params.
+//   Group 1 (assign)     : `<name> = ` (not `==`, not `.attr =`).
+//   Group 2 (block param): `|<name>, ...|` — first name only.
+var rubyDefRe = regexp.MustCompile(
+	`(?m)^\s*([A-Za-z_][\w]*)\s*(?:\+|-|\*|/|%|\*\*|&|\||\^|<<|>>|\|\||&&)?=(?:[^=])` +
+		`|\|\s*([A-Za-z_][\w]*)\s*[,|]`,
+)
+
+var rubyIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func rubyReservedDefUse(s string) bool {
+	switch s {
+	case "and", "or", "not", "if", "elsif", "else", "unless", "case", "when",
+		"while", "until", "for", "in", "do", "begin", "rescue", "ensure",
+		"raise", "return", "yield", "break", "next", "redo", "retry",
+		"def", "end", "class", "module", "self", "super", "nil", "true",
+		"false", "then", "require", "require_relative", "include", "extend",
+		"attr_reader", "attr_writer", "attr_accessor", "private", "public",
+		"protected", "puts", "print", "p", "lambda", "proc":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseRuby(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanRubyFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range rubyDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		}
+		if name == "" || rubyReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range rubyIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if rubyReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_rust.go
+++ b/internal/substrate/def_use_rust.go
@@ -1,0 +1,108 @@
+// Rust def-use sniffer (#2775 Phase 3C T2).
+//
+// Recognises:
+//   - Defs : `let <name> = ...`, `let mut <name> = ...`,
+//            `let <name>: T = ...`, bare reassignments `<name> = ...`,
+//            `for <name> in ...`.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Rust keywords
+//            and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `fn` header via the
+// scanRustFuncHeaders helper from effect_sinks_rust.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("rust", sniffDefUseRust) }
+
+// rustDefRe matches let-bindings, bare assignments, and for-loop iter
+// patterns.
+//   Group 1 (let)     : `let [mut] <name>[: T] =`.
+//   Group 2 (bare)    : `<name> = ` (not `==`, not `.field =`).
+//   Group 3 (for-in)  : `for <name> in`.
+var rustDefRe = regexp.MustCompile(
+	`\blet\s+(?:mut\s+)?([A-Za-z_][\w]*)\b` +
+		`|(?m)^\s*([A-Za-z_][\w]*)\s*=(?:[^=])` +
+		`|\bfor\s+([A-Za-z_][\w]*)\s+in\b`,
+)
+
+var rustIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func rustReservedDefUse(s string) bool {
+	switch s {
+	case "as", "break", "const", "continue", "crate", "else", "enum",
+		"extern", "false", "fn", "for", "if", "impl", "in", "let", "loop",
+		"match", "mod", "move", "mut", "pub", "ref", "return", "self",
+		"Self", "static", "struct", "super", "trait", "true", "type",
+		"unsafe", "use", "where", "while", "async", "await", "dyn",
+		"box", "do", "final", "macro", "override", "priv", "typeof",
+		"unsized", "virtual", "yield", "String", "Vec", "Option", "Result",
+		"Box", "Some", "None", "Ok", "Err", "println", "print", "format",
+		"panic", "vec":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseRust(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanRustFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range rustDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		}
+		if name == "" || rustReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range rustIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if rustReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_scala.go
+++ b/internal/substrate/def_use_scala.go
@@ -1,0 +1,108 @@
+// Scala def-use sniffer (#2775 Phase 3C T2).
+//
+// Recognises:
+//   - Defs : `val <name> = ...`, `var <name> = ...`, optional type
+//            ascription `: T`, bare reassignments `<name> = ...`,
+//            `for (<name> <- ...)`.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Scala
+//            keywords and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `def` header via the
+// scanScalaFuncHeaders helper from effect_sinks_scala.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("scala", sniffDefUseScala) }
+
+// scalaDefUseRe matches val/var-decls, bare assignments, and for-generators.
+//   Group 1 (val/var) : `(val|var) <name>`.
+//   Group 2 (bare)    : `<name> = ` (not `==`, not `.x =`).
+//   Group 3 (for-gen) : `<name> <-`.
+var scalaDefUseRe = regexp.MustCompile(
+	`\b(?:val|var)\s+([A-Za-z_][\w]*)\b` +
+		`|(?m)^\s*([A-Za-z_][\w]*)\s*=(?:[^=])` +
+		`|\b([A-Za-z_][\w]*)\s*<-\b`,
+)
+
+var scalaIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func scalaReservedDefUse(s string) bool {
+	switch s {
+	case "abstract", "case", "catch", "class", "def", "do", "else", "extends",
+		"false", "final", "finally", "for", "forSome", "if", "implicit",
+		"import", "lazy", "match", "new", "null", "object", "override",
+		"package", "private", "protected", "return", "sealed", "super",
+		"this", "throw", "trait", "true", "try", "type", "val", "var",
+		"while", "with", "yield", "given", "using", "then", "enum",
+		"String", "Int", "Long", "Short", "Byte", "Char", "Boolean",
+		"Float", "Double", "Unit", "Any", "AnyRef", "AnyVal", "Nothing",
+		"List", "Map", "Set", "Seq", "Option", "Some", "None", "Either",
+		"Left", "Right", "Future", "println", "print":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseScala(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanScalaFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range scalaDefUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		}
+		if name == "" || scalaReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range scalaIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if scalaReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_t2_test.go
+++ b/internal/substrate/def_use_t2_test.go
@@ -1,0 +1,143 @@
+// Phase 3C T2 def-use registration + primitive-coverage tests (#2775).
+package substrate
+
+import "testing"
+
+// TestDefUseRegistry_T2Languages asserts every T2 slug ships a def-use
+// sniffer. New languages added to the T2 set must extend this list.
+func TestDefUseRegistry_T2Languages(t *testing.T) {
+	for _, lang := range []string{"ruby", "php", "rust", "csharp", "kotlin", "elixir", "scala", "c-cpp"} {
+		if DefUseSnifferFor(lang) == nil {
+			t.Errorf("expected def-use sniffer registered for %q", lang)
+		}
+	}
+}
+
+// defUseFixture is one per-language canonical example. Each fixture is a
+// minimal function that defines a local and reads it back exactly once
+// — the sniffer must lift at least one def and one matching use.
+type defUseFixture struct {
+	lang    string
+	source  string
+	wantDef string // expected var name in at least one def
+	wantUse string // expected var name in at least one use
+}
+
+func TestDefUseT2_PrimitiveCoverage(t *testing.T) {
+	cases := []defUseFixture{
+		{
+			lang: "ruby",
+			source: "def greet(name)\n" +
+				"  message = \"hello \" + name\n" +
+				"  puts message\n" +
+				"end\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "php",
+			source: "<?php\n" +
+				"function greet($name) {\n" +
+				"  $message = 'hello ' . $name;\n" +
+				"  echo $message;\n" +
+				"}\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "rust",
+			source: "fn greet(name: &str) {\n" +
+				"  let message = format!(\"hello {}\", name);\n" +
+				"  println!(\"{}\", message);\n" +
+				"}\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "csharp",
+			source: "public class G {\n" +
+				"  public string Greet(string name) {\n" +
+				"    var message = \"hello \" + name;\n" +
+				"    return message;\n" +
+				"  }\n" +
+				"}\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "kotlin",
+			source: "fun greet(name: String): String {\n" +
+				"  val message = \"hello \" + name\n" +
+				"  return message\n" +
+				"}\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "elixir",
+			source: "defmodule Greeter do\n" +
+				"  def greet(name) do\n" +
+				"    message = \"hello \" <> name\n" +
+				"    IO.puts(message)\n" +
+				"  end\n" +
+				"end\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "scala",
+			source: "object Greeter {\n" +
+				"  def greet(name: String): String = {\n" +
+				"    val message = \"hello \" + name\n" +
+				"    message\n" +
+				"  }\n" +
+				"}\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "c-cpp",
+			source: "#include <string>\n" +
+				"std::string greet(const std::string &name) {\n" +
+				"  std::string message = \"hello \" + name;\n" +
+				"  return message;\n" +
+				"}\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.lang, func(t *testing.T) {
+			sniff := DefUseSnifferFor(c.lang)
+			if sniff == nil {
+				t.Fatalf("no sniffer registered for %q", c.lang)
+			}
+			defs, uses := sniff(c.source)
+			if !containsDefVar(defs, c.wantDef) {
+				t.Errorf("%s: expected def %q in %v", c.lang, c.wantDef, defs)
+			}
+			if !containsUseVar(uses, c.wantUse) {
+				t.Errorf("%s: expected use %q in %v", c.lang, c.wantUse, uses)
+			}
+		})
+	}
+}
+
+func containsDefVar(defs []VarDef, name string) bool {
+	for _, d := range defs {
+		if d.Var == name {
+			return true
+		}
+	}
+	return false
+}
+
+func containsUseVar(uses []VarUse, name string) bool {
+	for _, u := range uses {
+		if u.Var == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/substrate/template_pattern.go
+++ b/internal/substrate/template_pattern.go
@@ -1,0 +1,95 @@
+// Template-pattern catalog substrate (#2774 Phase 3D).
+//
+// Per-language sniffers lift template-shaped string literals from source.
+// Three template families are recognised:
+//
+//   - TemplateKindI18n   : translation keys (t("..."), gettext("..."),
+//                          i18n.t("..."), trans("..."), _("..."))
+//   - TemplateKindLog    : log-format primitives (console.log("..."),
+//                          logger.<level>("..."), log.<level>("...")
+//                          where the literal contains a format token
+//                          like "%s", "%d", "{}", "{name}").
+//   - TemplateKindSQL    : SQL template literals — string literals whose
+//                          content starts with a SQL verb keyword
+//                          (SELECT/INSERT/UPDATE/DELETE/WITH).
+//
+// The generic catalog pass in internal/links/template_pattern_pass.go
+// stores every match as a TemplatePattern record in the sidecar JSON
+// surfaced by archigraph_template_patterns. Overlaps with Phase 2B
+// (taint-flow SQL injection) are intentional: that pass tracks data
+// flow into the literal; this pass catalogues the literal itself.
+//
+// Design mirrors Phase 0/1A: per-language sniffers are pure functions
+// over file content, stateless and deterministic.
+package substrate
+
+import "sort"
+
+// TemplateKind labels the family of a template-pattern match.
+type TemplateKind string
+
+const (
+	TemplateKindI18n TemplateKind = "i18n"
+	TemplateKindLog  TemplateKind = "log_format"
+	TemplateKindSQL  TemplateKind = "sql"
+)
+
+// TemplatePattern is one lifted template-pattern match.
+type TemplatePattern struct {
+	// Function is the declaring function/method the literal occurs in.
+	// Empty when at module scope; the pass attributes those to the file.
+	Function string
+	// Line is the 1-indexed source line of the literal.
+	Line int
+	// Kind is the template family.
+	Kind TemplateKind
+	// Literal is the raw literal content (quote characters stripped).
+	// Bounded at maxLiteralLength to keep the sidecar focused.
+	Literal string
+	// Tag is a short identifier of the recogniser that matched
+	// (e.g. "t()", "console.log", "logger.info", "select").
+	Tag string
+}
+
+// maxLiteralLength bounds the per-match literal payload — longer ones
+// truncate with an ellipsis so the sidecar JSON stays a manageable size.
+const maxLiteralLength = 240
+
+// TruncateLiteral returns s truncated to maxLiteralLength with a "..."
+// suffix when truncation happened. Exposed so per-language sniffers can
+// share the same bound without re-implementing it.
+func TruncateLiteral(s string) string {
+	if len(s) <= maxLiteralLength {
+		return s
+	}
+	return s[:maxLiteralLength] + "..."
+}
+
+// TemplatePatternSnifferFn is the contract for per-language template
+// sniffers. Deterministic; nil-safe on empty content.
+type TemplatePatternSnifferFn func(content string) []TemplatePattern
+
+var templateRegistry = map[string]TemplatePatternSnifferFn{}
+
+// RegisterTemplatePatternSniffer installs a per-language template sniffer.
+func RegisterTemplatePatternSniffer(lang string, fn TemplatePatternSnifferFn) {
+	if lang == "" || fn == nil {
+		return
+	}
+	templateRegistry[lang] = fn
+}
+
+// TemplatePatternSnifferFor returns the registered sniffer for lang, or nil.
+func TemplatePatternSnifferFor(lang string) TemplatePatternSnifferFn {
+	return templateRegistry[lang]
+}
+
+// TemplatePatternLanguages returns the slugs of every registered sniffer.
+func TemplatePatternLanguages() []string {
+	out := make([]string, 0, len(templateRegistry))
+	for k := range templateRegistry {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/substrate/template_pattern_c_cpp.go
+++ b/internal/substrate/template_pattern_c_cpp.go
@@ -1,0 +1,114 @@
+// C / C++ template-pattern sniffer (#2775 Phase 3D T2).
+//
+// Recognises:
+//   - i18n        : gettext("key"), _("key"), N_("key") (GNU gettext idioms).
+//   - log_format  : printf("..."), fprintf(stderr, "..."), std::cerr <<,
+//                   spdlog::<level>("..."), LOG(...) << "..." (glog).
+//                   Conservative: only captures the literal first arg of
+//                   printf-family calls and the explicit spdlog/LOG forms.
+//   - sql         : Quoted string literals whose first non-whitespace
+//                   token is a SQL verb.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("c-cpp", sniffTemplatePatternsCCPP)
+}
+
+// cppI18nRe matches gettext("..."), _("..."), N_("..."). Group 1 = literal.
+var cppI18nRe = regexp.MustCompile(
+	`\b(?:gettext|_|N_|dgettext|ngettext)\s*\(\s*"([^"]+)"`,
+)
+
+// cppPrintfRe matches printf / fprintf / sprintf / snprintf with a literal
+// first format arg (after the optional stream arg). Group 1 = literal.
+var cppPrintfRe = regexp.MustCompile(
+	`\b(?:printf|fprintf|sprintf|snprintf|vprintf|vfprintf|puts|fputs)\s*\(\s*(?:[A-Za-z_][\w]*\s*,\s*)?"([^"]+)"`,
+)
+
+// cppSpdlogRe matches spdlog::<level>("..."). Group 1 = level, Group 2 = literal.
+var cppSpdlogRe = regexp.MustCompile(
+	`\bspdlog\s*::\s*([a-z]+)\s*\(\s*"([^"]+)"`,
+)
+
+// cppGlogRe matches LOG(INFO) << "..." / LOG(ERROR) << "...".
+// Group 1 = level, Group 2 = literal.
+var cppGlogRe = regexp.MustCompile(
+	`\bLOG\s*\(\s*([A-Z]+)\s*\)\s*<<\s*"([^"]+)"`,
+)
+
+// cppSQLRe matches a quoted literal whose first word is a SQL verb.
+var cppSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsCCPP(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanCCPPFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range cppI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "gettext",
+		})
+	}
+	for _, m := range cppPrintfRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "printf",
+		})
+	}
+	for _, m := range cppSpdlogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "spdlog." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range cppGlogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "LOG." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range cppSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_csharp.go
+++ b/internal/substrate/template_pattern_csharp.go
@@ -1,0 +1,80 @@
+// C# template-pattern sniffer (#2775 Phase 3D T2).
+//
+// Recognises:
+//   - i18n        : Localizer["key"], _localizer["key"], T("key"),
+//                   ResourceManager.GetString("key").
+//   - log_format  : _logger.Log<Level>("..."), logger.Information("..."),
+//                   Console.WriteLine("..."). Captures literal first arg.
+//   - sql         : Quoted/verbatim string literals whose first non-
+//                   whitespace token is a SQL verb (case-insensitive).
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("csharp", sniffTemplatePatternsCSharp)
+}
+
+// csharpI18nRe matches Localizer["..."], _localizer["..."], T("..."),
+// GetString("..."). Group 1 = the bare literal payload.
+var csharpI18nRe = regexp.MustCompile(
+	`\b(?:[Ll]ocalizer|_localizer|T|GetString)\s*[\["]\s*"?([^"\]]+)"?\s*[\]\)]`,
+)
+
+// csharpLogRe matches logger.<Level>("...") / _logger.<Level>("...") /
+// Log.<Level>("...") / Console.<Method>("..."). Group 1 = level, Group 2 = literal.
+var csharpLogRe = regexp.MustCompile(
+	`\b(?:_?[Ll]ogger|Log|Console)\s*\.\s*([A-Za-z]+)\s*\(\s*"([^"]+)"`,
+)
+
+// csharpSQLRe matches quoted (and verbatim @"...") string literals whose
+// first non-whitespace token is a SQL verb.
+var csharpSQLRe = regexp.MustCompile(
+	`@?"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsCSharp(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanCSharpFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range csharpI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "Localizer",
+		})
+	}
+	for _, m := range csharpLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "log." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range csharpSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_elixir.go
+++ b/internal/substrate/template_pattern_elixir.go
@@ -1,0 +1,94 @@
+// Elixir template-pattern sniffer (#2775 Phase 3D T2).
+//
+// Recognises:
+//   - i18n        : Gettext.gettext("key"), gettext("key"), dgettext("..."),
+//                   pgettext("..."). Phoenix's gen_gettext idioms.
+//   - log_format  : Logger.<level>("..."), IO.puts("..."), IO.inspect("...").
+//   - sql         : Quoted string literals whose first word is a SQL verb;
+//                   Ecto.Adapters.SQL.query!(repo, "SELECT ...").
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("elixir", sniffTemplatePatternsElixir)
+}
+
+// elixirI18nRe matches gettext("..."), dgettext("..."), Gettext.gettext("...").
+// Group 1 = the bare literal payload.
+var elixirI18nRe = regexp.MustCompile(
+	`\b(?:Gettext\.gettext|gettext|dgettext|pgettext|ngettext)\s*\(\s*"([^"]+)"`,
+)
+
+// elixirLogRe matches Logger.<level>("..."). Group 1 = level, Group 2 = literal.
+var elixirLogRe = regexp.MustCompile(
+	`\bLogger\s*\.\s*([a-z_]+)\s*\(\s*"([^"]+)"`,
+)
+
+// elixirIORe matches IO.puts / IO.inspect / IO.write with a string literal.
+var elixirIORe = regexp.MustCompile(
+	`\bIO\s*\.\s*(?:puts|inspect|write)\s*\(\s*"([^"]+)"`,
+)
+
+// elixirSQLRe matches a quoted literal whose first word is a SQL verb.
+var elixirSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsElixir(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanElixirFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range elixirI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "gettext",
+		})
+	}
+	for _, m := range elixirLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "Logger." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range elixirIORe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "IO.puts",
+		})
+	}
+	for _, m := range elixirSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_kotlin.go
+++ b/internal/substrate/template_pattern_kotlin.go
@@ -1,0 +1,96 @@
+// Kotlin template-pattern sniffer (#2775 Phase 3D T2).
+//
+// Recognises:
+//   - i18n        : getString(R.string.key, ...) (Android), context
+//                   .getString("key"), I18n.translate("key").
+//   - log_format  : Log.<level>(TAG, "..."), logger.<level>("..."),
+//                   println("...") with placeholder tokens.
+//   - sql         : Quoted/triple-quoted string literals whose first non-
+//                   whitespace token is a SQL verb.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("kotlin", sniffTemplatePatternsKotlin)
+}
+
+// kotlinI18nRe matches getString("..."), translate("..."), t("...").
+// Group 1 = the bare literal payload.
+var kotlinI18nRe = regexp.MustCompile(
+	`\b(?:getString|translate|t)\s*\(\s*"([^"]+)"`,
+)
+
+// kotlinLogRe matches Log.<level>(...) / logger.<level>(...).
+// Group 1 = level, Group 2 = literal.
+var kotlinLogRe = regexp.MustCompile(
+	`\b(?:Log|logger|log|LOGGER|LOG)\s*\.\s*([a-zA-Z_]+)\s*\(\s*(?:[^,"]*,\s*)?"([^"]+)"`,
+)
+
+// kotlinPrintlnRe matches println("...") / print("...").
+var kotlinPrintlnRe = regexp.MustCompile(
+	`\b(?:println|print)\s*\(\s*"([^"]+)"`,
+)
+
+// kotlinSQLRe matches a quoted literal whose first word is a SQL verb.
+var kotlinSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsKotlin(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanKotlinFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range kotlinI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "getString",
+		})
+	}
+	for _, m := range kotlinLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "log." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range kotlinPrintlnRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "println",
+		})
+	}
+	for _, m := range kotlinSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_php.go
+++ b/internal/substrate/template_pattern_php.go
@@ -1,0 +1,112 @@
+// PHP template-pattern sniffer (#2775 Phase 3D T2).
+//
+// Recognises:
+//   - i18n        : __("key"), _e("key"), trans("key"), __t("key"),
+//                   gettext("key") (Laravel / WordPress / Symfony idioms).
+//   - log_format  : Log::<level>("..."), logger->info("...") (Monolog),
+//                   error_log("..."), echo "<literal>".
+//   - sql         : Quoted strings starting with a SQL verb.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("php", sniffTemplatePatternsPHP)
+}
+
+// phpI18nRe matches __("..."), _e("..."), trans("..."), gettext("...").
+// Group 1 = the bare literal payload.
+var phpI18nRe = regexp.MustCompile(
+	`\b(?:__|_e|trans|__t|gettext|ngettext)\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// phpLogRe matches Log::<level>("..."), $logger->info("..."), error_log("...").
+// Group 1 = method/level, Group 2 = literal.
+var phpLogRe = regexp.MustCompile(
+	`\b(?:Log::|(?:\$\w+\s*->)|(?:\$this\s*->logger\s*->))([a-zA-Z_]+)\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// phpErrorLogRe matches the standalone error_log("..."). Group 1 = literal.
+var phpErrorLogRe = regexp.MustCompile(
+	`\berror_log\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// phpEchoRe matches `echo "literal"`. Group 1 = literal.
+var phpEchoRe = regexp.MustCompile(
+	`\becho\s+['"]([^'"]+)['"]`,
+)
+
+// phpSQLRe matches a quoted literal whose first word is a SQL verb.
+var phpSQLRe = regexp.MustCompile(
+	`['"](\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[\s\S]*?)['"]`,
+)
+
+func sniffTemplatePatternsPHP(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanPHPFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range phpI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "trans",
+		})
+	}
+	for _, m := range phpLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "log." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range phpErrorLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "error_log",
+		})
+	}
+	for _, m := range phpEchoRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "echo",
+		})
+	}
+	for _, m := range phpSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_ruby.go
+++ b/internal/substrate/template_pattern_ruby.go
@@ -1,0 +1,96 @@
+// Ruby template-pattern sniffer (#2775 Phase 3D T2).
+//
+// Recognises:
+//   - i18n        : I18n.t("key"), I18n.translate("key"), t("key"),
+//                   bare _("key") helpers commonly used in Rails views.
+//   - log_format  : logger.<level>("..."), Rails.logger.<level>("..."),
+//                   puts("...").
+//   - sql         : Quoted/heredoc strings whose first non-whitespace
+//                   token is a SQL verb (case-insensitive).
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("ruby", sniffTemplatePatternsRuby)
+}
+
+// rubyI18nRe matches I18n.t / I18n.translate / t / translate / _.
+// Group 1 = the bare literal payload.
+var rubyI18nRe = regexp.MustCompile(
+	`\b(?:I18n\.t|I18n\.translate|t|translate|_)\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// rubyLogRe matches logger.<level>("...") and Rails.logger.<level>("...").
+// Group 1 = level, Group 2 = literal.
+var rubyLogRe = regexp.MustCompile(
+	`\b(?:Rails\.logger|logger|log)\s*\.\s*([a-z_]+)\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// rubyPutsRe matches puts("...") / print("..."). Group 1 = literal.
+var rubyPutsRe = regexp.MustCompile(
+	`\b(?:puts|print|p)\s*\(?\s*['"]([^'"]+)['"]`,
+)
+
+// rubySQLRe matches a quoted literal whose first word is a SQL verb.
+var rubySQLRe = regexp.MustCompile(
+	`['"](\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[\s\S]*?)['"]`,
+)
+
+func sniffTemplatePatternsRuby(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanRubyFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range rubyI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "I18n.t",
+		})
+	}
+	for _, m := range rubyLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "logger." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range rubyPutsRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "puts",
+		})
+	}
+	for _, m := range rubySQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_rust.go
+++ b/internal/substrate/template_pattern_rust.go
@@ -1,0 +1,96 @@
+// Rust template-pattern sniffer (#2775 Phase 3D T2).
+//
+// Recognises:
+//   - i18n        : t!("key") (fluent / rust-i18n macros), gettext("key").
+//   - log_format  : log::<level>!("..."), tracing::<level>!("..."),
+//                   println!("...{}..."), eprintln!("...{}...").
+//   - sql         : sqlx::query("SELECT ..."), bare quoted/raw string
+//                   literals whose first non-whitespace token is a SQL verb.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("rust", sniffTemplatePatternsRust)
+}
+
+// rustI18nRe matches t!("..."), tr!("..."), gettext("...").
+// Group 1 = the bare literal payload.
+var rustI18nRe = regexp.MustCompile(
+	`\b(?:t!|tr!|gettext)\s*\(?\s*"([^"]+)"`,
+)
+
+// rustLogRe matches log::<lvl>!("...") and tracing::<lvl>!("...").
+// Group 1 = level, Group 2 = literal.
+var rustLogRe = regexp.MustCompile(
+	`\b(?:log|tracing)\s*::\s*([a-z]+)!\s*\(\s*"([^"]+)"`,
+)
+
+// rustPrintRe matches println!("...") / eprintln!("...") / print!("...").
+// Group 1 = literal.
+var rustPrintRe = regexp.MustCompile(
+	`\b(?:println|eprintln|print|eprint)!\s*\(\s*"([^"]+)"`,
+)
+
+// rustSQLRe matches a quoted literal whose first word is a SQL verb.
+var rustSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsRust(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanRustFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range rustI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "t!",
+		})
+	}
+	for _, m := range rustLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "log." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range rustPrintRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "println!",
+		})
+	}
+	for _, m := range rustSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_scala.go
+++ b/internal/substrate/template_pattern_scala.go
@@ -1,0 +1,96 @@
+// Scala template-pattern sniffer (#2775 Phase 3D T2).
+//
+// Recognises:
+//   - i18n        : Messages("key", ...) (Play), messagesApi("key"),
+//                   translate("key"), t("key").
+//   - log_format  : logger.<level>("..."), Logger.<level>("..."),
+//                   println("..."). Captures literal first arg.
+//   - sql         : Quoted/triple-quoted string literals whose first non-
+//                   whitespace token is a SQL verb.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("scala", sniffTemplatePatternsScala)
+}
+
+// scalaI18nRe matches Messages("key"), messagesApi("key"), translate("..."), t("...").
+// Group 1 = the bare literal payload.
+var scalaI18nRe = regexp.MustCompile(
+	`\b(?:Messages|messagesApi|translate|t)\s*\(\s*"([^"]+)"`,
+)
+
+// scalaLogRe matches logger.<level>(...) / Logger.<level>(...).
+// Group 1 = level, Group 2 = literal.
+var scalaLogRe = regexp.MustCompile(
+	`\b(?:logger|Logger|log|LOG)\s*\.\s*([a-zA-Z_]+)\s*\(\s*"([^"]+)"`,
+)
+
+// scalaPrintlnRe matches println("..."). Group 1 = literal.
+var scalaPrintlnRe = regexp.MustCompile(
+	`\bprintln\s*\(\s*"([^"]+)"`,
+)
+
+// scalaSQLRe matches a quoted literal whose first word is a SQL verb.
+var scalaSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsScala(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanScalaFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range scalaI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "Messages",
+		})
+	}
+	for _, m := range scalaLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "logger." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range scalaPrintlnRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "println",
+		})
+	}
+	for _, m := range scalaSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_t2_test.go
+++ b/internal/substrate/template_pattern_t2_test.go
@@ -1,0 +1,123 @@
+// Phase 3D T2 template-pattern registration + coverage tests (#2775).
+package substrate
+
+import "testing"
+
+// TestTemplatePatternRegistry_T2Languages asserts every T2 slug ships a
+// template-pattern sniffer. New languages added to the T2 set must
+// extend this list.
+func TestTemplatePatternRegistry_T2Languages(t *testing.T) {
+	for _, lang := range []string{"ruby", "php", "rust", "csharp", "kotlin", "elixir", "scala", "c-cpp"} {
+		if TemplatePatternSnifferFor(lang) == nil {
+			t.Errorf("expected template-pattern sniffer registered for %q", lang)
+		}
+	}
+}
+
+// templateFixture is one per-language canonical example with three
+// expected matches: an i18n key, a log-format literal, and an SQL
+// literal. The sniffer must recognise at least one of each kind.
+type templateFixture struct {
+	lang   string
+	source string
+}
+
+func TestTemplatePatternT2_PrimitiveCoverage(t *testing.T) {
+	cases := []templateFixture{
+		{
+			lang: "ruby",
+			source: "def show\n" +
+				"  msg = I18n.t(\"welcome.greeting\")\n" +
+				"  Rails.logger.info(\"showing %s\")\n" +
+				"  User.connection.execute(\"SELECT * FROM users\")\n" +
+				"end\n",
+		},
+		{
+			lang: "php",
+			source: "<?php\n" +
+				"function show() {\n" +
+				"  $m = __(\"welcome.greeting\");\n" +
+				"  Log::info(\"showing %s\");\n" +
+				"  $db->query(\"SELECT * FROM users\");\n" +
+				"}\n",
+		},
+		{
+			lang: "rust",
+			source: "fn show() {\n" +
+				"  let m = t!(\"welcome.greeting\");\n" +
+				"  log::info!(\"showing {}\");\n" +
+				"  sqlx::query(\"SELECT * FROM users\");\n" +
+				"}\n",
+		},
+		{
+			lang: "csharp",
+			source: "public class C {\n" +
+				"  public void Show() {\n" +
+				"    var m = _localizer[\"welcome.greeting\"];\n" +
+				"    _logger.LogInformation(\"showing {0}\");\n" +
+				"    db.Execute(@\"SELECT * FROM users\");\n" +
+				"  }\n" +
+				"}\n",
+		},
+		{
+			lang: "kotlin",
+			source: "fun show() {\n" +
+				"  val m = getString(\"welcome.greeting\")\n" +
+				"  Log.i(TAG, \"showing %s\")\n" +
+				"  db.execSQL(\"SELECT * FROM users\")\n" +
+				"}\n",
+		},
+		{
+			lang: "elixir",
+			source: "defmodule C do\n" +
+				"  def show do\n" +
+				"    m = gettext(\"welcome.greeting\")\n" +
+				"    Logger.info(\"showing ~p\")\n" +
+				"    Ecto.Adapters.SQL.query!(repo, \"SELECT * FROM users\")\n" +
+				"  end\n" +
+				"end\n",
+		},
+		{
+			lang: "scala",
+			source: "object C {\n" +
+				"  def show(): Unit = {\n" +
+				"    val m = Messages(\"welcome.greeting\")\n" +
+				"    logger.info(\"showing %s\")\n" +
+				"    db.run(\"SELECT * FROM users\")\n" +
+				"  }\n" +
+				"}\n",
+		},
+		{
+			lang: "c-cpp",
+			source: "#include <cstdio>\n" +
+				"void show() {\n" +
+				"  const char *m = gettext(\"welcome.greeting\");\n" +
+				"  printf(\"showing %s\");\n" +
+				"  exec_sql(\"SELECT * FROM users\");\n" +
+				"}\n",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.lang, func(t *testing.T) {
+			sniff := TemplatePatternSnifferFor(c.lang)
+			if sniff == nil {
+				t.Fatalf("no sniffer registered for %q", c.lang)
+			}
+			matches := sniff(c.source)
+			gotKinds := map[TemplateKind]bool{}
+			for _, m := range matches {
+				gotKinds[m.Kind] = true
+			}
+			if !gotKinds[TemplateKindI18n] {
+				t.Errorf("%s: expected at least one i18n match in %v", c.lang, matches)
+			}
+			if !gotKinds[TemplateKindLog] {
+				t.Errorf("%s: expected at least one log_format match in %v", c.lang, matches)
+			}
+			if !gotKinds[TemplateKindSQL] {
+				t.Errorf("%s: expected at least one sql match in %v", c.lang, matches)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Phase 3 mechanical port to T2 (ruby, php, rust, csharp, kotlin, elixir, scala, c-cpp). Mirrors #2774 (T1).

## Summary

Four sub-tasks shipped per the issue spec — each pays compound interest on the substrate:

| Sub-task | Per-lang code? | Surface |
|---|---|---|
| 3A pure-function tagging | No (derivative of Phase 1A) | `archigraph_pure_functions` |
| 3B module-cycle detection | No (Tarjan SCC over IMPORTS) | `archigraph_import_cycles` |
| 3C reaching-definitions / def-use chains | Yes, 8 sniffers (93–115 LOC) | `archigraph_def_use` |
| 3D template-pattern catalog (i18n/log/sql) | Yes, 8 sniffers (80–114 LOC) | `archigraph_template_patterns` |

## LOC per language (3C / 3D)

| lang | def_use | template_pattern |
|---|---:|---:|
| ruby | 100 | 96 |
| php | 95 | 112 |
| rust | 108 | 96 |
| csharp | 108 | 80 |
| kotlin | 112 | 96 |
| elixir | 93 | 94 |
| scala | 108 | 96 |
| c-cpp | 115 | 114 |

## Wiring

- `internal/links/links.go` — registers four new passes after the Phase 2A drift pass: pure → cycle → def-use → template-patterns. All four idempotent and sidecar-only.
- `internal/mcp/server.go` — registers four MCP tools backed by `internal/mcp/phase3_tools.go`.
- `internal/mcp/budget.go` — `TokenCeiling` 6000 → 6500 with documented +500 bump (four sidecar-reader tools pushed handshake past the prior ceiling).
- `internal/mcp/server_test.go` — TestToolNameSurface + TestElapsedMSCoverageAllTools updated to 53 tools with minimalArgs entries for the four new tools.

## Tests

- `TestDefUseRegistry_T2Languages` + `TestTemplatePatternRegistry_T2Languages` — assert all 8 T2 slugs are registered.
- `TestDefUseT2_PrimitiveCoverage` + `TestTemplatePatternT2_PrimitiveCoverage` — one canonical per-language fixture per sub-task (1 def + 1 use; 1 i18n + 1 log + 1 sql).

## Note on overlap with T1 (#2774)

T1 had not been opened as a PR when this branch was cut. This PR therefore bundles the generic Phase 3 infrastructure (`internal/substrate/{def_use,template_pattern}.go`, the four link passes, `internal/mcp/phase3_tools.go`) plus the T2 sniffers. When T1 lands first, the rebase will deconflict naturally because the generic files are identical byte-for-byte across both PRs by design.

## Coverage cells

```
implements-capability: lang.ruby.framework.rails/Substrate/pure_function:missing→partial
implements-capability: lang.ruby.framework.rails/Substrate/module_cycle:missing→partial
implements-capability: lang.ruby.framework.rails/Substrate/def_use:missing→partial
implements-capability: lang.ruby.framework.rails/Substrate/template_pattern:missing→partial
implements-capability: lang.php.framework.laravel/Substrate/pure_function:missing→partial
implements-capability: lang.php.framework.laravel/Substrate/module_cycle:missing→partial
implements-capability: lang.php.framework.laravel/Substrate/def_use:missing→partial
implements-capability: lang.php.framework.laravel/Substrate/template_pattern:missing→partial
implements-capability: lang.rust.framework.axum/Substrate/pure_function:missing→partial
implements-capability: lang.rust.framework.axum/Substrate/module_cycle:missing→partial
implements-capability: lang.rust.framework.axum/Substrate/def_use:missing→partial
implements-capability: lang.rust.framework.axum/Substrate/template_pattern:missing→partial
implements-capability: lang.csharp.framework.aspnet-core/Substrate/pure_function:missing→partial
implements-capability: lang.csharp.framework.aspnet-core/Substrate/module_cycle:missing→partial
implements-capability: lang.csharp.framework.aspnet-core/Substrate/def_use:missing→partial
implements-capability: lang.csharp.framework.aspnet-core/Substrate/template_pattern:missing→partial
implements-capability: lang.kotlin.framework.spring-boot/Substrate/pure_function:missing→partial
implements-capability: lang.kotlin.framework.spring-boot/Substrate/module_cycle:missing→partial
implements-capability: lang.kotlin.framework.spring-boot/Substrate/def_use:missing→partial
implements-capability: lang.kotlin.framework.spring-boot/Substrate/template_pattern:missing→partial
implements-capability: lang.elixir.framework.phoenix/Substrate/pure_function:missing→partial
implements-capability: lang.elixir.framework.phoenix/Substrate/module_cycle:missing→partial
implements-capability: lang.elixir.framework.phoenix/Substrate/def_use:missing→partial
implements-capability: lang.elixir.framework.phoenix/Substrate/template_pattern:missing→partial
implements-capability: lang.scala.framework.play/Substrate/pure_function:missing→partial
implements-capability: lang.scala.framework.play/Substrate/module_cycle:missing→partial
implements-capability: lang.scala.framework.play/Substrate/def_use:missing→partial
implements-capability: lang.scala.framework.play/Substrate/template_pattern:missing→partial
implements-capability: lang.c-cpp.framework.crow/Substrate/pure_function:missing→partial
implements-capability: lang.c-cpp.framework.crow/Substrate/module_cycle:missing→partial
implements-capability: lang.c-cpp.framework.crow/Substrate/def_use:missing→partial
implements-capability: lang.c-cpp.framework.crow/Substrate/template_pattern:missing→partial
```

(32 cells flipped = 8 T2 framework records × 4 sub-tasks.)

## Verification

- `go build ./...` clean.
- `go test ./internal/substrate/... ./internal/links/...` passes.
- `go test ./internal/mcp/...` passes modulo the pre-existing `TestNoSessionMetaInNonWhoamiHandlers/handleGetNode_(inspect)` failure on `origin/main` (unrelated to this change — asserts indexed_sha/indexed_ref do not leak through inspect handler metadata; reproduces clean from origin/main HEAD without any of the files in this PR).
- Self-rebased onto latest `origin/main` (post-#2772 Phase 2B T1 merge).

## Test plan

- [ ] CI green on `go test ./...`
- [ ] Run link passes against upvate fleet and confirm sidecars are written: `<group>-links-{pure-functions,module-cycles,def-use,template-patterns}.json`
- [ ] `archigraph_pure_functions`, `archigraph_import_cycles`, `archigraph_def_use`, `archigraph_template_patterns` return at least one finding each on the upvate corpus
- [ ] `cmd/mcp-audit` reports handshake within the 6500-token ceiling

Closes #2775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)